### PR TITLE
Add more SSE4.2 impls

### DIFF
--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -455,22 +455,22 @@ impl Simd for Fallback {
     #[inline(always)]
     fn mul_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         [
-            i8::mul(a[0usize], &b[0usize]),
-            i8::mul(a[1usize], &b[1usize]),
-            i8::mul(a[2usize], &b[2usize]),
-            i8::mul(a[3usize], &b[3usize]),
-            i8::mul(a[4usize], &b[4usize]),
-            i8::mul(a[5usize], &b[5usize]),
-            i8::mul(a[6usize], &b[6usize]),
-            i8::mul(a[7usize], &b[7usize]),
-            i8::mul(a[8usize], &b[8usize]),
-            i8::mul(a[9usize], &b[9usize]),
-            i8::mul(a[10usize], &b[10usize]),
-            i8::mul(a[11usize], &b[11usize]),
-            i8::mul(a[12usize], &b[12usize]),
-            i8::mul(a[13usize], &b[13usize]),
-            i8::mul(a[14usize], &b[14usize]),
-            i8::mul(a[15usize], &b[15usize]),
+            i8::wrapping_mul(a[0usize], b[0usize]),
+            i8::wrapping_mul(a[1usize], b[1usize]),
+            i8::wrapping_mul(a[2usize], b[2usize]),
+            i8::wrapping_mul(a[3usize], b[3usize]),
+            i8::wrapping_mul(a[4usize], b[4usize]),
+            i8::wrapping_mul(a[5usize], b[5usize]),
+            i8::wrapping_mul(a[6usize], b[6usize]),
+            i8::wrapping_mul(a[7usize], b[7usize]),
+            i8::wrapping_mul(a[8usize], b[8usize]),
+            i8::wrapping_mul(a[9usize], b[9usize]),
+            i8::wrapping_mul(a[10usize], b[10usize]),
+            i8::wrapping_mul(a[11usize], b[11usize]),
+            i8::wrapping_mul(a[12usize], b[12usize]),
+            i8::wrapping_mul(a[13usize], b[13usize]),
+            i8::wrapping_mul(a[14usize], b[14usize]),
+            i8::wrapping_mul(a[15usize], b[15usize]),
         ]
         .simd_into(self)
     }
@@ -891,22 +891,22 @@ impl Simd for Fallback {
     #[inline(always)]
     fn mul_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
         [
-            u8::mul(a[0usize], &b[0usize]),
-            u8::mul(a[1usize], &b[1usize]),
-            u8::mul(a[2usize], &b[2usize]),
-            u8::mul(a[3usize], &b[3usize]),
-            u8::mul(a[4usize], &b[4usize]),
-            u8::mul(a[5usize], &b[5usize]),
-            u8::mul(a[6usize], &b[6usize]),
-            u8::mul(a[7usize], &b[7usize]),
-            u8::mul(a[8usize], &b[8usize]),
-            u8::mul(a[9usize], &b[9usize]),
-            u8::mul(a[10usize], &b[10usize]),
-            u8::mul(a[11usize], &b[11usize]),
-            u8::mul(a[12usize], &b[12usize]),
-            u8::mul(a[13usize], &b[13usize]),
-            u8::mul(a[14usize], &b[14usize]),
-            u8::mul(a[15usize], &b[15usize]),
+            u8::wrapping_mul(a[0usize], b[0usize]),
+            u8::wrapping_mul(a[1usize], b[1usize]),
+            u8::wrapping_mul(a[2usize], b[2usize]),
+            u8::wrapping_mul(a[3usize], b[3usize]),
+            u8::wrapping_mul(a[4usize], b[4usize]),
+            u8::wrapping_mul(a[5usize], b[5usize]),
+            u8::wrapping_mul(a[6usize], b[6usize]),
+            u8::wrapping_mul(a[7usize], b[7usize]),
+            u8::wrapping_mul(a[8usize], b[8usize]),
+            u8::wrapping_mul(a[9usize], b[9usize]),
+            u8::wrapping_mul(a[10usize], b[10usize]),
+            u8::wrapping_mul(a[11usize], b[11usize]),
+            u8::wrapping_mul(a[12usize], b[12usize]),
+            u8::wrapping_mul(a[13usize], b[13usize]),
+            u8::wrapping_mul(a[14usize], b[14usize]),
+            u8::wrapping_mul(a[15usize], b[15usize]),
         ]
         .simd_into(self)
     }
@@ -1490,14 +1490,14 @@ impl Simd for Fallback {
     #[inline(always)]
     fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         [
-            i16::mul(a[0usize], &b[0usize]),
-            i16::mul(a[1usize], &b[1usize]),
-            i16::mul(a[2usize], &b[2usize]),
-            i16::mul(a[3usize], &b[3usize]),
-            i16::mul(a[4usize], &b[4usize]),
-            i16::mul(a[5usize], &b[5usize]),
-            i16::mul(a[6usize], &b[6usize]),
-            i16::mul(a[7usize], &b[7usize]),
+            i16::wrapping_mul(a[0usize], b[0usize]),
+            i16::wrapping_mul(a[1usize], b[1usize]),
+            i16::wrapping_mul(a[2usize], b[2usize]),
+            i16::wrapping_mul(a[3usize], b[3usize]),
+            i16::wrapping_mul(a[4usize], b[4usize]),
+            i16::wrapping_mul(a[5usize], b[5usize]),
+            i16::wrapping_mul(a[6usize], b[6usize]),
+            i16::wrapping_mul(a[7usize], b[7usize]),
         ]
         .simd_into(self)
     }
@@ -1767,14 +1767,14 @@ impl Simd for Fallback {
     #[inline(always)]
     fn mul_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
         [
-            u16::mul(a[0usize], &b[0usize]),
-            u16::mul(a[1usize], &b[1usize]),
-            u16::mul(a[2usize], &b[2usize]),
-            u16::mul(a[3usize], &b[3usize]),
-            u16::mul(a[4usize], &b[4usize]),
-            u16::mul(a[5usize], &b[5usize]),
-            u16::mul(a[6usize], &b[6usize]),
-            u16::mul(a[7usize], &b[7usize]),
+            u16::wrapping_mul(a[0usize], b[0usize]),
+            u16::wrapping_mul(a[1usize], b[1usize]),
+            u16::wrapping_mul(a[2usize], b[2usize]),
+            u16::wrapping_mul(a[3usize], b[3usize]),
+            u16::wrapping_mul(a[4usize], b[4usize]),
+            u16::wrapping_mul(a[5usize], b[5usize]),
+            u16::wrapping_mul(a[6usize], b[6usize]),
+            u16::wrapping_mul(a[7usize], b[7usize]),
         ]
         .simd_into(self)
     }
