### PR TITLE
Revert "Introduce int-from-mask conversion"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ This release has an [MSRV][] of 1.86.
 
 ## Added
 
-- `SimdInt::from_mask` allows construction of an integer vector from
-  the associated mask type. ([#75][] by [@Ralith][])
 - `SimdBase::witness` to fetch the `Simd` implementation associated with a
   generic vector. ([#76][] by [@Ralith][])
 - `Select` is now available on native-width masks. ([#77][] by [@Ralith][])

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -973,11 +973,6 @@ pub trait SimdInt<Element: SimdElement, S: Simd>:
     fn to_float<T: SimdCvtFloat<Self>>(self) -> T {
         T::float_from(self)
     }
-    #[doc = r" Construct the integer vector with the same representation as `mask`"]
-    #[doc = r""]
-    #[doc = r" Unset lanes become 0. Set lanes become -1 or the maximum value for signed or"]
-    #[doc = r" unsigned element types respectively."]
-    fn from_mask(mask: Self::Mask) -> Self;
     fn shrv(self, rhs: impl SimdInto<Self, S>) -> Self;
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
     fn simd_lt(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -552,13 +552,6 @@ impl<S: Simd> crate::SimdInt<i8, S> for i8x16<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i8x16<S> {
         self.simd.max_i8x16(self, rhs.simd_into(self.simd))
     }
-    #[inline(always)]
-    fn from_mask(mask: mask8x16<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
-    }
 }
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(16))]
@@ -797,13 +790,6 @@ impl<S: Simd> crate::SimdInt<u8, S> for u8x16<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u8x16<S> {
         self.simd.max_u8x16(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
-    fn from_mask(mask: mask8x16<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -1187,13 +1173,6 @@ impl<S: Simd> crate::SimdInt<i16, S> for i16x8<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i16x8<S> {
         self.simd.max_i16x8(self, rhs.simd_into(self.simd))
     }
-    #[inline(always)]
-    fn from_mask(mask: mask16x8<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
-    }
 }
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(16))]
@@ -1428,13 +1407,6 @@ impl<S: Simd> crate::SimdInt<u16, S> for u16x8<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u16x8<S> {
         self.simd.max_u16x8(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
-    fn from_mask(mask: mask16x8<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -1805,13 +1777,6 @@ impl<S: Simd> crate::SimdInt<i32, S> for i32x4<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i32x4<S> {
         self.simd.max_i32x4(self, rhs.simd_into(self.simd))
     }
-    #[inline(always)]
-    fn from_mask(mask: mask32x4<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
-    }
 }
 impl<S: Simd> SimdCvtTruncate<f32x4<S>> for i32x4<S> {
     fn truncate_from(x: f32x4<S>) -> Self {
@@ -2042,13 +2007,6 @@ impl<S: Simd> crate::SimdInt<u32, S> for u32x4<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u32x4<S> {
         self.simd.max_u32x4(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
-    fn from_mask(mask: mask32x4<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x4<S>> for u32x4<S> {
@@ -3165,13 +3123,6 @@ impl<S: Simd> crate::SimdInt<i8, S> for i8x32<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i8x32<S> {
         self.simd.max_i8x32(self, rhs.simd_into(self.simd))
     }
-    #[inline(always)]
-    fn from_mask(mask: mask8x32<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
-    }
 }
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(32))]
@@ -3426,13 +3377,6 @@ impl<S: Simd> crate::SimdInt<u8, S> for u8x32<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u8x32<S> {
         self.simd.max_u8x32(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
-    fn from_mask(mask: mask8x32<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -3840,13 +3784,6 @@ impl<S: Simd> crate::SimdInt<i16, S> for i16x16<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i16x16<S> {
         self.simd.max_i16x16(self, rhs.simd_into(self.simd))
     }
-    #[inline(always)]
-    fn from_mask(mask: mask16x16<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
-    }
 }
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(32))]
@@ -4089,13 +4026,6 @@ impl<S: Simd> crate::SimdInt<u16, S> for u16x16<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u16x16<S> {
         self.simd.max_u16x16(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
-    fn from_mask(mask: mask16x16<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -4483,13 +4413,6 @@ impl<S: Simd> crate::SimdInt<i32, S> for i32x8<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i32x8<S> {
         self.simd.max_i32x8(self, rhs.simd_into(self.simd))
     }
-    #[inline(always)]
-    fn from_mask(mask: mask32x8<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
-    }
 }
 impl<S: Simd> SimdCvtTruncate<f32x8<S>> for i32x8<S> {
     fn truncate_from(x: f32x8<S>) -> Self {
@@ -4729,13 +4652,6 @@ impl<S: Simd> crate::SimdInt<u32, S> for u32x8<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u32x8<S> {
         self.simd.max_u32x8(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
-    fn from_mask(mask: mask32x8<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x8<S>> for u32x8<S> {
@@ -5895,13 +5811,6 @@ impl<S: Simd> crate::SimdInt<i8, S> for i8x64<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i8x64<S> {
         self.simd.max_i8x64(self, rhs.simd_into(self.simd))
     }
-    #[inline(always)]
-    fn from_mask(mask: mask8x64<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
-    }
 }
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(64))]
@@ -6185,13 +6094,6 @@ impl<S: Simd> crate::SimdInt<u8, S> for u8x64<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u8x64<S> {
         self.simd.max_u8x64(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
-    fn from_mask(mask: mask8x64<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -6641,13 +6543,6 @@ impl<S: Simd> crate::SimdInt<i16, S> for i16x32<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i16x32<S> {
         self.simd.max_i16x32(self, rhs.simd_into(self.simd))
     }
-    #[inline(always)]
-    fn from_mask(mask: mask16x32<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
-    }
 }
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(64))]
@@ -6903,13 +6798,6 @@ impl<S: Simd> crate::SimdInt<u16, S> for u16x32<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u16x32<S> {
         self.simd.max_u16x32(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
-    fn from_mask(mask: mask16x32<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -7315,13 +7203,6 @@ impl<S: Simd> crate::SimdInt<i32, S> for i32x16<S> {
     fn max(self, rhs: impl SimdInto<Self, S>) -> i32x16<S> {
         self.simd.max_i32x16(self, rhs.simd_into(self.simd))
     }
-    #[inline(always)]
-    fn from_mask(mask: mask32x16<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
-    }
 }
 impl<S: Simd> SimdCvtTruncate<f32x16<S>> for i32x16<S> {
     fn truncate_from(x: f32x16<S>) -> Self {
@@ -7566,13 +7447,6 @@ impl<S: Simd> crate::SimdInt<u32, S> for u32x16<S> {
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> u32x16<S> {
         self.simd.max_u32x16(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
-    fn from_mask(mask: mask32x16<S>) -> Self {
-        Self {
-            val: unsafe { core::mem::transmute(mask.val) },
-            simd: mask.simd,
-        }
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x16<S>> for u32x16<S> {

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -138,12 +138,6 @@ fn mk_simd_int() -> TokenStream {
             #[inline(always)]
             fn to_float<T: SimdCvtFloat<Self>>(self) -> T { T::float_from(self) }
 
-            /// Construct the integer vector with the same representation as `mask`
-            ///
-            /// Unset lanes become 0. Set lanes become -1 or the maximum value for signed or
-            /// unsigned element types respectively.
-            fn from_mask(mask: Self::Mask) -> Self;
-
             #( #methods )*
         }
     }

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -274,17 +274,6 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
         }
     }
     let mask_ty = ty.mask_ty().rust();
-    if matches!(ty.scalar, ScalarType::Unsigned | ScalarType::Int) {
-        methods.push(quote! {
-            #[inline(always)]
-            fn from_mask(mask: #mask_ty<S>) -> Self {
-                Self {
-                    val: unsafe { core::mem::transmute(mask.val) },
-                    simd: mask.simd,
-                }
-            }
-        });
-    }
     let block_ty = VecType::new(ty.scalar, ty.scalar_bits, 128 / ty.scalar_bits).rust();
     let block_splat_body = match ty.n_bits() {
         64 => quote! {

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -1293,30 +1293,6 @@ fn simd_ge_i8x16<S: Simd>(simd: S) {
 }
 
 #[simd_test]
-fn mask_to_i8x16<S: Simd>(simd: S) {
-    let value = [-1; 16];
-    let mask = mask8x16::simd_from(value, simd);
-    let converted = i8x16::from_mask(mask);
-    assert_eq!(converted.val, value);
-}
-
-#[simd_test]
-fn mask_to_u8x16<S: Simd>(simd: S) {
-    let value = [-1; 16];
-    let mask = mask8x16::simd_from(value, simd);
-    let converted = u8x16::from_mask(mask);
-    assert_eq!(converted.val, value.map(|x| x as u8));
-}
-
-#[simd_test]
-fn mask_to_i8_native<S: Simd>(simd: S) {
-    let values = vec![-1; S::mask8s::N];
-    let mask = S::mask8s::from_slice(simd, &values);
-    let converted = S::i8s::from_mask(mask);
-    assert_eq!(converted.as_slice(), values);
-}
-
-#[simd_test]
 fn select_native_width_vectors<S: Simd>(simd: S) {
     // Test with native f32 vectors
     let a_f32 = S::f32s::from_slice(simd, &vec![1.0f32; S::f32s::N]);


### PR DESCRIPTION
This is redundant to bitcasting, as enabled in #81.

This does *not* revert the constraints on associated `Mask` types on native-width vectors, also introduced by #75. Those are still desirable.