### PR TITLE
Implement `core::ops::Not` for integer types

### DIFF
--- a/fearless_simd/src/generated/ops.rs
+++ b/fearless_simd/src/generated/ops.rs
@@ -354,6 +354,13 @@ impl<S: Simd> core::ops::BitXor<i8x16<S>> for i8 {
         rhs.simd.xor_i8x16(self.simd_into(rhs.simd), rhs)
     }
 }
+impl<S: Simd> core::ops::Not for i8x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_i8x16(self)
+    }
+}
 impl<S: Simd> core::ops::Shl<u32> for i8x16<S> {
     type Output = Self;
     #[inline(always)]
@@ -589,6 +596,13 @@ impl<S: Simd> core::ops::BitXor<u8x16<S>> for u8 {
     #[inline(always)]
     fn bitxor(self, rhs: u8x16<S>) -> Self::Output {
         rhs.simd.xor_u8x16(self.simd_into(rhs.simd), rhs)
+    }
+}
+impl<S: Simd> core::ops::Not for u8x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_u8x16(self)
     }
 }
 impl<S: Simd> core::ops::Shl<u32> for u8x16<S> {
@@ -941,6 +955,13 @@ impl<S: Simd> core::ops::BitXor<i16x8<S>> for i16 {
         rhs.simd.xor_i16x8(self.simd_into(rhs.simd), rhs)
     }
 }
+impl<S: Simd> core::ops::Not for i16x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_i16x8(self)
+    }
+}
 impl<S: Simd> core::ops::Shl<u32> for i16x8<S> {
     type Output = Self;
     #[inline(always)]
@@ -1176,6 +1197,13 @@ impl<S: Simd> core::ops::BitXor<u16x8<S>> for u16 {
     #[inline(always)]
     fn bitxor(self, rhs: u16x8<S>) -> Self::Output {
         rhs.simd.xor_u16x8(self.simd_into(rhs.simd), rhs)
+    }
+}
+impl<S: Simd> core::ops::Not for u16x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_u16x8(self)
     }
 }
 impl<S: Simd> core::ops::Shl<u32> for u16x8<S> {
@@ -1528,6 +1556,13 @@ impl<S: Simd> core::ops::BitXor<i32x4<S>> for i32 {
         rhs.simd.xor_i32x4(self.simd_into(rhs.simd), rhs)
     }
 }
+impl<S: Simd> core::ops::Not for i32x4<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_i32x4(self)
+    }
+}
 impl<S: Simd> core::ops::Shl<u32> for i32x4<S> {
     type Output = Self;
     #[inline(always)]
@@ -1763,6 +1798,13 @@ impl<S: Simd> core::ops::BitXor<u32x4<S>> for u32 {
     #[inline(always)]
     fn bitxor(self, rhs: u32x4<S>) -> Self::Output {
         rhs.simd.xor_u32x4(self.simd_into(rhs.simd), rhs)
+    }
+}
+impl<S: Simd> core::ops::Not for u32x4<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_u32x4(self)
     }
 }
 impl<S: Simd> core::ops::Shl<u32> for u32x4<S> {
@@ -2499,6 +2541,13 @@ impl<S: Simd> core::ops::BitXor<i8x32<S>> for i8 {
         rhs.simd.xor_i8x32(self.simd_into(rhs.simd), rhs)
     }
 }
+impl<S: Simd> core::ops::Not for i8x32<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_i8x32(self)
+    }
+}
 impl<S: Simd> core::ops::Shl<u32> for i8x32<S> {
     type Output = Self;
     #[inline(always)]
@@ -2734,6 +2783,13 @@ impl<S: Simd> core::ops::BitXor<u8x32<S>> for u8 {
     #[inline(always)]
     fn bitxor(self, rhs: u8x32<S>) -> Self::Output {
         rhs.simd.xor_u8x32(self.simd_into(rhs.simd), rhs)
+    }
+}
+impl<S: Simd> core::ops::Not for u8x32<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_u8x32(self)
     }
 }
 impl<S: Simd> core::ops::Shl<u32> for u8x32<S> {
@@ -3086,6 +3142,13 @@ impl<S: Simd> core::ops::BitXor<i16x16<S>> for i16 {
         rhs.simd.xor_i16x16(self.simd_into(rhs.simd), rhs)
     }
 }
+impl<S: Simd> core::ops::Not for i16x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_i16x16(self)
+    }
+}
 impl<S: Simd> core::ops::Shl<u32> for i16x16<S> {
     type Output = Self;
     #[inline(always)]
@@ -3321,6 +3384,13 @@ impl<S: Simd> core::ops::BitXor<u16x16<S>> for u16 {
     #[inline(always)]
     fn bitxor(self, rhs: u16x16<S>) -> Self::Output {
         rhs.simd.xor_u16x16(self.simd_into(rhs.simd), rhs)
+    }
+}
+impl<S: Simd> core::ops::Not for u16x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_u16x16(self)
     }
 }
 impl<S: Simd> core::ops::Shl<u32> for u16x16<S> {
@@ -3673,6 +3743,13 @@ impl<S: Simd> core::ops::BitXor<i32x8<S>> for i32 {
         rhs.simd.xor_i32x8(self.simd_into(rhs.simd), rhs)
     }
 }
