### PR TITLE
Use macos-latest for `x86_64-apple-darwin`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
       matrix:
         platform:
           - { target: aarch64-apple-darwin, os: macos-latest }
-          - { target: x86_64-apple-darwin, os: macos-13 }
+          - { target: x86_64-apple-darwin, os: macos-latest }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
           - { target: i686-pc-windows-msvc, os: windows-latest }


### PR DESCRIPTION
Just like windows image, macos image is also ready for cross compilation and it even includes rosetta so we can normally run tests.

My response to https://github.com/linebender/fearless_simd/pull/53#discussion_r2260226675