@@ -2132,10 +2132,10 @@ impl Simd for Fallback {
     #[inline(always)]
     fn mul_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         [
-            i32::mul(a[0usize], &b[0usize]),
-            i32::mul(a[1usize], &b[1usize]),
-            i32::mul(a[2usize], &b[2usize]),
-            i32::mul(a[3usize], &b[3usize]),
+            i32::wrapping_mul(a[0usize], b[0usize]),
+            i32::wrapping_mul(a[1usize], b[1usize]),
+            i32::wrapping_mul(a[2usize], b[2usize]),
+            i32::wrapping_mul(a[3usize], b[3usize]),
         ]
         .simd_into(self)
     }
@@ -2343,10 +2343,10 @@ impl Simd for Fallback {
     #[inline(always)]
     fn mul_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
         [
-            u32::mul(a[0usize], &b[0usize]),
-            u32::mul(a[1usize], &b[1usize]),
-            u32::mul(a[2usize], &b[2usize]),
-            u32::mul(a[3usize], &b[3usize]),
+            u32::wrapping_mul(a[0usize], b[0usize]),
+            u32::wrapping_mul(a[1usize], b[1usize]),
+            u32::wrapping_mul(a[2usize], b[2usize]),
+            u32::wrapping_mul(a[3usize], b[3usize]),
         ]
         .simd_into(self)
     }

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -3151,7 +3151,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn store_interleaved_128_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
         let fb = crate::Fallback::new();
-        fb.store_interleaved_128_f32x16(a.val.simd_into(fb), dest)
+        fb.store_interleaved_128_f32x16(a.val.simd_into(fb), dest);
     }
     #[inline(always)]
     fn reinterpret_u8_f32x16(self, a: f32x16<Self>) -> u8x64<Self> {
@@ -3463,7 +3463,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn store_interleaved_128_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
         let fb = crate::Fallback::new();
-        fb.store_interleaved_128_u8x64(a.val.simd_into(fb), dest)
+        fb.store_interleaved_128_u8x64(a.val.simd_into(fb), dest);
     }
     #[inline(always)]
     fn reinterpret_u32_u8x64(self, a: u8x64<Self>) -> u32x16<Self> {
@@ -3832,7 +3832,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn store_interleaved_128_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
         let fb = crate::Fallback::new();
-        fb.store_interleaved_128_u16x32(a.val.simd_into(fb), dest)
+        fb.store_interleaved_128_u16x32(a.val.simd_into(fb), dest);
     }
     #[inline(always)]
     fn narrow_u16x32(self, a: u16x32<Self>) -> u8x32<Self> {
@@ -4221,7 +4221,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn store_interleaved_128_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
         let fb = crate::Fallback::new();
-        fb.store_interleaved_128_u32x16(a.val.simd_into(fb), dest)
+        fb.store_interleaved_128_u32x16(a.val.simd_into(fb), dest);
     }
     #[inline(always)]
     fn reinterpret_u8_u32x16(self, a: u32x16<Self>) -> u8x64<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -876,7 +876,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn mul_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
-        unsafe { _mm_mul_epi32(a.into(), b.into()).simd_into(self) }
+        unsafe { _mm_mullo_epi32(a.into(), b.into()).simd_into(self) }
     }
     #[inline(always)]
     fn and_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
@@ -1011,7 +1011,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn mul_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
-        unsafe { _mm_mul_epi32(a.into(), b.into()).simd_into(self) }
+        unsafe { _mm_mullo_epi32(a.into(), b.into()).simd_into(self) }
     }
     #[inline(always)]
     fn and_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -473,7 +473,7 @@ impl Simd for Sse4_2 {
         unsafe {
             let raw = a.into();
             let high = _mm_cvtepu8_epi16(raw).simd_into(self);
-            let low = _mm_cvtepu8_epi16(_mm_slli_si128(raw, 8)).simd_into(self);
+            let low = _mm_cvtepu8_epi16(_mm_srli_si128::<8>(raw)).simd_into(self);
             self.combine_u16x8(high, low)
         }
     }

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -564,7 +564,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn shr_i16x8(self, a: i16x8<Self>, b: u32) -> i16x8<Self> {
-        unsafe { _mm_sra_epi16(a.into(), _mm_set1_epi16(b as _)).simd_into(self) }
+        unsafe { _mm_sra_epi16(a.into(), _mm_cvtsi32_si128(b as _)).simd_into(self) }
     }
     #[inline(always)]
     fn simd_eq_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
@@ -697,7 +697,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn shr_u16x8(self, a: u16x8<Self>, b: u32) -> u16x8<Self> {
-        unsafe { _mm_srl_epi16(a.into(), _mm_set1_epi16(b as _)).simd_into(self) }
+        unsafe { _mm_srl_epi16(a.into(), _mm_cvtsi32_si128(b as _)).simd_into(self) }
     }
     #[inline(always)]
     fn simd_eq_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
@@ -876,7 +876,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn shr_i32x4(self, a: i32x4<Self>, b: u32) -> i32x4<Self> {
-        unsafe { _mm_sra_epi32(a.into(), _mm_set1_epi32(b as _)).simd_into(self) }
+        unsafe { _mm_sra_epi32(a.into(), _mm_cvtsi32_si128(b as _)).simd_into(self) }
     }
     #[inline(always)]
     fn simd_eq_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