+impl<S: Simd> core::ops::Not for i32x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_i32x8(self)
+    }
+}
 impl<S: Simd> core::ops::Shl<u32> for i32x8<S> {
     type Output = Self;
     #[inline(always)]
@@ -3908,6 +3985,13 @@ impl<S: Simd> core::ops::BitXor<u32x8<S>> for u32 {
     #[inline(always)]
     fn bitxor(self, rhs: u32x8<S>) -> Self::Output {
         rhs.simd.xor_u32x8(self.simd_into(rhs.simd), rhs)
+    }
+}
+impl<S: Simd> core::ops::Not for u32x8<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_u32x8(self)
     }
 }
 impl<S: Simd> core::ops::Shl<u32> for u32x8<S> {
@@ -4644,6 +4728,13 @@ impl<S: Simd> core::ops::BitXor<i8x64<S>> for i8 {
         rhs.simd.xor_i8x64(self.simd_into(rhs.simd), rhs)
     }
 }
+impl<S: Simd> core::ops::Not for i8x64<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_i8x64(self)
+    }
+}
 impl<S: Simd> core::ops::Shl<u32> for i8x64<S> {
     type Output = Self;
     #[inline(always)]
@@ -4879,6 +4970,13 @@ impl<S: Simd> core::ops::BitXor<u8x64<S>> for u8 {
     #[inline(always)]
     fn bitxor(self, rhs: u8x64<S>) -> Self::Output {
         rhs.simd.xor_u8x64(self.simd_into(rhs.simd), rhs)
+    }
+}
+impl<S: Simd> core::ops::Not for u8x64<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_u8x64(self)
     }
 }
 impl<S: Simd> core::ops::Shl<u32> for u8x64<S> {
@@ -5231,6 +5329,13 @@ impl<S: Simd> core::ops::BitXor<i16x32<S>> for i16 {
         rhs.simd.xor_i16x32(self.simd_into(rhs.simd), rhs)
     }
 }
+impl<S: Simd> core::ops::Not for i16x32<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_i16x32(self)
+    }
+}
 impl<S: Simd> core::ops::Shl<u32> for i16x32<S> {
     type Output = Self;
     #[inline(always)]
@@ -5466,6 +5571,13 @@ impl<S: Simd> core::ops::BitXor<u16x32<S>> for u16 {
     #[inline(always)]
     fn bitxor(self, rhs: u16x32<S>) -> Self::Output {
         rhs.simd.xor_u16x32(self.simd_into(rhs.simd), rhs)
+    }
+}
+impl<S: Simd> core::ops::Not for u16x32<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_u16x32(self)
     }
 }
 impl<S: Simd> core::ops::Shl<u32> for u16x32<S> {
@@ -5818,6 +5930,13 @@ impl<S: Simd> core::ops::BitXor<i32x16<S>> for i32 {
         rhs.simd.xor_i32x16(self.simd_into(rhs.simd), rhs)
     }
 }
+impl<S: Simd> core::ops::Not for i32x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_i32x16(self)
+    }
+}
 impl<S: Simd> core::ops::Shl<u32> for i32x16<S> {
     type Output = Self;
     #[inline(always)]
@@ -6053,6 +6172,13 @@ impl<S: Simd> core::ops::BitXor<u32x16<S>> for u32 {
     #[inline(always)]
     fn bitxor(self, rhs: u32x16<S>) -> Self::Output {
         rhs.simd.xor_u32x16(self.simd_into(rhs.simd), rhs)
+    }
+}
+impl<S: Simd> core::ops::Not for u32x16<S> {
+    type Output = Self;
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        self.simd.not_u32x16(self)
     }
 }
 impl<S: Simd> core::ops::Shl<u32> for u32x16<S> {

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -1013,6 +1013,7 @@ pub trait SimdInt<Element: SimdElement, S: Simd>:
     + core::ops::MulAssign
     + core::ops::Mul<Element, Output = Self>
     + core::ops::MulAssign<Element>
+    + core::ops::Not<Output = Self>
     + core::ops::BitAnd<Output = Self>
     + core::ops::BitAndAssign
     + core::ops::BitAnd<Element, Output = Self>

--- a/fearless_simd_gen/src/mk_ops.rs
+++ b/fearless_simd_gen/src/mk_ops.rs
@@ -14,8 +14,8 @@ pub(crate) fn mk_ops() -> TokenStream {
     for ty in SIMD_TYPES {
         let ops = match ty.scalar {
             ScalarType::Float => &["neg", "add", "sub", "mul", "div"][..],
-            ScalarType::Int => &["neg", "add", "sub", "mul", "and", "or", "xor"],
-            ScalarType::Unsigned => &["add", "sub", "mul", "and", "or", "xor"],
+            ScalarType::Int => &["neg", "add", "sub", "mul", "and", "or", "xor", "not"],
+            ScalarType::Unsigned => &["add", "sub", "mul", "and", "or", "xor", "not"],
             ScalarType::Mask => &["and", "or", "xor", "not"],
         };
         let simd = ty.rust();

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -138,6 +138,7 @@ fn mk_simd_int() -> TokenStream {
             + core::ops::MulAssign
             + core::ops::Mul<Element, Output = Self>
             + core::ops::MulAssign<Element>
+            + core::ops::Not<Output = Self>
             + core::ops::BitAnd<Output = Self>
             + core::ops::BitAndAssign
             + core::ops::BitAnd<Element, Output = Self>


### PR DESCRIPTION
I don't know if there's a reason this wasn't implemented previously.