### PR TITLE
Add workspace lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,9 @@ resolver = "2"
 members = ["fearless_simd", "fearless_simd_gen", "fearless_simd_tests"]
 
 [workspace.package]
-license = "MIT/Apache-2.0"
 edition = "2024"
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/linebender/vello"
 
 
 [workspace.lints]

--- a/fearless_simd/Cargo.toml
+++ b/fearless_simd/Cargo.toml
@@ -3,6 +3,7 @@ name = "fearless_simd"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+repository.workspace = true
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 keywords = ["simd"]
 categories = ["hardware-support"]
@@ -15,6 +16,9 @@ safe_wrappers = []
 default = ["std"]
 std = []
 libm = ["dep:libm"]
+
+[lints]
+workspace=true
 
 [dependencies]
 bytemuck = "1.23.0"

--- a/fearless_simd/src/core_arch/aarch64/fp16.rs
+++ b/fearless_simd/src/core_arch/aarch64/fp16.rs
@@ -3,6 +3,14 @@
 
 //! Access to fp16 intrinsics on aarch64.
 
+#![cfg_attr(
+    feature = "safe_wrappers",
+    expect(
+        unreachable_pub,
+        reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+    )
+)]
+
 use core::arch::aarch64::*;
 
 use crate::core_arch::aarch64::Neon;
@@ -10,7 +18,10 @@ use crate::core_arch::aarch64::Neon;
 /// A token for FP16 intrinsics on aarch64.
 #[derive(Clone, Copy, Debug)]
 pub struct Fp16 {
-    #[allow(unused)]
+    #[allow(
+        unused,
+        reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+    )]
     neon: Neon,
 }
 

--- a/fearless_simd/src/core_arch/mod.rs
+++ b/fearless_simd/src/core_arch/mod.rs
@@ -3,6 +3,10 @@
 
 //! Access to architecture-specific intrinsics.
 
