### PR TITLE
Fix soundness of `simd_dispatch` using target-features 1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,
   # plus all the README.md files of the affected packages.
-  RUST_MIN_VER: "1.85"
+  RUST_MIN_VER: "1.86"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
   RUST_MIN_VER_PKGS: "-p fearless_simd"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find its changes [documented below](#011-2018-11-05).
 
 ## [Unreleased]
 
-This release has an [MSRV][] of 1.85.
+This release has an [MSRV][] of 1.86.
 
 There has been a complete rewrite of Fearless SIMD.
 For some details of the ideas used, see our blog post [*Towards fearless SIMD, 7 years later*](https://linebender.org/blog/towards-fearless-simd/).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/fearless_simd"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
-rust-version = "1.85"
+rust-version = "1.86"
 
 [workspace.lints]
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ It benefited from conversations with Luca Versari, though he is not responsible 
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Fearless SIMD has been verified to compile with **Rust 1.85** and later.
+This version of Fearless SIMD has been verified to compile with **Rust 1.86** and later.
 
 Future versions of Fearless SIMD might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/fearless_simd/README.md
+++ b/fearless_simd/README.md
@@ -63,7 +63,7 @@ use fearless_simd::{Simd, simd_dispatch};
 #[inline(always)]
 fn sigmoid_impl<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) { /* ... */ }
 
-simd_dispatch!(sigmoid(level, x: &[f32], out: &mut [f32]) = sigmoid_impl);
+simd_dispatch!(fn sigmoid(level, x: &[f32], out: &mut [f32]) = sigmoid_impl);
 ```
 
 A few things to note:

--- a/fearless_simd/README.md
+++ b/fearless_simd/README.md
@@ -129,7 +129,7 @@ At least one of `std` and `libm` is required; `std` overrides `libm`.
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Fearless SIMD has been verified to compile with **Rust 1.85** and later.
+This version of Fearless SIMD has been verified to compile with **Rust 1.86** and later.
 
 Future versions of Fearless SIMD might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/fearless_simd/examples/play.rs
+++ b/fearless_simd/examples/play.rs
@@ -30,7 +30,7 @@ fn foo_inner<S: Simd>(simd: S, x: f32) -> f32 {
     simd.splat_f32x4(x).sqrt()[0]
 }
 
-simd_dispatch!(foo(level, x: f32) -> f32 = foo_inner);
+simd_dispatch!(fn foo(level, x: f32) -> f32 = foo_inner);
 
 // currently requires `safe_wrappers` feature
 fn do_something_on_neon(_level: Level) -> f32 {

--- a/fearless_simd/examples/sigmoid.rs
+++ b/fearless_simd/examples/sigmoid.rs
@@ -18,7 +18,7 @@ fn sigmoid_impl<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
     }
 }
 
-simd_dispatch!(sigmoid(level, x: &[f32], out: &mut [f32]) = sigmoid_impl);
+simd_dispatch!(fn sigmoid(level, x: &[f32], out: &mut [f32]) = sigmoid_impl);
 
 fn main() {
     let level = Level::new();

--- a/fearless_simd/examples/srgb.rs
+++ b/fearless_simd/examples/srgb.rs
@@ -67,7 +67,7 @@ fn to_srgb_impl<S: Simd>(simd: S, rgba: [f32; 4]) -> [f32; 4] {
     result.into()
 }
 
-simd_dispatch!(to_srgb(level, rgba: [f32; 4]) -> [f32; 4] = to_srgb_impl);
+simd_dispatch!(fn to_srgb(level, rgba: [f32; 4]) -> [f32; 4] = to_srgb_impl);
 
 fn main() {
     let level = Level::new();

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -337,8 +337,7 @@ impl Level {
         #[cfg(target_arch = "aarch64")]
         #[target_feature(enable = "neon")]
         #[inline]
-        // unsafe not needed here with tf11, but can be justified
-        unsafe fn dispatch_neon<W: WithSimd>(f: W, neon: Neon) -> W::Output {
+        fn dispatch_neon<W: WithSimd>(f: W, neon: Neon) -> W::Output {
             f.with_simd(neon)
         }
 
@@ -351,14 +350,14 @@ impl Level {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         #[target_feature(enable = "sse4.2")]
         #[inline]
-        unsafe fn dispatch_sse4_2<W: WithSimd>(f: W, sse4_2: Sse4_2) -> W::Output {
+        fn dispatch_sse4_2<W: WithSimd>(f: W, sse4_2: Sse4_2) -> W::Output {
             f.with_simd(sse4_2)
         }
 
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         #[target_feature(enable = "avx2,fma")]
         #[inline]
-        unsafe fn dispatch_avx2<W: WithSimd>(f: W, avx2: Avx2) -> W::Output {
+        fn dispatch_avx2<W: WithSimd>(f: W, avx2: Avx2) -> W::Output {
             f.with_simd(avx2)
         }
 

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -25,7 +25,7 @@
 //! #[inline(always)]
 //! fn sigmoid_impl<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) { /* ... */ }
 //!
-//! simd_dispatch!(sigmoid(level, x: &[f32], out: &mut [f32]) = sigmoid_impl);
+//! simd_dispatch!(fn sigmoid(level, x: &[f32], out: &mut [f32]) = sigmoid_impl);
 //! ```
 //!
 //! A few things to note:

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -6,12 +6,21 @@
 /// Defines a new function which dispatches to a SIMD-generic function, enabling the correct
 /// target features.
 ///
+/// The `fn` token in the definition can be prefixed with a visibility (e.g. `pub`),
+/// to set the visibility of the outer function.
+/// We recommend that the implementation function remains private, and
+/// should only be called through the dispatch function.
+/// (The exact patterns for SIMD functions using Fearleess SIMD have not
+/// yet been designed/enumerated).
+///
 /// The implementation function (which is outside of this macro) *should* have the
 /// `#[inline(always)]` attribute.
 /// There are likely to be severe performance consequences if this is not the case, as
 /// Rust will be unable to inline SIMD intrinsics in that case.
 ///
 /// The `fn` token in the definition can be prefixed with `unsafe`, to allow an unsafe inner function.
+/// The safety comment added by you in the call to  `simd_dispatch` the function must have
+/// the preconditions required to call the inner function.
 ///
 /// # Examples
 ///

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -3,46 +3,92 @@
 
 //! Macros publicly exported
 
-#![expect(
-    missing_docs,
-    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
-)]
-
+/// Defines a new function which dispatches to a SIMD-generic function, enabling the correct
+/// target features.
+///
+/// The implementation function (which is outside of this macro) *should* have the
+/// `#[inline(always)]` attribute.
+/// There are likely to be severe performance consequences if this is not the case, as
+/// Rust will be unable to inline SIMD intrinsics in that case.
+///
+/// The `fn` token in the definition can be prefixed with `unsafe`, to allow an unsafe inner function.
+///
+/// # Examples
+///
+/// ```rust
+/// use fearless_simd::{Simd, simd_dispatch};
+///
+/// #[inline(always)]
+/// fn sigmoid_impl<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) { /* ... */ }
+///
+/// simd_dispatch!(fn sigmoid(level, x: &[f32], out: &mut [f32]) = sigmoid_impl);
+/// ```
+///
+/// The signature of the generated function will be:
+///
+/// ```rust
+/// use fearless_simd::Level;
+/// fn sigmoid(level: Level, x: &[f32], out: &mut [f32]) { /* ... */ }
+/// ```
 #[macro_export]
 macro_rules! simd_dispatch {
     (
         $( #[$meta:meta] )* $vis:vis
-        $func:ident ( level $( , $arg:ident : $ty:ty $(,)? )* ) $( -> $ret:ty )?
+        unsafe fn $func:ident ( level $( , $arg:ident : $ty:ty $(,)? )* ) $( -> $ret:ty )?
+        = $inner:ident
+    ) => {
+        simd_dispatch!{@impl => $(#[$meta])* $vis (unsafe) fn $func (level, $(,$arg:$ty,)*) $(->$ret)? = $inner}
+    };
+    (
+        $( #[$meta:meta] )* $vis:vis
+        fn $func:ident ( level $( , $arg:ident : $ty:ty $(,)? )* ) $( -> $ret:ty )?
+        = $inner:ident
+    ) => {
+        simd_dispatch!{@impl => $(#[$meta])* $vis () fn $func (level $(,$arg:$ty)*) $(->$ret)? = $inner}
+    };
+    (
+        @impl => $( #[$meta:meta] )* $vis:vis
+        ($($unsafe: ident)?) fn $func:ident ( level $( , $arg:ident : $ty:ty $(,)? )* ) $( -> $ret:ty )?
         = $inner:ident
     ) => {
         $( #[$meta] )* $vis
-        fn $func(level: $crate::Level $(, $arg: $ty )*) $( -> $ret )? {
+        $($unsafe)? fn $func(level: $crate::Level $(, $arg: $ty )*) $( -> $ret )? {
             #[cfg(target_arch = "aarch64")]
             #[target_feature(enable = "neon")]
             #[inline]
-            unsafe fn inner_neon(neon: $crate::aarch64::Neon $( , $arg: $ty )* ) $( -> $ret )? {
-                $inner( neon $( , $arg )* )
+            $($unsafe)? fn inner_neon(neon: $crate::aarch64::Neon $( , $arg: $ty )* ) $( -> $ret )? {
+                $($unsafe)? {
+                    $inner( neon $( , $arg )* )
+                }
             }
             #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
             #[inline]
-            unsafe fn inner_wasm_simd128(simd128: $crate::wasm32::WasmSimd128 $( , $arg: $ty )* ) $( -> $ret )? {
-                $inner( simd128 $( , $arg )* )
+            $($unsafe)? fn inner_wasm_simd128(simd128: $crate::wasm32::WasmSimd128 $( , $arg: $ty )* ) $( -> $ret )? {
+                $($unsafe)? {
+                    $inner( simd128 $( , $arg )* )
+                }
             }
             #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
             #[target_feature(enable = "sse4.2")]
             #[inline]
-            unsafe fn inner_sse4_2(sse4_2: $crate::x86::Sse4_2 $( , $arg: $ty )* ) $( -> $ret )? {
-                $inner( sse4_2 $( , $arg )* )
+            $($unsafe)? fn inner_sse4_2(sse4_2: $crate::x86::Sse4_2 $( , $arg: $ty )* ) $( -> $ret )? {
+                $($unsafe)? {
+                    $inner( sse4_2 $( , $arg )* )
+                }
             }
             #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
             #[target_feature(enable = "avx2,fma")]
             #[inline]
-            unsafe fn inner_avx2(avx2: $crate::x86::Avx2 $( , $arg: $ty )* ) $( -> $ret )? {
-                $inner( avx2 $( , $arg )* )
+            $($unsafe)? fn inner_avx2(avx2: $crate::x86::Avx2 $( , $arg: $ty )* ) $( -> $ret )? {
+                $($unsafe)? {
+                    $inner( avx2 $( , $arg )* )
+                }
             }
             match level {
                 $crate::Level::Fallback(fb) => {
-                    $inner(fb $( , $arg )* )
+                    $($unsafe)? {
+                        $inner(fb $( , $arg )* )
+                    }
                 },
                 #[cfg(target_arch = "aarch64")]
                 $crate::Level::Neon(neon) => unsafe { inner_neon (neon $( , $arg )* ) }


### PR DESCRIPTION
Previously, you would be able to write an unsafe function, and then call it using `simd_dispatch` without needing the `unsafe` token at the call site. E.g.

```rust
/// # Safety
///
/// `value` must be `Some`
#[inline(always)]
unsafe fn evil<S: Simd>(simd: S, value: Option<u32>) -> u32 {
     value.unwrap_unchecked()
}

simd_dispatch!(disguised(level, value: Option<u32>) -> u32);

fn unwitting(){
    disguised(None);
}
```

This is a real soundness hole, if `fearless_simd` expands to wider use, as it would effectively mean that external crates are unable to write unsafe "simd-compatible" functions. 

The fix is to require the `unsafe` token in the macro definition in these cases; we detect a true unsafe case without this unsafe block by using target feature 1.1.

In adding support for `unsafe`, I've also added a requirement that each function definition created in `simd_dispatch` is prefixed with the `fn` token. This isn't fundamental, but seems worth requiring.

This does bump up our MSRV to 1.86, for target feature 1.1