### PR TITLE
Remove sentence fragment

### DIFF
--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -48,8 +48,7 @@
 //!
 //! Fearless SIMD relies heavily on Rust's inlining support to create functions which have the
 //! given target features enabled.
-//! As such, most functions which you write when using Fearless SIMD should have the `#[inline(always)]` attribute.
-//! This is required because in LLVM, functions with different target features cannot.
+//! As such, most functions which you write when using Fearless SIMD should have the `#[inline(always)]` attribute..
 //!
 //! <!--
 //! # Kernels vs not kernels


### PR DESCRIPTION
Fixes https://github.com/linebender/fearless_simd/issues/90

The fragment was trying to point to
https://doc.rust-lang.org/reference/attributes/codegen.html#r-attributes.codegen.target_feature.inline

But it was entirely backwards in that case anyway.