### PR TITLE
Fix match statement for `no_std` build

### DIFF
--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -78,6 +78,7 @@ macro_rules! simd_dispatch {
                 Level::Fallback(fb) => $inner(fb $( , $arg )* ),
                 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
                 Level::WasmSimd128(wasm) => unsafe { inner_wasm_simd128 (wasm $( , $arg )* ) }
+                _ => unreachable!()
             }
         }
     };


### PR DESCRIPTION
In a previous PR the `Level` enum was marked as non-exhaustive, but we forgot to add the corresponding branch in one of the `simd_dispatch` macros. We probably should configure CI so this is caught in the future.