@@ -1011,7 +1011,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn shr_u32x4(self, a: u32x4<Self>, b: u32) -> u32x4<Self> {
-        unsafe { _mm_srl_epi32(a.into(), _mm_set1_epi32(b as _)).simd_into(self) }
+        unsafe { _mm_srl_epi32(a.into(), _mm_cvtsi32_si128(b as _)).simd_into(self) }
     }
     #[inline(always)]
     fn simd_eq_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -210,11 +210,15 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_u32_f32x4(self, a: f32x4<Self>) -> u32x4<Self> {
-        unsafe { _mm_cvtps_epi32(_mm_floor_ps(a.into())).simd_into(self) }
+        unsafe {
+            _mm_cvtps_epi32(_mm_max_ps(_mm_floor_ps(a.into()), _mm_set1_ps(0.0))).simd_into(self)
+        }
     }
     #[inline(always)]
     fn cvt_i32_f32x4(self, a: f32x4<Self>) -> i32x4<Self> {
-        unsafe { _mm_cvtps_epi32(_mm_floor_ps(a.into())).simd_into(self) }
+        unsafe {
+            _mm_cvtps_epi32(_mm_max_ps(_mm_floor_ps(a.into()), _mm_set1_ps(0.0))).simd_into(self)
+        }
     }
     #[inline(always)]
     fn splat_i8x16(self, val: i8) -> i8x16<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -216,9 +216,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_i32_f32x4(self, a: f32x4<Self>) -> i32x4<Self> {
-        unsafe {
-            _mm_cvtps_epi32(_mm_max_ps(_mm_floor_ps(a.into()), _mm_set1_ps(0.0))).simd_into(self)
-        }
+        unsafe { _mm_cvtps_epi32(a.trunc().into()).simd_into(self) }
     }
     #[inline(always)]
     fn splat_i8x16(self, val: i8) -> i8x16<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -564,7 +564,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
-        todo!()
+        unsafe { _mm_mullo_epi16(a.into(), b.into()).simd_into(self) }
     }
     #[inline(always)]
     fn and_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
@@ -697,7 +697,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn mul_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
-        todo!()
+        unsafe { _mm_mullo_epi16(a.into(), b.into()).simd_into(self) }
     }
     #[inline(always)]
     fn and_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -272,23 +272,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn simd_le_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
