### PR TITLE
64 bit ints

### DIFF
--- a/fearless_simd/src/traits.rs
+++ b/fearless_simd/src/traits.rs
@@ -119,6 +119,10 @@ impl SimdElement for i64 {
     type Mask = i64;
 }
 
+impl SimdElement for u64 {
+    type Mask = u64;
+}
+
 /// Construction of integer vectors from floats by truncation
 pub trait SimdCvtTruncate<T> {
     fn truncate_from(x: T) -> Self;

--- a/fearless_simd/src/traits.rs
+++ b/fearless_simd/src/traits.rs
@@ -120,7 +120,7 @@ impl SimdElement for i64 {
 }
 
 impl SimdElement for u64 {
-    type Mask = u64;
+    type Mask = i64;
 }
 
 /// Construction of integer vectors from floats by truncation

--- a/fearless_simd_gen/src/mk_avx2.rs
+++ b/fearless_simd_gen/src/mk_avx2.rs
@@ -112,12 +112,12 @@ fn mk_simd_impl() -> TokenStream {
             type i16s = i16x8<Self>;
             type u32s = u32x4<Self>;
             type i32s = i32x4<Self>;
-            type u64s = u64x4<Self>;
-            type i64s = i64x4<Self>;
+            type u64s = u64x2<Self>;
+            type i64s = i64x2<Self>;
             type mask8s = mask8x16<Self>;
             type mask16s = mask16x8<Self>;
             type mask32s = mask32x4<Self>;
-            type mask64s = mask64x4<Self>;
+            type mask64s = mask64x2<Self>;
             #[inline(always)]
             fn level(self) -> Level {
                 Level::#level_tok(self)

--- a/fearless_simd_gen/src/mk_avx2.rs
+++ b/fearless_simd_gen/src/mk_avx2.rs
@@ -112,9 +112,12 @@ fn mk_simd_impl() -> TokenStream {
             type i16s = i16x8<Self>;
             type u32s = u32x4<Self>;
             type i32s = i32x4<Self>;
+            type u64s = u64x4<Self>;
+            type i64s = i64x4<Self>;
             type mask8s = mask8x16<Self>;
             type mask16s = mask16x8<Self>;
             type mask32s = mask32x4<Self>;
+            type mask64s = mask64x4<Self>;
             #[inline(always)]
             fn level(self) -> Level {
                 Level::#level_tok(self)

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -407,7 +407,7 @@ fn mk_simd_impl() -> TokenStream {
             type mask8s = mask8x16<Self>;
             type mask16s = mask16x8<Self>;
             type mask32s = mask32x4<Self>;
-            type mask64s = mask64x4<Self>;
+            type mask64s = mask64x2<Self>;
             #[inline(always)]
             fn level(self) -> Level {
                 Level::#level_tok(self)

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -402,9 +402,12 @@ fn mk_simd_impl() -> TokenStream {
             type i16s = i16x8<Self>;
             type u32s = u32x4<Self>;
             type i32s = i32x4<Self>;
+            type u64s = u64x4<Self>;
+            type i64s = i64x4<Self>;
             type mask8s = mask8x16<Self>;
             type mask16s = mask16x8<Self>;
             type mask32s = mask32x4<Self>;
+            type mask64s = mask64x4<Self>;
             #[inline(always)]
             fn level(self) -> Level {
                 Level::#level_tok(self)

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -402,8 +402,8 @@ fn mk_simd_impl() -> TokenStream {
             type i16s = i16x8<Self>;
             type u32s = u32x4<Self>;
             type i32s = i32x4<Self>;
-            type u64s = u64x4<Self>;
-            type i64s = i64x4<Self>;
+            type u64s = u64x2<Self>;
+            type i64s = i64x2<Self>;
             type mask8s = mask8x16<Self>;
             type mask16s = mask16x8<Self>;
             type mask32s = mask32x4<Self>;

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -409,9 +409,12 @@ fn mk_simd_impl(level: Level) -> TokenStream {
             type i16s = i16x8<Self>;
             type u32s = u32x4<Self>;
             type i32s = i32x4<Self>;
+            type u64s = u64x2<Self>;
+            type i64s = i64x2<Self>;
             type mask8s = mask8x16<Self>;
             type mask16s = mask16x8<Self>;
             type mask32s = mask32x4<Self>;
+            type mask64s = mask64x2<Self>;
             #[inline(always)]
             fn level(self) -> Level {
                 Level::#level_tok(self)

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -45,7 +45,7 @@ pub fn mk_simd_trait() -> TokenStream {
             type i32s: SimdInt<i32, Self, Block = i32x4<Self>, Mask = Self::mask32s, Bytes = <Self::u32s as Bytes>::Bytes> + SimdCvtTruncate<Self::f32s>
                 + core::ops::Neg<Output = Self::i32s>;
             type u64s: SimdInt<u64, Self, Block = u64x2<Self>, Mask = Self::mask64s>; // + SimdCvtTruncate<Self::f64s>;
-            type i64s: SimdInt<i64, Self, Block = i64x2<Self>, Mask = Self::mask64s, Bytes = <Self::u64s as Bytes>::Bytes>; // + SimdCvtTruncate<Self::f64s>;
+            type i64s: SimdInt<i64, Self, Block = i64x2<Self>, Mask = Self::mask64s, Bytes = <Self::u64s as Bytes>::Bytes> + core::ops::Neg<Output = Self::i64s>; // + SimdCvtTruncate<Self::f64s>;
             type mask8s: SimdMask<i8, Self, Block = mask8x16<Self>, Bytes = <Self::u8s as Bytes>::Bytes> + Select<Self::u8s> + Select<Self::i8s> + Select<Self::mask8s>;
             type mask16s: SimdMask<i16, Self, Block = mask16x8<Self>, Bytes = <Self::u16s as Bytes>::Bytes> + Select<Self::u16s> + Select<Self::i16s> + Select<Self::mask16s>;
             type mask32s: SimdMask<i32, Self, Block = mask32x4<Self>, Bytes = <Self::u32s as Bytes>::Bytes> + Select<Self::f32s> + Select<Self::u32s> + Select<Self::i32s> + Select<Self::mask32s>;

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -45,16 +45,11 @@ pub fn mk_simd_trait() -> TokenStream {
             type i32s: SimdInt<i32, Self, Block = i32x4<Self>, Mask = Self::mask32s, Bytes = <Self::u32s as Bytes>::Bytes> + SimdCvtTruncate<Self::f32s>
                 + core::ops::Neg<Output = Self::i32s>;
             type u64s: SimdInt<u64, Self, Block = u64x2<Self>, Mask = Self::mask64s>; // + SimdCvtTruncate<Self::f64s>;
-            type i64s: SimdInt<i64, Self, Block = i64x2<Self>, Mask = Self::mask64s, Bytes = <Self::u32s as Bytes>::Bytes>; // + SimdCvtTruncate<Self::f64s>;
+            type i64s: SimdInt<i64, Self, Block = i64x2<Self>, Mask = Self::mask64s, Bytes = <Self::u64s as Bytes>::Bytes>; // + SimdCvtTruncate<Self::f64s>;
             type mask8s: SimdMask<i8, Self, Block = mask8x16<Self>, Bytes = <Self::u8s as Bytes>::Bytes> + Select<Self::u8s> + Select<Self::i8s> + Select<Self::mask8s>;
             type mask16s: SimdMask<i16, Self, Block = mask16x8<Self>, Bytes = <Self::u16s as Bytes>::Bytes> + Select<Self::u16s> + Select<Self::i16s> + Select<Self::mask16s>;
-            type mask32s: SimdMask<i32, Self, Block = mask32x4<Self>, Bytes = <Self::u32s as Bytes>::Bytes>
-            type mask8s: SimdMask<i8, Self, Block = mask8x16<Self>, Bytes = <Self::u8s as Bytes>::Bytes> + Select<Self::u8s> + Select<Self::i8s> + Select<Self::mask8s>;
-            type mask16s: SimdMask<i16, Self, Block = mask16x8<Self>, Bytes = <Self::u16s as Bytes>::Bytes> + Select<Self::u16s> + Select<Self::i16s> + Select<Self::mask16s>;
-            type mask32s: SimdMask<i32, Self, Block = mask32x4<Self>, Bytes = <Self::u32s as Bytes>::Bytes>
-                + Select<Self::f32s> + Select<Self::u32s> + Select<Self::i32s> + Select<Self::mask32s>;
-            type mask64s: SimdMask<i64, Self, Block = mask64x2<Self>, Bytes = <Self::u64s as Bytes>::Bytes>
-                + Select<Self::u64s> + Select<Self::i64s> + Select<Self::mask64s>; // + Select<Self::f64s>
+            type mask32s: SimdMask<i32, Self, Block = mask32x4<Self>, Bytes = <Self::u32s as Bytes>::Bytes> + Select<Self::f32s> + Select<Self::u32s> + Select<Self::i32s> + Select<Self::mask32s>;
+            type mask64s: SimdMask<i64, Self, Block = mask64x2<Self>, Bytes = <Self::u64s as Bytes>::Bytes> + Select<Self::u64s> + Select<Self::i64s> + Select<Self::mask64s>; // + Select<Self::f64s>
             fn level(self) -> Level;
 
             /// Call function with CPU features enabled.

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -44,10 +44,17 @@ pub fn mk_simd_trait() -> TokenStream {
             type u32s: SimdInt<u32, Self, Block = u32x4<Self>, Mask = Self::mask32s> + SimdCvtTruncate<Self::f32s>;
             type i32s: SimdInt<i32, Self, Block = i32x4<Self>, Mask = Self::mask32s, Bytes = <Self::u32s as Bytes>::Bytes> + SimdCvtTruncate<Self::f32s>
                 + core::ops::Neg<Output = Self::i32s>;
+            type u64s: SimdInt<u64, Self, Block = u64x2<Self>, Mask = Self::mask64s>; // + SimdCvtTruncate<Self::f64s>;
+            type i64s: SimdInt<i64, Self, Block = i64x2<Self>, Mask = Self::mask64s, Bytes = <Self::u32s as Bytes>::Bytes>; // + SimdCvtTruncate<Self::f64s>;
+            type mask8s: SimdMask<i8, Self, Block = mask8x16<Self>, Bytes = <Self::u8s as Bytes>::Bytes> + Select<Self::u8s> + Select<Self::i8s> + Select<Self::mask8s>;
+            type mask16s: SimdMask<i16, Self, Block = mask16x8<Self>, Bytes = <Self::u16s as Bytes>::Bytes> + Select<Self::u16s> + Select<Self::i16s> + Select<Self::mask16s>;
+            type mask32s: SimdMask<i32, Self, Block = mask32x4<Self>, Bytes = <Self::u32s as Bytes>::Bytes>
             type mask8s: SimdMask<i8, Self, Block = mask8x16<Self>, Bytes = <Self::u8s as Bytes>::Bytes> + Select<Self::u8s> + Select<Self::i8s> + Select<Self::mask8s>;
             type mask16s: SimdMask<i16, Self, Block = mask16x8<Self>, Bytes = <Self::u16s as Bytes>::Bytes> + Select<Self::u16s> + Select<Self::i16s> + Select<Self::mask16s>;
             type mask32s: SimdMask<i32, Self, Block = mask32x4<Self>, Bytes = <Self::u32s as Bytes>::Bytes>
                 + Select<Self::f32s> + Select<Self::u32s> + Select<Self::i32s> + Select<Self::mask32s>;
+            type mask64s: SimdMask<i64, Self, Block = mask64x2<Self>, Bytes = <Self::u64s as Bytes>::Bytes>
+                + Select<Self::u64s> + Select<Self::i64s> + Select<Self::mask64s>; // + Select<Self::f64s>
             fn level(self) -> Level;
 
             /// Call function with CPU features enabled.

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -611,6 +611,16 @@ pub(crate) fn handle_unzip(
         quote! { unsafe { #intrinsic::<#mask>(a.into(), b.into()).simd_into(self) } }
     } else {
         match vec_ty.scalar_bits {
+            64 => {
+                let op = if select_even { "lo" } else { "hi" };
+                let intrinsic = format_ident!("_mm_unpack{op}_epi64");
+
+                quote! {
+                    unsafe {
+                        #intrinsic(a.into(), b.into()).simd_into(self)
+                    }
+                }
+            }
             32 => {
                 let op = if select_even { "lo" } else { "hi" };
 

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -305,12 +305,9 @@ pub(crate) fn handle_compare(
                 quote! { a.into(), b.into() }
             };
 
-            let res = quote! {
+            quote! {
                 #cmp(#args)
-            };
-
-            let str = res.to_string();
-            res
+            }
         } else {
             arch.expr(method, vec_ty, &args)
         }

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -286,8 +286,9 @@ pub(crate) fn handle_compare(
 
                 #gt(#args)
             }
-        } else if vec_ty.scalar == ScalarType::Int {
+        } else if vec_ty.scalar == ScalarType::Int && vec_ty.scalar_bits == 64 && vec_ty.len == 2 {
             let gt = simple_intrinsic("cmpgt", vec_ty.scalar, vec_ty.scalar_bits, ty_bits);
+            // SSE4.2 only has signed GT for i64
             let args = if method == "simd_lt" {
                 quote! { b.into(), a.into() }
             } else {

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -386,6 +386,13 @@ fn mk_simd_impl(level: Level) -> TokenStream {
                             quote! { 2, 3, 6, 7 },
                             quote! { u32x4_shuffle },
                         ),
+                        64 => (
+                            quote! { 0, 2 },
+                            quote! { 1, 3 },
+                            quote! { 0, 1 },
+                            quote! { 2, 3 },
+                            quote! { u64x2_shuffle },
+                        ),
                         _ => panic!("unsupported scalar_bits"),
                     };
 
@@ -455,6 +462,7 @@ fn mk_simd_impl(level: Level) -> TokenStream {
                             quote! { 2, 6, 3, 7 },
                             quote! { u32x4_shuffle },
                         ),
+                        64 => (quote! { 0, 2 }, quote! { 1, 3 }, quote! { u64x2_shuffle }),
                         _ => panic!("unsupported scalar_bits"),
                     };
 

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -534,9 +534,12 @@ fn mk_simd_impl(level: Level) -> TokenStream {
             type i16s = i16x8<Self>;
             type u32s = u32x4<Self>;
             type i32s = i32x4<Self>;
+            type u64s = u64x2<Self>;
+            type i64s = i64x2<Self>;
             type mask8s = mask8x16<Self>;
             type mask16s = mask16x8<Self>;
             type mask32s = mask32x4<Self>;
+            type mask64s = mask64x2<Self>;
 
             #[inline(always)]
             fn level(self) -> Level {

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -12,7 +12,6 @@ use quote::{format_ident, quote};
 
 use crate::generic::scalar_binary;
 use crate::ops::valid_reinterpret;
-use crate::types::VecType;
 use crate::{
     arch::{Arch, wasm::Wasm},
     generic::{generic_combine, generic_op, generic_split},

--- a/fearless_simd_gen/src/types.rs
+++ b/fearless_simd_gen/src/types.rs
@@ -116,6 +116,8 @@ pub const SIMD_TYPES: &[VecType] = &[
     VecType::new(ScalarType::Mask, 32, 4),
     VecType::new(ScalarType::Float, 64, 2),
     VecType::new(ScalarType::Mask, 64, 2),
+    VecType::new(ScalarType::Int, 64, 2),
+    VecType::new(ScalarType::Unsigned, 64, 2),
     // 256 bit types
     VecType::new(ScalarType::Float, 32, 8),
     VecType::new(ScalarType::Int, 8, 32),
@@ -129,6 +131,8 @@ pub const SIMD_TYPES: &[VecType] = &[
     VecType::new(ScalarType::Mask, 32, 8),
     VecType::new(ScalarType::Float, 64, 4),
     VecType::new(ScalarType::Mask, 64, 4),
+    VecType::new(ScalarType::Int, 64, 4),
+    VecType::new(ScalarType::Unsigned, 64, 4),
     // 512 bit types
     VecType::new(ScalarType::Float, 32, 16),
     VecType::new(ScalarType::Int, 8, 64),
@@ -142,6 +146,8 @@ pub const SIMD_TYPES: &[VecType] = &[
     VecType::new(ScalarType::Mask, 32, 16),
     VecType::new(ScalarType::Float, 64, 8),
     VecType::new(ScalarType::Mask, 64, 8),
+    VecType::new(ScalarType::Int, 64, 8),
+    VecType::new(ScalarType::Unsigned, 64, 8),
 ];
 
 pub fn type_imports() -> TokenStream {

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -704,6 +704,20 @@ fn zip_high_u32x4<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn zip_low_u64x2<S: Simd>(simd: S) {
+    let a = u64x2::from_slice(simd, &[0, 1]);
+    let b = u64x2::from_slice(simd, &[4, 5]);
+    assert_eq!(simd.zip_low_u64x2(a, b).val, [0, 4]);
+}
+
+#[simd_test]
+fn zip_high_u64x2<S: Simd>(simd: S) {
+    let a = u64x2::from_slice(simd, &[0, 1]);
+    let b = u64x2::from_slice(simd, &[4, 5]);
+    assert_eq!(simd.zip_high_u64x2(a, b).val, [1, 5]);
+}
+
+#[simd_test]
 fn unzip_low_f32x4<S: Simd>(simd: S) {
     let a = f32x4::from_slice(simd, &[1.0, 2.0, 3.0, 4.0]);
     let b = f32x4::from_slice(simd, &[5.0, 6.0, 7.0, 8.0]);
@@ -869,6 +883,34 @@ fn unzip_high_u32x4<S: Simd>(simd: S) {
     let a = u32x4::from_slice(simd, &[1, 2, 3, 4]);
     let b = u32x4::from_slice(simd, &[5, 6, 7, 8]);
     assert_eq!(simd.unzip_high_u32x4(a, b).val, [2, 4, 6, 8]);
+}
+
+#[simd_test]
+fn unzip_low_i64x2<S: Simd>(simd: S) {
+    let a = i64x2::from_slice(simd, &[1, 2]);
+    let b = i64x2::from_slice(simd, &[3, 4]);
+    assert_eq!(simd.unzip_low_i64x2(a, b).val, [1, 3]);
+}
+
+#[simd_test]
+fn unzip_high_i64x2<S: Simd>(simd: S) {
+    let a = i64x2::from_slice(simd, &[1, 2]);
+    let b = i64x2::from_slice(simd, &[3, 4]);
+    assert_eq!(simd.unzip_high_i64x2(a, b).val, [2, 4]);
+}
+
+#[simd_test]
+fn unzip_low_u64x2<S: Simd>(simd: S) {
+    let a = u64x2::from_slice(simd, &[1, 2]);
+    let b = u64x2::from_slice(simd, &[3, 4]);
+    assert_eq!(simd.unzip_low_u64x2(a, b).val, [1, 3]);
+}
+
+#[simd_test]
+fn unzip_high_u64x2<S: Simd>(simd: S) {
+    let a = u64x2::from_slice(simd, &[1, 2]);
+    let b = u64x2::from_slice(simd, &[3, 4]);
+    assert_eq!(simd.unzip_high_u64x2(a, b).val, [2, 4]);
 }
 
 #[simd_test]
@@ -1354,11 +1396,18 @@ fn select_native_width_vectors<S: Simd>(simd: S) {
     assert_eq!(result_i16.as_slice(), vec![50i16; S::i16s::N]);
 
     // Test with native u64 vectors
-    let a_i16 = S::i64s::from_slice(simd, &vec![50i64; S::i64s::N]);
-    let b_i16 = S::i64s::from_slice(simd, &vec![-50i64; S::i64s::N]);
+    let a_i64 = S::i64s::from_slice(simd, &vec![50i64; S::i64s::N]);
+    let b_i64 = S::i64s::from_slice(simd, &vec![-50i64; S::i64s::N]);
+    let mask_i64 = S::mask64s::from_slice(simd, &vec![-1i64; S::mask64s::N]);
+    let result_i64 = mask_i64.select(a_i64, b_i64);
+    assert_eq!(result_i64.as_slice(), vec![50i64; S::i64s::N]);
+
+    // Test with native u64 vectors
+    let a_u64 = S::u64s::from_slice(simd, &vec![100u64; S::u64s::N]);
+    let b_u64 = S::u64s::from_slice(simd, &vec![200u64; S::u64s::N]);
     let mask_u64 = S::mask64s::from_slice(simd, &vec![-1i64; S::mask64s::N]);
-    let result_i16 = mask_u64.select(a_i16, b_i16);
-    assert_eq!(result_i16.as_slice(), vec![50i64; S::i64s::N]);
+    let result_u64 = mask_u64.select(a_u64, b_u64);
+    assert_eq!(result_u64.as_slice(), vec![100u64; S::u64s::N]);
 }
 
 #[simd_test]

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -1349,6 +1349,54 @@ fn simd_ge_i8x16<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn simd_ge_i64x2<S: Simd>(simd: S) {
+    let vals = i64x2::from_slice(simd, &[0, -45]);
+    let mask = vals.simd_ge(i64x2::splat(simd, -1));
+
+    assert_eq!(mask.val, [-1, 0]);
+}
+
+#[simd_test]
+fn simd_le_i64x2<S: Simd>(simd: S) {
+    let vals = i64x2::from_slice(simd, &[0, -45]);
+    let mask = vals.simd_le(i64x2::splat(simd, -1));
+
+    assert_eq!(mask.val, [0, -1]);
+}
+
+#[simd_test]
+fn simd_ge_u64x2<S: Simd>(simd: S) {
+    let vals = u64x2::from_slice(simd, &[0, 45]);
+    let mask = vals.simd_ge(u64x2::splat(simd, 45));
+
+    assert_eq!(mask.val, [0, -1]);
+}
+
+#[simd_test]
+fn simd_le_u64x2<S: Simd>(simd: S) {
+    let vals = u64x2::from_slice(simd, &[0, 45]);
+    let mask = vals.simd_le(u64x2::splat(simd, 45));
+
+    assert_eq!(mask.val, [-1, -1]);
+}
+
+#[simd_test]
+fn simd_lt_u64x2<S: Simd>(simd: S) {
+    let vals = u64x2::from_slice(simd, &[0, 45]);
+    let mask = vals.simd_lt(u64x2::splat(simd, 45));
+
+    assert_eq!(mask.val, [-1, 0]);
+}
+
+#[simd_test]
+fn simd_gt_u64x2<S: Simd>(simd: S) {
+    let vals = u64x2::from_slice(simd, &[0, 45]);
+    let mask = vals.simd_gt(u64x2::splat(simd, 45));
+
+    assert_eq!(mask.val, [0, 0]);
+}
+
+#[simd_test]
 fn select_native_width_vectors<S: Simd>(simd: S) {
     // Test with native f32 vectors
     let a_f32 = S::f32s::from_slice(simd, &vec![1.0f32; S::f32s::N]);

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -1397,6 +1397,22 @@ fn simd_gt_u64x2<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn simd_eq_u64x2<S: Simd>(simd: S) {
+    let vals = u64x2::from_slice(simd, &[45, 45]);
+    let mask = vals.simd_eq(u64x2::splat(simd, 45));
+
+    assert_eq!(mask.val, [-1, -1]);
+}
+
+#[simd_test]
+fn simd_eq_i64x2<S: Simd>(simd: S) {
+    let vals = i64x2::from_slice(simd, &[-3, -3]);
+    let mask = vals.simd_eq(i64x2::splat(simd, -3));
+
+    assert_eq!(mask.val, [-1, -1]);
+}
+
+#[simd_test]
 fn select_native_width_vectors<S: Simd>(simd: S) {
     // Test with native f32 vectors
     let a_f32 = S::f32s::from_slice(simd, &vec![1.0f32; S::f32s::N]);

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -1157,6 +1157,23 @@ fn select_mask32x4<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn select_u64x2<S: Simd>(simd: S) {
+    let mask = mask64x2::from_slice(simd, &[0, -1]);
+    let b = u64x2::from_slice(simd, &[100000, 200000]);
+    let c = u64x2::from_slice(simd, &[1000, 2000]);
+    assert_eq!(mask.select(b, c).val, [1000, 200000]);
+}
+
+#[simd_test]
+fn select_mask64x2<S: Simd>(simd: S) {
+    let mask = mask64x2::from_slice(simd, &[-1, 0]);
+    let b = mask64x2::from_slice(simd, &[-1, 42]);
+    let c = mask64x2::from_slice(simd, &[100, -1]);
+    let result: mask64x2<_> = mask.select(b, c);
+    assert_eq!(result.val, [-1, -1]);
+}
+
+#[simd_test]
 fn widen_u8x16<S: Simd>(simd: S) {
     let a = u8x16::from_slice(
         simd,

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -1357,17 +1357,17 @@ fn simd_ge_i64x2<S: Simd>(simd: S) {
 }
 
 #[simd_test]
-fn simd_le_i64x2<S: Simd>(simd: S) {
-    let vals = i64x2::from_slice(simd, &[0, -45]);
-    let mask = vals.simd_le(i64x2::splat(simd, -1));
+fn simd_ge_u64x2<S: Simd>(simd: S) {
+    let vals = u64x2::from_slice(simd, &[0, 45]);
+    let mask = vals.simd_ge(u64x2::splat(simd, 45));
 
     assert_eq!(mask.val, [0, -1]);
 }
 
 #[simd_test]
-fn simd_ge_u64x2<S: Simd>(simd: S) {
-    let vals = u64x2::from_slice(simd, &[0, 45]);
-    let mask = vals.simd_ge(u64x2::splat(simd, 45));
+fn simd_le_i64x2<S: Simd>(simd: S) {
+    let vals = i64x2::from_slice(simd, &[0, -45]);
+    let mask = vals.simd_le(i64x2::splat(simd, -1));
 
     assert_eq!(mask.val, [0, -1]);
 }
@@ -1389,11 +1389,27 @@ fn simd_lt_u64x2<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn simd_lt_i64x2<S: Simd>(simd: S) {
+    let vals = i64x2::from_slice(simd, &[0, -45]);
+    let mask = vals.simd_lt(i64x2::splat(simd, 0));
+
+    assert_eq!(mask.val, [0, -1]);
+}
+
+#[simd_test]
 fn simd_gt_u64x2<S: Simd>(simd: S) {
     let vals = u64x2::from_slice(simd, &[0, 45]);
     let mask = vals.simd_gt(u64x2::splat(simd, 45));
 
     assert_eq!(mask.val, [0, 0]);
+}
+
+#[simd_test]
+fn simd_gt_i64x2<S: Simd>(simd: S) {
+    let vals = i64x2::from_slice(simd, &[0, 45]);
+    let mask = vals.simd_gt(i64x2::splat(simd, 44));
+
+    assert_eq!(mask.val, [0, -1]);
 }
 
 #[simd_test]

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -1352,6 +1352,13 @@ fn select_native_width_vectors<S: Simd>(simd: S) {
     let b_i16 = S::i16s::from_slice(simd, &vec![-50i16; S::i16s::N]);
     let result_i16 = mask_u16.select(a_i16, b_i16);
     assert_eq!(result_i16.as_slice(), vec![50i16; S::i16s::N]);
+
+    // Test with native u64 vectors
+    let a_i16 = S::i64s::from_slice(simd, &vec![50i64; S::i64s::N]);
+    let b_i16 = S::i64s::from_slice(simd, &vec![-50i64; S::i64s::N]);
+    let mask_u64 = S::mask64s::from_slice(simd, &vec![-1i64; S::mask64s::N]);
+    let result_i16 = mask_u64.select(a_i16, b_i16);
+    assert_eq!(result_i16.as_slice(), vec![50i64; S::i64s::N]);
 }
 
 #[simd_test]

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -1504,7 +1504,7 @@ fn select_native_width_vectors<S: Simd>(simd: S) {
     let result_i16 = mask_u16.select(a_i16, b_i16);
     assert_eq!(result_i16.as_slice(), vec![50i16; S::i16s::N]);
 
-    // Test with native u64 vectors
+    // Test with native i64 vectors
     let a_i64 = S::i64s::from_slice(simd, &vec![50i64; S::i64s::N]);
     let b_i64 = S::i64s::from_slice(simd, &vec![-50i64; S::i64s::N]);
     let mask_i64 = S::mask64s::from_slice(simd, &vec![-1i64; S::mask64s::N]);

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -987,6 +987,12 @@ fn shr_u32x4<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn shr_u64x2<S: Simd>(simd: S) {
+    let a = u64x2::from_slice(simd, &[u64::MAX, 2147483648u64]);
+    assert_eq!((a >> 8).val, [u64::MAX >> 8, 8388608]);
+}
+
+#[simd_test]
 fn shrv_u32x4<S: Simd>(simd: S) {
     let a = u32x4::from_slice(simd, &[u32::MAX, 2147483648, 65536, 256]);
     assert_eq!(
@@ -1009,6 +1015,12 @@ fn shrv_u32x4_varied<S: Simd>(simd: S) {
 fn shl_u32x4<S: Simd>(simd: S) {
     let a = u32x4::from_slice(simd, &[0xFFFFFFFF, 0xFFFF, 0xFF, 0]);
     assert_eq!((a << 4).val, [0xFFFFFFF0, 0xFFFF0, 0xFF0, 0]);
+}
+
+#[simd_test]
+fn shl_u64x2<S: Simd>(simd: S) {
+    let a = u64x2::from_slice(simd, &[0xFFFFFFFFFFFFFFFu64, 0]);
+    assert_eq!((a << 4).val, [0xFFFFFFFFFFFFFFF0u64, 0]);
 }
 
 #[simd_test]


### PR DESCRIPTION
I began drafting out a basic 64-bit integer support.
A few tests has been added to assist development a few more are likely to be added.

I didn't check-in the generated code from `cargo run -p fearless_simd_gen` yet since i think its easier to review w/o.

Whats next:

1. test on other architectures than x86
2. Iron out undetected mistakes
3. Add more tests

This is tested with `cargo test -p fearless_simd_tests` and `RUSTFLAGS=-Ctarget-feature=+simd128 wasm-pack test --headless --firefox` (note: i couldn't get --chrome to work on my)

Both passes with the additional tests after generated code has been updated.