### PR TITLE
[WASM] Add f64x2 operations and unzip

### DIFF
--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -112,11 +112,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn unzip_low_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
-        todo!()
+        u32x4_shuffle::<0, 2, 4, 6>(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn unzip_high_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
-        todo!()
+        u32x4_shuffle::<1, 3, 5, 7>(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn max_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
@@ -263,11 +263,19 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn unzip_low_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
-        todo!()
+        u8x16_shuffle::<0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30>(
+            a.into(),
+            b.into(),
+        )
+        .simd_into(self)
     }
     #[inline(always)]
     fn unzip_high_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
-        todo!()
+        u8x16_shuffle::<1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31>(
+            a.into(),
+            b.into(),
+        )
+        .simd_into(self)
     }
     #[inline(always)]
     fn select_i8x16(self, a: mask8x16<Self>, b: i8x16<Self>, c: i8x16<Self>) -> i8x16<Self> {
@@ -370,11 +378,19 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn unzip_low_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
-        todo!()
+        u8x16_shuffle::<0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30>(
+            a.into(),
+            b.into(),
+        )
+        .simd_into(self)
     }
     #[inline(always)]
     fn unzip_high_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
-        todo!()
+        u8x16_shuffle::<1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31>(
+            a.into(),
+            b.into(),
+        )
+        .simd_into(self)
     }
     #[inline(always)]
     fn select_u8x16(self, a: mask8x16<Self>, b: u8x16<Self>, c: u8x16<Self>) -> u8x16<Self> {
@@ -511,11 +527,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn unzip_low_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
-        todo!()
+        u16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14>(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn unzip_high_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
-        todo!()
+        u16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn select_i16x8(self, a: mask16x8<Self>, b: i16x8<Self>, c: i16x8<Self>) -> i16x8<Self> {
@@ -610,11 +626,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn unzip_low_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
-        todo!()
+        u16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14>(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn unzip_high_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
-        todo!()
+        u16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn select_u16x8(self, a: mask16x8<Self>, b: u16x8<Self>, c: u16x8<Self>) -> u16x8<Self> {
@@ -749,11 +765,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn unzip_low_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
-        todo!()
+        u32x4_shuffle::<0, 2, 4, 6>(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn unzip_high_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
-        todo!()
+        u32x4_shuffle::<1, 3, 5, 7>(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn select_i32x4(self, a: mask32x4<Self>, b: i32x4<Self>, c: i32x4<Self>) -> i32x4<Self> {
@@ -852,11 +868,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn unzip_low_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
-        todo!()
+        u32x4_shuffle::<0, 2, 4, 6>(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn unzip_high_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
-        todo!()
+        u32x4_shuffle::<1, 3, 5, 7>(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn select_u32x4(self, a: mask32x4<Self>, b: u32x4<Self>, c: u32x4<Self>) -> u32x4<Self> {
@@ -991,11 +1007,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn unzip_low_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
-        todo!()
+        u64x2_shuffle::<0, 2>(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn unzip_high_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
-        todo!()
+        u64x2_shuffle::<1, 3>(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn max_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -136,11 +136,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn madd_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
-        self.add_f32x4(a, self.mul_f32x4(b, c))
+        a.add(b.mul(c))
     }
     #[inline(always)]
     fn msub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
-        self.sub_f32x4(a, self.mul_f32x4(b, c))
+        a.sub(b.mul(c))
     }
     #[inline(always)]
     fn floor_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
@@ -148,7 +148,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn fract_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
-        self.sub_f32x4(a, self.trunc_f32x4(a))
+        a.sub(a.trunc())
     }
     #[inline(always)]
     fn trunc_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
@@ -947,15 +947,15 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn abs_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
-        todo!();
+        f64x2_abs(a.into()).simd_into(self)
     }
     #[inline(always)]
     fn neg_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
-        todo!();
+        f64x2_neg(a.into()).simd_into(self)
     }
     #[inline(always)]
     fn sqrt_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
-        todo!();
+        f64x2_sqrt(a.into()).simd_into(self)
     }
     #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
@@ -975,7 +975,10 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn copysign_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
-        todo!()
+        let sign_mask = f64x2_splat(-0.0_f64);
+        let sign_bits = v128_and(b.into(), sign_mask.into());
+        let magnitude = v128_andnot(a.into(), sign_mask.into());
+        v128_or(magnitude, sign_bits).simd_into(self)
     }
     #[inline(always)]
     fn simd_eq_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> mask64x2<Self> {
@@ -1030,24 +1033,24 @@ impl Simd for WasmSimd128 {
         f64x2_pmin(b.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
-    fn madd_f64x2(self, _: f64x2<Self>, _: f64x2<Self>, _: f64x2<Self>) -> f64x2<Self> {
-        todo!()
+    fn madd_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        a.add(b.mul(c))
     }
     #[inline(always)]
-    fn msub_f64x2(self, _: f64x2<Self>, _: f64x2<Self>, _: f64x2<Self>) -> f64x2<Self> {
-        todo!()
+    fn msub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        a.sub(b.mul(c))
     }
     #[inline(always)]
     fn floor_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
-        todo!();
+        f64x2_floor(a.into()).simd_into(self)
     }
     #[inline(always)]
     fn fract_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
-        todo!();
+        a.sub(a.trunc())
     }
     #[inline(always)]
     fn trunc_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
-        todo!();
+        f64x2_trunc(a.into()).simd_into(self)
     }
     #[inline(always)]
     fn select_f64x2(self, a: mask64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -9,7 +9,7 @@ use crate::{
     arch::{Arch, wasm::Wasm},
     generic::{generic_combine, generic_op, generic_split},
     ops::{OpSig, TyFlavor, ops_for_type},
-    types::{SIMD_TYPES, ScalarType, VecType, type_imports},
+    types::{SIMD_TYPES, ScalarType, type_imports},
 };
 
 #[derive(Clone, Copy)]
@@ -65,50 +65,43 @@ fn mk_simd_impl(level: Level) -> TokenStream {
                     }
                 }
                 OpSig::Unary => {
-                    if vec_ty.scalar_bits != 64 || vec_ty.scalar != ScalarType::Float {
-                        let args = [quote! { a.into() }];
-                        let expr = if matches!(method, "fract") {
-                            assert_eq!(ty_name, "f32x4", "only support fract_f32x4");
-                            quote! {
-                                self.sub_f32x4(a, self.trunc_f32x4(a))
-                            }
-                        } else {
-                            let expr = Wasm.expr(method, vec_ty, &args);
-                            quote! { #expr.simd_into(self) }
-                        };
+                    let args = [quote! { a.into() }];
+                    let expr = if matches!(method, "fract") {
+                        assert_eq!(
+                            vec_ty.scalar,
+                            ScalarType::Float,
+                            "only float supports fract"
+                        );
 
                         quote! {
-                            #[inline(always)]
-                            fn #method_ident(self, a: #ty<Self>) -> #ret_ty {
-                                #expr
-                            }
+                            a.sub(a.trunc())
                         }
                     } else {
-                        quote! {
-                            #[inline(always)]
-                            fn #method_ident(self, a: #ty<Self>) -> #ret_ty {
-                                todo!();
-                            }
+                        let expr = Wasm.expr(method, vec_ty, &args);
+                        quote! { #expr.simd_into(self) }
+                    };
+
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, a: #ty<Self>) -> #ret_ty {
+                            #expr
                         }
                     }
                 }
                 OpSig::Binary if method == "copysign" => {
-                    if ty_name == "f32x4" {
-                        quote! {
-                            #[inline(always)]
-                            fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ret_ty {
-                                let sign_mask = f32x4_splat(-0.0_f32);
-                                let sign_bits = v128_and(b.into(), sign_mask.into());
-                                let magnitude = v128_andnot(a.into(), sign_mask.into());
-                                v128_or(magnitude, sign_bits).simd_into(self)
-                            }
-                        }
-                    } else {
-                        quote! {
-                            #[inline(always)]
-                            fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ret_ty {
-                                todo!()
-                            }
+                    let splat: Ident = format_ident!("{}_splat", vec_ty.rust_name());
+                    let sign_mask_literal = match vec_ty.scalar_bits {
+                        32 => quote! { -0.0_f32 },
+                        64 => quote! { -0.0_f64 },
+                        _ => unimplemented!(),
+                    };
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ret_ty {
+                            let sign_mask = #splat(#sign_mask_literal);
+                            let sign_bits = v128_and(b.into(), sign_mask.into());
+                            let magnitude = v128_andnot(a.into(), sign_mask.into());
+                            v128_or(magnitude, sign_bits).simd_into(self)
                         }
                     }
                 }
@@ -162,37 +155,18 @@ fn mk_simd_impl(level: Level) -> TokenStream {
                     }
                 }
                 OpSig::Ternary => {
-                    if vec_ty.scalar_bits == 64 && vec_ty.scalar == ScalarType::Float {
-                        quote! {
-                            #[inline(always)]
-                            fn #method_ident(self, _: #ty<Self>, _: #ty<Self>, _: #ty<Self>) -> #ret_ty {
-                                todo!()
-                            }
-                        }
-                    } else if matches!(method, "madd" | "msub") {
-                        let first_ident = {
-                            let str = if method == "madd" {
-                                "add_f32x4"
-                            } else {
-                                "sub_f32x4"
-                            };
-
-                            Ident::new(str, Span::call_site())
+                    if matches!(method, "madd" | "msub") {
+                        let first_ident = if method == "madd" {
+                            quote! {add}
+                        } else {
+                            quote! {sub}
                         };
 
-                        assert_eq!(
-                            vec_ty,
-                            &VecType {
-                                scalar: ScalarType::Float,
-                                scalar_bits: 32,
-                                len: 4,
-                            }
-                        );
                         // TODO: `relaxed-simd` has madd.
                         quote! {
                             #[inline(always)]
                             fn #method_ident(self, a: #ty<Self>, b: #ty<Self>, c: #ty<Self>) -> #ret_ty {
-                                self.#first_ident(a, self.mul_f32x4(b, c))
+                                a.#first_ident(b.mul(c))
                             }
                         }
                     } else {

--- a/fearless_simd_tests/tests/wasm.rs
+++ b/fearless_simd_tests/tests/wasm.rs
@@ -790,6 +790,168 @@ test_wasm_simd_parity! {
     }
 }
 
+// Unzip Low and High
+
+test_wasm_simd_parity! {
+    fn unzip_low_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[1.0, 2.0, 3.0, 4.0]);
+            let b = f32x4::from_slice(s, &[5.0, 6.0, 7.0, 8.0]);
+            s.unzip_low_f32x4(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_high_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[1.0, 2.0, 3.0, 4.0]);
+            let b = f32x4::from_slice(s, &[5.0, 6.0, 7.0, 8.0]);
+            s.unzip_high_f32x4(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_low_i8x16() {
+        |s| -> [i8; 16] {
+            let a = i8x16::from_slice(s, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+            let b = i8x16::from_slice(s, &[17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
+            s.unzip_low_i8x16(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_high_i8x16() {
+        |s| -> [i8; 16] {
+            let a = i8x16::from_slice(s, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+            let b = i8x16::from_slice(s, &[17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
+            s.unzip_high_i8x16(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_low_u8x16() {
+        |s| -> [u8; 16] {
+            let a = u8x16::from_slice(s, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+            let b = u8x16::from_slice(s, &[17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
+            s.unzip_low_u8x16(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_high_u8x16() {
+        |s| -> [u8; 16] {
+            let a = u8x16::from_slice(s, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+            let b = u8x16::from_slice(s, &[17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
+            s.unzip_high_u8x16(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_low_i16x8() {
+        |s| -> [i16; 8] {
+            let a = i16x8::from_slice(s, &[1, 2, 3, 4, 5, 6, 7, 8]);
+            let b = i16x8::from_slice(s, &[9, 10, 11, 12, 13, 14, 15, 16]);
+            s.unzip_low_i16x8(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_high_i16x8() {
+        |s| -> [i16; 8] {
+            let a = i16x8::from_slice(s, &[1, 2, 3, 4, 5, 6, 7, 8]);
+            let b = i16x8::from_slice(s, &[9, 10, 11, 12, 13, 14, 15, 16]);
+            s.unzip_high_i16x8(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_low_u16x8() {
+        |s| -> [u16; 8] {
+            let a = u16x8::from_slice(s, &[1, 2, 3, 4, 5, 6, 7, 8]);
+            let b = u16x8::from_slice(s, &[9, 10, 11, 12, 13, 14, 15, 16]);
+            s.unzip_low_u16x8(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_high_u16x8() {
+        |s| -> [u16; 8] {
+            let a = u16x8::from_slice(s, &[1, 2, 3, 4, 5, 6, 7, 8]);
+            let b = u16x8::from_slice(s, &[9, 10, 11, 12, 13, 14, 15, 16]);
+            s.unzip_high_u16x8(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_low_i32x4() {
+        |s| -> [i32; 4] {
+            let a = i32x4::from_slice(s, &[1, 2, 3, 4]);
+            let b = i32x4::from_slice(s, &[5, 6, 7, 8]);
+            s.unzip_low_i32x4(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_high_i32x4() {
+        |s| -> [i32; 4] {
+            let a = i32x4::from_slice(s, &[1, 2, 3, 4]);
+            let b = i32x4::from_slice(s, &[5, 6, 7, 8]);
+            s.unzip_high_i32x4(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_low_u32x4() {
+        |s| -> [u32; 4] {
+            let a = u32x4::from_slice(s, &[1, 2, 3, 4]);
+            let b = u32x4::from_slice(s, &[5, 6, 7, 8]);
+            s.unzip_low_u32x4(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_high_u32x4() {
+        |s| -> [u32; 4] {
+            let a = u32x4::from_slice(s, &[1, 2, 3, 4]);
+            let b = u32x4::from_slice(s, &[5, 6, 7, 8]);
+            s.unzip_high_u32x4(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_low_f64x2() {
+        |s| -> [f64; 2] {
+            let a = f64x2::from_slice(s, &[1.0, 2.0]);
+            let b = f64x2::from_slice(s, &[3.0, 4.0]);
+            s.unzip_low_f64x2(a, b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn unzip_high_f64x2() {
+        |s| -> [f64; 2] {
+            let a = f64x2::from_slice(s, &[1.0, 2.0]);
+            let b = f64x2::from_slice(s, &[3.0, 4.0]);
+            s.unzip_high_f64x2(a, b).into()
+        }
+    }
+}
+
 // Right Shift
 
 test_wasm_simd_parity! {

--- a/fearless_simd_tests/tests/wasm.rs
+++ b/fearless_simd_tests/tests/wasm.rs
@@ -1170,3 +1170,91 @@ test_wasm_simd_parity! {
         }
     }
 }
+
+// f64x2 operations
+
+test_wasm_simd_parity! {
+    fn abs_f64x2() {
+        |s| -> [f64; 2] {
+            let a = f64x2::from_slice(s, &[-1.5, 2.5]);
+            a.abs().into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn neg_f64x2() {
+        |s| -> [f64; 2] {
+            let a = f64x2::from_slice(s, &[1.5, -2.5]);
+            a.neg().into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn sqrt_f64x2() {
+        |s| -> [f64; 2] {
+            let a = f64x2::from_slice(s, &[4.0, 9.0]);
+            a.sqrt().into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn copysign_f64x2() {
+        |s| -> [f64; 2] {
+            let a = f64x2::from_slice(s, &[1.5, -2.5]);
+            let b = f64x2::from_slice(s, &[-1.0, 1.0]);
+            a.copysign(b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn msub_f64x2() {
+        |s| -> [f64; 2] {
+            let a = f64x2::from_slice(s, &[2.0, 3.0]);
+            let b = f64x2::from_slice(s, &[4.0, 5.0]);
+            let c = f64x2::from_slice(s, &[1.0, 2.0]);
+            a.msub(b, c).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn madd_f64x2() {
+        |s| -> [f64; 2] {
+            let a = f64x2::from_slice(s, &[2.0, 3.0]);
+            let b = f64x2::from_slice(s, &[4.0, 5.0]);
+            let c = f64x2::from_slice(s, &[1.0, 2.0]);
+            a.madd(b, c).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn floor_f64x2() {
+        |s| -> [f64; 2] {
+            let a = f64x2::from_slice(s, &[1.7, -2.3]);
+            a.floor().into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn fract_f64x2() {
+        |s| -> [f64; 2] {
+            let a = f64x2::from_slice(s, &[1.7, -2.3]);
+            a.fract().into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn trunc_f64x2() {
+        |s| -> [f64; 2] {
+            let a = f64x2::from_slice(s, &[1.7, -2.3]);
+            a.trunc().into()
+        }
+    }
+}


### PR DESCRIPTION
### Context

This is a WASM architecture followup to https://github.com/linebender/fearless_simd/pull/33. Implementing this PR removes all `todo!()` calls from the generated WASM file.

### How

 - Add `unzip`.
 - Add `f64x2` implementations.

I also cleaned up some other implementations to use generic methods instead of type-specific methods. For example we can express `fract` generically as `a.sub(a.trunc())` which then works on both `f32x4` and `f64x2`.


### Test plan

Added unit tests for full coverage of new methods.