-        unsafe {
-            _mm_or_si128(
-                _mm_cmplt_epi8(a.into(), b.into()),
-                _mm_cmpeq_epi8(a.into(), b.into()),
-            )
-            .simd_into(self)
-        }
+        unsafe { _mm_cmpeq_epi8(_mm_min_epi8(a.into(), b.into()), a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn simd_ge_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
-        unsafe {
-            _mm_or_si128(
-                _mm_cmpgt_epi8(a.into(), b.into()),
-                _mm_cmpeq_epi8(a.into(), b.into()),
-            )
-            .simd_into(self)
-        }
+        unsafe { _mm_cmpeq_epi8(_mm_max_epi8(a.into(), b.into()), a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn simd_gt_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
@@ -405,35 +393,38 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn simd_eq_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
-        unsafe { _mm_cmpeq_epi8(a.into(), b.into()).simd_into(self) }
+        unsafe {
+            let sign_bit = _mm_set1_epi8(0x80u8 as _);
+            let a_signed = _mm_xor_si128(a.into(), sign_bit);
+            let b_signed = _mm_xor_si128(b.into(), sign_bit);
+            _mm_cmpgt_epi8(a_signed, b_signed).simd_into(self)
+        }
     }
     #[inline(always)]
     fn simd_lt_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
-        unsafe { _mm_cmplt_epi8(a.into(), b.into()).simd_into(self) }
+        unsafe {
+            let sign_bit = _mm_set1_epi8(0x80u8 as _);
+            let a_signed = _mm_xor_si128(a.into(), sign_bit);
+            let b_signed = _mm_xor_si128(b.into(), sign_bit);
+            _mm_cmpgt_epi8(b_signed, a_signed).simd_into(self)
+        }
     }
     #[inline(always)]
     fn simd_le_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
-        unsafe {
-            _mm_or_si128(
-                _mm_cmplt_epi8(a.into(), b.into()),
-                _mm_cmpeq_epi8(a.into(), b.into()),
-            )
-            .simd_into(self)
-        }
+        unsafe { _mm_cmpeq_epi8(_mm_min_epu8(a.into(), b.into()), a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn simd_ge_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
-        unsafe {
-            _mm_or_si128(
-                _mm_cmpgt_epi8(a.into(), b.into()),
-                _mm_cmpeq_epi8(a.into(), b.into()),
-            )
-            .simd_into(self)
-        }
+        unsafe { _mm_cmpeq_epi8(_mm_max_epu8(a.into(), b.into()), a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn simd_gt_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
-        unsafe { _mm_cmpgt_epi8(a.into(), b.into()).simd_into(self) }
+        unsafe {
+            let sign_bit = _mm_set1_epi8(0x80u8 as _);
+            let a_signed = _mm_xor_si128(a.into(), sign_bit);
+            let b_signed = _mm_xor_si128(b.into(), sign_bit);
+            _mm_cmpgt_epi8(a_signed, b_signed).simd_into(self)
+        }
     }
     #[inline(always)]
     fn zip_low_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -473,11 +464,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn min_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
-        unsafe { _mm_min_epi8(a.into(), b.into()).simd_into(self) }
+        unsafe { _mm_min_epu8(a.into(), b.into()).simd_into(self) }
     }
     #[inline(always)]
     fn max_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
-        unsafe { _mm_max_epi8(a.into(), b.into()).simd_into(self) }
+        unsafe { _mm_max_epu8(a.into(), b.into()).simd_into(self) }
     }
     #[inline(always)]
     fn combine_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x32<Self> {
@@ -594,23 +585,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn simd_le_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
-        unsafe {
-            _mm_or_si128(
-                _mm_cmplt_epi16(a.into(), b.into()),
-                _mm_cmpeq_epi16(a.into(), b.into()),
-            )
-            .simd_into(self)
-        }
+        unsafe { _mm_cmpeq_epi16(_mm_min_epi16(a.into(), b.into()), a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn simd_ge_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
-        unsafe {
-            _mm_or_si128(
-                _mm_cmpgt_epi16(a.into(), b.into()),
-                _mm_cmpeq_epi16(a.into(), b.into()),
-            )
-            .simd_into(self)
-        }
+        unsafe { _mm_cmpeq_epi16(_mm_max_epi16(a.into(), b.into()), a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn simd_gt_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
@@ -719,35 +698,38 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn simd_eq_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
-        unsafe { _mm_cmpeq_epi16(a.into(), b.into()).simd_into(self) }
+        unsafe {
+            let sign_bit = _mm_set1_epi16(0x8000u16 as _);
+            let a_signed = _mm_xor_si128(a.into(), sign_bit);
+            let b_signed = _mm_xor_si128(b.into(), sign_bit);
+            _mm_cmpgt_epi16(a_signed, b_signed).simd_into(self)
+        }
     }
     #[inline(always)]
     fn simd_lt_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
-        unsafe { _mm_cmplt_epi16(a.into(), b.into()).simd_into(self) }
+        unsafe {
+            let sign_bit = _mm_set1_epi16(0x8000u16 as _);
+            let a_signed = _mm_xor_si128(a.into(), sign_bit);
+            let b_signed = _mm_xor_si128(b.into(), sign_bit);
+            _mm_cmpgt_epi16(b_signed, a_signed).simd_into(self)
+        }
     }
     #[inline(always)]
     fn simd_le_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
-        unsafe {
-            _mm_or_si128(
-                _mm_cmplt_epi16(a.into(), b.into()),
-                _mm_cmpeq_epi16(a.into(), b.into()),
-            )
-            .simd_into(self)
-        }
+        unsafe { _mm_cmpeq_epi16(_mm_min_epu16(a.into(), b.into()), a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn simd_ge_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
-        unsafe {
-            _mm_or_si128(
-                _mm_cmpgt_epi16(a.into(), b.into()),
-                _mm_cmpeq_epi16(a.into(), b.into()),
-            )
-            .simd_into(self)
-        }
+        unsafe { _mm_cmpeq_epi16(_mm_max_epu16(a.into(), b.into()), a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn simd_gt_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
-        unsafe { _mm_cmpgt_epi16(a.into(), b.into()).simd_into(self) }
+        unsafe {
+            let sign_bit = _mm_set1_epi16(0x8000u16 as _);
+            let a_signed = _mm_xor_si128(a.into(), sign_bit);
+            let b_signed = _mm_xor_si128(b.into(), sign_bit);
+            _mm_cmpgt_epi16(a_signed, b_signed).simd_into(self)
+        }
     }
     #[inline(always)]
     fn zip_low_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -787,11 +769,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn min_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
-        unsafe { _mm_min_epi16(a.into(), b.into()).simd_into(self) }
+        unsafe { _mm_min_epu16(a.into(), b.into()).simd_into(self) }
     }
     #[inline(always)]
     fn max_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
-        unsafe { _mm_max_epi16(a.into(), b.into()).simd_into(self) }
+        unsafe { _mm_max_epu16(a.into(), b.into()).simd_into(self) }
     }
     #[inline(always)]
     fn combine_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x16<Self> {
@@ -906,23 +888,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn simd_le_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
-        unsafe {
-            _mm_or_si128(
-                _mm_cmplt_epi32(a.into(), b.into()),
-                _mm_cmpeq_epi32(a.into(), b.into()),
-            )
-            .simd_into(self)
-        }
+        unsafe { _mm_cmpeq_epi32(_mm_min_epi32(a.into(), b.into()), a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn simd_ge_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
-        unsafe {
-            _mm_or_si128(
-                _mm_cmpgt_epi32(a.into(), b.into()),
-                _mm_cmpeq_epi32(a.into(), b.into()),
-            )
-            .simd_into(self)
-        }
+        unsafe { _mm_cmpeq_epi32(_mm_max_epi32(a.into(), b.into()), a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn simd_gt_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
@@ -1033,35 +1003,38 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn simd_eq_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
-        unsafe { _mm_cmpeq_epi32(a.into(), b.into()).simd_into(self) }
+        unsafe {
+            let sign_bit = _mm_set1_epi32(0x80000000u32 as _);
+            let a_signed = _mm_xor_si128(a.into(), sign_bit);
+            let b_signed = _mm_xor_si128(b.into(), sign_bit);
+            _mm_cmpgt_epi32(a_signed, b_signed).simd_into(self)
+        }
     }
     #[inline(always)]
     fn simd_lt_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
-        unsafe { _mm_cmplt_epi32(a.into(), b.into()).simd_into(self) }
+        unsafe {
+            let sign_bit = _mm_set1_epi32(0x80000000u32 as _);
+            let a_signed = _mm_xor_si128(a.into(), sign_bit);
+            let b_signed = _mm_xor_si128(b.into(), sign_bit);
+            _mm_cmpgt_epi32(b_signed, a_signed).simd_into(self)
+        }
     }
     #[inline(always)]
     fn simd_le_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
-        unsafe {
-            _mm_or_si128(
-                _mm_cmplt_epi32(a.into(), b.into()),
-                _mm_cmpeq_epi32(a.into(), b.into()),
-            )
-            .simd_into(self)
-        }
+        unsafe { _mm_cmpeq_epi32(_mm_min_epu32(a.into(), b.into()), a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn simd_ge_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
-        unsafe {
-            _mm_or_si128(
-                _mm_cmpgt_epi32(a.into(), b.into()),
-                _mm_cmpeq_epi32(a.into(), b.into()),
-            )
-            .simd_into(self)
-        }
+        unsafe { _mm_cmpeq_epi32(_mm_max_epu32(a.into(), b.into()), a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn simd_gt_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
-        unsafe { _mm_cmpgt_epi32(a.into(), b.into()).simd_into(self) }
+        unsafe {
+            let sign_bit = _mm_set1_epi32(0x80000000u32 as _);
+            let a_signed = _mm_xor_si128(a.into(), sign_bit);
+            let b_signed = _mm_xor_si128(b.into(), sign_bit);
+            _mm_cmpgt_epi32(a_signed, b_signed).simd_into(self)
+        }
     }
     #[inline(always)]
     fn zip_low_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -1099,11 +1072,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn min_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
-        unsafe { _mm_min_epi32(a.into(), b.into()).simd_into(self) }
+        unsafe { _mm_min_epu32(a.into(), b.into()).simd_into(self) }
     }
     #[inline(always)]
     fn max_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
-        unsafe { _mm_max_epi32(a.into(), b.into()).simd_into(self) }
+        unsafe { _mm_max_epu32(a.into(), b.into()).simd_into(self) }
     }
     #[inline(always)]
     fn combine_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x8<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -2215,7 +2215,13 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn narrow_u16x16(self, a: u16x16<Self>) -> u8x16<Self> {
         let (a, b) = self.split_u16x16(a);
-        unsafe { _mm_packus_epi16(a.into(), b.into()).simd_into(self) }
+        unsafe {
+            let mask = _mm_set1_epi16(0xFF);
+            let lo_masked = _mm_and_si128(a.into(), mask);
+            let hi_masked = _mm_and_si128(b.into(), mask);
+            let result = _mm_packus_epi16(lo_masked, hi_masked);
+            result.simd_into(self)
+        }
     }
     #[inline(always)]
     fn reinterpret_u8_u16x16(self, a: u16x16<Self>) -> u8x32<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -3139,11 +3139,15 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn load_interleaved_128_f32x16(self, src: &[f32; 16usize]) -> f32x16<Self> {
-        todo!()
+        crate::Fallback::new()
+            .load_interleaved_128_f32x16(src)
+            .val
+            .simd_into(self)
     }
     #[inline(always)]
     fn store_interleaved_128_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        todo!()
+        let fb = crate::Fallback::new();
+        fb.store_interleaved_128_f32x16(a.val.simd_into(fb), dest)
     }
     #[inline(always)]
     fn reinterpret_u8_f32x16(self, a: f32x16<Self>) -> u8x64<Self> {
@@ -3447,11 +3451,15 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn load_interleaved_128_u8x64(self, src: &[u8; 64usize]) -> u8x64<Self> {
-        todo!()
+        crate::Fallback::new()
+            .load_interleaved_128_u8x64(src)
+            .val
+            .simd_into(self)
     }
     #[inline(always)]
     fn store_interleaved_128_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
-        todo!()
+        let fb = crate::Fallback::new();
+        fb.store_interleaved_128_u8x64(a.val.simd_into(fb), dest)
     }
     #[inline(always)]
     fn reinterpret_u32_u8x64(self, a: u8x64<Self>) -> u32x16<Self> {
@@ -3812,11 +3820,15 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn load_interleaved_128_u16x32(self, src: &[u16; 32usize]) -> u16x32<Self> {
-        todo!()
+        crate::Fallback::new()
+            .load_interleaved_128_u16x32(src)
+            .val
+            .simd_into(self)
     }
     #[inline(always)]
     fn store_interleaved_128_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
-        todo!()
+        let fb = crate::Fallback::new();
+        fb.store_interleaved_128_u16x32(a.val.simd_into(fb), dest)
     }
     #[inline(always)]
     fn narrow_u16x32(self, a: u16x32<Self>) -> u8x32<Self> {
@@ -4183,11 +4195,15 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn load_interleaved_128_u32x16(self, src: &[u32; 16usize]) -> u32x16<Self> {
-        todo!()
+        crate::Fallback::new()
+            .load_interleaved_128_u32x16(src)
+            .val
+            .simd_into(self)
     }
     #[inline(always)]
     fn store_interleaved_128_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
-        todo!()
+        let fb = crate::Fallback::new();
+        fb.store_interleaved_128_u32x16(a.val.simd_into(fb), dest)
     }
     #[inline(always)]
     fn reinterpret_u8_u32x16(self, a: u32x16<Self>) -> u8x64<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -250,7 +250,15 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn shr_i8x16(self, a: i8x16<Self>, b: u32) -> i8x16<Self> {
-        todo!()
+        unsafe {
+            let val = a.into();
+            let shift_count = _mm_cvtsi32_si128(b as i32);
+            let lo_16 = _mm_unpacklo_epi8(val, _mm_cmplt_epi8(val, _mm_setzero_si128()));
+            let hi_16 = _mm_unpackhi_epi8(val, _mm_cmplt_epi8(val, _mm_setzero_si128()));
+            let lo_shifted = _mm_sra_epi16(lo_16, shift_count);
+            let hi_shifted = _mm_sra_epi16(hi_16, shift_count);
+            _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(self)
+        }
     }
     #[inline(always)]
     fn simd_eq_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
@@ -383,7 +391,15 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn shr_u8x16(self, a: u8x16<Self>, b: u32) -> u8x16<Self> {
-        todo!()
+        unsafe {
+            let val = a.into();
+            let shift_count = _mm_cvtsi32_si128(b as i32);
+            let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
+            let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
+            let lo_shifted = _mm_srl_epi16(lo_16, shift_count);
+            let hi_shifted = _mm_srl_epi16(hi_16, shift_count);
+            _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(self)
+        }
     }
     #[inline(always)]
     fn simd_eq_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {

--- a/fearless_simd_dev_macros/src/lib.rs
+++ b/fearless_simd_dev_macros/src/lib.rs
@@ -124,8 +124,7 @@ fn exclude_sse4(name: &str) -> bool {
         name,
         // works incorrectly for any values larger than i32::MAX and smaller than 0.
         "cvt_u32_f32x4" | "cvt_f32_u32x4" | "saturate_float_to_int",
-    ) || name.contains("interleaved")
-        || name.contains("precise")
+    ) || name.contains("precise")
 }
 
 #[allow(dead_code, reason = "on purpose.")]

--- a/fearless_simd_dev_macros/src/lib.rs
+++ b/fearless_simd_dev_macros/src/lib.rs
@@ -123,9 +123,7 @@ fn exclude_sse4(name: &str) -> bool {
     matches!(
         name,
         // works incorrectly for any values larger than i32::MAX and smaller than 0.
-        "cvt_u32_f32x4" | "cvt_f32_u32x4"
-            | "narrow_u16x16"
-            | "saturate_float_to_int",
+        "cvt_u32_f32x4" | "cvt_f32_u32x4" | "saturate_float_to_int",
     ) || name.contains("interleaved")
         || name.contains("precise")
         || name.contains("shr")

--- a/fearless_simd_dev_macros/src/lib.rs
+++ b/fearless_simd_dev_macros/src/lib.rs
@@ -123,9 +123,7 @@ fn exclude_sse4(name: &str) -> bool {
     matches!(
         name,
         // works incorrectly for any values larger than i32::MAX and smaller than 0.
-        "cvt_u32_f32x4"
-            | "cvt_f32_u32x4"
-            | "widen_u8x16"
+        "cvt_u32_f32x4" | "cvt_f32_u32x4"
             | "narrow_u16x16"
             | "saturate_float_to_int",
     ) || name.contains("interleaved")

--- a/fearless_simd_dev_macros/src/lib.rs
+++ b/fearless_simd_dev_macros/src/lib.rs
@@ -126,7 +126,6 @@ fn exclude_sse4(name: &str) -> bool {
         "cvt_u32_f32x4" | "cvt_f32_u32x4" | "saturate_float_to_int",
     ) || name.contains("interleaved")
         || name.contains("precise")
-        || name.contains("shr")
 }
 
 #[allow(dead_code, reason = "on purpose.")]

--- a/fearless_simd_gen/src/arch/fallback.rs
+++ b/fearless_simd_gen/src/arch/fallback.rs
@@ -29,7 +29,13 @@ pub(crate) fn translate_op(op: &str, is_float: bool) -> Option<&'static str> {
                 "wrapping_sub"
             }
         }
-        "mul" => "mul",
+        "mul" => {
+            if is_float {
+                "mul"
+            } else {
+                "wrapping_mul"
+            }
+        }
         "div" => "div",
         "simd_eq" => "eq",
         "simd_lt" => "lt",

--- a/fearless_simd_gen/src/arch/sse4_2.rs
+++ b/fearless_simd_gen/src/arch/sse4_2.rs
@@ -86,19 +86,16 @@ impl Arch for Sse4_2 {
                         #or(#and(mask, #b), #andnot(mask, #a))
                     }
                 }
-                "mul" => match (ty.scalar, ty.scalar_bits) {
-                    (ScalarType::Float, _) | (ScalarType::Int | ScalarType::Unsigned, 32) => {
-                        let suffix = op_suffix(ty.scalar, ty.scalar_bits, false);
-                        let intrinsic = format_ident!("_mm_mul_{suffix}");
-                        quote! { #intrinsic ( #( #args ),* ) }
-                    }
-                    (ScalarType::Int | ScalarType::Unsigned, _) => {
-                        let suffix = op_suffix(ty.scalar, ty.scalar_bits, false);
-                        let intrinsic = format_ident!("_mm_mullo_{suffix}");
-                        quote! { #intrinsic ( #( #args ),* ) }
-                    }
-                    (ScalarType::Mask, _) => unreachable!(),
-                },
+                "mul" => {
+                    let suffix = op_suffix(ty.scalar, ty.scalar_bits, false);
+                    let intrinsic = if matches!(ty.scalar, ScalarType::Int | ScalarType::Unsigned) {
+                        format_ident!("_mm_mullo_{suffix}")
+                    } else {
+                        format_ident!("_mm_mul_{suffix}")
+                    };
+
+                    quote! { #intrinsic ( #( #args ),* ) }
+                }
                 _ => unimplemented!("{}", op),
             }
         }

--- a/fearless_simd_gen/src/arch/sse4_2.rs
+++ b/fearless_simd_gen/src/arch/sse4_2.rs
@@ -47,9 +47,11 @@ impl Arch for Sse4_2 {
 
     fn expr(&self, op: &str, ty: &VecType, args: &[TokenStream]) -> TokenStream {
         if let Some(op_name) = translate_op(op) {
+            let sign_aware = matches!(op, "max" | "min");
+
             let suffix = match op_name {
                 "and" | "or" | "xor" => "si128",
-                _ => op_suffix(ty.scalar, ty.scalar_bits, false),
+                _ => op_suffix(ty.scalar, ty.scalar_bits, sign_aware),
             };
             let intrinsic = format_ident!("_mm_{op_name}_{suffix}");
             quote! { #intrinsic ( #( #args ),* ) }
@@ -134,6 +136,11 @@ pub(crate) fn set1_intrinsic(ty: ScalarType, bits: usize) -> Ident {
 
 pub(crate) fn simple_intrinsic(name: &str, ty: ScalarType, bits: usize) -> Ident {
     let suffix = op_suffix(ty, bits, true);
+    format_ident!("_mm_{name}_{suffix}")
+}
+
+pub(crate) fn simple_sign_unaware_intrinsic(name: &str, ty: ScalarType, bits: usize) -> Ident {
+    let suffix = op_suffix(ty, bits, false);
     format_ident!("_mm_{name}_{suffix}")
 }
 

--- a/fearless_simd_gen/src/arch/sse4_2.rs
+++ b/fearless_simd_gen/src/arch/sse4_2.rs
@@ -158,3 +158,10 @@ pub(crate) fn pack_intrinsic(from_bits: usize, signed: bool) -> Ident {
     let suffix = op_suffix(ScalarType::Int, from_bits, false);
     format_ident!("_mm_pack{unsigned}s_{suffix}")
 }
+
+pub(crate) fn unpack_intrinsic(scalar_type: ScalarType, scalar_bits: usize, low: bool) -> Ident {
+    let suffix = op_suffix(scalar_type, scalar_bits, false);
+
+    let low_pref = if low { "lo" } else { "hi" };
+    format_ident!("_mm_unpack{low_pref}_{suffix}")
+}

--- a/fearless_simd_gen/src/arch/sse4_2.rs
+++ b/fearless_simd_gen/src/arch/sse4_2.rs
@@ -93,7 +93,9 @@ impl Arch for Sse4_2 {
                         quote! { #intrinsic ( #( #args ),* ) }
                     }
                     (ScalarType::Int | ScalarType::Unsigned, _) => {
-                        quote! { todo!() }
+                        let suffix = op_suffix(ty.scalar, ty.scalar_bits, false);
+                        let intrinsic = format_ident!("_mm_mullo_{suffix}");
+                        quote! { #intrinsic ( #( #args ),* ) }
                     }
                     (ScalarType::Mask, _) => unreachable!(),
                 },

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -456,7 +456,10 @@ fn interleave_indices(
 
 /// Whether the second argument of the function needs to be passed by reference.
 fn rhs_reference(method: &str) -> bool {
-    !matches!(method, "copysign" | "min" | "max" | "wrapping_sub")
+    !matches!(
+        method,
+        "copysign" | "min" | "max" | "wrapping_sub" | "wrapping_mul"
+    )
 }
 
 fn make_list(items: Vec<TokenStream>) -> TokenStream {

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -464,7 +464,9 @@ fn mk_simd_impl() -> TokenStream {
                     if vec_ty.scalar == ScalarType::Float {
                         let floor_intrinsic =
                             simple_intrinsic("floor", vec_ty.scalar, vec_ty.scalar_bits);
-                        expr = quote! { #floor_intrinsic(#expr) };
+                        let max_intrinsic = simple_intrinsic("max", vec_ty.scalar, vec_ty.scalar_bits);
+                        let set = set1_intrinsic(vec_ty.scalar, vec_ty.scalar_bits);
+                        expr = quote! { #max_intrinsic(#floor_intrinsic(#expr), #set(0.0)) };
                     }
 
                     quote! {

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -464,7 +464,8 @@ fn mk_simd_impl() -> TokenStream {
                     if vec_ty.scalar == ScalarType::Float {
                         let floor_intrinsic =
                             simple_intrinsic("floor", vec_ty.scalar, vec_ty.scalar_bits);
-                        let max_intrinsic = simple_intrinsic("max", vec_ty.scalar, vec_ty.scalar_bits);
+                        let max_intrinsic =
+                            simple_intrinsic("max", vec_ty.scalar, vec_ty.scalar_bits);
                         let set = set1_intrinsic(vec_ty.scalar, vec_ty.scalar_bits);
                         expr = quote! { #max_intrinsic(#floor_intrinsic(#expr), #set(0.0)) };
                     }

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -496,7 +496,7 @@ fn mk_simd_impl() -> TokenStream {
                     quote! {
                         #[inline(always)]
                         fn #method_ident(self, #arg) -> #ret_ty {
-                            todo!()
+                            crate::Fallback::new().#method_ident(src).val.simd_into(self)
                         }
                     }
                 }
@@ -505,7 +505,8 @@ fn mk_simd_impl() -> TokenStream {
                     quote! {
                         #[inline(always)]
                         fn #method_ident(self, #arg) -> #ret_ty {
-                            todo!()
+                            let fb = crate::Fallback::new();
+                            fb.#method_ident(a.val.simd_into(fb), dest)
                         }
                     }
                 }

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -499,7 +499,10 @@ fn mk_simd_impl() -> TokenStream {
                     // Implementing interleaved loading/storing for 32-bit is still quite doable, It's unclear
                     // how hard it would be for u16/u8. For now we only implement it for u32 since this is needed
                     // in packing in vello_cpu, where performance is very critical.
-                    let expr = if block_size == 128 && vec_ty.scalar == ScalarType::Unsigned && vec_ty.scalar_bits == 32 {
+                    let expr = if block_size == 128
+                        && vec_ty.scalar == ScalarType::Unsigned
+                        && vec_ty.scalar_bits == 32
+                    {
                         quote! {
                             unsafe {
                                 // TODO: Once we support u64, we could do all of this using just zip + unzip
@@ -524,10 +527,9 @@ fn mk_simd_impl() -> TokenStream {
                                 )
                             }
                         }
-                    }   else {
+                    } else {
                         quote! { crate::Fallback::new().#method_ident(src).val.simd_into(self) }
                     };
-
 
                     quote! {
                         #[inline(always)]
@@ -542,7 +544,7 @@ fn mk_simd_impl() -> TokenStream {
                         #[inline(always)]
                         fn #method_ident(self, #arg) -> #ret_ty {
                             let fb = crate::Fallback::new();
-                            fb.#method_ident(a.val.simd_into(fb), dest)
+                            fb.#method_ident(a.val.simd_into(fb), dest);
                         }
                     }
                 }

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -195,8 +195,9 @@ fn mk_simd_impl() -> TokenStream {
                                 unsafe {
                                     let raw = a.into();
                                     let high = #extend(raw).simd_into(self);
-                                    // TODO: Document the magic number 8
-                                    let low = #extend(_mm_slli_si128(raw, 8)).simd_into(self);
+                                    // Shift by 8 since we want to get the higher part into the
+                                    // lower position.
+                                    let low = #extend(_mm_srli_si128::<8>(raw)).simd_into(self);
                                     self.#combine(high, low)
                                 }
                             }

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -296,11 +296,10 @@ fn mk_simd_impl() -> TokenStream {
                     } else {
                         let suffix = op_suffix(vec_ty.scalar, scalar_bits, false);
                         let intrinsic = format_ident!("_mm_{op}_{suffix}");
-                        let set1 = set1_intrinsic(vec_ty.scalar, scalar_bits);
                         quote! {
                             #[inline(always)]
                             fn #method_ident(self, a: #ty<Self>, b: u32) -> #ret_ty {
-                                unsafe { #intrinsic(a.into(), #set1(b as _)).simd_into(self) }
+                                unsafe { #intrinsic(a.into(), _mm_cvtsi32_si128(b as _)).simd_into(self) }
                             }
                         }
                     }

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -227,7 +227,7 @@ fn mk_simd_impl() -> TokenStream {
                     _ => unreachable!(),
                 },
                 OpSig::Binary => {
-                    if method == "mul" && (vec_ty.scalar_bits == 8 || vec_ty.scalar_bits == 16) {
+                    if method == "mul" && vec_ty.scalar_bits == 8 {
                         quote! {
                             #[inline(always)]
                             fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ret_ty {

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::arch::Arch;
-use crate::arch::sse4_2::{Sse4_2, cvt_intrinsic, extend_intrinsic, op_suffix, pack_intrinsic, set1_intrinsic, simple_intrinsic, unpack_intrinsic};
+use crate::arch::sse4_2::{
+    Sse4_2, cvt_intrinsic, extend_intrinsic, op_suffix, pack_intrinsic, set1_intrinsic,
+    simple_intrinsic, unpack_intrinsic,
+};
 use crate::generic::{generic_combine, generic_op, generic_split};
 use crate::ops::{
     OpSig, TyFlavor, load_interleaved_arg_ty, ops_for_type, reinterpret_ty,
@@ -256,7 +259,7 @@ fn mk_simd_impl() -> TokenStream {
                         // 16 bit, shift, and then back to 8-bit
 
                         let unpack_hi = unpack_intrinsic(ScalarType::Int, 8, false);
-                        let unpack_lo =  unpack_intrinsic(ScalarType::Int, 8, true);
+                        let unpack_lo = unpack_intrinsic(ScalarType::Int, 8, true);
 
                         let extend_expr = |expr| match vec_ty.scalar {
                             ScalarType::Unsigned => quote! {
@@ -265,7 +268,7 @@ fn mk_simd_impl() -> TokenStream {
                             ScalarType::Int => quote! {
                                  #expr(val, _mm_cmplt_epi8(val, _mm_setzero_si128()))
                             },
-                            _ => unimplemented!()
+                            _ => unimplemented!(),
                         };
 
                         let extend_intrinsic_lo = extend_expr(unpack_lo);

--- a/fearless_simd_tests/tests/harness.rs
+++ b/fearless_simd_tests/tests/harness.rs
@@ -1162,3 +1162,11 @@ fn mul_u16x8<S: Simd>(simd: S) {
 
     assert_eq!((a * b).val, [0, 40, 130, 630, 49464, 0, 0, 0]);
 }
+
+#[simd_test]
+fn mul_u32x4<S: Simd>(simd: S) {
+    let a = u32x4::from_slice(simd, &[1, 5464, 23234, 456456]);
+    let b = u32x4::from_slice(simd, &[23, 34, 565, 34234]);
+
+    assert_eq!((a * b).val, [23, 185776, 13127210, 2741412816]);
+}

--- a/fearless_simd_tests/tests/harness.rs
+++ b/fearless_simd_tests/tests/harness.rs
@@ -1154,3 +1154,11 @@ fn trunc_f64x2<S: Simd>(simd: S) {
     let a = f64x2::from_slice(simd, &[1.7, -2.3]);
     assert_eq!(a.trunc().val, [1.0, -2.0]);
 }
+
+#[simd_test]
+fn mul_u16x8<S: Simd>(simd: S) {
+    let a = u16x8::from_slice(simd, &[0, 5, 10, 30, 500, 0, 0, 0]);
+    let b = u16x8::from_slice(simd, &[5, 8, 13, 21, 230, 0, 0, 0]);
+
+    assert_eq!((a * b).val, [0, 40, 130, 630, 49464, 0, 0, 0]);
+}

--- a/fearless_simd_tests/tests/harness.rs
+++ b/fearless_simd_tests/tests/harness.rs
@@ -1170,3 +1170,11 @@ fn mul_u32x4<S: Simd>(simd: S) {
 
     assert_eq!((a * b).val, [23, 185776, 13127210, 2741412816]);
 }
+
+#[simd_test]
+fn mul_f32x4<S: Simd>(simd: S) {
+    let a = f32x4::from_slice(simd, &[-10.3, 0.0, 13.34, 234234.0]);
+    let b = f32x4::from_slice(simd, &[-8.1, 7.9, -9.8, 3243.6]);
+
+    assert_eq!((a * b).val, [83.43001, 0.0, -130.73201, 759761400.0]);
+}

--- a/fearless_simd_tests/tests/harness.rs
+++ b/fearless_simd_tests/tests/harness.rs
@@ -1185,3 +1185,81 @@ fn cvt_i32_f32x4<S: Simd>(simd: S) {
 
     assert_eq!(a.cvt_i32().val, [-10, 0, 13, 234234]);
 }
+
+#[simd_test]
+fn simd_ge_u8x16<S: Simd>(simd: S) {
+    let vals = u8x16::from_slice(
+        simd,
+        &[
+            0, 12, 34, 50, 220, 180, 127, 128, 255, 50, 33, 126, 0, 0, 0, 0,
+        ],
+    );
+    let mask = vals.simd_ge(u8x16::splat(simd, 128));
+
+    assert_eq!(
+        mask.val,
+        [0, 0, 0, 0, -1, -1, 0, -1, -1, 0, 0, 0, 0, 0, 0, 0]
+    );
+}
+
+#[simd_test]
+fn simd_gt_u8x16<S: Simd>(simd: S) {
+    let vals = u8x16::from_slice(
+        simd,
+        &[
+            0, 12, 34, 50, 220, 180, 127, 128, 255, 50, 33, 126, 0, 0, 0, 0,
+        ],
+    );
+    let mask = vals.simd_gt(u8x16::splat(simd, 128));
+
+    assert_eq!(
+        mask.val,
+        [0, 0, 0, 0, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0]
+    );
+}
+
+#[simd_test]
+fn simd_le_u8x16<S: Simd>(simd: S) {
+    let vals = u8x16::from_slice(
+        simd,
+        &[
+            0, 12, 34, 50, 220, 180, 127, 128, 255, 50, 33, 126, 0, 0, 0, 0,
+        ],
+    );
+    let mask = vals.simd_le(u8x16::splat(simd, 128));
+
+    assert_eq!(
+        mask.val,
+        [-1, -1, -1, -1, 0, 0, -1, -1, 0, -1, -1, -1, -1, -1, -1, -1]
+    );
+}
+
+#[simd_test]
+fn simd_lt_u8x16<S: Simd>(simd: S) {
+    let vals = u8x16::from_slice(
+        simd,
+        &[
+            0, 12, 34, 50, 220, 180, 127, 128, 255, 50, 33, 126, 0, 0, 0, 0,
+        ],
+    );
+    let mask = vals.simd_lt(u8x16::splat(simd, 128));
+
+    assert_eq!(
+        mask.val,
+        [-1, -1, -1, -1, 0, 0, -1, 0, 0, -1, -1, -1, -1, -1, -1, -1]
+    );
+}
+
+#[simd_test]
+fn simd_ge_i8x16<S: Simd>(simd: S) {
+    let vals = i8x16::from_slice(
+        simd,
+        &[0, -45, -12, 34, 89, 122, -122, 13, -1, 0, 0, 0, 0, 0, 0, 0],
+    );
+    let mask = vals.simd_ge(i8x16::splat(simd, -1));
+
+    assert_eq!(
+        mask.val,
+        [-1, 0, 0, -1, -1, -1, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1]
+    );
+}

--- a/fearless_simd_tests/tests/harness.rs
+++ b/fearless_simd_tests/tests/harness.rs
@@ -1178,3 +1178,10 @@ fn mul_f32x4<S: Simd>(simd: S) {
 
     assert_eq!((a * b).val, [83.43001, 0.0, -130.73201, 759761400.0]);
 }
+
+#[simd_test]
+fn cvt_i32_f32x4<S: Simd>(simd: S) {
+    let a = f32x4::from_slice(simd, &[-10.3, -0.9, 13.34, 234234.8]);
+
+    assert_eq!(a.cvt_i32().val, [-10, 0, 13, 234234]);
+}


### PR DESCRIPTION
This is enough to make the whole test suite pass with SSE4.2! There is still something wrong because performance is absolute trash on some benchmarks (I presume some functions are not being inlined properly), but at least the tests pass!

This also fixes an issue where we didn't use wrapping semantics in the scalar code (this also applies to some other arithmetic operations, but for now I've only fixed it for `mul`).