### PR TITLE
Introduce int-from-mask conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ You can find its changes [documented below](#020-2025-08-26).
 
 This release has an [MSRV][] of 1.86.
 
+## Added
+
+- `SimdInt::from_mask` allows construction of an integer vector from
+  the associated mask type. ([#75][] by [@Ralith][])
+
 ## Fixed
 
 - `Simd` now requires consistent mask types for native-width

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -920,6 +920,11 @@ pub trait SimdInt<Element: SimdElement, S: Simd>:
     fn to_float<T: SimdCvtFloat<Self>>(self) -> T {
         T::float_from(self)
     }
+    #[doc = r" Construct the integer vector with the same representation as `mask`"]
+    #[doc = r""]
+    #[doc = r" Unset lanes become 0. Set lanes become -1 or the maximum value for signed or"]
+    #[doc = r" unsigned element types respectively."]
+    fn from_mask(mask: Self::Mask) -> Self;
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
     fn simd_lt(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
     fn simd_le(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -536,6 +536,13 @@ impl<S: Simd> crate::SimdInt<i8, S> for i8x16<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i8x16<S> {
         self.simd.max_i8x16(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn from_mask(mask: mask8x16<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
+    }
 }
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(16))]
@@ -762,6 +769,13 @@ impl<S: Simd> crate::SimdInt<u8, S> for u8x16<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u8x16<S> {
         self.simd.max_u8x16(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn from_mask(mask: mask8x16<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -1129,6 +1143,13 @@ impl<S: Simd> crate::SimdInt<i16, S> for i16x8<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i16x8<S> {
         self.simd.max_i16x8(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn from_mask(mask: mask16x8<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
+    }
 }
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(16))]
@@ -1351,6 +1372,13 @@ impl<S: Simd> crate::SimdInt<u16, S> for u16x8<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u16x8<S> {
         self.simd.max_u16x8(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn from_mask(mask: mask16x8<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -1705,6 +1733,13 @@ impl<S: Simd> crate::SimdInt<i32, S> for i32x4<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i32x4<S> {
         self.simd.max_i32x4(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn from_mask(mask: mask32x4<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f32x4<S>> for i32x4<S> {
     fn truncate_from(x: f32x4<S>) -> Self {
@@ -1923,6 +1958,13 @@ impl<S: Simd> crate::SimdInt<u32, S> for u32x4<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u32x4<S> {
         self.simd.max_u32x4(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn from_mask(mask: mask32x4<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x4<S>> for u32x4<S> {
@@ -3011,6 +3053,13 @@ impl<S: Simd> crate::SimdInt<i8, S> for i8x32<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i8x32<S> {
         self.simd.max_i8x32(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn from_mask(mask: mask8x32<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
+    }
 }
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(32))]
@@ -3253,6 +3302,13 @@ impl<S: Simd> crate::SimdInt<u8, S> for u8x32<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u8x32<S> {
         self.simd.max_u8x32(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn from_mask(mask: mask8x32<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -3644,6 +3700,13 @@ impl<S: Simd> crate::SimdInt<i16, S> for i16x16<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i16x16<S> {
         self.simd.max_i16x16(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn from_mask(mask: mask16x16<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
+    }
 }
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(32))]
@@ -3874,6 +3937,13 @@ impl<S: Simd> crate::SimdInt<u16, S> for u16x16<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u16x16<S> {
         self.simd.max_u16x16(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn from_mask(mask: mask16x16<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -4245,6 +4315,13 @@ impl<S: Simd> crate::SimdInt<i32, S> for i32x8<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i32x8<S> {
         self.simd.max_i32x8(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn from_mask(mask: mask32x8<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f32x8<S>> for i32x8<S> {
     fn truncate_from(x: f32x8<S>) -> Self {
@@ -4472,6 +4549,13 @@ impl<S: Simd> crate::SimdInt<u32, S> for u32x8<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u32x8<S> {
         self.simd.max_u32x8(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn from_mask(mask: mask32x8<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x8<S>> for u32x8<S> {
@@ -5603,6 +5687,13 @@ impl<S: Simd> crate::SimdInt<i8, S> for i8x64<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i8x64<S> {
         self.simd.max_i8x64(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn from_mask(mask: mask8x64<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
+    }
 }
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(64))]
@@ -5874,6 +5965,13 @@ impl<S: Simd> crate::SimdInt<u8, S> for u8x64<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u8x64<S> {
         self.simd.max_u8x64(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn from_mask(mask: mask8x64<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -6307,6 +6405,13 @@ impl<S: Simd> crate::SimdInt<i16, S> for i16x32<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i16x32<S> {
         self.simd.max_i16x32(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn from_mask(mask: mask16x32<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
+    }
 }
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(64))]
@@ -6550,6 +6655,13 @@ impl<S: Simd> crate::SimdInt<u16, S> for u16x32<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u16x32<S> {
         self.simd.max_u16x32(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn from_mask(mask: mask16x32<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -6939,6 +7051,13 @@ impl<S: Simd> crate::SimdInt<i32, S> for i32x16<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i32x16<S> {
         self.simd.max_i32x16(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn from_mask(mask: mask32x16<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f32x16<S>> for i32x16<S> {
     fn truncate_from(x: f32x16<S>) -> Self {
@@ -7171,6 +7290,13 @@ impl<S: Simd> crate::SimdInt<u32, S> for u32x16<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u32x16<S> {
         self.simd.max_u32x16(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn from_mask(mask: mask32x16<S>) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(mask.val) },
+            simd: mask.simd,
+        }
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x16<S>> for u32x16<S> {

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -134,6 +134,12 @@ fn mk_simd_int() -> TokenStream {
             #[inline(always)]
             fn to_float<T: SimdCvtFloat<Self>>(self) -> T { T::float_from(self) }
 
+            /// Construct the integer vector with the same representation as `mask`
+            ///
+            /// Unset lanes become 0. Set lanes become -1 or the maximum value for signed or
+            /// unsigned element types respectively.
+            fn from_mask(mask: Self::Mask) -> Self;
+
             #( #methods )*
         }
     }

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -274,6 +274,17 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
         }
     }
     let mask_ty = ty.mask_ty().rust();
+    if matches!(ty.scalar, ScalarType::Unsigned | ScalarType::Int) {
+        methods.push(quote! {
+            #[inline(always)]
+            fn from_mask(mask: #mask_ty<S>) -> Self {
+                Self {
+                    val: unsafe { core::mem::transmute(mask.val) },
+                    simd: mask.simd,
+                }
+            }
+        });
+    }
     let block_ty = VecType::new(ty.scalar, ty.scalar_bits, 128 / ty.scalar_bits).rust();
     let block_splat_body = match ty.n_bits() {
         64 => quote! {

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -1263,3 +1263,27 @@ fn simd_ge_i8x16<S: Simd>(simd: S) {
         [-1, 0, 0, -1, -1, -1, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1]
     );
 }
+
+#[simd_test]
+fn mask_to_i8x16<S: Simd>(simd: S) {
+    let value = [-1; 16];
+    let mask = mask8x16::simd_from(value, simd);
+    let converted = i8x16::from_mask(mask);
+    assert_eq!(converted.val, value);
+}
+
+#[simd_test]
+fn mask_to_u8x16<S: Simd>(simd: S) {
+    let value = [-1; 16];
+    let mask = mask8x16::simd_from(value, simd);
+    let converted = u8x16::from_mask(mask);
+    assert_eq!(converted.val, value.map(|x| x as u8));
+}
+
+#[simd_test]
+fn mask_to_i8_native<S: Simd>(simd: S) {
+    let values = vec![-1; S::mask8s::N];
+    let mask = S::mask8s::from_slice(simd, &values);
+    let converted = S::i8s::from_mask(mask);
+    assert_eq!(converted.as_slice(), values);
+}


### PR DESCRIPTION
I have some logic that needs a -1 if a comparison passes and a 0 otherwise, which makes this very convenient. Not sure if transmute is precisely the idiomatic approach here, but I figure it works.