### PR TITLE
Suppress redundant SimdInt::shrv method

### DIFF
--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -1005,7 +1005,6 @@ pub trait SimdInt<Element: SimdElement, S: Simd>:
     fn to_float<T: SimdCvtFloat<Self>>(self) -> T {
         T::float_from(self)
     }
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> Self;
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
     fn simd_lt(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
     fn simd_le(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -505,10 +505,6 @@ impl<S: Simd> crate::SimdBase<i8, S> for i8x16<S> {
 }
 impl<S: Simd> crate::SimdInt<i8, S> for i8x16<S> {
     #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> i8x16<S> {
-        self.simd.shrv_i8x16(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask8x16<S> {
         self.simd.simd_eq_i8x16(self, rhs.simd_into(self.simd))
     }
@@ -743,10 +739,6 @@ impl<S: Simd> crate::SimdBase<u8, S> for u8x16<S> {
     }
 }
 impl<S: Simd> crate::SimdInt<u8, S> for u8x16<S> {
-    #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> u8x16<S> {
-        self.simd.shrv_u8x16(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask8x16<S> {
         self.simd.simd_eq_u8x16(self, rhs.simd_into(self.simd))
@@ -1126,10 +1118,6 @@ impl<S: Simd> crate::SimdBase<i16, S> for i16x8<S> {
 }
 impl<S: Simd> crate::SimdInt<i16, S> for i16x8<S> {
     #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> i16x8<S> {
-        self.simd.shrv_i16x8(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask16x8<S> {
         self.simd.simd_eq_i16x8(self, rhs.simd_into(self.simd))
     }
@@ -1360,10 +1348,6 @@ impl<S: Simd> crate::SimdBase<u16, S> for u16x8<S> {
     }
 }
 impl<S: Simd> crate::SimdInt<u16, S> for u16x8<S> {
-    #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> u16x8<S> {
-        self.simd.shrv_u16x8(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask16x8<S> {
         self.simd.simd_eq_u16x8(self, rhs.simd_into(self.simd))
@@ -1730,10 +1714,6 @@ impl<S: Simd> crate::SimdBase<i32, S> for i32x4<S> {
 }
 impl<S: Simd> crate::SimdInt<i32, S> for i32x4<S> {
     #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> i32x4<S> {
-        self.simd.shrv_i32x4(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask32x4<S> {
         self.simd.simd_eq_i32x4(self, rhs.simd_into(self.simd))
     }
@@ -1960,10 +1940,6 @@ impl<S: Simd> crate::SimdBase<u32, S> for u32x4<S> {
     }
 }
 impl<S: Simd> crate::SimdInt<u32, S> for u32x4<S> {
-    #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> u32x4<S> {
-        self.simd.shrv_u32x4(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask32x4<S> {
         self.simd.simd_eq_u32x4(self, rhs.simd_into(self.simd))
@@ -3076,10 +3052,6 @@ impl<S: Simd> crate::SimdBase<i8, S> for i8x32<S> {
 }
 impl<S: Simd> crate::SimdInt<i8, S> for i8x32<S> {
     #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> i8x32<S> {
-        self.simd.shrv_i8x32(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask8x32<S> {
         self.simd.simd_eq_i8x32(self, rhs.simd_into(self.simd))
     }
@@ -3330,10 +3302,6 @@ impl<S: Simd> crate::SimdBase<u8, S> for u8x32<S> {
     }
 }
 impl<S: Simd> crate::SimdInt<u8, S> for u8x32<S> {
-    #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> u8x32<S> {
-        self.simd.shrv_u8x32(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask8x32<S> {
         self.simd.simd_eq_u8x32(self, rhs.simd_into(self.simd))
@@ -3737,10 +3705,6 @@ impl<S: Simd> crate::SimdBase<i16, S> for i16x16<S> {
 }
 impl<S: Simd> crate::SimdInt<i16, S> for i16x16<S> {
     #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> i16x16<S> {
-        self.simd.shrv_i16x16(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask16x16<S> {
         self.simd.simd_eq_i16x16(self, rhs.simd_into(self.simd))
     }
@@ -3979,10 +3943,6 @@ impl<S: Simd> crate::SimdBase<u16, S> for u16x16<S> {
     }
 }
 impl<S: Simd> crate::SimdInt<u16, S> for u16x16<S> {
-    #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> u16x16<S> {
-        self.simd.shrv_u16x16(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask16x16<S> {
         self.simd.simd_eq_u16x16(self, rhs.simd_into(self.simd))
@@ -4366,10 +4326,6 @@ impl<S: Simd> crate::SimdBase<i32, S> for i32x8<S> {
 }
 impl<S: Simd> crate::SimdInt<i32, S> for i32x8<S> {
     #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> i32x8<S> {
-        self.simd.shrv_i32x8(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask32x8<S> {
         self.simd.simd_eq_i32x8(self, rhs.simd_into(self.simd))
     }
@@ -4605,10 +4561,6 @@ impl<S: Simd> crate::SimdBase<u32, S> for u32x8<S> {
     }
 }
 impl<S: Simd> crate::SimdInt<u32, S> for u32x8<S> {
-    #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> u32x8<S> {
-        self.simd.shrv_u32x8(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask32x8<S> {
         self.simd.simd_eq_u32x8(self, rhs.simd_into(self.simd))
@@ -5764,10 +5716,6 @@ impl<S: Simd> crate::SimdBase<i8, S> for i8x64<S> {
 }
 impl<S: Simd> crate::SimdInt<i8, S> for i8x64<S> {
     #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> i8x64<S> {
-        self.simd.shrv_i8x64(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask8x64<S> {
         self.simd.simd_eq_i8x64(self, rhs.simd_into(self.simd))
     }
@@ -6047,10 +5995,6 @@ impl<S: Simd> crate::SimdBase<u8, S> for u8x64<S> {
     }
 }
 impl<S: Simd> crate::SimdInt<u8, S> for u8x64<S> {
-    #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> u8x64<S> {
-        self.simd.shrv_u8x64(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask8x64<S> {
         self.simd.simd_eq_u8x64(self, rhs.simd_into(self.simd))
@@ -6496,10 +6440,6 @@ impl<S: Simd> crate::SimdBase<i16, S> for i16x32<S> {
 }
 impl<S: Simd> crate::SimdInt<i16, S> for i16x32<S> {
     #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> i16x32<S> {
-        self.simd.shrv_i16x32(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask16x32<S> {
         self.simd.simd_eq_i16x32(self, rhs.simd_into(self.simd))
     }
@@ -6751,10 +6691,6 @@ impl<S: Simd> crate::SimdBase<u16, S> for u16x32<S> {
     }
 }
 impl<S: Simd> crate::SimdInt<u16, S> for u16x32<S> {
-    #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> u16x32<S> {
-        self.simd.shrv_u16x32(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask16x32<S> {
         self.simd.simd_eq_u16x32(self, rhs.simd_into(self.simd))
@@ -7156,10 +7092,6 @@ impl<S: Simd> crate::SimdBase<i32, S> for i32x16<S> {
 }
 impl<S: Simd> crate::SimdInt<i32, S> for i32x16<S> {
     #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> i32x16<S> {
-        self.simd.shrv_i32x16(self, rhs.simd_into(self.simd))
-    }
-    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask32x16<S> {
         self.simd.simd_eq_i32x16(self, rhs.simd_into(self.simd))
     }
@@ -7400,10 +7332,6 @@ impl<S: Simd> crate::SimdBase<u32, S> for u32x16<S> {
     }
 }
 impl<S: Simd> crate::SimdInt<u32, S> for u32x16<S> {
-    #[inline(always)]
-    fn shrv(self, rhs: impl SimdInto<Self, S>) -> u32x16<S> {
-        self.simd.shrv_u32x16(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> mask32x16<S> {
         self.simd.simd_eq_u32x16(self, rhs.simd_into(self.simd))

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -106,7 +106,7 @@ pub const MASK_OPS: &[(&str, OpSig)] = &[
 
 /// Ops covered by `core::ops`
 pub const CORE_OPS: &[&str] = &[
-    "not", "neg", "add", "sub", "mul", "div", "and", "or", "xor", "shr",
+    "not", "neg", "add", "sub", "mul", "div", "and", "or", "xor", "shr", "shrv",
 ];
 
 pub fn ops_for_type(ty: &VecType, cvt: bool) -> Vec<(&str, OpSig)> {


### PR DESCRIPTION
This is covered by a core operator trait. Oversight in #79.