+#![expect(
+    missing_docs,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
 #![cfg_attr(
     not(target_arch = "wasm32"),
     expect(

--- a/fearless_simd/src/core_arch/x86_64/avx.rs
+++ b/fearless_simd/src/core_arch/x86_64/avx.rs
@@ -11,7 +11,7 @@
 use crate::impl_macros::delegate;
 use core::arch::x86_64::*;
 
-/// A token for AVX intrinsics on x86_64.
+/// A token for AVX intrinsics on `x86_64`.
 #[derive(Clone, Copy, Debug)]
 pub struct Avx {
     _private: (),

--- a/fearless_simd/src/core_arch/x86_64/avx2.rs
+++ b/fearless_simd/src/core_arch/x86_64/avx2.rs
@@ -6,7 +6,7 @@
 use crate::impl_macros::delegate;
 use core::arch::x86_64::*;
 
-/// A token for AVX2 intrinsics on x86_64.
+/// A token for AVX2 intrinsics on `x86_64`.
 #[derive(Clone, Copy, Debug)]
 pub struct Avx2 {
     _private: (),

--- a/fearless_simd/src/core_arch/x86_64/fma.rs
+++ b/fearless_simd/src/core_arch/x86_64/fma.rs
@@ -6,7 +6,7 @@
 use crate::impl_macros::delegate;
 use core::arch::x86_64::*;
 
-/// A token for FMA intrinsics on x86_64.
+/// A token for FMA intrinsics on `x86_64`.
 #[derive(Clone, Copy, Debug)]
 pub struct Fma {
     _private: (),

--- a/fearless_simd/src/core_arch/x86_64/mod.rs
+++ b/fearless_simd/src/core_arch/x86_64/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Access to intrinsics on x86_64.
+//! Access to intrinsics on `x86_64`.
 
 mod avx;
 mod avx2;

--- a/fearless_simd/src/core_arch/x86_64/sse.rs
+++ b/fearless_simd/src/core_arch/x86_64/sse.rs
@@ -6,7 +6,7 @@
 use crate::impl_macros::delegate;
 use core::arch::x86_64::*;
 
-/// A token for SSE intrinsics on x86_64.
+/// A token for SSE intrinsics on `x86_64`.
 #[derive(Clone, Copy, Debug)]
 pub struct Sse {
     _private: (),

--- a/fearless_simd/src/core_arch/x86_64/sse2.rs
+++ b/fearless_simd/src/core_arch/x86_64/sse2.rs
@@ -14,7 +14,7 @@
 use crate::impl_macros::delegate;
 use core::arch::x86_64::*;
 
-/// A token for SSE2 intrinsics on x86_64.
+/// A token for SSE2 intrinsics on `x86_64`.
 #[derive(Clone, Copy, Debug)]
 pub struct Sse2 {
     _private: (),

--- a/fearless_simd/src/core_arch/x86_64/sse3.rs
+++ b/fearless_simd/src/core_arch/x86_64/sse3.rs
@@ -6,7 +6,7 @@
 use crate::impl_macros::delegate;
 use core::arch::x86_64::*;
 
-/// A token for SSE3 intrinsics on x86_64.
+/// A token for SSE3 intrinsics on `x86_64`.
 #[derive(Clone, Copy, Debug)]
 pub struct Sse3 {
     _private: (),

--- a/fearless_simd/src/core_arch/x86_64/sse4_1.rs
+++ b/fearless_simd/src/core_arch/x86_64/sse4_1.rs
@@ -6,7 +6,7 @@
 use crate::impl_macros::delegate;
 use core::arch::x86_64::*;
 
-/// A token for SSE4.1 intrinsics on x86_64.
+/// A token for SSE4.1 intrinsics on `x86_64`.
 #[derive(Clone, Copy, Debug)]
 pub struct Sse4_1 {
     _private: (),

--- a/fearless_simd/src/core_arch/x86_64/sse4_2.rs
+++ b/fearless_simd/src/core_arch/x86_64/sse4_2.rs
@@ -6,7 +6,7 @@
 use crate::impl_macros::delegate;
 use core::arch::x86_64::*;
 
-/// A token for SSE4.2 intrinsics on x86_64.
+/// A token for SSE4.2 intrinsics on `x86_64`.
 #[derive(Clone, Copy, Debug)]
 pub struct Sse4_2 {
     _private: (),

--- a/fearless_simd/src/core_arch/x86_64/ssse3.rs
+++ b/fearless_simd/src/core_arch/x86_64/ssse3.rs
@@ -6,7 +6,7 @@
 use crate::impl_macros::delegate;
 use core::arch::x86_64::*;
 
-/// A token for SSSE3 intrinsics on x86_64.
+/// A token for SSSE3 intrinsics on `x86_64`.
 #[derive(Clone, Copy, Debug)]
 pub struct Ssse3 {
     _private: (),

--- a/fearless_simd/src/generated.rs
+++ b/fearless_simd/src/generated.rs
@@ -1,6 +1,13 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![expect(
+    missing_docs,
+    clippy::cast_possible_truncation,
+    clippy::unseparated_literal_suffix,
+    trivial_numeric_casts,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
 #![cfg_attr(
     target_arch = "x86_64",
     expect(

--- a/fearless_simd/src/half_assed.rs
+++ b/fearless_simd/src/half_assed.rs
@@ -8,11 +8,20 @@
         reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
     )
 )]
+#![expect(
+    clippy::unseparated_literal_suffix,
+    clippy::cast_possible_truncation,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
 
 // Much of the code below is copy-pasted from half-rs by Kathryn Long, version 2.4.1.
 // <https://github.com/VoidStarKat/half-rs/releases/tag/v2.4.1>
 #[derive(Clone, Copy, Default)]
 #[repr(transparent)]
+#[expect(
+    missing_debug_implementations,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
 pub struct f16(u16);
 
 impl f16 {

--- a/fearless_simd/src/impl_macros.rs
+++ b/fearless_simd/src/impl_macros.rs
@@ -3,9 +3,11 @@
 
 //! Macros used by implementations
 
-// Not all macros will be used by all implementations.
-#![allow(unused_macros)]
-#![allow(unused_imports)]
+#![allow(
+    unused_macros,
+    unused_imports,
+    reason = "Not all macros will be used by all implementations"
+)]
 
 // Adapted from similar macro in pulp
 macro_rules! delegate {
@@ -17,7 +19,7 @@ macro_rules! delegate {
         ) $(-> $ret: ty)?;
     )*) => {
         $(
-            #[allow(clippy::not_unsafe_ptr_arg_deref)]
+            #[allow(clippy::not_unsafe_ptr_arg_deref, reason = "TODO: https://github.com/linebender/fearless_simd/issues/40")]
             #[doc=concat!("See [`", stringify!($prefix), "::", stringify!($func), "`].")]
             $(#[$attr])*
             #[inline(always)]

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -3,10 +3,12 @@
 
 //! A helper library to make SIMD more friendly.
 
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, reason = "TODO")]
 #![expect(clippy::unused_unit, reason = "easier for code generation")]
 #![expect(
     clippy::new_without_default,
+    missing_docs,
+    clippy::use_self,
     reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
 )]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -3,6 +3,11 @@
 
 //! Macros publicly exported
 
+#![expect(
+    missing_docs,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+
 #[cfg(feature = "std")]
 #[macro_export]
 macro_rules! simd_dispatch {

--- a/fearless_simd/src/traits.rs
+++ b/fearless_simd/src/traits.rs
@@ -1,6 +1,10 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![expect(
+    missing_docs,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
 use crate::{Level, Simd};
 
 pub trait Select<T> {
@@ -36,6 +40,7 @@ pub trait Bytes: Sized {
 }
 
 pub(crate) mod seal {
+    #[expect(unnameable_types, reason = "TODO")]
     pub trait Seal {}
 }
 

--- a/fearless_simd_gen/Cargo.toml
+++ b/fearless_simd_gen/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 rust-version = "1.85"
 publish = false
 
+[lints]
+workspace=true
+
 [dependencies]
 proc-macro2 = "1.0.94"
 quote = "1.0.40"

--- a/fearless_simd_gen/src/arch/fallback.rs
+++ b/fearless_simd_gen/src/arch/fallback.rs
@@ -3,6 +3,7 @@
 
 #![expect(
     clippy::match_single_binding,
+    unreachable_pub,
     reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
 )]
 

--- a/fearless_simd_gen/src/arch/neon.rs
+++ b/fearless_simd_gen/src/arch/neon.rs
@@ -1,6 +1,11 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![expect(
+    unreachable_pub,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+
 use crate::arch::Arch;
 use crate::types::{ScalarType, VecType};
 use proc_macro2::{Ident, Span, TokenStream};

--- a/fearless_simd_gen/src/arch/wasm.rs
+++ b/fearless_simd_gen/src/arch/wasm.rs
@@ -4,6 +4,7 @@
 #![expect(
     clippy::match_single_binding,
     clippy::uninlined_format_args,
+    unreachable_pub,
     reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
 )]
 

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -1,6 +1,12 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![expect(
+    unreachable_pub,
+    clippy::shadow_unrelated,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 

--- a/fearless_simd_gen/src/main.rs
+++ b/fearless_simd_gen/src/main.rs
@@ -1,6 +1,12 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![expect(
+    missing_docs,
+    clippy::use_self,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+
 use std::{fs::File, io::Write, path::Path};
 
 use clap::{Parser, ValueEnum};

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -1,6 +1,12 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![expect(
+    unreachable_pub,
+    clippy::shadow_unrelated,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+
 use crate::arch::fallback::Fallback;
 use crate::arch::{Arch, fallback};
 use crate::generic::{generic_combine, generic_op, generic_split};

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -3,6 +3,8 @@
 
 #![expect(
     clippy::uninlined_format_args,
+    unreachable_pub,
+    clippy::shadow_unrelated,
     reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
 )]
 
@@ -446,7 +448,7 @@ fn mk_type_impl() -> TokenStream {
                     unsafe { core::mem::transmute(value.val) }
                 }
             }
-        })
+        });
     }
     quote! {
         #( #result )*

--- a/fearless_simd_gen/src/mk_ops.rs
+++ b/fearless_simd_gen/src/mk_ops.rs
@@ -1,6 +1,11 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![expect(
+    unreachable_pub,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -1,6 +1,12 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![expect(
+    unreachable_pub,
+    clippy::shadow_unrelated,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -1,6 +1,11 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![expect(
+    unreachable_pub,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{format_ident, quote};
 
@@ -170,7 +175,7 @@ pub fn mk_simd_types() -> TokenStream {
 
 /// Create the impl block for the type
 ///
-/// This may go away, as possibly all methods will be subsumed by the vec_impl.
+/// This may go away, as possibly all methods will be subsumed by the `vec_impl`.
 fn simd_impl(ty: &VecType) -> TokenStream {
     let name = ty.rust();
     let ty_name = ty.rust_name();

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -1,6 +1,13 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![expect(
+    unreachable_pub,
+    clippy::shadow_unrelated,
+    clippy::missing_assert_message,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 
@@ -607,7 +614,7 @@ fn mk_type_impl() -> TokenStream {
                     unsafe { core::mem::transmute(value.val) }
                 }
             }
-        })
+        });
     }
     quote! {
         #( #result )*

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -1,6 +1,12 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![expect(
+    unreachable_pub,
+    clippy::shadow_unrelated,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+
 use proc_macro2::TokenStream;
 use quote::quote;
 
@@ -97,7 +103,7 @@ pub const MASK_OPS: &[(&str, OpSig)] = &[
     ("simd_eq", OpSig::Compare),
 ];
 
-/// Ops covered by core::ops
+/// Ops covered by `core::ops`
 pub const CORE_OPS: &[&str] = &[
     "not", "neg", "add", "sub", "mul", "div", "and", "or", "xor", "shr",
 ];

--- a/fearless_simd_gen/src/types.rs
+++ b/fearless_simd_gen/src/types.rs
@@ -1,6 +1,11 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![expect(
+    unreachable_pub,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 

--- a/fearless_simd_tests/Cargo.toml
+++ b/fearless_simd_tests/Cargo.toml
@@ -14,6 +14,9 @@ publish = false
 name = "tests"
 path = "tests/mod.rs"
 
+[lints]
+workspace=true
+
 [dependencies]
 fearless_simd = { workspace = true }
 


### PR DESCRIPTION
This PR follows the great observation that we were not applying lints in crates.
Here: https://github.com/linebender/fearless_simd/pull/39#discussion_r2241836153


This PR follows the same philosophy as https://github.com/linebender/fearless_simd/pull/39 which is to plug all lint errors with `expect` calls and TODO reasons.
