### PR TITLE
Implement splatting for masks

### DIFF
--- a/fearless_simd/src/generated/ops.rs
+++ b/fearless_simd/src/generated/ops.rs
@@ -357,6 +357,20 @@ impl<S: Simd> core::ops::BitAnd for mask8x16<S> {
         self.simd.and_mask8x16(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitAnd<i8> for mask8x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitand(self, rhs: i8) -> Self::Output {
+        self.simd.and_mask8x16(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitAnd<mask8x16<S>> for i8 {
+    type Output = mask8x16<S>;
+    #[inline(always)]
+    fn bitand(self, rhs: mask8x16<S>) -> Self::Output {
+        rhs.simd.and_mask8x16(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitOr for mask8x16<S> {
     type Output = Self;
     #[inline(always)]
@@ -364,11 +378,39 @@ impl<S: Simd> core::ops::BitOr for mask8x16<S> {
         self.simd.or_mask8x16(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitOr<i8> for mask8x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitor(self, rhs: i8) -> Self::Output {
+        self.simd.or_mask8x16(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitOr<mask8x16<S>> for i8 {
+    type Output = mask8x16<S>;
+    #[inline(always)]
+    fn bitor(self, rhs: mask8x16<S>) -> Self::Output {
+        rhs.simd.or_mask8x16(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitXor for mask8x16<S> {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.simd.xor_mask8x16(self, rhs)
+    }
+}
+impl<S: Simd> core::ops::BitXor<i8> for mask8x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitxor(self, rhs: i8) -> Self::Output {
+        self.simd.xor_mask8x16(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitXor<mask8x16<S>> for i8 {
+    type Output = mask8x16<S>;
+    #[inline(always)]
+    fn bitxor(self, rhs: mask8x16<S>) -> Self::Output {
+        rhs.simd.xor_mask8x16(self.simd_into(rhs.simd), rhs)
     }
 }
 impl<S: Simd> core::ops::Not for mask8x16<S> {
@@ -637,6 +679,20 @@ impl<S: Simd> core::ops::BitAnd for mask16x8<S> {
         self.simd.and_mask16x8(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitAnd<i16> for mask16x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitand(self, rhs: i16) -> Self::Output {
+        self.simd.and_mask16x8(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitAnd<mask16x8<S>> for i16 {
+    type Output = mask16x8<S>;
+    #[inline(always)]
+    fn bitand(self, rhs: mask16x8<S>) -> Self::Output {
+        rhs.simd.and_mask16x8(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitOr for mask16x8<S> {
     type Output = Self;
     #[inline(always)]
@@ -644,11 +700,39 @@ impl<S: Simd> core::ops::BitOr for mask16x8<S> {
         self.simd.or_mask16x8(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitOr<i16> for mask16x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitor(self, rhs: i16) -> Self::Output {
+        self.simd.or_mask16x8(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitOr<mask16x8<S>> for i16 {
+    type Output = mask16x8<S>;
+    #[inline(always)]
+    fn bitor(self, rhs: mask16x8<S>) -> Self::Output {
+        rhs.simd.or_mask16x8(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitXor for mask16x8<S> {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.simd.xor_mask16x8(self, rhs)
+    }
+}
+impl<S: Simd> core::ops::BitXor<i16> for mask16x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitxor(self, rhs: i16) -> Self::Output {
+        self.simd.xor_mask16x8(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitXor<mask16x8<S>> for i16 {
+    type Output = mask16x8<S>;
+    #[inline(always)]
+    fn bitxor(self, rhs: mask16x8<S>) -> Self::Output {
+        rhs.simd.xor_mask16x8(self.simd_into(rhs.simd), rhs)
     }
 }
 impl<S: Simd> core::ops::Not for mask16x8<S> {
@@ -917,6 +1001,20 @@ impl<S: Simd> core::ops::BitAnd for mask32x4<S> {
         self.simd.and_mask32x4(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitAnd<i32> for mask32x4<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitand(self, rhs: i32) -> Self::Output {
+        self.simd.and_mask32x4(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitAnd<mask32x4<S>> for i32 {
+    type Output = mask32x4<S>;
+    #[inline(always)]
+    fn bitand(self, rhs: mask32x4<S>) -> Self::Output {
+        rhs.simd.and_mask32x4(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitOr for mask32x4<S> {
     type Output = Self;
     #[inline(always)]
@@ -924,11 +1022,39 @@ impl<S: Simd> core::ops::BitOr for mask32x4<S> {
         self.simd.or_mask32x4(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitOr<i32> for mask32x4<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitor(self, rhs: i32) -> Self::Output {
+        self.simd.or_mask32x4(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitOr<mask32x4<S>> for i32 {
+    type Output = mask32x4<S>;
+    #[inline(always)]
+    fn bitor(self, rhs: mask32x4<S>) -> Self::Output {
+        rhs.simd.or_mask32x4(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitXor for mask32x4<S> {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.simd.xor_mask32x4(self, rhs)
+    }
+}
+impl<S: Simd> core::ops::BitXor<i32> for mask32x4<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitxor(self, rhs: i32) -> Self::Output {
+        self.simd.xor_mask32x4(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitXor<mask32x4<S>> for i32 {
+    type Output = mask32x4<S>;
+    #[inline(always)]
+    fn bitxor(self, rhs: mask32x4<S>) -> Self::Output {
+        rhs.simd.xor_mask32x4(self.simd_into(rhs.simd), rhs)
     }
 }
 impl<S: Simd> core::ops::Not for mask32x4<S> {
@@ -1036,6 +1162,20 @@ impl<S: Simd> core::ops::BitAnd for mask64x2<S> {
         self.simd.and_mask64x2(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitAnd<i64> for mask64x2<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitand(self, rhs: i64) -> Self::Output {
+        self.simd.and_mask64x2(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitAnd<mask64x2<S>> for i64 {
+    type Output = mask64x2<S>;
+    #[inline(always)]
+    fn bitand(self, rhs: mask64x2<S>) -> Self::Output {
+        rhs.simd.and_mask64x2(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitOr for mask64x2<S> {
     type Output = Self;
     #[inline(always)]
@@ -1043,11 +1183,39 @@ impl<S: Simd> core::ops::BitOr for mask64x2<S> {
         self.simd.or_mask64x2(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitOr<i64> for mask64x2<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitor(self, rhs: i64) -> Self::Output {
+        self.simd.or_mask64x2(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitOr<mask64x2<S>> for i64 {
+    type Output = mask64x2<S>;
+    #[inline(always)]
+    fn bitor(self, rhs: mask64x2<S>) -> Self::Output {
+        rhs.simd.or_mask64x2(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitXor for mask64x2<S> {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.simd.xor_mask64x2(self, rhs)
+    }
+}
+impl<S: Simd> core::ops::BitXor<i64> for mask64x2<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitxor(self, rhs: i64) -> Self::Output {
+        self.simd.xor_mask64x2(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitXor<mask64x2<S>> for i64 {
+    type Output = mask64x2<S>;
+    #[inline(always)]
+    fn bitxor(self, rhs: mask64x2<S>) -> Self::Output {
+        rhs.simd.xor_mask64x2(self.simd_into(rhs.simd), rhs)
     }
 }
 impl<S: Simd> core::ops::Not for mask64x2<S> {
@@ -1407,6 +1575,20 @@ impl<S: Simd> core::ops::BitAnd for mask8x32<S> {
         self.simd.and_mask8x32(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitAnd<i8> for mask8x32<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitand(self, rhs: i8) -> Self::Output {
+        self.simd.and_mask8x32(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitAnd<mask8x32<S>> for i8 {
+    type Output = mask8x32<S>;
+    #[inline(always)]
+    fn bitand(self, rhs: mask8x32<S>) -> Self::Output {
+        rhs.simd.and_mask8x32(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitOr for mask8x32<S> {
     type Output = Self;
     #[inline(always)]
@@ -1414,11 +1596,39 @@ impl<S: Simd> core::ops::BitOr for mask8x32<S> {
         self.simd.or_mask8x32(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitOr<i8> for mask8x32<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitor(self, rhs: i8) -> Self::Output {
+        self.simd.or_mask8x32(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitOr<mask8x32<S>> for i8 {
+    type Output = mask8x32<S>;
+    #[inline(always)]
+    fn bitor(self, rhs: mask8x32<S>) -> Self::Output {
+        rhs.simd.or_mask8x32(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitXor for mask8x32<S> {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.simd.xor_mask8x32(self, rhs)
+    }
+}
+impl<S: Simd> core::ops::BitXor<i8> for mask8x32<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitxor(self, rhs: i8) -> Self::Output {
+        self.simd.xor_mask8x32(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitXor<mask8x32<S>> for i8 {
+    type Output = mask8x32<S>;
+    #[inline(always)]
+    fn bitxor(self, rhs: mask8x32<S>) -> Self::Output {
+        rhs.simd.xor_mask8x32(self.simd_into(rhs.simd), rhs)
     }
 }
 impl<S: Simd> core::ops::Not for mask8x32<S> {
@@ -1687,6 +1897,20 @@ impl<S: Simd> core::ops::BitAnd for mask16x16<S> {
         self.simd.and_mask16x16(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitAnd<i16> for mask16x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitand(self, rhs: i16) -> Self::Output {
+        self.simd.and_mask16x16(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitAnd<mask16x16<S>> for i16 {
+    type Output = mask16x16<S>;
+    #[inline(always)]
+    fn bitand(self, rhs: mask16x16<S>) -> Self::Output {
+        rhs.simd.and_mask16x16(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitOr for mask16x16<S> {
     type Output = Self;
     #[inline(always)]
@@ -1694,11 +1918,39 @@ impl<S: Simd> core::ops::BitOr for mask16x16<S> {
         self.simd.or_mask16x16(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitOr<i16> for mask16x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitor(self, rhs: i16) -> Self::Output {
+        self.simd.or_mask16x16(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitOr<mask16x16<S>> for i16 {
+    type Output = mask16x16<S>;
+    #[inline(always)]
+    fn bitor(self, rhs: mask16x16<S>) -> Self::Output {
+        rhs.simd.or_mask16x16(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitXor for mask16x16<S> {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.simd.xor_mask16x16(self, rhs)
+    }
+}
+impl<S: Simd> core::ops::BitXor<i16> for mask16x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitxor(self, rhs: i16) -> Self::Output {
+        self.simd.xor_mask16x16(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitXor<mask16x16<S>> for i16 {
+    type Output = mask16x16<S>;
+    #[inline(always)]
+    fn bitxor(self, rhs: mask16x16<S>) -> Self::Output {
+        rhs.simd.xor_mask16x16(self.simd_into(rhs.simd), rhs)
     }
 }
 impl<S: Simd> core::ops::Not for mask16x16<S> {
@@ -1967,6 +2219,20 @@ impl<S: Simd> core::ops::BitAnd for mask32x8<S> {
         self.simd.and_mask32x8(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitAnd<i32> for mask32x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitand(self, rhs: i32) -> Self::Output {
+        self.simd.and_mask32x8(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitAnd<mask32x8<S>> for i32 {
+    type Output = mask32x8<S>;
+    #[inline(always)]
+    fn bitand(self, rhs: mask32x8<S>) -> Self::Output {
+        rhs.simd.and_mask32x8(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitOr for mask32x8<S> {
     type Output = Self;
     #[inline(always)]
@@ -1974,11 +2240,39 @@ impl<S: Simd> core::ops::BitOr for mask32x8<S> {
         self.simd.or_mask32x8(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitOr<i32> for mask32x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitor(self, rhs: i32) -> Self::Output {
+        self.simd.or_mask32x8(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitOr<mask32x8<S>> for i32 {
+    type Output = mask32x8<S>;
+    #[inline(always)]
+    fn bitor(self, rhs: mask32x8<S>) -> Self::Output {
+        rhs.simd.or_mask32x8(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitXor for mask32x8<S> {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.simd.xor_mask32x8(self, rhs)
+    }
+}
+impl<S: Simd> core::ops::BitXor<i32> for mask32x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitxor(self, rhs: i32) -> Self::Output {
+        self.simd.xor_mask32x8(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitXor<mask32x8<S>> for i32 {
+    type Output = mask32x8<S>;
+    #[inline(always)]
+    fn bitxor(self, rhs: mask32x8<S>) -> Self::Output {
+        rhs.simd.xor_mask32x8(self.simd_into(rhs.simd), rhs)
     }
 }
 impl<S: Simd> core::ops::Not for mask32x8<S> {
@@ -2086,6 +2380,20 @@ impl<S: Simd> core::ops::BitAnd for mask64x4<S> {
         self.simd.and_mask64x4(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitAnd<i64> for mask64x4<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitand(self, rhs: i64) -> Self::Output {
+        self.simd.and_mask64x4(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitAnd<mask64x4<S>> for i64 {
+    type Output = mask64x4<S>;
+    #[inline(always)]
+    fn bitand(self, rhs: mask64x4<S>) -> Self::Output {
+        rhs.simd.and_mask64x4(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitOr for mask64x4<S> {
     type Output = Self;
     #[inline(always)]
@@ -2093,11 +2401,39 @@ impl<S: Simd> core::ops::BitOr for mask64x4<S> {
         self.simd.or_mask64x4(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitOr<i64> for mask64x4<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitor(self, rhs: i64) -> Self::Output {
+        self.simd.or_mask64x4(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitOr<mask64x4<S>> for i64 {
+    type Output = mask64x4<S>;
+    #[inline(always)]
+    fn bitor(self, rhs: mask64x4<S>) -> Self::Output {
+        rhs.simd.or_mask64x4(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitXor for mask64x4<S> {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.simd.xor_mask64x4(self, rhs)
+    }
+}
+impl<S: Simd> core::ops::BitXor<i64> for mask64x4<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitxor(self, rhs: i64) -> Self::Output {
+        self.simd.xor_mask64x4(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitXor<mask64x4<S>> for i64 {
+    type Output = mask64x4<S>;
+    #[inline(always)]
+    fn bitxor(self, rhs: mask64x4<S>) -> Self::Output {
+        rhs.simd.xor_mask64x4(self.simd_into(rhs.simd), rhs)
     }
 }
 impl<S: Simd> core::ops::Not for mask64x4<S> {
@@ -2457,6 +2793,20 @@ impl<S: Simd> core::ops::BitAnd for mask8x64<S> {
         self.simd.and_mask8x64(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitAnd<i8> for mask8x64<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitand(self, rhs: i8) -> Self::Output {
+        self.simd.and_mask8x64(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitAnd<mask8x64<S>> for i8 {
+    type Output = mask8x64<S>;
+    #[inline(always)]
+    fn bitand(self, rhs: mask8x64<S>) -> Self::Output {
+        rhs.simd.and_mask8x64(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitOr for mask8x64<S> {
     type Output = Self;
     #[inline(always)]
@@ -2464,11 +2814,39 @@ impl<S: Simd> core::ops::BitOr for mask8x64<S> {
         self.simd.or_mask8x64(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitOr<i8> for mask8x64<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitor(self, rhs: i8) -> Self::Output {
+        self.simd.or_mask8x64(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitOr<mask8x64<S>> for i8 {
+    type Output = mask8x64<S>;
+    #[inline(always)]
+    fn bitor(self, rhs: mask8x64<S>) -> Self::Output {
+        rhs.simd.or_mask8x64(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitXor for mask8x64<S> {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.simd.xor_mask8x64(self, rhs)
+    }
+}
+impl<S: Simd> core::ops::BitXor<i8> for mask8x64<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitxor(self, rhs: i8) -> Self::Output {
+        self.simd.xor_mask8x64(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitXor<mask8x64<S>> for i8 {
+    type Output = mask8x64<S>;
+    #[inline(always)]
+    fn bitxor(self, rhs: mask8x64<S>) -> Self::Output {
+        rhs.simd.xor_mask8x64(self.simd_into(rhs.simd), rhs)
     }
 }
 impl<S: Simd> core::ops::Not for mask8x64<S> {
@@ -2737,6 +3115,20 @@ impl<S: Simd> core::ops::BitAnd for mask16x32<S> {
         self.simd.and_mask16x32(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitAnd<i16> for mask16x32<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitand(self, rhs: i16) -> Self::Output {
+        self.simd.and_mask16x32(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitAnd<mask16x32<S>> for i16 {
+    type Output = mask16x32<S>;
+    #[inline(always)]
+    fn bitand(self, rhs: mask16x32<S>) -> Self::Output {
+        rhs.simd.and_mask16x32(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitOr for mask16x32<S> {
     type Output = Self;
     #[inline(always)]
@@ -2744,11 +3136,39 @@ impl<S: Simd> core::ops::BitOr for mask16x32<S> {
         self.simd.or_mask16x32(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitOr<i16> for mask16x32<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitor(self, rhs: i16) -> Self::Output {
+        self.simd.or_mask16x32(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitOr<mask16x32<S>> for i16 {
+    type Output = mask16x32<S>;
+    #[inline(always)]
+    fn bitor(self, rhs: mask16x32<S>) -> Self::Output {
+        rhs.simd.or_mask16x32(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitXor for mask16x32<S> {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.simd.xor_mask16x32(self, rhs)
+    }
+}
+impl<S: Simd> core::ops::BitXor<i16> for mask16x32<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitxor(self, rhs: i16) -> Self::Output {
+        self.simd.xor_mask16x32(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitXor<mask16x32<S>> for i16 {
+    type Output = mask16x32<S>;
+    #[inline(always)]
+    fn bitxor(self, rhs: mask16x32<S>) -> Self::Output {
+        rhs.simd.xor_mask16x32(self.simd_into(rhs.simd), rhs)
     }
 }
 impl<S: Simd> core::ops::Not for mask16x32<S> {
@@ -3017,6 +3437,20 @@ impl<S: Simd> core::ops::BitAnd for mask32x16<S> {
         self.simd.and_mask32x16(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitAnd<i32> for mask32x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitand(self, rhs: i32) -> Self::Output {
+        self.simd.and_mask32x16(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitAnd<mask32x16<S>> for i32 {
+    type Output = mask32x16<S>;
+    #[inline(always)]
+    fn bitand(self, rhs: mask32x16<S>) -> Self::Output {
+        rhs.simd.and_mask32x16(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitOr for mask32x16<S> {
     type Output = Self;
     #[inline(always)]
@@ -3024,11 +3458,39 @@ impl<S: Simd> core::ops::BitOr for mask32x16<S> {
         self.simd.or_mask32x16(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitOr<i32> for mask32x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitor(self, rhs: i32) -> Self::Output {
+        self.simd.or_mask32x16(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitOr<mask32x16<S>> for i32 {
+    type Output = mask32x16<S>;
+    #[inline(always)]
+    fn bitor(self, rhs: mask32x16<S>) -> Self::Output {
+        rhs.simd.or_mask32x16(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitXor for mask32x16<S> {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.simd.xor_mask32x16(self, rhs)
+    }
+}
+impl<S: Simd> core::ops::BitXor<i32> for mask32x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitxor(self, rhs: i32) -> Self::Output {
+        self.simd.xor_mask32x16(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitXor<mask32x16<S>> for i32 {
+    type Output = mask32x16<S>;
+    #[inline(always)]
+    fn bitxor(self, rhs: mask32x16<S>) -> Self::Output {
+        rhs.simd.xor_mask32x16(self.simd_into(rhs.simd), rhs)
     }
 }
 impl<S: Simd> core::ops::Not for mask32x16<S> {
@@ -3136,6 +3598,20 @@ impl<S: Simd> core::ops::BitAnd for mask64x8<S> {
         self.simd.and_mask64x8(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitAnd<i64> for mask64x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitand(self, rhs: i64) -> Self::Output {
+        self.simd.and_mask64x8(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitAnd<mask64x8<S>> for i64 {
+    type Output = mask64x8<S>;
+    #[inline(always)]
+    fn bitand(self, rhs: mask64x8<S>) -> Self::Output {
+        rhs.simd.and_mask64x8(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitOr for mask64x8<S> {
     type Output = Self;
     #[inline(always)]
@@ -3143,11 +3619,39 @@ impl<S: Simd> core::ops::BitOr for mask64x8<S> {
         self.simd.or_mask64x8(self, rhs)
     }
 }
+impl<S: Simd> core::ops::BitOr<i64> for mask64x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitor(self, rhs: i64) -> Self::Output {
+        self.simd.or_mask64x8(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitOr<mask64x8<S>> for i64 {
+    type Output = mask64x8<S>;
+    #[inline(always)]
+    fn bitor(self, rhs: mask64x8<S>) -> Self::Output {
+        rhs.simd.or_mask64x8(self.simd_into(rhs.simd), rhs)
+    }
+}
 impl<S: Simd> core::ops::BitXor for mask64x8<S> {
     type Output = Self;
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.simd.xor_mask64x8(self, rhs)
+    }
+}
+impl<S: Simd> core::ops::BitXor<i64> for mask64x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn bitxor(self, rhs: i64) -> Self::Output {
+        self.simd.xor_mask64x8(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> core::ops::BitXor<mask64x8<S>> for i64 {
+    type Output = mask64x8<S>;
+    #[inline(always)]
+    fn bitxor(self, rhs: mask64x8<S>) -> Self::Output {
+        rhs.simd.xor_mask64x8(self.simd_into(rhs.simd), rhs)
     }
 }
 impl<S: Simd> core::ops::Not for mask64x8<S> {

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -812,6 +812,12 @@ impl<S: Simd> core::ops::DerefMut for mask8x16<S> {
         &mut self.val
     }
 }
+impl<S: Simd> SimdFrom<i8, S> for mask8x16<S> {
+    #[inline(always)]
+    fn simd_from(value: i8, simd: S) -> Self {
+        simd.splat_mask8x16(value)
+    }
+}
 impl<S: Simd> Select<mask8x16<S>> for mask8x16<S> {
     #[inline(always)]
     fn select(self, if_true: mask8x16<S>, if_false: mask8x16<S>) -> mask8x16<S> {
@@ -1387,6 +1393,12 @@ impl<S: Simd> core::ops::DerefMut for mask16x8<S> {
         &mut self.val
     }
 }
+impl<S: Simd> SimdFrom<i16, S> for mask16x8<S> {
+    #[inline(always)]
+    fn simd_from(value: i16, simd: S) -> Self {
+        simd.splat_mask16x8(value)
+    }
+}
 impl<S: Simd> Select<mask16x8<S>> for mask16x8<S> {
     #[inline(always)]
     fn select(self, if_true: mask16x8<S>, if_false: mask16x8<S>) -> mask16x8<S> {
@@ -1949,6 +1961,12 @@ impl<S: Simd> core::ops::DerefMut for mask32x4<S> {
         &mut self.val
     }
 }
+impl<S: Simd> SimdFrom<i32, S> for mask32x4<S> {
+    #[inline(always)]
+    fn simd_from(value: i32, simd: S) -> Self {
+        simd.splat_mask32x4(value)
+    }
+}
 impl<S: Simd> Select<mask32x4<S>> for mask32x4<S> {
     #[inline(always)]
     fn select(self, if_true: mask32x4<S>, if_false: mask32x4<S>) -> mask32x4<S> {
@@ -2339,6 +2357,12 @@ impl<S: Simd> core::ops::DerefMut for mask64x2<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.val
+    }
+}
+impl<S: Simd> SimdFrom<i64, S> for mask64x2<S> {
+    #[inline(always)]
+    fn simd_from(value: i64, simd: S) -> Self {
+        simd.splat_mask64x2(value)
     }
 }
 impl<S: Simd> Select<mask64x2<S>> for mask64x2<S> {
@@ -3295,6 +3319,12 @@ impl<S: Simd> core::ops::DerefMut for mask8x32<S> {
         &mut self.val
     }
 }
+impl<S: Simd> SimdFrom<i8, S> for mask8x32<S> {
+    #[inline(always)]
+    fn simd_from(value: i8, simd: S) -> Self {
+        simd.splat_mask8x32(value)
+    }
+}
 impl<S: Simd> Select<mask8x32<S>> for mask8x32<S> {
     #[inline(always)]
     fn select(self, if_true: mask8x32<S>, if_false: mask8x32<S>) -> mask8x32<S> {
@@ -3894,6 +3924,12 @@ impl<S: Simd> core::ops::DerefMut for mask16x16<S> {
         &mut self.val
     }
 }
+impl<S: Simd> SimdFrom<i16, S> for mask16x16<S> {
+    #[inline(always)]
+    fn simd_from(value: i16, simd: S) -> Self {
+        simd.splat_mask16x16(value)
+    }
+}
 impl<S: Simd> Select<mask16x16<S>> for mask16x16<S> {
     #[inline(always)]
     fn select(self, if_true: mask16x16<S>, if_false: mask16x16<S>) -> mask16x16<S> {
@@ -4483,6 +4519,12 @@ impl<S: Simd> core::ops::DerefMut for mask32x8<S> {
         &mut self.val
     }
 }
+impl<S: Simd> SimdFrom<i32, S> for mask32x8<S> {
+    #[inline(always)]
+    fn simd_from(value: i32, simd: S) -> Self {
+        simd.splat_mask32x8(value)
+    }
+}
 impl<S: Simd> Select<mask32x8<S>> for mask32x8<S> {
     #[inline(always)]
     fn select(self, if_true: mask32x8<S>, if_false: mask32x8<S>) -> mask32x8<S> {
@@ -4873,6 +4915,12 @@ impl<S: Simd> core::ops::DerefMut for mask64x4<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.val
+    }
+}
+impl<S: Simd> SimdFrom<i64, S> for mask64x4<S> {
+    #[inline(always)]
+    fn simd_from(value: i64, simd: S) -> Self {
+        simd.splat_mask64x4(value)
     }
 }
 impl<S: Simd> Select<mask64x4<S>> for mask64x4<S> {
@@ -5924,6 +5972,12 @@ impl<S: Simd> core::ops::DerefMut for mask8x64<S> {
         &mut self.val
     }
 }
+impl<S: Simd> SimdFrom<i8, S> for mask8x64<S> {
+    #[inline(always)]
+    fn simd_from(value: i8, simd: S) -> Self {
+        simd.splat_mask8x64(value)
+    }
+}
 impl<S: Simd> Select<mask8x64<S>> for mask8x64<S> {
     #[inline(always)]
     fn select(self, if_true: mask8x64<S>, if_false: mask8x64<S>) -> mask8x64<S> {
@@ -6562,6 +6616,12 @@ impl<S: Simd> core::ops::DerefMut for mask16x32<S> {
         &mut self.val
     }
 }
+impl<S: Simd> SimdFrom<i16, S> for mask16x32<S> {
+    #[inline(always)]
+    fn simd_from(value: i16, simd: S) -> Self {
+        simd.splat_mask16x32(value)
+    }
+}
 impl<S: Simd> Select<mask16x32<S>> for mask16x32<S> {
     #[inline(always)]
     fn select(self, if_true: mask16x32<S>, if_false: mask16x32<S>) -> mask16x32<S> {
@@ -7166,6 +7226,12 @@ impl<S: Simd> core::ops::DerefMut for mask32x16<S> {
         &mut self.val
     }
 }
+impl<S: Simd> SimdFrom<i32, S> for mask32x16<S> {
+    #[inline(always)]
+    fn simd_from(value: i32, simd: S) -> Self {
+        simd.splat_mask32x16(value)
+    }
+}
 impl<S: Simd> Select<mask32x16<S>> for mask32x16<S> {
     #[inline(always)]
     fn select(self, if_true: mask32x16<S>, if_false: mask32x16<S>) -> mask32x16<S> {
@@ -7568,6 +7634,12 @@ impl<S: Simd> core::ops::DerefMut for mask64x8<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.val
+    }
+}
+impl<S: Simd> SimdFrom<i64, S> for mask64x8<S> {
+    #[inline(always)]
+    fn simd_from(value: i64, simd: S) -> Self {
+        simd.splat_mask64x8(value)
     }
 }
 impl<S: Simd> Select<mask64x8<S>> for mask64x8<S> {

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -22,7 +22,7 @@ pub fn mk_simd_types() -> TokenStream {
         let select = Ident::new(&format!("select_{}", ty.rust_name()), Span::call_site());
         let bytes = VecType::new(ScalarType::Unsigned, 8, align).rust();
         let mask = ty.mask_ty().rust();
-        let scalar_impl = if ty.scalar != ScalarType::Mask {
+        let scalar_impl = {
             let splat = Ident::new(&format!("splat_{}", ty.rust_name()), Span::call_site());
             quote! {
                 impl<S: Simd> SimdFrom<#rust_scalar, S> for #name<S> {
@@ -32,9 +32,6 @@ pub fn mk_simd_types() -> TokenStream {
                     }
                 }
             }
-        } else {
-            // TODO: consider implementing splat for masks; portable_simd does
-            quote! {}
         };
         let impl_block = simd_impl(ty);
         let simd_from_items = make_list(


### PR DESCRIPTION
This will be convenient for e.g. polyfilling `!` with `^ !0` in SSE4.2.