### PR TITLE
Add f64<->f32 widening/narrowing conversions

### DIFF
--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -338,6 +338,16 @@ impl Simd for Fallback {
         result.simd_into(self)
     }
     #[inline(always)]
+    fn widen_f32x4(self, a: f32x4<Self>) -> f64x4<Self> {
+        [
+            a[0usize] as f64,
+            a[1usize] as f64,
+            a[2usize] as f64,
+            a[3usize] as f64,
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn reinterpret_f64_f32x4(self, a: f32x4<Self>) -> f64x2<Self> {
         f64x2 {
             val: bytemuck::cast(a.val),
@@ -3251,6 +3261,11 @@ impl Simd for Fallback {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
+    fn widen_f32x8(self, a: f32x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f64x4(self.widen_f32x4(a0), self.widen_f32x4(a1))
+    }
+    #[inline(always)]
     fn reinterpret_f64_f32x8(self, a: f32x8<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f64x2(
@@ -4684,6 +4699,16 @@ impl Simd for Fallback {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
+    fn narrow_f64x4(self, a: f64x4<Self>) -> f32x4<Self> {
+        [
+            a[0usize] as f32,
+            a[1usize] as f32,
+            a[2usize] as f32,
+            a[3usize] as f32,
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn reinterpret_f32_f64x4(self, a: f64x4<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f64x4(a);
         self.combine_f32x4(
@@ -4934,22 +4959,6 @@ impl Simd for Fallback {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn reinterpret_f64_f32x16(self, a: f32x16<Self>) -> f64x8<Self> {
-        let (a0, a1) = self.split_f32x16(a);
-        self.combine_f64x4(
-            self.reinterpret_f64_f32x8(a0),
-            self.reinterpret_f64_f32x8(a1),
-        )
-    }
-    #[inline(always)]
-    fn reinterpret_i32_f32x16(self, a: f32x16<Self>) -> i32x16<Self> {
-        let (a0, a1) = self.split_f32x16(a);
-        self.combine_i32x8(
-            self.reinterpret_i32_f32x8(a0),
-            self.reinterpret_i32_f32x8(a1),
-        )
-    }
-    #[inline(always)]
     fn load_interleaved_128_f32x16(self, src: &[f32; 16usize]) -> f32x16<Self> {
         [
             src[0usize],
@@ -4978,6 +4987,22 @@ impl Simd for Fallback {
             a[13usize], a[2usize], a[6usize], a[10usize], a[14usize], a[3usize], a[7usize],
             a[11usize], a[15usize],
         ];
+    }
+    #[inline(always)]
+    fn reinterpret_f64_f32x16(self, a: f32x16<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_f64x4(
+            self.reinterpret_f64_f32x8(a0),
+            self.reinterpret_f64_f32x8(a1),
+        )
+    }
+    #[inline(always)]
+    fn reinterpret_i32_f32x16(self, a: f32x16<Self>) -> i32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_i32x8(
+            self.reinterpret_i32_f32x8(a0),
+            self.reinterpret_i32_f32x8(a1),
+        )
     }
     #[inline(always)]
     fn reinterpret_u8_f32x16(self, a: f32x16<Self>) -> u8x64<Self> {
@@ -6487,6 +6512,11 @@ impl Simd for Fallback {
         b0.copy_from_slice(&a.val[0..4usize]);
         b1.copy_from_slice(&a.val[4usize..8usize]);
         (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn narrow_f64x8(self, a: f64x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f32x4(self.narrow_f64x4(a0), self.narrow_f64x4(a1))
     }
     #[inline(always)]
     fn reinterpret_f32_f64x8(self, a: f64x8<Self>) -> f32x16<Self> {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -184,6 +184,14 @@ impl Simd for Neon {
         result.simd_into(self)
     }
     #[inline(always)]
+    fn widen_f32x4(self, a: f32x4<Self>) -> f64x4<Self> {
+        unsafe {
+            let low = vcvt_f64_f32(vget_low_f32(a.into()));
+            let high = vcvt_high_f64_f32(a.into());
+            float64x2x2_t(low, high).simd_into(self)
+        }
+    }
+    #[inline(always)]
     fn reinterpret_f64_f32x4(self, a: f32x4<Self>) -> f64x2<Self> {
         unsafe { vreinterpretq_f64_f32(a.into()).simd_into(self) }
     }
@@ -1399,6 +1407,11 @@ impl Simd for Neon {
         b0.copy_from_slice(&a.val[0..4usize]);
         b1.copy_from_slice(&a.val[4usize..8usize]);
         (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn widen_f32x8(self, a: f32x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f64x4(self.widen_f32x4(a0), self.widen_f32x4(a1))
     }
     #[inline(always)]
     fn reinterpret_f64_f32x8(self, a: f32x8<Self>) -> f64x4<Self> {
@@ -2821,6 +2834,13 @@ impl Simd for Neon {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
+    fn narrow_f64x4(self, a: f64x4<Self>) -> f32x4<Self> {
+        unsafe {
+            let converted: float64x2x2_t = a.into();
+            vcvt_high_f32_f64(vcvt_f32_f64(converted.0), converted.1).simd_into(self)
+        }
+    }
+    #[inline(always)]
     fn reinterpret_f32_f64x4(self, a: f64x4<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f64x4(a);
         self.combine_f32x4(
@@ -3071,6 +3091,14 @@ impl Simd for Neon {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
+    fn load_interleaved_128_f32x16(self, src: &[f32; 16usize]) -> f32x16<Self> {
+        unsafe { vld4q_f32(src.as_ptr()).simd_into(self) }
+    }
+    #[inline(always)]
+    fn store_interleaved_128_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
+        unsafe { vst4q_f32(dest.as_mut_ptr(), a.into()) }
+    }
+    #[inline(always)]
     fn reinterpret_f64_f32x16(self, a: f32x16<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f64x4(
@@ -3085,14 +3113,6 @@ impl Simd for Neon {
             self.reinterpret_i32_f32x8(a0),
             self.reinterpret_i32_f32x8(a1),
         )
-    }
-    #[inline(always)]
-    fn load_interleaved_128_f32x16(self, src: &[f32; 16usize]) -> f32x16<Self> {
-        unsafe { vld4q_f32(src.as_ptr()).simd_into(self) }
-    }
-    #[inline(always)]
-    fn store_interleaved_128_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        unsafe { vst4q_f32(dest.as_mut_ptr(), a.into()) }
     }
     #[inline(always)]
     fn reinterpret_u8_f32x16(self, a: f32x16<Self>) -> u8x64<Self> {
@@ -4463,6 +4483,11 @@ impl Simd for Neon {
         b0.copy_from_slice(&a.val[0..4usize]);
         b1.copy_from_slice(&a.val[4usize..8usize]);
         (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn narrow_f64x8(self, a: f64x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f32x4(self.narrow_f64x4(a0), self.narrow_f64x4(a1))
     }
     #[inline(always)]
     fn reinterpret_f32_f64x8(self, a: f64x8<Self>) -> f32x16<Self> {

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -96,6 +96,7 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
     fn trunc_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
     fn select_f32x4(self, a: mask32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
     fn combine_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x8<Self>;
+    fn widen_f32x4(self, a: f32x4<Self>) -> f64x4<Self>;
     fn reinterpret_f64_f32x4(self, a: f32x4<Self>) -> f64x2<Self>;
     fn reinterpret_i32_f32x4(self, a: f32x4<Self>) -> i32x4<Self>;
     fn reinterpret_u8_f32x4(self, a: f32x4<Self>) -> u8x16<Self>;
@@ -374,6 +375,7 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
     fn select_f32x8(self, a: mask32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self>;
     fn combine_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x16<Self>;
     fn split_f32x8(self, a: f32x8<Self>) -> (f32x4<Self>, f32x4<Self>);
+    fn widen_f32x8(self, a: f32x8<Self>) -> f64x8<Self>;
     fn reinterpret_f64_f32x8(self, a: f32x8<Self>) -> f64x4<Self>;
     fn reinterpret_i32_f32x8(self, a: f32x8<Self>) -> i32x8<Self>;
     fn reinterpret_u8_f32x8(self, a: f32x8<Self>) -> u8x32<Self>;
@@ -619,6 +621,7 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
     fn select_f64x4(self, a: mask64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self>;
     fn combine_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x8<Self>;
     fn split_f64x4(self, a: f64x4<Self>) -> (f64x2<Self>, f64x2<Self>);
+    fn narrow_f64x4(self, a: f64x4<Self>) -> f32x4<Self>;
     fn reinterpret_f32_f64x4(self, a: f64x4<Self>) -> f32x8<Self>;
     fn splat_mask64x4(self, val: i64) -> mask64x4<Self>;
     fn not_mask64x4(self, a: mask64x4<Self>) -> mask64x4<Self>;
@@ -663,10 +666,10 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
     fn trunc_f32x16(self, a: f32x16<Self>) -> f32x16<Self>;
     fn select_f32x16(self, a: mask32x16<Self>, b: f32x16<Self>, c: f32x16<Self>) -> f32x16<Self>;
     fn split_f32x16(self, a: f32x16<Self>) -> (f32x8<Self>, f32x8<Self>);
-    fn reinterpret_f64_f32x16(self, a: f32x16<Self>) -> f64x8<Self>;
-    fn reinterpret_i32_f32x16(self, a: f32x16<Self>) -> i32x16<Self>;
     fn load_interleaved_128_f32x16(self, src: &[f32; 16usize]) -> f32x16<Self>;
     fn store_interleaved_128_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> ();
+    fn reinterpret_f64_f32x16(self, a: f32x16<Self>) -> f64x8<Self>;
+    fn reinterpret_i32_f32x16(self, a: f32x16<Self>) -> i32x16<Self>;
     fn reinterpret_u8_f32x16(self, a: f32x16<Self>) -> u8x64<Self>;
     fn reinterpret_u32_f32x16(self, a: f32x16<Self>) -> u32x16<Self>;
     fn cvt_u32_f32x16(self, a: f32x16<Self>) -> u32x16<Self>;
@@ -905,6 +908,7 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
     fn trunc_f64x8(self, a: f64x8<Self>) -> f64x8<Self>;
     fn select_f64x8(self, a: mask64x8<Self>, b: f64x8<Self>, c: f64x8<Self>) -> f64x8<Self>;
     fn split_f64x8(self, a: f64x8<Self>) -> (f64x4<Self>, f64x4<Self>);
+    fn narrow_f64x8(self, a: f64x8<Self>) -> f32x8<Self>;
     fn reinterpret_f32_f64x8(self, a: f64x8<Self>) -> f32x16<Self>;
     fn splat_mask64x8(self, val: i64) -> mask64x8<Self>;
     fn not_mask64x8(self, a: mask64x8<Self>) -> mask64x8<Self>;

--- a/fearless_simd_gen/src/mk_avx2.rs
+++ b/fearless_simd_gen/src/mk_avx2.rs
@@ -352,8 +352,8 @@ pub(crate) fn handle_widen_narrow(
         }
         "narrow" => {
             let dst_width = t.n_bits();
-            match (dst_width, vec_ty.n_bits()) {
-                (128, 256) => {
+            match (vec_ty.scalar, dst_width, vec_ty.n_bits()) {
+                (ScalarType::Unsigned, 128, 256) => {
                     let mask = match t.scalar_bits {
                         8 => {
                             quote! { 0, 2, 4, 6, 8, 10, 12, 14, -1, -1, -1, -1, -1, -1, -1, -1 }
@@ -371,7 +371,14 @@ pub(crate) fn handle_widen_narrow(
                         }
                     }
                 }
-                (256, 512) => {
+                (ScalarType::Float, 128, 256) => {
+                    quote! {
+                        unsafe {
+                            _mm256_cvtpd_ps(a.into()).simd_into(self)
+                        }
+                    }
+                }
+                (ScalarType::Unsigned, 256, 512) => {
                     let mask = set1_intrinsic(&VecType::new(
                         vec_ty.scalar,
                         vec_ty.scalar_bits,
@@ -395,6 +402,17 @@ pub(crate) fn handle_widen_narrow(
                             // properly afterwards.
                             let result = _mm256_permute4x64_epi64::<0b_11_01_10_00>(#pack(lo_masked, hi_masked));
                             result.simd_into(self)
+                        }
+                    }
+                }
+                (ScalarType::Float, 256, 512) => {
+                    let split = format_ident!("split_{}", vec_ty.rust_name());
+                    quote! {
+                        let (a, b) = self.#split(a);
+                        unsafe {
+                            let lo = _mm256_cvtpd_ps(a.into());
+                            let hi = _mm256_cvtpd_ps(b.into());
+                            _mm256_setr_m128(lo, hi).simd_into(self)
                         }
                     }
                 }

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -348,6 +348,23 @@ pub(crate) fn handle_widen_narrow(
                 }
                 .rust_name()
             );
+            let shifted = if vec_ty.scalar == ScalarType::Float {
+                let to_ints = cast_ident(
+                    ScalarType::Float,
+                    ScalarType::Int,
+                    vec_ty.scalar_bits,
+                    vec_ty.n_bits(),
+                );
+                let from_ints = cast_ident(
+                    ScalarType::Int,
+                    ScalarType::Float,
+                    vec_ty.scalar_bits,
+                    vec_ty.n_bits(),
+                );
+                quote! { #from_ints(_mm_srli_si128::<8>(#to_ints(raw))) }
+            } else {
+                quote! { _mm_srli_si128::<8>(raw) }
+            };
             quote! {
                 #method_sig {
                     unsafe {
@@ -355,37 +372,55 @@ pub(crate) fn handle_widen_narrow(
                         let high = #extend(raw).simd_into(self);
                         // Shift by 8 since we want to get the higher part into the
                         // lower position.
-                        let low = #extend(_mm_srli_si128::<8>(raw)).simd_into(self);
+                        let low = #extend(#shifted).simd_into(self);
                         self.#combine(high, low)
                     }
                 }
             }
         }
         "narrow" => {
-            let mask = set1_intrinsic(&VecType::new(
-                vec_ty.scalar,
-                vec_ty.scalar_bits,
-                vec_ty.len / 2,
-            ));
-            let pack = pack_intrinsic(
-                vec_ty.scalar_bits,
-                matches!(vec_ty.scalar, ScalarType::Int),
-                t.n_bits(),
-            );
-            let split = format_ident!("split_{}", vec_ty.rust_name());
-            quote! {
-                #method_sig {
-                    let (a, b) = self.#split(a);
-                    unsafe {
-                        // Note that SSE4.2 only has an intrinsic for saturating cast,
-                        // but not wrapping.
-                        let mask = #mask(0xFF);
-                        let lo_masked = _mm_and_si128(a.into(), mask);
-                        let hi_masked = _mm_and_si128(b.into(), mask);
-                        let result = #pack(lo_masked, hi_masked);
-                        result.simd_into(self)
+            match (vec_ty.scalar, t.n_bits(), vec_ty.n_bits()) {
+                (ScalarType::Unsigned, 128, 256) => {
+                    let mask = set1_intrinsic(&VecType::new(
+                        vec_ty.scalar,
+                        vec_ty.scalar_bits,
+                        vec_ty.len / 2,
+                    ));
+                    let pack = pack_intrinsic(
+                        vec_ty.scalar_bits,
+                        matches!(vec_ty.scalar, ScalarType::Int),
+                        t.n_bits(),
+                    );
+                    let split = format_ident!("split_{}", vec_ty.rust_name());
+                    quote! {
+                        #method_sig {
+                            let (a, b) = self.#split(a);
+                            unsafe {
+                                // Note that SSE4.2 only has an intrinsic for saturating cast,
+                                // but not wrapping.
+                                let mask = #mask(0xFF);
+                                let lo_masked = _mm_and_si128(a.into(), mask);
+                                let hi_masked = _mm_and_si128(b.into(), mask);
+                                let result = #pack(lo_masked, hi_masked);
+                                result.simd_into(self)
+                            }
+                        }
                     }
                 }
+                (ScalarType::Float, 128, 256) => {
+                    let split = format_ident!("split_{}", vec_ty.rust_name());
+                    quote! {
+                        #method_sig {
+                            let (a, b) = self.#split(a);
+                            unsafe {
+                                let lo = _mm_cvtpd_ps(a.into());
+                                let hi = _mm_cvtpd_ps(b.into());
+                                _mm_movelh_ps(lo, hi).simd_into(self)
+                            }
+                        }
+                    }
+                }
+                _ => unimplemented!(),
             }
         }
         _ => unreachable!(),

--- a/fearless_simd_gen/src/types.rs
+++ b/fearless_simd_gen/src/types.rs
@@ -74,27 +74,19 @@ impl VecType {
     }
 
     pub fn widened(&self) -> Option<VecType> {
-        if matches!(self.scalar, ScalarType::Mask | ScalarType::Float)
-            || self.n_bits() > 256
-            || self.scalar_bits != 8
-        {
-            return None;
+        match (self.scalar, self.n_bits(), self.scalar_bits) {
+            (ScalarType::Unsigned, 128 | 256, 8) => Some(Self::new(self.scalar, 16, self.len)),
+            (ScalarType::Float, 128 | 256, 32) => Some(Self::new(self.scalar, 64, self.len)),
+            _ => None,
         }
-
-        let scalar_bits = self.scalar_bits * 2;
-        Some(Self::new(self.scalar, scalar_bits, self.len))
     }
 
     pub fn narrowed(&self) -> Option<VecType> {
-        if matches!(self.scalar, ScalarType::Mask | ScalarType::Float)
-            || self.n_bits() < 256
-            || self.scalar_bits != 16
-        {
-            return None;
+        match (self.scalar, self.n_bits(), self.scalar_bits) {
+            (ScalarType::Unsigned, 256 | 512, 16) => Some(Self::new(self.scalar, 8, self.len)),
+            (ScalarType::Float, 256 | 512, 64) => Some(Self::new(self.scalar, 32, self.len)),
+            _ => None,
         }
-
-        let scalar_bits = self.scalar_bits / 2;
-        Some(Self::new(self.scalar, scalar_bits, self.len))
     }
 
     pub fn mask_ty(&self) -> Self {

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -9,6 +9,10 @@
     clippy::unseparated_literal_suffix,
     reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
 )]
+#![expect(
+    clippy::approx_constant,
+    reason = "these constants are good test vectors"
+)]
 
 //! Tests for `fearless_simd`.
 
@@ -2376,6 +2380,71 @@ fn narrow_u16x32<S: Simd>(simd: S) {
         [
             0, 1, 127, 128, 255, 0, 44, 232, 128, 192, 224, 240, 248, 252, 254, 255, 100, 200, 255,
             0, 0, 0, 0, 0, 0, 0, 0, 255, 0, 1, 2, 3
+        ]
+    );
+}
+
+#[simd_test]
+fn widen_f32x4<S: Simd>(simd: S) {
+    let a = f32x4::from_slice(simd, &[1.0, -2.5, 3.14159, 0.0]);
+    assert_eq!(simd.widen_f32x4(a).val, [1.0, -2.5, 3.141590118408203, 0.0]);
+}
+
+#[simd_test]
+fn widen_f32x8<S: Simd>(simd: S) {
+    let a = f32x8::from_slice(
+        simd,
+        &[1.0, -2.5, 3.14159, 0.0, 100.25, -0.5, f32::MAX, f32::MIN],
+    );
+    let result = simd.widen_f32x8(a);
+    assert_eq!(
+        result.val,
+        [
+            1.0,
+            -2.5,
+            3.141590118408203,
+            0.0,
+            100.25,
+            -0.5,
+            f32::MAX as f64,
+            f32::MIN as f64
+        ]
+    );
+}
+
+#[simd_test]
+fn narrow_f64x4<S: Simd>(simd: S) {
+    let a = f64x4::from_slice(simd, &[1.0, -2.5, 3.14159265358979, 0.0]);
+    assert_eq!(simd.narrow_f64x4(a).val, [1.0, -2.5, 3.1415927, 0.0]);
+}
+
+#[simd_test]
+fn narrow_f64x8<S: Simd>(simd: S) {
+    let a = f64x8::from_slice(
+        simd,
+        &[
+            1.0,
+            -2.5,
+            3.14159265358979,
+            0.0,
+            100.25,
+            -0.5,
+            f64::MAX,
+            f64::MIN,
+        ],
+    );
+    let result = simd.narrow_f64x8(a);
+    assert_eq!(
+        result.val,
+        [
+            1.0,
+            -2.5,
+            3.1415927,
+            0.0,
+            100.25,
+            -0.5,
+            f32::INFINITY,
+            f32::NEG_INFINITY
         ]
     );
 }


### PR DESCRIPTION
These were requested in [#simd > Quickly deinterleaving the underlying Simd arrays?](https://xi.zulipchat.com/#narrow/channel/514230-simd/topic/Quickly.20deinterleaving.20the.20underlying.20Simd.20arrays.3F/with/555683403), and seem useful.

They are a bit unusual in Neon, which has specific instructions for converting the low and high halves (and combining the two).

Due to some rearrangement and cleanup of the code generation, the reinterpret ops have been moved around a bit. They haven't been changed at all.