### PR TITLE
Update obsolete doc_auto_cfg feature to doc_cfg

### DIFF
--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -95,7 +95,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(non_camel_case_types, reason = "TODO")]
 #![expect(clippy::unused_unit, reason = "easier for code generation")]
 #![expect(


### PR DESCRIPTION
This broke CI; see https://github.com/rust-lang/rust/pull/138907.