### PR TITLE
Constrain `Output` type for indexing ops

### DIFF
--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -927,8 +927,8 @@ pub trait SimdBase<Element: SimdElement, S: Simd>:
     + 'static
     + crate::Bytes
     + SimdFrom<Element, S>
-    + core::ops::Index<usize>
-    + core::ops::IndexMut<usize>
+    + core::ops::Index<usize, Output = Element>
+    + core::ops::IndexMut<usize, Output = Element>
 {
     const N: usize;
     #[doc = r" A SIMD vector mask with the same number of elements."]

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -64,7 +64,7 @@ fn mk_simd_base() -> TokenStream {
         pub trait SimdBase<Element: SimdElement, S: Simd>:
             Copy + Sync + Send + 'static
             + crate::Bytes + SimdFrom<Element, S>
-            + core::ops::Index<usize> + core::ops::IndexMut<usize>
+            + core::ops::Index<usize, Output = Element> + core::ops::IndexMut<usize, Output = Element>
         {
             const N: usize;
             /// A SIMD vector mask with the same number of elements.


### PR DESCRIPTION
An oversight from #112: we can't currently use indexing ops in the native-width associated types (`f32s`, etc.) because we never specified their output type. This PR fixes that.