### PR TITLE
Add `f64s` and `mask64s` associated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This release has an [MSRV][] of 1.88.
 - All vector types now implement `Index` and `IndexMut`. ([#112][] by [@Ralith][])
 - 256-bit vector types now use native AVX2 intrinsics on supported platforms. ([#115][] by [@valadaptive][])
 - 8-bit integer multiplication is now implemented on x86. ([#115][] by [@valadaptive][])
+- New native-width associated types: `f64s` and `mask64s`. ([#125][] by [@valadaptive][])
 
 ### Fixed
 
@@ -116,6 +117,7 @@ No changelog was kept for this release.
 [#105]: https://github.com/linebender/fearless_simd/pull/105
 [#115]: https://github.com/linebender/fearless_simd/pull/115
 [#123]: https://github.com/linebender/fearless_simd/pull/123
+[#125]: https://github.com/linebender/fearless_simd/pull/125
 
 [Unreleased]: https://github.com/linebender/fearless_simd/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/linebender/fearless_simd/compare/v0.3.0...v0.2.0

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -36,6 +36,7 @@ impl Avx2 {
 impl Seal for Avx2 {}
 impl Simd for Avx2 {
     type f32s = f32x8<Self>;
+    type f64s = f64x4<Self>;
     type u8s = u8x32<Self>;
     type i8s = i8x32<Self>;
     type u16s = u16x16<Self>;
@@ -45,6 +46,7 @@ impl Simd for Avx2 {
     type mask8s = mask8x32<Self>;
     type mask16s = mask16x16<Self>;
     type mask32s = mask32x8<Self>;
+    type mask64s = mask64x4<Self>;
     #[inline(always)]
     fn level(self) -> Level {
         Level::Avx2(self)

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -72,6 +72,7 @@ impl Fallback {
 impl Seal for Fallback {}
 impl Simd for Fallback {
     type f32s = f32x4<Self>;
+    type f64s = f64x2<Self>;
     type u8s = u8x16<Self>;
     type i8s = i8x16<Self>;
     type u16s = u16x8<Self>;
@@ -81,6 +82,7 @@ impl Simd for Fallback {
     type mask8s = mask8x16<Self>;
     type mask16s = mask16x8<Self>;
     type mask32s = mask32x4<Self>;
+    type mask64s = mask64x2<Self>;
     #[inline(always)]
     fn level(self) -> Level {
         #[cfg(feature = "force_support_fallback")]

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -27,6 +27,7 @@ impl Neon {
 impl Seal for Neon {}
 impl Simd for Neon {
     type f32s = f32x4<Self>;
+    type f64s = f64x2<Self>;
     type u8s = u8x16<Self>;
     type i8s = i8x16<Self>;
     type u16s = u16x8<Self>;
@@ -36,6 +37,7 @@ impl Simd for Neon {
     type mask8s = mask8x16<Self>;
     type mask16s = mask16x8<Self>;
     type mask32s = mask32x4<Self>;
+    type mask64s = mask64x2<Self>;
     #[inline(always)]
     fn level(self) -> Level {
         Level::Neon(self)

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -23,6 +23,7 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
             Bytes = <Self::u32s as Bytes>::Bytes,
         > + SimdCvtFloat<Self::u32s>
         + SimdCvtFloat<Self::i32s>;
+    type f64s: SimdFloat<f64, Self, Block = f64x2<Self>, Mask = Self::mask64s>;
     type u8s: SimdInt<u8, Self, Block = u8x16<Self>, Mask = Self::mask8s>;
     type i8s: SimdInt<
             i8,
@@ -62,6 +63,9 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
         + Select<Self::u32s>
         + Select<Self::i32s>
         + Select<Self::mask32s>;
+    type mask64s: SimdMask<i64, Self, Block = mask64x2<Self>>
+        + Select<Self::f64s>
+        + Select<Self::mask64s>;
     fn level(self) -> Level;
     #[doc = r" Call function with CPU features enabled."]
     #[doc = r""]

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -36,6 +36,7 @@ impl Sse4_2 {
 impl Seal for Sse4_2 {}
 impl Simd for Sse4_2 {
     type f32s = f32x4<Self>;
+    type f64s = f64x2<Self>;
     type u8s = u8x16<Self>;
     type i8s = i8x16<Self>;
     type u16s = u16x8<Self>;
@@ -45,6 +46,7 @@ impl Simd for Sse4_2 {
     type mask8s = mask8x16<Self>;
     type mask16s = mask16x8<Self>;
     type mask32s = mask32x4<Self>;
+    type mask64s = mask64x2<Self>;
     #[inline(always)]
     fn level(self) -> Level {
         #[cfg(not(all(target_feature = "avx2", target_feature = "fma")))]

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -25,6 +25,7 @@ impl WasmSimd128 {
 impl Seal for WasmSimd128 {}
 impl Simd for WasmSimd128 {
     type f32s = f32x4<Self>;
+    type f64s = f64x2<Self>;
     type u8s = u8x16<Self>;
     type i8s = i8x16<Self>;
     type u16s = u16x8<Self>;
@@ -34,6 +35,7 @@ impl Simd for WasmSimd128 {
     type mask8s = mask8x16<Self>;
     type mask16s = mask16x8<Self>;
     type mask32s = mask32x4<Self>;
+    type mask64s = mask64x2<Self>;
     #[inline(always)]
     fn level(self) -> Level {
         Level::WasmSimd128(self)

--- a/fearless_simd_gen/src/mk_avx2.rs
+++ b/fearless_simd_gen/src/mk_avx2.rs
@@ -97,6 +97,7 @@ fn mk_simd_impl() -> TokenStream {
     quote! {
         impl Simd for #level_tok {
             type f32s = f32x8<Self>;
+            type f64s = f64x4<Self>;
             type u8s = u8x32<Self>;
             type i8s = i8x32<Self>;
             type u16s = u16x16<Self>;
@@ -106,6 +107,7 @@ fn mk_simd_impl() -> TokenStream {
             type mask8s = mask8x32<Self>;
             type mask16s = mask16x16<Self>;
             type mask32s = mask32x8<Self>;
+            type mask64s = mask64x4<Self>;
             #[inline(always)]
             fn level(self) -> Level {
                 Level::#level_tok(self)

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -385,6 +385,7 @@ fn mk_simd_impl() -> TokenStream {
     quote! {
         impl Simd for #level_tok {
             type f32s = f32x4<Self>;
+            type f64s = f64x2<Self>;
             type u8s = u8x16<Self>;
             type i8s = i8x16<Self>;
             type u16s = u16x8<Self>;
@@ -394,6 +395,7 @@ fn mk_simd_impl() -> TokenStream {
             type mask8s = mask8x16<Self>;
             type mask16s = mask16x8<Self>;
             type mask32s = mask32x4<Self>;
+            type mask64s = mask64x2<Self>;
             #[inline(always)]
             fn level(self) -> Level {
                 #[cfg(feature = "force_support_fallback")]

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -401,6 +401,7 @@ fn mk_simd_impl(level: Level) -> TokenStream {
     quote! {
         impl Simd for #level_tok {
             type f32s = f32x4<Self>;
+            type f64s = f64x2<Self>;
             type u8s = u8x16<Self>;
             type i8s = i8x16<Self>;
             type u16s = u16x8<Self>;
@@ -410,6 +411,7 @@ fn mk_simd_impl(level: Level) -> TokenStream {
             type mask8s = mask8x16<Self>;
             type mask16s = mask16x8<Self>;
             type mask32s = mask32x4<Self>;
+            type mask64s = mask64x2<Self>;
             #[inline(always)]
             fn level(self) -> Level {
                 Level::#level_tok(self)

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -32,6 +32,7 @@ pub(crate) fn mk_simd_trait() -> TokenStream {
         // TODO: Seal
         pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
             type f32s: SimdFloat<f32, Self, Block = f32x4<Self>, Mask = Self::mask32s, Bytes = <Self::u32s as Bytes>::Bytes> + SimdCvtFloat<Self::u32s> + SimdCvtFloat<Self::i32s>;
+            type f64s: SimdFloat<f64, Self, Block = f64x2<Self>, Mask = Self::mask64s>;
             type u8s: SimdInt<u8, Self, Block = u8x16<Self>, Mask = Self::mask8s>;
             type i8s: SimdInt<i8, Self, Block = i8x16<Self>, Mask = Self::mask8s, Bytes = <Self::u8s as Bytes>::Bytes> + core::ops::Neg<Output = Self::i8s>;
             type u16s: SimdInt<u16, Self, Block = u16x8<Self>, Mask = Self::mask16s>;
@@ -43,6 +44,7 @@ pub(crate) fn mk_simd_trait() -> TokenStream {
             type mask16s: SimdMask<i16, Self, Block = mask16x8<Self>, Bytes = <Self::u16s as Bytes>::Bytes> + Select<Self::u16s> + Select<Self::i16s> + Select<Self::mask16s>;
             type mask32s: SimdMask<i32, Self, Block = mask32x4<Self>, Bytes = <Self::u32s as Bytes>::Bytes>
                 + Select<Self::f32s> + Select<Self::u32s> + Select<Self::i32s> + Select<Self::mask32s>;
+            type mask64s: SimdMask<i64, Self, Block = mask64x2<Self>> + Select<Self::f64s> + Select<Self::mask64s>;
             fn level(self) -> Level;
 
             /// Call function with CPU features enabled.

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -96,6 +96,7 @@ fn mk_simd_impl() -> TokenStream {
     quote! {
         impl Simd for #level_tok {
             type f32s = f32x4<Self>;
+            type f64s = f64x2<Self>;
             type u8s = u8x16<Self>;
             type i8s = i8x16<Self>;
             type u16s = u16x8<Self>;
@@ -105,6 +106,7 @@ fn mk_simd_impl() -> TokenStream {
             type mask8s = mask8x16<Self>;
             type mask16s = mask16x8<Self>;
             type mask32s = mask32x4<Self>;
+            type mask64s = mask64x2<Self>;
             #[inline(always)]
             fn level(self) -> Level {
                 #[cfg(not(all(target_feature = "avx2", target_feature = "fma")))]

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -519,6 +519,7 @@ fn mk_simd_impl(level: Level) -> TokenStream {
     quote! {
         impl Simd for #level_tok {
             type f32s = f32x4<Self>;
+            type f64s = f64x2<Self>;
             type u8s = u8x16<Self>;
             type i8s = i8x16<Self>;
             type u16s = u16x8<Self>;
@@ -528,6 +529,7 @@ fn mk_simd_impl(level: Level) -> TokenStream {
             type mask8s = mask8x16<Self>;
             type mask16s = mask16x8<Self>;
             type mask32s = mask32x4<Self>;
+            type mask64s = mask64x2<Self>;
 
             #[inline(always)]
             fn level(self) -> Level {


### PR DESCRIPTION
Stacked on #123 since it touches the same code.

Adding 64-bit *integer* types is tricky because SSE4.2 and AVX2 are missing some important 64-bit operations, and I don't feel comfortable implementing those until #124 is addressed. However, we already have `mask64x[N]` and `f64x[N]` types.

The `f32s` associated type has a `Bytes = <Self::u32s as Bytes>::Bytes` constraint, which misled me into thinking that a float type *needs* an associated int type, but that constraint is only there to assert that the two share the same `Bytes` type.