### PR TITLE
Clean up method signature codegen

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -3099,8 +3099,8 @@ impl Simd for Avx2 {
         }
     }
     #[inline(always)]
-    fn splat_f32x16(self, a: f32) -> f32x16<Self> {
-        let half = self.splat_f32x8(a);
+    fn splat_f32x16(self, val: f32) -> f32x16<Self> {
+        let half = self.splat_f32x8(val);
         self.combine_f32x8(half, half)
     }
     #[inline(always)]
@@ -3374,8 +3374,8 @@ impl Simd for Avx2 {
         self.combine_i32x8(self.cvt_i32_f32x8(a0), self.cvt_i32_f32x8(a1))
     }
     #[inline(always)]
-    fn splat_i8x64(self, a: i8) -> i8x64<Self> {
-        let half = self.splat_i8x32(a);
+    fn splat_i8x64(self, val: i8) -> i8x64<Self> {
+        let half = self.splat_i8x32(val);
         self.combine_i8x32(half, half)
     }
     #[inline(always)]
@@ -3420,14 +3420,14 @@ impl Simd for Avx2 {
         self.combine_i8x32(self.not_i8x32(a0), self.not_i8x32(a1))
     }
     #[inline(always)]
-    fn shl_i8x64(self, a: i8x64<Self>, b: u32) -> i8x64<Self> {
+    fn shl_i8x64(self, a: i8x64<Self>, shift: u32) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
-        self.combine_i8x32(self.shl_i8x32(a0, b), self.shl_i8x32(a1, b))
+        self.combine_i8x32(self.shl_i8x32(a0, shift), self.shl_i8x32(a1, shift))
     }
     #[inline(always)]
-    fn shr_i8x64(self, a: i8x64<Self>, b: u32) -> i8x64<Self> {
+    fn shr_i8x64(self, a: i8x64<Self>, shift: u32) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
-        self.combine_i8x32(self.shr_i8x32(a0, b), self.shr_i8x32(a1, b))
+        self.combine_i8x32(self.shr_i8x32(a0, shift), self.shr_i8x32(a1, shift))
     }
     #[inline(always)]
     fn shrv_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -3535,8 +3535,8 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
-    fn splat_u8x64(self, a: u8) -> u8x64<Self> {
-        let half = self.splat_u8x32(a);
+    fn splat_u8x64(self, val: u8) -> u8x64<Self> {
+        let half = self.splat_u8x32(val);
         self.combine_u8x32(half, half)
     }
     #[inline(always)]
@@ -3581,14 +3581,14 @@ impl Simd for Avx2 {
         self.combine_u8x32(self.not_u8x32(a0), self.not_u8x32(a1))
     }
     #[inline(always)]
-    fn shl_u8x64(self, a: u8x64<Self>, b: u32) -> u8x64<Self> {
+    fn shl_u8x64(self, a: u8x64<Self>, shift: u32) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
-        self.combine_u8x32(self.shl_u8x32(a0, b), self.shl_u8x32(a1, b))
+        self.combine_u8x32(self.shl_u8x32(a0, shift), self.shl_u8x32(a1, shift))
     }
     #[inline(always)]
-    fn shr_u8x64(self, a: u8x64<Self>, b: u32) -> u8x64<Self> {
+    fn shr_u8x64(self, a: u8x64<Self>, shift: u32) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
-        self.combine_u8x32(self.shr_u8x32(a0, b), self.shr_u8x32(a1, b))
+        self.combine_u8x32(self.shr_u8x32(a0, shift), self.shr_u8x32(a1, shift))
     }
     #[inline(always)]
     fn shrv_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -3741,8 +3741,8 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
-    fn splat_mask8x64(self, a: i8) -> mask8x64<Self> {
-        let half = self.splat_mask8x32(a);
+    fn splat_mask8x64(self, val: i8) -> mask8x64<Self> {
+        let half = self.splat_mask8x32(val);
         self.combine_mask8x32(half, half)
     }
     #[inline(always)]
@@ -3818,8 +3818,8 @@ impl Simd for Avx2 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i16x32(self, a: i16) -> i16x32<Self> {
-        let half = self.splat_i16x16(a);
+    fn splat_i16x32(self, val: i16) -> i16x32<Self> {
+        let half = self.splat_i16x16(val);
         self.combine_i16x16(half, half)
     }
     #[inline(always)]
@@ -3864,14 +3864,14 @@ impl Simd for Avx2 {
         self.combine_i16x16(self.not_i16x16(a0), self.not_i16x16(a1))
     }
     #[inline(always)]
-    fn shl_i16x32(self, a: i16x32<Self>, b: u32) -> i16x32<Self> {
+    fn shl_i16x32(self, a: i16x32<Self>, shift: u32) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
-        self.combine_i16x16(self.shl_i16x16(a0, b), self.shl_i16x16(a1, b))
+        self.combine_i16x16(self.shl_i16x16(a0, shift), self.shl_i16x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_i16x32(self, a: i16x32<Self>, b: u32) -> i16x32<Self> {
+    fn shr_i16x32(self, a: i16x32<Self>, shift: u32) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
-        self.combine_i16x16(self.shr_i16x16(a0, b), self.shr_i16x16(a1, b))
+        self.combine_i16x16(self.shr_i16x16(a0, shift), self.shr_i16x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -3988,8 +3988,8 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
-    fn splat_u16x32(self, a: u16) -> u16x32<Self> {
-        let half = self.splat_u16x16(a);
+    fn splat_u16x32(self, val: u16) -> u16x32<Self> {
+        let half = self.splat_u16x16(val);
         self.combine_u16x16(half, half)
     }
     #[inline(always)]
@@ -4034,14 +4034,14 @@ impl Simd for Avx2 {
         self.combine_u16x16(self.not_u16x16(a0), self.not_u16x16(a1))
     }
     #[inline(always)]
-    fn shl_u16x32(self, a: u16x32<Self>, b: u32) -> u16x32<Self> {
+    fn shl_u16x32(self, a: u16x32<Self>, shift: u32) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
-        self.combine_u16x16(self.shl_u16x16(a0, b), self.shl_u16x16(a1, b))
+        self.combine_u16x16(self.shl_u16x16(a0, shift), self.shl_u16x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_u16x32(self, a: u16x32<Self>, b: u32) -> u16x32<Self> {
+    fn shr_u16x32(self, a: u16x32<Self>, shift: u32) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
-        self.combine_u16x16(self.shr_u16x16(a0, b), self.shr_u16x16(a1, b))
+        self.combine_u16x16(self.shr_u16x16(a0, shift), self.shr_u16x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -4221,8 +4221,8 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
-    fn splat_mask16x32(self, a: i16) -> mask16x32<Self> {
-        let half = self.splat_mask16x16(a);
+    fn splat_mask16x32(self, val: i16) -> mask16x32<Self> {
+        let half = self.splat_mask16x16(val);
         self.combine_mask16x16(half, half)
     }
     #[inline(always)]
@@ -4301,8 +4301,8 @@ impl Simd for Avx2 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i32x16(self, a: i32) -> i32x16<Self> {
-        let half = self.splat_i32x8(a);
+    fn splat_i32x16(self, val: i32) -> i32x16<Self> {
+        let half = self.splat_i32x8(val);
         self.combine_i32x8(half, half)
     }
     #[inline(always)]
@@ -4347,14 +4347,14 @@ impl Simd for Avx2 {
         self.combine_i32x8(self.not_i32x8(a0), self.not_i32x8(a1))
     }
     #[inline(always)]
-    fn shl_i32x16(self, a: i32x16<Self>, b: u32) -> i32x16<Self> {
+    fn shl_i32x16(self, a: i32x16<Self>, shift: u32) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
-        self.combine_i32x8(self.shl_i32x8(a0, b), self.shl_i32x8(a1, b))
+        self.combine_i32x8(self.shl_i32x8(a0, shift), self.shl_i32x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_i32x16(self, a: i32x16<Self>, b: u32) -> i32x16<Self> {
+    fn shr_i32x16(self, a: i32x16<Self>, shift: u32) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
-        self.combine_i32x8(self.shr_i32x8(a0, b), self.shr_i32x8(a1, b))
+        self.combine_i32x8(self.shr_i32x8(a0, shift), self.shr_i32x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -4467,8 +4467,8 @@ impl Simd for Avx2 {
         self.combine_f32x8(self.cvt_f32_i32x8(a0), self.cvt_f32_i32x8(a1))
     }
     #[inline(always)]
-    fn splat_u32x16(self, a: u32) -> u32x16<Self> {
-        let half = self.splat_u32x8(a);
+    fn splat_u32x16(self, val: u32) -> u32x16<Self> {
+        let half = self.splat_u32x8(val);
         self.combine_u32x8(half, half)
     }
     #[inline(always)]
@@ -4513,14 +4513,14 @@ impl Simd for Avx2 {
         self.combine_u32x8(self.not_u32x8(a0), self.not_u32x8(a1))
     }
     #[inline(always)]
-    fn shl_u32x16(self, a: u32x16<Self>, b: u32) -> u32x16<Self> {
+    fn shl_u32x16(self, a: u32x16<Self>, shift: u32) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
-        self.combine_u32x8(self.shl_u32x8(a0, b), self.shl_u32x8(a1, b))
+        self.combine_u32x8(self.shl_u32x8(a0, shift), self.shl_u32x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_u32x16(self, a: u32x16<Self>, b: u32) -> u32x16<Self> {
+    fn shr_u32x16(self, a: u32x16<Self>, shift: u32) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
-        self.combine_u32x8(self.shr_u32x8(a0, b), self.shr_u32x8(a1, b))
+        self.combine_u32x8(self.shr_u32x8(a0, shift), self.shr_u32x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -4665,8 +4665,8 @@ impl Simd for Avx2 {
         self.combine_f32x8(self.cvt_f32_u32x8(a0), self.cvt_f32_u32x8(a1))
     }
     #[inline(always)]
-    fn splat_mask32x16(self, a: i32) -> mask32x16<Self> {
-        let half = self.splat_mask32x8(a);
+    fn splat_mask32x16(self, val: i32) -> mask32x16<Self> {
+        let half = self.splat_mask32x8(val);
         self.combine_mask32x8(half, half)
     }
     #[inline(always)]
@@ -4742,8 +4742,8 @@ impl Simd for Avx2 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f64x8(self, a: f64) -> f64x8<Self> {
-        let half = self.splat_f64x4(a);
+    fn splat_f64x8(self, val: f64) -> f64x8<Self> {
+        let half = self.splat_f64x4(val);
         self.combine_f64x4(half, half)
     }
     #[inline(always)]
@@ -4941,8 +4941,8 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
-    fn splat_mask64x8(self, a: i64) -> mask64x8<Self> {
-        let half = self.splat_mask64x4(a);
+    fn splat_mask64x8(self, val: i64) -> mask64x8<Self> {
+        let half = self.splat_mask64x4(val);
         self.combine_mask64x4(half, half)
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -3225,8 +3225,8 @@ impl Simd for Fallback {
         result.simd_into(self)
     }
     #[inline(always)]
-    fn splat_f32x8(self, a: f32) -> f32x8<Self> {
-        let half = self.splat_f32x4(a);
+    fn splat_f32x8(self, val: f32) -> f32x8<Self> {
+        let half = self.splat_f32x4(val);
         self.combine_f32x4(half, half)
     }
     #[inline(always)]
@@ -3462,8 +3462,8 @@ impl Simd for Fallback {
         self.combine_i32x4(self.cvt_i32_f32x4(a0), self.cvt_i32_f32x4(a1))
     }
     #[inline(always)]
-    fn splat_i8x32(self, a: i8) -> i8x32<Self> {
-        let half = self.splat_i8x16(a);
+    fn splat_i8x32(self, val: i8) -> i8x32<Self> {
+        let half = self.splat_i8x16(val);
         self.combine_i8x16(half, half)
     }
     #[inline(always)]
@@ -3508,14 +3508,14 @@ impl Simd for Fallback {
         self.combine_i8x16(self.not_i8x16(a0), self.not_i8x16(a1))
     }
     #[inline(always)]
-    fn shl_i8x32(self, a: i8x32<Self>, b: u32) -> i8x32<Self> {
+    fn shl_i8x32(self, a: i8x32<Self>, shift: u32) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
-        self.combine_i8x16(self.shl_i8x16(a0, b), self.shl_i8x16(a1, b))
+        self.combine_i8x16(self.shl_i8x16(a0, shift), self.shl_i8x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_i8x32(self, a: i8x32<Self>, b: u32) -> i8x32<Self> {
+    fn shr_i8x32(self, a: i8x32<Self>, shift: u32) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
-        self.combine_i8x16(self.shr_i8x16(a0, b), self.shr_i8x16(a1, b))
+        self.combine_i8x16(self.shr_i8x16(a0, shift), self.shr_i8x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -3630,8 +3630,8 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
-    fn splat_u8x32(self, a: u8) -> u8x32<Self> {
-        let half = self.splat_u8x16(a);
+    fn splat_u8x32(self, val: u8) -> u8x32<Self> {
+        let half = self.splat_u8x16(val);
         self.combine_u8x16(half, half)
     }
     #[inline(always)]
@@ -3676,14 +3676,14 @@ impl Simd for Fallback {
         self.combine_u8x16(self.not_u8x16(a0), self.not_u8x16(a1))
     }
     #[inline(always)]
-    fn shl_u8x32(self, a: u8x32<Self>, b: u32) -> u8x32<Self> {
+    fn shl_u8x32(self, a: u8x32<Self>, shift: u32) -> u8x32<Self> {
         let (a0, a1) = self.split_u8x32(a);
-        self.combine_u8x16(self.shl_u8x16(a0, b), self.shl_u8x16(a1, b))
+        self.combine_u8x16(self.shl_u8x16(a0, shift), self.shl_u8x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_u8x32(self, a: u8x32<Self>, b: u32) -> u8x32<Self> {
+    fn shr_u8x32(self, a: u8x32<Self>, shift: u32) -> u8x32<Self> {
         let (a0, a1) = self.split_u8x32(a);
-        self.combine_u8x16(self.shr_u8x16(a0, b), self.shr_u8x16(a1, b))
+        self.combine_u8x16(self.shr_u8x16(a0, shift), self.shr_u8x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
@@ -3793,8 +3793,8 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
-    fn splat_mask8x32(self, a: i8) -> mask8x32<Self> {
-        let half = self.splat_mask8x16(a);
+    fn splat_mask8x32(self, val: i8) -> mask8x32<Self> {
+        let half = self.splat_mask8x16(val);
         self.combine_mask8x16(half, half)
     }
     #[inline(always)]
@@ -3877,8 +3877,8 @@ impl Simd for Fallback {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i16x16(self, a: i16) -> i16x16<Self> {
-        let half = self.splat_i16x8(a);
+    fn splat_i16x16(self, val: i16) -> i16x16<Self> {
+        let half = self.splat_i16x8(val);
         self.combine_i16x8(half, half)
     }
     #[inline(always)]
@@ -3923,14 +3923,14 @@ impl Simd for Fallback {
         self.combine_i16x8(self.not_i16x8(a0), self.not_i16x8(a1))
     }
     #[inline(always)]
-    fn shl_i16x16(self, a: i16x16<Self>, b: u32) -> i16x16<Self> {
+    fn shl_i16x16(self, a: i16x16<Self>, shift: u32) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
-        self.combine_i16x8(self.shl_i16x8(a0, b), self.shl_i16x8(a1, b))
+        self.combine_i16x8(self.shl_i16x8(a0, shift), self.shl_i16x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_i16x16(self, a: i16x16<Self>, b: u32) -> i16x16<Self> {
+    fn shr_i16x16(self, a: i16x16<Self>, shift: u32) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
-        self.combine_i16x8(self.shr_i16x8(a0, b), self.shr_i16x8(a1, b))
+        self.combine_i16x8(self.shr_i16x8(a0, shift), self.shr_i16x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -4045,8 +4045,8 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
-    fn splat_u16x16(self, a: u16) -> u16x16<Self> {
-        let half = self.splat_u16x8(a);
+    fn splat_u16x16(self, val: u16) -> u16x16<Self> {
+        let half = self.splat_u16x8(val);
         self.combine_u16x8(half, half)
     }
     #[inline(always)]
@@ -4091,14 +4091,14 @@ impl Simd for Fallback {
         self.combine_u16x8(self.not_u16x8(a0), self.not_u16x8(a1))
     }
     #[inline(always)]
-    fn shl_u16x16(self, a: u16x16<Self>, b: u32) -> u16x16<Self> {
+    fn shl_u16x16(self, a: u16x16<Self>, shift: u32) -> u16x16<Self> {
         let (a0, a1) = self.split_u16x16(a);
-        self.combine_u16x8(self.shl_u16x8(a0, b), self.shl_u16x8(a1, b))
+        self.combine_u16x8(self.shl_u16x8(a0, shift), self.shl_u16x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_u16x16(self, a: u16x16<Self>, b: u32) -> u16x16<Self> {
+    fn shr_u16x16(self, a: u16x16<Self>, shift: u32) -> u16x16<Self> {
         let (a0, a1) = self.split_u16x16(a);
-        self.combine_u16x8(self.shr_u16x8(a0, b), self.shr_u16x8(a1, b))
+        self.combine_u16x8(self.shr_u16x8(a0, shift), self.shr_u16x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -4230,8 +4230,8 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
-    fn splat_mask16x16(self, a: i16) -> mask16x16<Self> {
-        let half = self.splat_mask16x8(a);
+    fn splat_mask16x16(self, val: i16) -> mask16x16<Self> {
+        let half = self.splat_mask16x8(val);
         self.combine_mask16x8(half, half)
     }
     #[inline(always)]
@@ -4314,8 +4314,8 @@ impl Simd for Fallback {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i32x8(self, a: i32) -> i32x8<Self> {
-        let half = self.splat_i32x4(a);
+    fn splat_i32x8(self, val: i32) -> i32x8<Self> {
+        let half = self.splat_i32x4(val);
         self.combine_i32x4(half, half)
     }
     #[inline(always)]
@@ -4360,14 +4360,14 @@ impl Simd for Fallback {
         self.combine_i32x4(self.not_i32x4(a0), self.not_i32x4(a1))
     }
     #[inline(always)]
-    fn shl_i32x8(self, a: i32x8<Self>, b: u32) -> i32x8<Self> {
+    fn shl_i32x8(self, a: i32x8<Self>, shift: u32) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
-        self.combine_i32x4(self.shl_i32x4(a0, b), self.shl_i32x4(a1, b))
+        self.combine_i32x4(self.shl_i32x4(a0, shift), self.shl_i32x4(a1, shift))
     }
     #[inline(always)]
-    fn shr_i32x8(self, a: i32x8<Self>, b: u32) -> i32x8<Self> {
+    fn shr_i32x8(self, a: i32x8<Self>, shift: u32) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
-        self.combine_i32x4(self.shr_i32x4(a0, b), self.shr_i32x4(a1, b))
+        self.combine_i32x4(self.shr_i32x4(a0, shift), self.shr_i32x4(a1, shift))
     }
     #[inline(always)]
     fn shrv_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -4487,8 +4487,8 @@ impl Simd for Fallback {
         self.combine_f32x4(self.cvt_f32_i32x4(a0), self.cvt_f32_i32x4(a1))
     }
     #[inline(always)]
-    fn splat_u32x8(self, a: u32) -> u32x8<Self> {
-        let half = self.splat_u32x4(a);
+    fn splat_u32x8(self, val: u32) -> u32x8<Self> {
+        let half = self.splat_u32x4(val);
         self.combine_u32x4(half, half)
     }
     #[inline(always)]
@@ -4533,14 +4533,14 @@ impl Simd for Fallback {
         self.combine_u32x4(self.not_u32x4(a0), self.not_u32x4(a1))
     }
     #[inline(always)]
-    fn shl_u32x8(self, a: u32x8<Self>, b: u32) -> u32x8<Self> {
+    fn shl_u32x8(self, a: u32x8<Self>, shift: u32) -> u32x8<Self> {
         let (a0, a1) = self.split_u32x8(a);
-        self.combine_u32x4(self.shl_u32x4(a0, b), self.shl_u32x4(a1, b))
+        self.combine_u32x4(self.shl_u32x4(a0, shift), self.shl_u32x4(a1, shift))
     }
     #[inline(always)]
-    fn shr_u32x8(self, a: u32x8<Self>, b: u32) -> u32x8<Self> {
+    fn shr_u32x8(self, a: u32x8<Self>, shift: u32) -> u32x8<Self> {
         let (a0, a1) = self.split_u32x8(a);
-        self.combine_u32x4(self.shr_u32x4(a0, b), self.shr_u32x4(a1, b))
+        self.combine_u32x4(self.shr_u32x4(a0, shift), self.shr_u32x4(a1, shift))
     }
     #[inline(always)]
     fn shrv_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
@@ -4647,8 +4647,8 @@ impl Simd for Fallback {
         self.combine_f32x4(self.cvt_f32_u32x4(a0), self.cvt_f32_u32x4(a1))
     }
     #[inline(always)]
-    fn splat_mask32x8(self, a: i32) -> mask32x8<Self> {
-        let half = self.splat_mask32x4(a);
+    fn splat_mask32x8(self, val: i32) -> mask32x8<Self> {
+        let half = self.splat_mask32x4(val);
         self.combine_mask32x4(half, half)
     }
     #[inline(always)]
@@ -4731,8 +4731,8 @@ impl Simd for Fallback {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f64x4(self, a: f64) -> f64x4<Self> {
-        let half = self.splat_f64x2(a);
+    fn splat_f64x4(self, val: f64) -> f64x4<Self> {
+        let half = self.splat_f64x2(val);
         self.combine_f64x2(half, half)
     }
     #[inline(always)]
@@ -4937,8 +4937,8 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
-    fn splat_mask64x4(self, a: i64) -> mask64x4<Self> {
-        let half = self.splat_mask64x2(a);
+    fn splat_mask64x4(self, val: i64) -> mask64x4<Self> {
+        let half = self.splat_mask64x2(val);
         self.combine_mask64x2(half, half)
     }
     #[inline(always)]
@@ -5021,8 +5021,8 @@ impl Simd for Fallback {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f32x16(self, a: f32) -> f32x16<Self> {
-        let half = self.splat_f32x8(a);
+    fn splat_f32x16(self, val: f32) -> f32x16<Self> {
+        let half = self.splat_f32x8(val);
         self.combine_f32x8(half, half)
     }
     #[inline(always)]
@@ -5281,8 +5281,8 @@ impl Simd for Fallback {
         self.combine_i32x8(self.cvt_i32_f32x8(a0), self.cvt_i32_f32x8(a1))
     }
     #[inline(always)]
-    fn splat_i8x64(self, a: i8) -> i8x64<Self> {
-        let half = self.splat_i8x32(a);
+    fn splat_i8x64(self, val: i8) -> i8x64<Self> {
+        let half = self.splat_i8x32(val);
         self.combine_i8x32(half, half)
     }
     #[inline(always)]
@@ -5327,14 +5327,14 @@ impl Simd for Fallback {
         self.combine_i8x32(self.not_i8x32(a0), self.not_i8x32(a1))
     }
     #[inline(always)]
-    fn shl_i8x64(self, a: i8x64<Self>, b: u32) -> i8x64<Self> {
+    fn shl_i8x64(self, a: i8x64<Self>, shift: u32) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
-        self.combine_i8x32(self.shl_i8x32(a0, b), self.shl_i8x32(a1, b))
+        self.combine_i8x32(self.shl_i8x32(a0, shift), self.shl_i8x32(a1, shift))
     }
     #[inline(always)]
-    fn shr_i8x64(self, a: i8x64<Self>, b: u32) -> i8x64<Self> {
+    fn shr_i8x64(self, a: i8x64<Self>, shift: u32) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
-        self.combine_i8x32(self.shr_i8x32(a0, b), self.shr_i8x32(a1, b))
+        self.combine_i8x32(self.shr_i8x32(a0, shift), self.shr_i8x32(a1, shift))
     }
     #[inline(always)]
     fn shrv_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -5442,8 +5442,8 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
-    fn splat_u8x64(self, a: u8) -> u8x64<Self> {
-        let half = self.splat_u8x32(a);
+    fn splat_u8x64(self, val: u8) -> u8x64<Self> {
+        let half = self.splat_u8x32(val);
         self.combine_u8x32(half, half)
     }
     #[inline(always)]
@@ -5488,14 +5488,14 @@ impl Simd for Fallback {
         self.combine_u8x32(self.not_u8x32(a0), self.not_u8x32(a1))
     }
     #[inline(always)]
-    fn shl_u8x64(self, a: u8x64<Self>, b: u32) -> u8x64<Self> {
+    fn shl_u8x64(self, a: u8x64<Self>, shift: u32) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
-        self.combine_u8x32(self.shl_u8x32(a0, b), self.shl_u8x32(a1, b))
+        self.combine_u8x32(self.shl_u8x32(a0, shift), self.shl_u8x32(a1, shift))
     }
     #[inline(always)]
-    fn shr_u8x64(self, a: u8x64<Self>, b: u32) -> u8x64<Self> {
+    fn shr_u8x64(self, a: u8x64<Self>, shift: u32) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
-        self.combine_u8x32(self.shr_u8x32(a0, b), self.shr_u8x32(a1, b))
+        self.combine_u8x32(self.shr_u8x32(a0, shift), self.shr_u8x32(a1, shift))
     }
     #[inline(always)]
     fn shrv_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -5678,8 +5678,8 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
-    fn splat_mask8x64(self, a: i8) -> mask8x64<Self> {
-        let half = self.splat_mask8x32(a);
+    fn splat_mask8x64(self, val: i8) -> mask8x64<Self> {
+        let half = self.splat_mask8x32(val);
         self.combine_mask8x32(half, half)
     }
     #[inline(always)]
@@ -5755,8 +5755,8 @@ impl Simd for Fallback {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i16x32(self, a: i16) -> i16x32<Self> {
-        let half = self.splat_i16x16(a);
+    fn splat_i16x32(self, val: i16) -> i16x32<Self> {
+        let half = self.splat_i16x16(val);
         self.combine_i16x16(half, half)
     }
     #[inline(always)]
@@ -5801,14 +5801,14 @@ impl Simd for Fallback {
         self.combine_i16x16(self.not_i16x16(a0), self.not_i16x16(a1))
     }
     #[inline(always)]
-    fn shl_i16x32(self, a: i16x32<Self>, b: u32) -> i16x32<Self> {
+    fn shl_i16x32(self, a: i16x32<Self>, shift: u32) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
-        self.combine_i16x16(self.shl_i16x16(a0, b), self.shl_i16x16(a1, b))
+        self.combine_i16x16(self.shl_i16x16(a0, shift), self.shl_i16x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_i16x32(self, a: i16x32<Self>, b: u32) -> i16x32<Self> {
+    fn shr_i16x32(self, a: i16x32<Self>, shift: u32) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
-        self.combine_i16x16(self.shr_i16x16(a0, b), self.shr_i16x16(a1, b))
+        self.combine_i16x16(self.shr_i16x16(a0, shift), self.shr_i16x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -5925,8 +5925,8 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
-    fn splat_u16x32(self, a: u16) -> u16x32<Self> {
-        let half = self.splat_u16x16(a);
+    fn splat_u16x32(self, val: u16) -> u16x32<Self> {
+        let half = self.splat_u16x16(val);
         self.combine_u16x16(half, half)
     }
     #[inline(always)]
@@ -5971,14 +5971,14 @@ impl Simd for Fallback {
         self.combine_u16x16(self.not_u16x16(a0), self.not_u16x16(a1))
     }
     #[inline(always)]
-    fn shl_u16x32(self, a: u16x32<Self>, b: u32) -> u16x32<Self> {
+    fn shl_u16x32(self, a: u16x32<Self>, shift: u32) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
-        self.combine_u16x16(self.shl_u16x16(a0, b), self.shl_u16x16(a1, b))
+        self.combine_u16x16(self.shl_u16x16(a0, shift), self.shl_u16x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_u16x32(self, a: u16x32<Self>, b: u32) -> u16x32<Self> {
+    fn shr_u16x32(self, a: u16x32<Self>, shift: u32) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
-        self.combine_u16x16(self.shr_u16x16(a0, b), self.shr_u16x16(a1, b))
+        self.combine_u16x16(self.shr_u16x16(a0, shift), self.shr_u16x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -6143,8 +6143,8 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
-    fn splat_mask16x32(self, a: i16) -> mask16x32<Self> {
-        let half = self.splat_mask16x16(a);
+    fn splat_mask16x32(self, val: i16) -> mask16x32<Self> {
+        let half = self.splat_mask16x16(val);
         self.combine_mask16x16(half, half)
     }
     #[inline(always)]
@@ -6223,8 +6223,8 @@ impl Simd for Fallback {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i32x16(self, a: i32) -> i32x16<Self> {
-        let half = self.splat_i32x8(a);
+    fn splat_i32x16(self, val: i32) -> i32x16<Self> {
+        let half = self.splat_i32x8(val);
         self.combine_i32x8(half, half)
     }
     #[inline(always)]
@@ -6269,14 +6269,14 @@ impl Simd for Fallback {
         self.combine_i32x8(self.not_i32x8(a0), self.not_i32x8(a1))
     }
     #[inline(always)]
-    fn shl_i32x16(self, a: i32x16<Self>, b: u32) -> i32x16<Self> {
+    fn shl_i32x16(self, a: i32x16<Self>, shift: u32) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
-        self.combine_i32x8(self.shl_i32x8(a0, b), self.shl_i32x8(a1, b))
+        self.combine_i32x8(self.shl_i32x8(a0, shift), self.shl_i32x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_i32x16(self, a: i32x16<Self>, b: u32) -> i32x16<Self> {
+    fn shr_i32x16(self, a: i32x16<Self>, shift: u32) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
-        self.combine_i32x8(self.shr_i32x8(a0, b), self.shr_i32x8(a1, b))
+        self.combine_i32x8(self.shr_i32x8(a0, shift), self.shr_i32x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -6389,8 +6389,8 @@ impl Simd for Fallback {
         self.combine_f32x8(self.cvt_f32_i32x8(a0), self.cvt_f32_i32x8(a1))
     }
     #[inline(always)]
-    fn splat_u32x16(self, a: u32) -> u32x16<Self> {
-        let half = self.splat_u32x8(a);
+    fn splat_u32x16(self, val: u32) -> u32x16<Self> {
+        let half = self.splat_u32x8(val);
         self.combine_u32x8(half, half)
     }
     #[inline(always)]
@@ -6435,14 +6435,14 @@ impl Simd for Fallback {
         self.combine_u32x8(self.not_u32x8(a0), self.not_u32x8(a1))
     }
     #[inline(always)]
-    fn shl_u32x16(self, a: u32x16<Self>, b: u32) -> u32x16<Self> {
+    fn shl_u32x16(self, a: u32x16<Self>, shift: u32) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
-        self.combine_u32x8(self.shl_u32x8(a0, b), self.shl_u32x8(a1, b))
+        self.combine_u32x8(self.shl_u32x8(a0, shift), self.shl_u32x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_u32x16(self, a: u32x16<Self>, b: u32) -> u32x16<Self> {
+    fn shr_u32x16(self, a: u32x16<Self>, shift: u32) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
-        self.combine_u32x8(self.shr_u32x8(a0, b), self.shr_u32x8(a1, b))
+        self.combine_u32x8(self.shr_u32x8(a0, shift), self.shr_u32x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -6572,8 +6572,8 @@ impl Simd for Fallback {
         self.combine_f32x8(self.cvt_f32_u32x8(a0), self.cvt_f32_u32x8(a1))
     }
     #[inline(always)]
-    fn splat_mask32x16(self, a: i32) -> mask32x16<Self> {
-        let half = self.splat_mask32x8(a);
+    fn splat_mask32x16(self, val: i32) -> mask32x16<Self> {
+        let half = self.splat_mask32x8(val);
         self.combine_mask32x8(half, half)
     }
     #[inline(always)]
@@ -6649,8 +6649,8 @@ impl Simd for Fallback {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f64x8(self, a: f64) -> f64x8<Self> {
-        let half = self.splat_f64x4(a);
+    fn splat_f64x8(self, val: f64) -> f64x8<Self> {
+        let half = self.splat_f64x4(val);
         self.combine_f64x4(half, half)
     }
     #[inline(always)]
@@ -6848,8 +6848,8 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
-    fn splat_mask64x8(self, a: i64) -> mask64x8<Self> {
-        let half = self.splat_mask64x4(a);
+    fn splat_mask64x8(self, val: i64) -> mask64x8<Self> {
+        let half = self.splat_mask64x4(val);
         self.combine_mask64x4(half, half)
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -1298,8 +1298,8 @@ impl Simd for Neon {
         result.simd_into(self)
     }
     #[inline(always)]
-    fn splat_f32x8(self, a: f32) -> f32x8<Self> {
-        let half = self.splat_f32x4(a);
+    fn splat_f32x8(self, val: f32) -> f32x8<Self> {
+        let half = self.splat_f32x4(val);
         self.combine_f32x4(half, half)
     }
     #[inline(always)]
@@ -1535,8 +1535,8 @@ impl Simd for Neon {
         self.combine_i32x4(self.cvt_i32_f32x4(a0), self.cvt_i32_f32x4(a1))
     }
     #[inline(always)]
-    fn splat_i8x32(self, a: i8) -> i8x32<Self> {
-        let half = self.splat_i8x16(a);
+    fn splat_i8x32(self, val: i8) -> i8x32<Self> {
+        let half = self.splat_i8x16(val);
         self.combine_i8x16(half, half)
     }
     #[inline(always)]
@@ -1581,14 +1581,14 @@ impl Simd for Neon {
         self.combine_i8x16(self.not_i8x16(a0), self.not_i8x16(a1))
     }
     #[inline(always)]
-    fn shl_i8x32(self, a: i8x32<Self>, b: u32) -> i8x32<Self> {
+    fn shl_i8x32(self, a: i8x32<Self>, shift: u32) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
-        self.combine_i8x16(self.shl_i8x16(a0, b), self.shl_i8x16(a1, b))
+        self.combine_i8x16(self.shl_i8x16(a0, shift), self.shl_i8x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_i8x32(self, a: i8x32<Self>, b: u32) -> i8x32<Self> {
+    fn shr_i8x32(self, a: i8x32<Self>, shift: u32) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
-        self.combine_i8x16(self.shr_i8x16(a0, b), self.shr_i8x16(a1, b))
+        self.combine_i8x16(self.shr_i8x16(a0, shift), self.shr_i8x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -1703,8 +1703,8 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
-    fn splat_u8x32(self, a: u8) -> u8x32<Self> {
-        let half = self.splat_u8x16(a);
+    fn splat_u8x32(self, val: u8) -> u8x32<Self> {
+        let half = self.splat_u8x16(val);
         self.combine_u8x16(half, half)
     }
     #[inline(always)]
@@ -1749,14 +1749,14 @@ impl Simd for Neon {
         self.combine_u8x16(self.not_u8x16(a0), self.not_u8x16(a1))
     }
     #[inline(always)]
-    fn shl_u8x32(self, a: u8x32<Self>, b: u32) -> u8x32<Self> {
+    fn shl_u8x32(self, a: u8x32<Self>, shift: u32) -> u8x32<Self> {
         let (a0, a1) = self.split_u8x32(a);
-        self.combine_u8x16(self.shl_u8x16(a0, b), self.shl_u8x16(a1, b))
+        self.combine_u8x16(self.shl_u8x16(a0, shift), self.shl_u8x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_u8x32(self, a: u8x32<Self>, b: u32) -> u8x32<Self> {
+    fn shr_u8x32(self, a: u8x32<Self>, shift: u32) -> u8x32<Self> {
         let (a0, a1) = self.split_u8x32(a);
-        self.combine_u8x16(self.shr_u8x16(a0, b), self.shr_u8x16(a1, b))
+        self.combine_u8x16(self.shr_u8x16(a0, shift), self.shr_u8x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
@@ -1866,8 +1866,8 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
-    fn splat_mask8x32(self, a: i8) -> mask8x32<Self> {
-        let half = self.splat_mask8x16(a);
+    fn splat_mask8x32(self, val: i8) -> mask8x32<Self> {
+        let half = self.splat_mask8x16(val);
         self.combine_mask8x16(half, half)
     }
     #[inline(always)]
@@ -1950,8 +1950,8 @@ impl Simd for Neon {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i16x16(self, a: i16) -> i16x16<Self> {
-        let half = self.splat_i16x8(a);
+    fn splat_i16x16(self, val: i16) -> i16x16<Self> {
+        let half = self.splat_i16x8(val);
         self.combine_i16x8(half, half)
     }
     #[inline(always)]
@@ -1996,14 +1996,14 @@ impl Simd for Neon {
         self.combine_i16x8(self.not_i16x8(a0), self.not_i16x8(a1))
     }
     #[inline(always)]
-    fn shl_i16x16(self, a: i16x16<Self>, b: u32) -> i16x16<Self> {
+    fn shl_i16x16(self, a: i16x16<Self>, shift: u32) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
-        self.combine_i16x8(self.shl_i16x8(a0, b), self.shl_i16x8(a1, b))
+        self.combine_i16x8(self.shl_i16x8(a0, shift), self.shl_i16x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_i16x16(self, a: i16x16<Self>, b: u32) -> i16x16<Self> {
+    fn shr_i16x16(self, a: i16x16<Self>, shift: u32) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
-        self.combine_i16x8(self.shr_i16x8(a0, b), self.shr_i16x8(a1, b))
+        self.combine_i16x8(self.shr_i16x8(a0, shift), self.shr_i16x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -2118,8 +2118,8 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
-    fn splat_u16x16(self, a: u16) -> u16x16<Self> {
-        let half = self.splat_u16x8(a);
+    fn splat_u16x16(self, val: u16) -> u16x16<Self> {
+        let half = self.splat_u16x8(val);
         self.combine_u16x8(half, half)
     }
     #[inline(always)]
@@ -2164,14 +2164,14 @@ impl Simd for Neon {
         self.combine_u16x8(self.not_u16x8(a0), self.not_u16x8(a1))
     }
     #[inline(always)]
-    fn shl_u16x16(self, a: u16x16<Self>, b: u32) -> u16x16<Self> {
+    fn shl_u16x16(self, a: u16x16<Self>, shift: u32) -> u16x16<Self> {
         let (a0, a1) = self.split_u16x16(a);
-        self.combine_u16x8(self.shl_u16x8(a0, b), self.shl_u16x8(a1, b))
+        self.combine_u16x8(self.shl_u16x8(a0, shift), self.shl_u16x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_u16x16(self, a: u16x16<Self>, b: u32) -> u16x16<Self> {
+    fn shr_u16x16(self, a: u16x16<Self>, shift: u32) -> u16x16<Self> {
         let (a0, a1) = self.split_u16x16(a);
-        self.combine_u16x8(self.shr_u16x8(a0, b), self.shr_u16x8(a1, b))
+        self.combine_u16x8(self.shr_u16x8(a0, shift), self.shr_u16x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -2290,8 +2290,8 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
-    fn splat_mask16x16(self, a: i16) -> mask16x16<Self> {
-        let half = self.splat_mask16x8(a);
+    fn splat_mask16x16(self, val: i16) -> mask16x16<Self> {
+        let half = self.splat_mask16x8(val);
         self.combine_mask16x8(half, half)
     }
     #[inline(always)]
@@ -2374,8 +2374,8 @@ impl Simd for Neon {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i32x8(self, a: i32) -> i32x8<Self> {
-        let half = self.splat_i32x4(a);
+    fn splat_i32x8(self, val: i32) -> i32x8<Self> {
+        let half = self.splat_i32x4(val);
         self.combine_i32x4(half, half)
     }
     #[inline(always)]
@@ -2420,14 +2420,14 @@ impl Simd for Neon {
         self.combine_i32x4(self.not_i32x4(a0), self.not_i32x4(a1))
     }
     #[inline(always)]
-    fn shl_i32x8(self, a: i32x8<Self>, b: u32) -> i32x8<Self> {
+    fn shl_i32x8(self, a: i32x8<Self>, shift: u32) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
-        self.combine_i32x4(self.shl_i32x4(a0, b), self.shl_i32x4(a1, b))
+        self.combine_i32x4(self.shl_i32x4(a0, shift), self.shl_i32x4(a1, shift))
     }
     #[inline(always)]
-    fn shr_i32x8(self, a: i32x8<Self>, b: u32) -> i32x8<Self> {
+    fn shr_i32x8(self, a: i32x8<Self>, shift: u32) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
-        self.combine_i32x4(self.shr_i32x4(a0, b), self.shr_i32x4(a1, b))
+        self.combine_i32x4(self.shr_i32x4(a0, shift), self.shr_i32x4(a1, shift))
     }
     #[inline(always)]
     fn shrv_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -2547,8 +2547,8 @@ impl Simd for Neon {
         self.combine_f32x4(self.cvt_f32_i32x4(a0), self.cvt_f32_i32x4(a1))
     }
     #[inline(always)]
-    fn splat_u32x8(self, a: u32) -> u32x8<Self> {
-        let half = self.splat_u32x4(a);
+    fn splat_u32x8(self, val: u32) -> u32x8<Self> {
+        let half = self.splat_u32x4(val);
         self.combine_u32x4(half, half)
     }
     #[inline(always)]
@@ -2593,14 +2593,14 @@ impl Simd for Neon {
         self.combine_u32x4(self.not_u32x4(a0), self.not_u32x4(a1))
     }
     #[inline(always)]
-    fn shl_u32x8(self, a: u32x8<Self>, b: u32) -> u32x8<Self> {
+    fn shl_u32x8(self, a: u32x8<Self>, shift: u32) -> u32x8<Self> {
         let (a0, a1) = self.split_u32x8(a);
-        self.combine_u32x4(self.shl_u32x4(a0, b), self.shl_u32x4(a1, b))
+        self.combine_u32x4(self.shl_u32x4(a0, shift), self.shl_u32x4(a1, shift))
     }
     #[inline(always)]
-    fn shr_u32x8(self, a: u32x8<Self>, b: u32) -> u32x8<Self> {
+    fn shr_u32x8(self, a: u32x8<Self>, shift: u32) -> u32x8<Self> {
         let (a0, a1) = self.split_u32x8(a);
-        self.combine_u32x4(self.shr_u32x4(a0, b), self.shr_u32x4(a1, b))
+        self.combine_u32x4(self.shr_u32x4(a0, shift), self.shr_u32x4(a1, shift))
     }
     #[inline(always)]
     fn shrv_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
@@ -2707,8 +2707,8 @@ impl Simd for Neon {
         self.combine_f32x4(self.cvt_f32_u32x4(a0), self.cvt_f32_u32x4(a1))
     }
     #[inline(always)]
-    fn splat_mask32x8(self, a: i32) -> mask32x8<Self> {
-        let half = self.splat_mask32x4(a);
+    fn splat_mask32x8(self, val: i32) -> mask32x8<Self> {
+        let half = self.splat_mask32x4(val);
         self.combine_mask32x4(half, half)
     }
     #[inline(always)]
@@ -2791,8 +2791,8 @@ impl Simd for Neon {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f64x4(self, a: f64) -> f64x4<Self> {
-        let half = self.splat_f64x2(a);
+    fn splat_f64x4(self, val: f64) -> f64x4<Self> {
+        let half = self.splat_f64x2(val);
         self.combine_f64x2(half, half)
     }
     #[inline(always)]
@@ -2997,8 +2997,8 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
-    fn splat_mask64x4(self, a: i64) -> mask64x4<Self> {
-        let half = self.splat_mask64x2(a);
+    fn splat_mask64x4(self, val: i64) -> mask64x4<Self> {
+        let half = self.splat_mask64x2(val);
         self.combine_mask64x2(half, half)
     }
     #[inline(always)]
@@ -3081,8 +3081,8 @@ impl Simd for Neon {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f32x16(self, a: f32) -> f32x16<Self> {
-        let half = self.splat_f32x8(a);
+    fn splat_f32x16(self, val: f32) -> f32x16<Self> {
+        let half = self.splat_f32x8(val);
         self.combine_f32x8(half, half)
     }
     #[inline(always)]
@@ -3319,8 +3319,8 @@ impl Simd for Neon {
         self.combine_i32x8(self.cvt_i32_f32x8(a0), self.cvt_i32_f32x8(a1))
     }
     #[inline(always)]
-    fn splat_i8x64(self, a: i8) -> i8x64<Self> {
-        let half = self.splat_i8x32(a);
+    fn splat_i8x64(self, val: i8) -> i8x64<Self> {
+        let half = self.splat_i8x32(val);
         self.combine_i8x32(half, half)
     }
     #[inline(always)]
@@ -3365,14 +3365,14 @@ impl Simd for Neon {
         self.combine_i8x32(self.not_i8x32(a0), self.not_i8x32(a1))
     }
     #[inline(always)]
-    fn shl_i8x64(self, a: i8x64<Self>, b: u32) -> i8x64<Self> {
+    fn shl_i8x64(self, a: i8x64<Self>, shift: u32) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
-        self.combine_i8x32(self.shl_i8x32(a0, b), self.shl_i8x32(a1, b))
+        self.combine_i8x32(self.shl_i8x32(a0, shift), self.shl_i8x32(a1, shift))
     }
     #[inline(always)]
-    fn shr_i8x64(self, a: i8x64<Self>, b: u32) -> i8x64<Self> {
+    fn shr_i8x64(self, a: i8x64<Self>, shift: u32) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
-        self.combine_i8x32(self.shr_i8x32(a0, b), self.shr_i8x32(a1, b))
+        self.combine_i8x32(self.shr_i8x32(a0, shift), self.shr_i8x32(a1, shift))
     }
     #[inline(always)]
     fn shrv_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -3480,8 +3480,8 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
-    fn splat_u8x64(self, a: u8) -> u8x64<Self> {
-        let half = self.splat_u8x32(a);
+    fn splat_u8x64(self, val: u8) -> u8x64<Self> {
+        let half = self.splat_u8x32(val);
         self.combine_u8x32(half, half)
     }
     #[inline(always)]
@@ -3526,14 +3526,14 @@ impl Simd for Neon {
         self.combine_u8x32(self.not_u8x32(a0), self.not_u8x32(a1))
     }
     #[inline(always)]
-    fn shl_u8x64(self, a: u8x64<Self>, b: u32) -> u8x64<Self> {
+    fn shl_u8x64(self, a: u8x64<Self>, shift: u32) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
-        self.combine_u8x32(self.shl_u8x32(a0, b), self.shl_u8x32(a1, b))
+        self.combine_u8x32(self.shl_u8x32(a0, shift), self.shl_u8x32(a1, shift))
     }
     #[inline(always)]
-    fn shr_u8x64(self, a: u8x64<Self>, b: u32) -> u8x64<Self> {
+    fn shr_u8x64(self, a: u8x64<Self>, shift: u32) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
-        self.combine_u8x32(self.shr_u8x32(a0, b), self.shr_u8x32(a1, b))
+        self.combine_u8x32(self.shr_u8x32(a0, shift), self.shr_u8x32(a1, shift))
     }
     #[inline(always)]
     fn shrv_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -3639,8 +3639,8 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
-    fn splat_mask8x64(self, a: i8) -> mask8x64<Self> {
-        let half = self.splat_mask8x32(a);
+    fn splat_mask8x64(self, val: i8) -> mask8x64<Self> {
+        let half = self.splat_mask8x32(val);
         self.combine_mask8x32(half, half)
     }
     #[inline(always)]
@@ -3716,8 +3716,8 @@ impl Simd for Neon {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i16x32(self, a: i16) -> i16x32<Self> {
-        let half = self.splat_i16x16(a);
+    fn splat_i16x32(self, val: i16) -> i16x32<Self> {
+        let half = self.splat_i16x16(val);
         self.combine_i16x16(half, half)
     }
     #[inline(always)]
@@ -3762,14 +3762,14 @@ impl Simd for Neon {
         self.combine_i16x16(self.not_i16x16(a0), self.not_i16x16(a1))
     }
     #[inline(always)]
-    fn shl_i16x32(self, a: i16x32<Self>, b: u32) -> i16x32<Self> {
+    fn shl_i16x32(self, a: i16x32<Self>, shift: u32) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
-        self.combine_i16x16(self.shl_i16x16(a0, b), self.shl_i16x16(a1, b))
+        self.combine_i16x16(self.shl_i16x16(a0, shift), self.shl_i16x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_i16x32(self, a: i16x32<Self>, b: u32) -> i16x32<Self> {
+    fn shr_i16x32(self, a: i16x32<Self>, shift: u32) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
-        self.combine_i16x16(self.shr_i16x16(a0, b), self.shr_i16x16(a1, b))
+        self.combine_i16x16(self.shr_i16x16(a0, shift), self.shr_i16x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -3886,8 +3886,8 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
-    fn splat_u16x32(self, a: u16) -> u16x32<Self> {
-        let half = self.splat_u16x16(a);
+    fn splat_u16x32(self, val: u16) -> u16x32<Self> {
+        let half = self.splat_u16x16(val);
         self.combine_u16x16(half, half)
     }
     #[inline(always)]
@@ -3932,14 +3932,14 @@ impl Simd for Neon {
         self.combine_u16x16(self.not_u16x16(a0), self.not_u16x16(a1))
     }
     #[inline(always)]
-    fn shl_u16x32(self, a: u16x32<Self>, b: u32) -> u16x32<Self> {
+    fn shl_u16x32(self, a: u16x32<Self>, shift: u32) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
-        self.combine_u16x16(self.shl_u16x16(a0, b), self.shl_u16x16(a1, b))
+        self.combine_u16x16(self.shl_u16x16(a0, shift), self.shl_u16x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_u16x32(self, a: u16x32<Self>, b: u32) -> u16x32<Self> {
+    fn shr_u16x32(self, a: u16x32<Self>, shift: u32) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
-        self.combine_u16x16(self.shr_u16x16(a0, b), self.shr_u16x16(a1, b))
+        self.combine_u16x16(self.shr_u16x16(a0, shift), self.shr_u16x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -4064,8 +4064,8 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
-    fn splat_mask16x32(self, a: i16) -> mask16x32<Self> {
-        let half = self.splat_mask16x16(a);
+    fn splat_mask16x32(self, val: i16) -> mask16x32<Self> {
+        let half = self.splat_mask16x16(val);
         self.combine_mask16x16(half, half)
     }
     #[inline(always)]
@@ -4144,8 +4144,8 @@ impl Simd for Neon {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i32x16(self, a: i32) -> i32x16<Self> {
-        let half = self.splat_i32x8(a);
+    fn splat_i32x16(self, val: i32) -> i32x16<Self> {
+        let half = self.splat_i32x8(val);
         self.combine_i32x8(half, half)
     }
     #[inline(always)]
@@ -4190,14 +4190,14 @@ impl Simd for Neon {
         self.combine_i32x8(self.not_i32x8(a0), self.not_i32x8(a1))
     }
     #[inline(always)]
-    fn shl_i32x16(self, a: i32x16<Self>, b: u32) -> i32x16<Self> {
+    fn shl_i32x16(self, a: i32x16<Self>, shift: u32) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
-        self.combine_i32x8(self.shl_i32x8(a0, b), self.shl_i32x8(a1, b))
+        self.combine_i32x8(self.shl_i32x8(a0, shift), self.shl_i32x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_i32x16(self, a: i32x16<Self>, b: u32) -> i32x16<Self> {
+    fn shr_i32x16(self, a: i32x16<Self>, shift: u32) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
-        self.combine_i32x8(self.shr_i32x8(a0, b), self.shr_i32x8(a1, b))
+        self.combine_i32x8(self.shr_i32x8(a0, shift), self.shr_i32x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -4310,8 +4310,8 @@ impl Simd for Neon {
         self.combine_f32x8(self.cvt_f32_i32x8(a0), self.cvt_f32_i32x8(a1))
     }
     #[inline(always)]
-    fn splat_u32x16(self, a: u32) -> u32x16<Self> {
-        let half = self.splat_u32x8(a);
+    fn splat_u32x16(self, val: u32) -> u32x16<Self> {
+        let half = self.splat_u32x8(val);
         self.combine_u32x8(half, half)
     }
     #[inline(always)]
@@ -4356,14 +4356,14 @@ impl Simd for Neon {
         self.combine_u32x8(self.not_u32x8(a0), self.not_u32x8(a1))
     }
     #[inline(always)]
-    fn shl_u32x16(self, a: u32x16<Self>, b: u32) -> u32x16<Self> {
+    fn shl_u32x16(self, a: u32x16<Self>, shift: u32) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
-        self.combine_u32x8(self.shl_u32x8(a0, b), self.shl_u32x8(a1, b))
+        self.combine_u32x8(self.shl_u32x8(a0, shift), self.shl_u32x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_u32x16(self, a: u32x16<Self>, b: u32) -> u32x16<Self> {
+    fn shr_u32x16(self, a: u32x16<Self>, shift: u32) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
-        self.combine_u32x8(self.shr_u32x8(a0, b), self.shr_u32x8(a1, b))
+        self.combine_u32x8(self.shr_u32x8(a0, shift), self.shr_u32x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -4471,8 +4471,8 @@ impl Simd for Neon {
         self.combine_f32x8(self.cvt_f32_u32x8(a0), self.cvt_f32_u32x8(a1))
     }
     #[inline(always)]
-    fn splat_mask32x16(self, a: i32) -> mask32x16<Self> {
-        let half = self.splat_mask32x8(a);
+    fn splat_mask32x16(self, val: i32) -> mask32x16<Self> {
+        let half = self.splat_mask32x8(val);
         self.combine_mask32x8(half, half)
     }
     #[inline(always)]
@@ -4548,8 +4548,8 @@ impl Simd for Neon {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f64x8(self, a: f64) -> f64x8<Self> {
-        let half = self.splat_f64x4(a);
+    fn splat_f64x8(self, val: f64) -> f64x8<Self> {
+        let half = self.splat_f64x4(val);
         self.combine_f64x4(half, half)
     }
     #[inline(always)]
@@ -4747,8 +4747,8 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
-    fn splat_mask64x8(self, a: i64) -> mask64x8<Self> {
-        let half = self.splat_mask64x4(a);
+    fn splat_mask64x8(self, val: i64) -> mask64x8<Self> {
+        let half = self.splat_mask64x4(val);
         self.combine_mask64x4(half, half)
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -1454,8 +1454,8 @@ impl Simd for Sse4_2 {
         result.simd_into(self)
     }
     #[inline(always)]
-    fn splat_f32x8(self, a: f32) -> f32x8<Self> {
-        let half = self.splat_f32x4(a);
+    fn splat_f32x8(self, val: f32) -> f32x8<Self> {
+        let half = self.splat_f32x4(val);
         self.combine_f32x4(half, half)
     }
     #[inline(always)]
@@ -1691,8 +1691,8 @@ impl Simd for Sse4_2 {
         self.combine_i32x4(self.cvt_i32_f32x4(a0), self.cvt_i32_f32x4(a1))
     }
     #[inline(always)]
-    fn splat_i8x32(self, a: i8) -> i8x32<Self> {
-        let half = self.splat_i8x16(a);
+    fn splat_i8x32(self, val: i8) -> i8x32<Self> {
+        let half = self.splat_i8x16(val);
         self.combine_i8x16(half, half)
     }
     #[inline(always)]
@@ -1737,14 +1737,14 @@ impl Simd for Sse4_2 {
         self.combine_i8x16(self.not_i8x16(a0), self.not_i8x16(a1))
     }
     #[inline(always)]
-    fn shl_i8x32(self, a: i8x32<Self>, b: u32) -> i8x32<Self> {
+    fn shl_i8x32(self, a: i8x32<Self>, shift: u32) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
-        self.combine_i8x16(self.shl_i8x16(a0, b), self.shl_i8x16(a1, b))
+        self.combine_i8x16(self.shl_i8x16(a0, shift), self.shl_i8x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_i8x32(self, a: i8x32<Self>, b: u32) -> i8x32<Self> {
+    fn shr_i8x32(self, a: i8x32<Self>, shift: u32) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
-        self.combine_i8x16(self.shr_i8x16(a0, b), self.shr_i8x16(a1, b))
+        self.combine_i8x16(self.shr_i8x16(a0, shift), self.shr_i8x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -1859,8 +1859,8 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
-    fn splat_u8x32(self, a: u8) -> u8x32<Self> {
-        let half = self.splat_u8x16(a);
+    fn splat_u8x32(self, val: u8) -> u8x32<Self> {
+        let half = self.splat_u8x16(val);
         self.combine_u8x16(half, half)
     }
     #[inline(always)]
@@ -1905,14 +1905,14 @@ impl Simd for Sse4_2 {
         self.combine_u8x16(self.not_u8x16(a0), self.not_u8x16(a1))
     }
     #[inline(always)]
-    fn shl_u8x32(self, a: u8x32<Self>, b: u32) -> u8x32<Self> {
+    fn shl_u8x32(self, a: u8x32<Self>, shift: u32) -> u8x32<Self> {
         let (a0, a1) = self.split_u8x32(a);
-        self.combine_u8x16(self.shl_u8x16(a0, b), self.shl_u8x16(a1, b))
+        self.combine_u8x16(self.shl_u8x16(a0, shift), self.shl_u8x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_u8x32(self, a: u8x32<Self>, b: u32) -> u8x32<Self> {
+    fn shr_u8x32(self, a: u8x32<Self>, shift: u32) -> u8x32<Self> {
         let (a0, a1) = self.split_u8x32(a);
-        self.combine_u8x16(self.shr_u8x16(a0, b), self.shr_u8x16(a1, b))
+        self.combine_u8x16(self.shr_u8x16(a0, shift), self.shr_u8x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
@@ -2022,8 +2022,8 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
-    fn splat_mask8x32(self, a: i8) -> mask8x32<Self> {
-        let half = self.splat_mask8x16(a);
+    fn splat_mask8x32(self, val: i8) -> mask8x32<Self> {
+        let half = self.splat_mask8x16(val);
         self.combine_mask8x16(half, half)
     }
     #[inline(always)]
@@ -2106,8 +2106,8 @@ impl Simd for Sse4_2 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i16x16(self, a: i16) -> i16x16<Self> {
-        let half = self.splat_i16x8(a);
+    fn splat_i16x16(self, val: i16) -> i16x16<Self> {
+        let half = self.splat_i16x8(val);
         self.combine_i16x8(half, half)
     }
     #[inline(always)]
@@ -2152,14 +2152,14 @@ impl Simd for Sse4_2 {
         self.combine_i16x8(self.not_i16x8(a0), self.not_i16x8(a1))
     }
     #[inline(always)]
-    fn shl_i16x16(self, a: i16x16<Self>, b: u32) -> i16x16<Self> {
+    fn shl_i16x16(self, a: i16x16<Self>, shift: u32) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
-        self.combine_i16x8(self.shl_i16x8(a0, b), self.shl_i16x8(a1, b))
+        self.combine_i16x8(self.shl_i16x8(a0, shift), self.shl_i16x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_i16x16(self, a: i16x16<Self>, b: u32) -> i16x16<Self> {
+    fn shr_i16x16(self, a: i16x16<Self>, shift: u32) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
-        self.combine_i16x8(self.shr_i16x8(a0, b), self.shr_i16x8(a1, b))
+        self.combine_i16x8(self.shr_i16x8(a0, shift), self.shr_i16x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -2274,8 +2274,8 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
-    fn splat_u16x16(self, a: u16) -> u16x16<Self> {
-        let half = self.splat_u16x8(a);
+    fn splat_u16x16(self, val: u16) -> u16x16<Self> {
+        let half = self.splat_u16x8(val);
         self.combine_u16x8(half, half)
     }
     #[inline(always)]
@@ -2320,14 +2320,14 @@ impl Simd for Sse4_2 {
         self.combine_u16x8(self.not_u16x8(a0), self.not_u16x8(a1))
     }
     #[inline(always)]
-    fn shl_u16x16(self, a: u16x16<Self>, b: u32) -> u16x16<Self> {
+    fn shl_u16x16(self, a: u16x16<Self>, shift: u32) -> u16x16<Self> {
         let (a0, a1) = self.split_u16x16(a);
-        self.combine_u16x8(self.shl_u16x8(a0, b), self.shl_u16x8(a1, b))
+        self.combine_u16x8(self.shl_u16x8(a0, shift), self.shl_u16x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_u16x16(self, a: u16x16<Self>, b: u32) -> u16x16<Self> {
+    fn shr_u16x16(self, a: u16x16<Self>, shift: u32) -> u16x16<Self> {
         let (a0, a1) = self.split_u16x16(a);
-        self.combine_u16x8(self.shr_u16x8(a0, b), self.shr_u16x8(a1, b))
+        self.combine_u16x8(self.shr_u16x8(a0, shift), self.shr_u16x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -2448,8 +2448,8 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
-    fn splat_mask16x16(self, a: i16) -> mask16x16<Self> {
-        let half = self.splat_mask16x8(a);
+    fn splat_mask16x16(self, val: i16) -> mask16x16<Self> {
+        let half = self.splat_mask16x8(val);
         self.combine_mask16x8(half, half)
     }
     #[inline(always)]
@@ -2532,8 +2532,8 @@ impl Simd for Sse4_2 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i32x8(self, a: i32) -> i32x8<Self> {
-        let half = self.splat_i32x4(a);
+    fn splat_i32x8(self, val: i32) -> i32x8<Self> {
+        let half = self.splat_i32x4(val);
         self.combine_i32x4(half, half)
     }
     #[inline(always)]
@@ -2578,14 +2578,14 @@ impl Simd for Sse4_2 {
         self.combine_i32x4(self.not_i32x4(a0), self.not_i32x4(a1))
     }
     #[inline(always)]
-    fn shl_i32x8(self, a: i32x8<Self>, b: u32) -> i32x8<Self> {
+    fn shl_i32x8(self, a: i32x8<Self>, shift: u32) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
-        self.combine_i32x4(self.shl_i32x4(a0, b), self.shl_i32x4(a1, b))
+        self.combine_i32x4(self.shl_i32x4(a0, shift), self.shl_i32x4(a1, shift))
     }
     #[inline(always)]
-    fn shr_i32x8(self, a: i32x8<Self>, b: u32) -> i32x8<Self> {
+    fn shr_i32x8(self, a: i32x8<Self>, shift: u32) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
-        self.combine_i32x4(self.shr_i32x4(a0, b), self.shr_i32x4(a1, b))
+        self.combine_i32x4(self.shr_i32x4(a0, shift), self.shr_i32x4(a1, shift))
     }
     #[inline(always)]
     fn shrv_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -2705,8 +2705,8 @@ impl Simd for Sse4_2 {
         self.combine_f32x4(self.cvt_f32_i32x4(a0), self.cvt_f32_i32x4(a1))
     }
     #[inline(always)]
-    fn splat_u32x8(self, a: u32) -> u32x8<Self> {
-        let half = self.splat_u32x4(a);
+    fn splat_u32x8(self, val: u32) -> u32x8<Self> {
+        let half = self.splat_u32x4(val);
         self.combine_u32x4(half, half)
     }
     #[inline(always)]
@@ -2751,14 +2751,14 @@ impl Simd for Sse4_2 {
         self.combine_u32x4(self.not_u32x4(a0), self.not_u32x4(a1))
     }
     #[inline(always)]
-    fn shl_u32x8(self, a: u32x8<Self>, b: u32) -> u32x8<Self> {
+    fn shl_u32x8(self, a: u32x8<Self>, shift: u32) -> u32x8<Self> {
         let (a0, a1) = self.split_u32x8(a);
-        self.combine_u32x4(self.shl_u32x4(a0, b), self.shl_u32x4(a1, b))
+        self.combine_u32x4(self.shl_u32x4(a0, shift), self.shl_u32x4(a1, shift))
     }
     #[inline(always)]
-    fn shr_u32x8(self, a: u32x8<Self>, b: u32) -> u32x8<Self> {
+    fn shr_u32x8(self, a: u32x8<Self>, shift: u32) -> u32x8<Self> {
         let (a0, a1) = self.split_u32x8(a);
-        self.combine_u32x4(self.shr_u32x4(a0, b), self.shr_u32x4(a1, b))
+        self.combine_u32x4(self.shr_u32x4(a0, shift), self.shr_u32x4(a1, shift))
     }
     #[inline(always)]
     fn shrv_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
@@ -2865,8 +2865,8 @@ impl Simd for Sse4_2 {
         self.combine_f32x4(self.cvt_f32_u32x4(a0), self.cvt_f32_u32x4(a1))
     }
     #[inline(always)]
-    fn splat_mask32x8(self, a: i32) -> mask32x8<Self> {
-        let half = self.splat_mask32x4(a);
+    fn splat_mask32x8(self, val: i32) -> mask32x8<Self> {
+        let half = self.splat_mask32x4(val);
         self.combine_mask32x4(half, half)
     }
     #[inline(always)]
@@ -2949,8 +2949,8 @@ impl Simd for Sse4_2 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f64x4(self, a: f64) -> f64x4<Self> {
-        let half = self.splat_f64x2(a);
+    fn splat_f64x4(self, val: f64) -> f64x4<Self> {
+        let half = self.splat_f64x2(val);
         self.combine_f64x2(half, half)
     }
     #[inline(always)]
@@ -3155,8 +3155,8 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
-    fn splat_mask64x4(self, a: i64) -> mask64x4<Self> {
-        let half = self.splat_mask64x2(a);
+    fn splat_mask64x4(self, val: i64) -> mask64x4<Self> {
+        let half = self.splat_mask64x2(val);
         self.combine_mask64x2(half, half)
     }
     #[inline(always)]
@@ -3239,8 +3239,8 @@ impl Simd for Sse4_2 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f32x16(self, a: f32) -> f32x16<Self> {
-        let half = self.splat_f32x8(a);
+    fn splat_f32x16(self, val: f32) -> f32x16<Self> {
+        let half = self.splat_f32x8(val);
         self.combine_f32x8(half, half)
     }
     #[inline(always)]
@@ -3514,8 +3514,8 @@ impl Simd for Sse4_2 {
         self.combine_i32x8(self.cvt_i32_f32x8(a0), self.cvt_i32_f32x8(a1))
     }
     #[inline(always)]
-    fn splat_i8x64(self, a: i8) -> i8x64<Self> {
-        let half = self.splat_i8x32(a);
+    fn splat_i8x64(self, val: i8) -> i8x64<Self> {
+        let half = self.splat_i8x32(val);
         self.combine_i8x32(half, half)
     }
     #[inline(always)]
@@ -3560,14 +3560,14 @@ impl Simd for Sse4_2 {
         self.combine_i8x32(self.not_i8x32(a0), self.not_i8x32(a1))
     }
     #[inline(always)]
-    fn shl_i8x64(self, a: i8x64<Self>, b: u32) -> i8x64<Self> {
+    fn shl_i8x64(self, a: i8x64<Self>, shift: u32) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
-        self.combine_i8x32(self.shl_i8x32(a0, b), self.shl_i8x32(a1, b))
+        self.combine_i8x32(self.shl_i8x32(a0, shift), self.shl_i8x32(a1, shift))
     }
     #[inline(always)]
-    fn shr_i8x64(self, a: i8x64<Self>, b: u32) -> i8x64<Self> {
+    fn shr_i8x64(self, a: i8x64<Self>, shift: u32) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
-        self.combine_i8x32(self.shr_i8x32(a0, b), self.shr_i8x32(a1, b))
+        self.combine_i8x32(self.shr_i8x32(a0, shift), self.shr_i8x32(a1, shift))
     }
     #[inline(always)]
     fn shrv_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -3675,8 +3675,8 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
-    fn splat_u8x64(self, a: u8) -> u8x64<Self> {
-        let half = self.splat_u8x32(a);
+    fn splat_u8x64(self, val: u8) -> u8x64<Self> {
+        let half = self.splat_u8x32(val);
         self.combine_u8x32(half, half)
     }
     #[inline(always)]
@@ -3721,14 +3721,14 @@ impl Simd for Sse4_2 {
         self.combine_u8x32(self.not_u8x32(a0), self.not_u8x32(a1))
     }
     #[inline(always)]
-    fn shl_u8x64(self, a: u8x64<Self>, b: u32) -> u8x64<Self> {
+    fn shl_u8x64(self, a: u8x64<Self>, shift: u32) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
-        self.combine_u8x32(self.shl_u8x32(a0, b), self.shl_u8x32(a1, b))
+        self.combine_u8x32(self.shl_u8x32(a0, shift), self.shl_u8x32(a1, shift))
     }
     #[inline(always)]
-    fn shr_u8x64(self, a: u8x64<Self>, b: u32) -> u8x64<Self> {
+    fn shr_u8x64(self, a: u8x64<Self>, shift: u32) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
-        self.combine_u8x32(self.shr_u8x32(a0, b), self.shr_u8x32(a1, b))
+        self.combine_u8x32(self.shr_u8x32(a0, shift), self.shr_u8x32(a1, shift))
     }
     #[inline(always)]
     fn shrv_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -3881,8 +3881,8 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
-    fn splat_mask8x64(self, a: i8) -> mask8x64<Self> {
-        let half = self.splat_mask8x32(a);
+    fn splat_mask8x64(self, val: i8) -> mask8x64<Self> {
+        let half = self.splat_mask8x32(val);
         self.combine_mask8x32(half, half)
     }
     #[inline(always)]
@@ -3958,8 +3958,8 @@ impl Simd for Sse4_2 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i16x32(self, a: i16) -> i16x32<Self> {
-        let half = self.splat_i16x16(a);
+    fn splat_i16x32(self, val: i16) -> i16x32<Self> {
+        let half = self.splat_i16x16(val);
         self.combine_i16x16(half, half)
     }
     #[inline(always)]
@@ -4004,14 +4004,14 @@ impl Simd for Sse4_2 {
         self.combine_i16x16(self.not_i16x16(a0), self.not_i16x16(a1))
     }
     #[inline(always)]
-    fn shl_i16x32(self, a: i16x32<Self>, b: u32) -> i16x32<Self> {
+    fn shl_i16x32(self, a: i16x32<Self>, shift: u32) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
-        self.combine_i16x16(self.shl_i16x16(a0, b), self.shl_i16x16(a1, b))
+        self.combine_i16x16(self.shl_i16x16(a0, shift), self.shl_i16x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_i16x32(self, a: i16x32<Self>, b: u32) -> i16x32<Self> {
+    fn shr_i16x32(self, a: i16x32<Self>, shift: u32) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
-        self.combine_i16x16(self.shr_i16x16(a0, b), self.shr_i16x16(a1, b))
+        self.combine_i16x16(self.shr_i16x16(a0, shift), self.shr_i16x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -4128,8 +4128,8 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
-    fn splat_u16x32(self, a: u16) -> u16x32<Self> {
-        let half = self.splat_u16x16(a);
+    fn splat_u16x32(self, val: u16) -> u16x32<Self> {
+        let half = self.splat_u16x16(val);
         self.combine_u16x16(half, half)
     }
     #[inline(always)]
@@ -4174,14 +4174,14 @@ impl Simd for Sse4_2 {
         self.combine_u16x16(self.not_u16x16(a0), self.not_u16x16(a1))
     }
     #[inline(always)]
-    fn shl_u16x32(self, a: u16x32<Self>, b: u32) -> u16x32<Self> {
+    fn shl_u16x32(self, a: u16x32<Self>, shift: u32) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
-        self.combine_u16x16(self.shl_u16x16(a0, b), self.shl_u16x16(a1, b))
+        self.combine_u16x16(self.shl_u16x16(a0, shift), self.shl_u16x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_u16x32(self, a: u16x32<Self>, b: u32) -> u16x32<Self> {
+    fn shr_u16x32(self, a: u16x32<Self>, shift: u32) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
-        self.combine_u16x16(self.shr_u16x16(a0, b), self.shr_u16x16(a1, b))
+        self.combine_u16x16(self.shr_u16x16(a0, shift), self.shr_u16x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -4353,8 +4353,8 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
-    fn splat_mask16x32(self, a: i16) -> mask16x32<Self> {
-        let half = self.splat_mask16x16(a);
+    fn splat_mask16x32(self, val: i16) -> mask16x32<Self> {
+        let half = self.splat_mask16x16(val);
         self.combine_mask16x16(half, half)
     }
     #[inline(always)]
@@ -4433,8 +4433,8 @@ impl Simd for Sse4_2 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i32x16(self, a: i32) -> i32x16<Self> {
-        let half = self.splat_i32x8(a);
+    fn splat_i32x16(self, val: i32) -> i32x16<Self> {
+        let half = self.splat_i32x8(val);
         self.combine_i32x8(half, half)
     }
     #[inline(always)]
@@ -4479,14 +4479,14 @@ impl Simd for Sse4_2 {
         self.combine_i32x8(self.not_i32x8(a0), self.not_i32x8(a1))
     }
     #[inline(always)]
-    fn shl_i32x16(self, a: i32x16<Self>, b: u32) -> i32x16<Self> {
+    fn shl_i32x16(self, a: i32x16<Self>, shift: u32) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
-        self.combine_i32x8(self.shl_i32x8(a0, b), self.shl_i32x8(a1, b))
+        self.combine_i32x8(self.shl_i32x8(a0, shift), self.shl_i32x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_i32x16(self, a: i32x16<Self>, b: u32) -> i32x16<Self> {
+    fn shr_i32x16(self, a: i32x16<Self>, shift: u32) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
-        self.combine_i32x8(self.shr_i32x8(a0, b), self.shr_i32x8(a1, b))
+        self.combine_i32x8(self.shr_i32x8(a0, shift), self.shr_i32x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -4599,8 +4599,8 @@ impl Simd for Sse4_2 {
         self.combine_f32x8(self.cvt_f32_i32x8(a0), self.cvt_f32_i32x8(a1))
     }
     #[inline(always)]
-    fn splat_u32x16(self, a: u32) -> u32x16<Self> {
-        let half = self.splat_u32x8(a);
+    fn splat_u32x16(self, val: u32) -> u32x16<Self> {
+        let half = self.splat_u32x8(val);
         self.combine_u32x8(half, half)
     }
     #[inline(always)]
@@ -4645,14 +4645,14 @@ impl Simd for Sse4_2 {
         self.combine_u32x8(self.not_u32x8(a0), self.not_u32x8(a1))
     }
     #[inline(always)]
-    fn shl_u32x16(self, a: u32x16<Self>, b: u32) -> u32x16<Self> {
+    fn shl_u32x16(self, a: u32x16<Self>, shift: u32) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
-        self.combine_u32x8(self.shl_u32x8(a0, b), self.shl_u32x8(a1, b))
+        self.combine_u32x8(self.shl_u32x8(a0, shift), self.shl_u32x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_u32x16(self, a: u32x16<Self>, b: u32) -> u32x16<Self> {
+    fn shr_u32x16(self, a: u32x16<Self>, shift: u32) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
-        self.combine_u32x8(self.shr_u32x8(a0, b), self.shr_u32x8(a1, b))
+        self.combine_u32x8(self.shr_u32x8(a0, shift), self.shr_u32x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -4797,8 +4797,8 @@ impl Simd for Sse4_2 {
         self.combine_f32x8(self.cvt_f32_u32x8(a0), self.cvt_f32_u32x8(a1))
     }
     #[inline(always)]
-    fn splat_mask32x16(self, a: i32) -> mask32x16<Self> {
-        let half = self.splat_mask32x8(a);
+    fn splat_mask32x16(self, val: i32) -> mask32x16<Self> {
+        let half = self.splat_mask32x8(val);
         self.combine_mask32x8(half, half)
     }
     #[inline(always)]
@@ -4874,8 +4874,8 @@ impl Simd for Sse4_2 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f64x8(self, a: f64) -> f64x8<Self> {
-        let half = self.splat_f64x4(a);
+    fn splat_f64x8(self, val: f64) -> f64x8<Self> {
+        let half = self.splat_f64x4(val);
         self.combine_f64x4(half, half)
     }
     #[inline(always)]
@@ -5073,8 +5073,8 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
-    fn splat_mask64x8(self, a: i64) -> mask64x8<Self> {
-        let half = self.splat_mask64x4(a);
+    fn splat_mask64x8(self, val: i64) -> mask64x8<Self> {
+        let half = self.splat_mask64x4(val);
         self.combine_mask64x4(half, half)
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -1401,8 +1401,8 @@ impl Simd for WasmSimd128 {
         result.simd_into(self)
     }
     #[inline(always)]
-    fn splat_f32x8(self, a: f32) -> f32x8<Self> {
-        let half = self.splat_f32x4(a);
+    fn splat_f32x8(self, val: f32) -> f32x8<Self> {
+        let half = self.splat_f32x4(val);
         self.combine_f32x4(half, half)
     }
     #[inline(always)]
@@ -1638,8 +1638,8 @@ impl Simd for WasmSimd128 {
         self.combine_i32x4(self.cvt_i32_f32x4(a0), self.cvt_i32_f32x4(a1))
     }
     #[inline(always)]
-    fn splat_i8x32(self, a: i8) -> i8x32<Self> {
-        let half = self.splat_i8x16(a);
+    fn splat_i8x32(self, val: i8) -> i8x32<Self> {
+        let half = self.splat_i8x16(val);
         self.combine_i8x16(half, half)
     }
     #[inline(always)]
@@ -1684,14 +1684,14 @@ impl Simd for WasmSimd128 {
         self.combine_i8x16(self.not_i8x16(a0), self.not_i8x16(a1))
     }
     #[inline(always)]
-    fn shl_i8x32(self, a: i8x32<Self>, b: u32) -> i8x32<Self> {
+    fn shl_i8x32(self, a: i8x32<Self>, shift: u32) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
-        self.combine_i8x16(self.shl_i8x16(a0, b), self.shl_i8x16(a1, b))
+        self.combine_i8x16(self.shl_i8x16(a0, shift), self.shl_i8x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_i8x32(self, a: i8x32<Self>, b: u32) -> i8x32<Self> {
+    fn shr_i8x32(self, a: i8x32<Self>, shift: u32) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
-        self.combine_i8x16(self.shr_i8x16(a0, b), self.shr_i8x16(a1, b))
+        self.combine_i8x16(self.shr_i8x16(a0, shift), self.shr_i8x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -1806,8 +1806,8 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
-    fn splat_u8x32(self, a: u8) -> u8x32<Self> {
-        let half = self.splat_u8x16(a);
+    fn splat_u8x32(self, val: u8) -> u8x32<Self> {
+        let half = self.splat_u8x16(val);
         self.combine_u8x16(half, half)
     }
     #[inline(always)]
@@ -1852,14 +1852,14 @@ impl Simd for WasmSimd128 {
         self.combine_u8x16(self.not_u8x16(a0), self.not_u8x16(a1))
     }
     #[inline(always)]
-    fn shl_u8x32(self, a: u8x32<Self>, b: u32) -> u8x32<Self> {
+    fn shl_u8x32(self, a: u8x32<Self>, shift: u32) -> u8x32<Self> {
         let (a0, a1) = self.split_u8x32(a);
-        self.combine_u8x16(self.shl_u8x16(a0, b), self.shl_u8x16(a1, b))
+        self.combine_u8x16(self.shl_u8x16(a0, shift), self.shl_u8x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_u8x32(self, a: u8x32<Self>, b: u32) -> u8x32<Self> {
+    fn shr_u8x32(self, a: u8x32<Self>, shift: u32) -> u8x32<Self> {
         let (a0, a1) = self.split_u8x32(a);
-        self.combine_u8x16(self.shr_u8x16(a0, b), self.shr_u8x16(a1, b))
+        self.combine_u8x16(self.shr_u8x16(a0, shift), self.shr_u8x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
@@ -1969,8 +1969,8 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
-    fn splat_mask8x32(self, a: i8) -> mask8x32<Self> {
-        let half = self.splat_mask8x16(a);
+    fn splat_mask8x32(self, val: i8) -> mask8x32<Self> {
+        let half = self.splat_mask8x16(val);
         self.combine_mask8x16(half, half)
     }
     #[inline(always)]
@@ -2053,8 +2053,8 @@ impl Simd for WasmSimd128 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i16x16(self, a: i16) -> i16x16<Self> {
-        let half = self.splat_i16x8(a);
+    fn splat_i16x16(self, val: i16) -> i16x16<Self> {
+        let half = self.splat_i16x8(val);
         self.combine_i16x8(half, half)
     }
     #[inline(always)]
@@ -2099,14 +2099,14 @@ impl Simd for WasmSimd128 {
         self.combine_i16x8(self.not_i16x8(a0), self.not_i16x8(a1))
     }
     #[inline(always)]
-    fn shl_i16x16(self, a: i16x16<Self>, b: u32) -> i16x16<Self> {
+    fn shl_i16x16(self, a: i16x16<Self>, shift: u32) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
-        self.combine_i16x8(self.shl_i16x8(a0, b), self.shl_i16x8(a1, b))
+        self.combine_i16x8(self.shl_i16x8(a0, shift), self.shl_i16x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_i16x16(self, a: i16x16<Self>, b: u32) -> i16x16<Self> {
+    fn shr_i16x16(self, a: i16x16<Self>, shift: u32) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
-        self.combine_i16x8(self.shr_i16x8(a0, b), self.shr_i16x8(a1, b))
+        self.combine_i16x8(self.shr_i16x8(a0, shift), self.shr_i16x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -2221,8 +2221,8 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
-    fn splat_u16x16(self, a: u16) -> u16x16<Self> {
-        let half = self.splat_u16x8(a);
+    fn splat_u16x16(self, val: u16) -> u16x16<Self> {
+        let half = self.splat_u16x8(val);
         self.combine_u16x8(half, half)
     }
     #[inline(always)]
@@ -2267,14 +2267,14 @@ impl Simd for WasmSimd128 {
         self.combine_u16x8(self.not_u16x8(a0), self.not_u16x8(a1))
     }
     #[inline(always)]
-    fn shl_u16x16(self, a: u16x16<Self>, b: u32) -> u16x16<Self> {
+    fn shl_u16x16(self, a: u16x16<Self>, shift: u32) -> u16x16<Self> {
         let (a0, a1) = self.split_u16x16(a);
-        self.combine_u16x8(self.shl_u16x8(a0, b), self.shl_u16x8(a1, b))
+        self.combine_u16x8(self.shl_u16x8(a0, shift), self.shl_u16x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_u16x16(self, a: u16x16<Self>, b: u32) -> u16x16<Self> {
+    fn shr_u16x16(self, a: u16x16<Self>, shift: u32) -> u16x16<Self> {
         let (a0, a1) = self.split_u16x16(a);
-        self.combine_u16x8(self.shr_u16x8(a0, b), self.shr_u16x8(a1, b))
+        self.combine_u16x8(self.shr_u16x8(a0, shift), self.shr_u16x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -2393,8 +2393,8 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
-    fn splat_mask16x16(self, a: i16) -> mask16x16<Self> {
-        let half = self.splat_mask16x8(a);
+    fn splat_mask16x16(self, val: i16) -> mask16x16<Self> {
+        let half = self.splat_mask16x8(val);
         self.combine_mask16x8(half, half)
     }
     #[inline(always)]
@@ -2477,8 +2477,8 @@ impl Simd for WasmSimd128 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i32x8(self, a: i32) -> i32x8<Self> {
-        let half = self.splat_i32x4(a);
+    fn splat_i32x8(self, val: i32) -> i32x8<Self> {
+        let half = self.splat_i32x4(val);
         self.combine_i32x4(half, half)
     }
     #[inline(always)]
@@ -2523,14 +2523,14 @@ impl Simd for WasmSimd128 {
         self.combine_i32x4(self.not_i32x4(a0), self.not_i32x4(a1))
     }
     #[inline(always)]
-    fn shl_i32x8(self, a: i32x8<Self>, b: u32) -> i32x8<Self> {
+    fn shl_i32x8(self, a: i32x8<Self>, shift: u32) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
-        self.combine_i32x4(self.shl_i32x4(a0, b), self.shl_i32x4(a1, b))
+        self.combine_i32x4(self.shl_i32x4(a0, shift), self.shl_i32x4(a1, shift))
     }
     #[inline(always)]
-    fn shr_i32x8(self, a: i32x8<Self>, b: u32) -> i32x8<Self> {
+    fn shr_i32x8(self, a: i32x8<Self>, shift: u32) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
-        self.combine_i32x4(self.shr_i32x4(a0, b), self.shr_i32x4(a1, b))
+        self.combine_i32x4(self.shr_i32x4(a0, shift), self.shr_i32x4(a1, shift))
     }
     #[inline(always)]
     fn shrv_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -2650,8 +2650,8 @@ impl Simd for WasmSimd128 {
         self.combine_f32x4(self.cvt_f32_i32x4(a0), self.cvt_f32_i32x4(a1))
     }
     #[inline(always)]
-    fn splat_u32x8(self, a: u32) -> u32x8<Self> {
-        let half = self.splat_u32x4(a);
+    fn splat_u32x8(self, val: u32) -> u32x8<Self> {
+        let half = self.splat_u32x4(val);
         self.combine_u32x4(half, half)
     }
     #[inline(always)]
@@ -2696,14 +2696,14 @@ impl Simd for WasmSimd128 {
         self.combine_u32x4(self.not_u32x4(a0), self.not_u32x4(a1))
     }
     #[inline(always)]
-    fn shl_u32x8(self, a: u32x8<Self>, b: u32) -> u32x8<Self> {
+    fn shl_u32x8(self, a: u32x8<Self>, shift: u32) -> u32x8<Self> {
         let (a0, a1) = self.split_u32x8(a);
-        self.combine_u32x4(self.shl_u32x4(a0, b), self.shl_u32x4(a1, b))
+        self.combine_u32x4(self.shl_u32x4(a0, shift), self.shl_u32x4(a1, shift))
     }
     #[inline(always)]
-    fn shr_u32x8(self, a: u32x8<Self>, b: u32) -> u32x8<Self> {
+    fn shr_u32x8(self, a: u32x8<Self>, shift: u32) -> u32x8<Self> {
         let (a0, a1) = self.split_u32x8(a);
-        self.combine_u32x4(self.shr_u32x4(a0, b), self.shr_u32x4(a1, b))
+        self.combine_u32x4(self.shr_u32x4(a0, shift), self.shr_u32x4(a1, shift))
     }
     #[inline(always)]
     fn shrv_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
@@ -2810,8 +2810,8 @@ impl Simd for WasmSimd128 {
         self.combine_f32x4(self.cvt_f32_u32x4(a0), self.cvt_f32_u32x4(a1))
     }
     #[inline(always)]
-    fn splat_mask32x8(self, a: i32) -> mask32x8<Self> {
-        let half = self.splat_mask32x4(a);
+    fn splat_mask32x8(self, val: i32) -> mask32x8<Self> {
+        let half = self.splat_mask32x4(val);
         self.combine_mask32x4(half, half)
     }
     #[inline(always)]
@@ -2894,8 +2894,8 @@ impl Simd for WasmSimd128 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f64x4(self, a: f64) -> f64x4<Self> {
-        let half = self.splat_f64x2(a);
+    fn splat_f64x4(self, val: f64) -> f64x4<Self> {
+        let half = self.splat_f64x2(val);
         self.combine_f64x2(half, half)
     }
     #[inline(always)]
@@ -3100,8 +3100,8 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
-    fn splat_mask64x4(self, a: i64) -> mask64x4<Self> {
-        let half = self.splat_mask64x2(a);
+    fn splat_mask64x4(self, val: i64) -> mask64x4<Self> {
+        let half = self.splat_mask64x2(val);
         self.combine_mask64x2(half, half)
     }
     #[inline(always)]
@@ -3184,8 +3184,8 @@ impl Simd for WasmSimd128 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f32x16(self, a: f32) -> f32x16<Self> {
-        let half = self.splat_f32x8(a);
+    fn splat_f32x16(self, val: f32) -> f32x16<Self> {
+        let half = self.splat_f32x8(val);
         self.combine_f32x8(half, half)
     }
     #[inline(always)]
@@ -3456,8 +3456,8 @@ impl Simd for WasmSimd128 {
         self.combine_i32x8(self.cvt_i32_f32x8(a0), self.cvt_i32_f32x8(a1))
     }
     #[inline(always)]
-    fn splat_i8x64(self, a: i8) -> i8x64<Self> {
-        let half = self.splat_i8x32(a);
+    fn splat_i8x64(self, val: i8) -> i8x64<Self> {
+        let half = self.splat_i8x32(val);
         self.combine_i8x32(half, half)
     }
     #[inline(always)]
@@ -3502,14 +3502,14 @@ impl Simd for WasmSimd128 {
         self.combine_i8x32(self.not_i8x32(a0), self.not_i8x32(a1))
     }
     #[inline(always)]
-    fn shl_i8x64(self, a: i8x64<Self>, b: u32) -> i8x64<Self> {
+    fn shl_i8x64(self, a: i8x64<Self>, shift: u32) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
-        self.combine_i8x32(self.shl_i8x32(a0, b), self.shl_i8x32(a1, b))
+        self.combine_i8x32(self.shl_i8x32(a0, shift), self.shl_i8x32(a1, shift))
     }
     #[inline(always)]
-    fn shr_i8x64(self, a: i8x64<Self>, b: u32) -> i8x64<Self> {
+    fn shr_i8x64(self, a: i8x64<Self>, shift: u32) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
-        self.combine_i8x32(self.shr_i8x32(a0, b), self.shr_i8x32(a1, b))
+        self.combine_i8x32(self.shr_i8x32(a0, shift), self.shr_i8x32(a1, shift))
     }
     #[inline(always)]
     fn shrv_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -3617,8 +3617,8 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
-    fn splat_u8x64(self, a: u8) -> u8x64<Self> {
-        let half = self.splat_u8x32(a);
+    fn splat_u8x64(self, val: u8) -> u8x64<Self> {
+        let half = self.splat_u8x32(val);
         self.combine_u8x32(half, half)
     }
     #[inline(always)]
@@ -3663,14 +3663,14 @@ impl Simd for WasmSimd128 {
         self.combine_u8x32(self.not_u8x32(a0), self.not_u8x32(a1))
     }
     #[inline(always)]
-    fn shl_u8x64(self, a: u8x64<Self>, b: u32) -> u8x64<Self> {
+    fn shl_u8x64(self, a: u8x64<Self>, shift: u32) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
-        self.combine_u8x32(self.shl_u8x32(a0, b), self.shl_u8x32(a1, b))
+        self.combine_u8x32(self.shl_u8x32(a0, shift), self.shl_u8x32(a1, shift))
     }
     #[inline(always)]
-    fn shr_u8x64(self, a: u8x64<Self>, b: u32) -> u8x64<Self> {
+    fn shr_u8x64(self, a: u8x64<Self>, shift: u32) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
-        self.combine_u8x32(self.shr_u8x32(a0, b), self.shr_u8x32(a1, b))
+        self.combine_u8x32(self.shr_u8x32(a0, shift), self.shr_u8x32(a1, shift))
     }
     #[inline(always)]
     fn shrv_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -3834,8 +3834,8 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
-    fn splat_mask8x64(self, a: i8) -> mask8x64<Self> {
-        let half = self.splat_mask8x32(a);
+    fn splat_mask8x64(self, val: i8) -> mask8x64<Self> {
+        let half = self.splat_mask8x32(val);
         self.combine_mask8x32(half, half)
     }
     #[inline(always)]
@@ -3911,8 +3911,8 @@ impl Simd for WasmSimd128 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i16x32(self, a: i16) -> i16x32<Self> {
-        let half = self.splat_i16x16(a);
+    fn splat_i16x32(self, val: i16) -> i16x32<Self> {
+        let half = self.splat_i16x16(val);
         self.combine_i16x16(half, half)
     }
     #[inline(always)]
@@ -3957,14 +3957,14 @@ impl Simd for WasmSimd128 {
         self.combine_i16x16(self.not_i16x16(a0), self.not_i16x16(a1))
     }
     #[inline(always)]
-    fn shl_i16x32(self, a: i16x32<Self>, b: u32) -> i16x32<Self> {
+    fn shl_i16x32(self, a: i16x32<Self>, shift: u32) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
-        self.combine_i16x16(self.shl_i16x16(a0, b), self.shl_i16x16(a1, b))
+        self.combine_i16x16(self.shl_i16x16(a0, shift), self.shl_i16x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_i16x32(self, a: i16x32<Self>, b: u32) -> i16x32<Self> {
+    fn shr_i16x32(self, a: i16x32<Self>, shift: u32) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
-        self.combine_i16x16(self.shr_i16x16(a0, b), self.shr_i16x16(a1, b))
+        self.combine_i16x16(self.shr_i16x16(a0, shift), self.shr_i16x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -4081,8 +4081,8 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
-    fn splat_u16x32(self, a: u16) -> u16x32<Self> {
-        let half = self.splat_u16x16(a);
+    fn splat_u16x32(self, val: u16) -> u16x32<Self> {
+        let half = self.splat_u16x16(val);
         self.combine_u16x16(half, half)
     }
     #[inline(always)]
@@ -4127,14 +4127,14 @@ impl Simd for WasmSimd128 {
         self.combine_u16x16(self.not_u16x16(a0), self.not_u16x16(a1))
     }
     #[inline(always)]
-    fn shl_u16x32(self, a: u16x32<Self>, b: u32) -> u16x32<Self> {
+    fn shl_u16x32(self, a: u16x32<Self>, shift: u32) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
-        self.combine_u16x16(self.shl_u16x16(a0, b), self.shl_u16x16(a1, b))
+        self.combine_u16x16(self.shl_u16x16(a0, shift), self.shl_u16x16(a1, shift))
     }
     #[inline(always)]
-    fn shr_u16x32(self, a: u16x32<Self>, b: u32) -> u16x32<Self> {
+    fn shr_u16x32(self, a: u16x32<Self>, shift: u32) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
-        self.combine_u16x16(self.shr_u16x16(a0, b), self.shr_u16x16(a1, b))
+        self.combine_u16x16(self.shr_u16x16(a0, shift), self.shr_u16x16(a1, shift))
     }
     #[inline(always)]
     fn shrv_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -4293,8 +4293,8 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
-    fn splat_mask16x32(self, a: i16) -> mask16x32<Self> {
-        let half = self.splat_mask16x16(a);
+    fn splat_mask16x32(self, val: i16) -> mask16x32<Self> {
+        let half = self.splat_mask16x16(val);
         self.combine_mask16x16(half, half)
     }
     #[inline(always)]
@@ -4373,8 +4373,8 @@ impl Simd for WasmSimd128 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_i32x16(self, a: i32) -> i32x16<Self> {
-        let half = self.splat_i32x8(a);
+    fn splat_i32x16(self, val: i32) -> i32x16<Self> {
+        let half = self.splat_i32x8(val);
         self.combine_i32x8(half, half)
     }
     #[inline(always)]
@@ -4419,14 +4419,14 @@ impl Simd for WasmSimd128 {
         self.combine_i32x8(self.not_i32x8(a0), self.not_i32x8(a1))
     }
     #[inline(always)]
-    fn shl_i32x16(self, a: i32x16<Self>, b: u32) -> i32x16<Self> {
+    fn shl_i32x16(self, a: i32x16<Self>, shift: u32) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
-        self.combine_i32x8(self.shl_i32x8(a0, b), self.shl_i32x8(a1, b))
+        self.combine_i32x8(self.shl_i32x8(a0, shift), self.shl_i32x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_i32x16(self, a: i32x16<Self>, b: u32) -> i32x16<Self> {
+    fn shr_i32x16(self, a: i32x16<Self>, shift: u32) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
-        self.combine_i32x8(self.shr_i32x8(a0, b), self.shr_i32x8(a1, b))
+        self.combine_i32x8(self.shr_i32x8(a0, shift), self.shr_i32x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -4539,8 +4539,8 @@ impl Simd for WasmSimd128 {
         self.combine_f32x8(self.cvt_f32_i32x8(a0), self.cvt_f32_i32x8(a1))
     }
     #[inline(always)]
-    fn splat_u32x16(self, a: u32) -> u32x16<Self> {
-        let half = self.splat_u32x8(a);
+    fn splat_u32x16(self, val: u32) -> u32x16<Self> {
+        let half = self.splat_u32x8(val);
         self.combine_u32x8(half, half)
     }
     #[inline(always)]
@@ -4585,14 +4585,14 @@ impl Simd for WasmSimd128 {
         self.combine_u32x8(self.not_u32x8(a0), self.not_u32x8(a1))
     }
     #[inline(always)]
-    fn shl_u32x16(self, a: u32x16<Self>, b: u32) -> u32x16<Self> {
+    fn shl_u32x16(self, a: u32x16<Self>, shift: u32) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
-        self.combine_u32x8(self.shl_u32x8(a0, b), self.shl_u32x8(a1, b))
+        self.combine_u32x8(self.shl_u32x8(a0, shift), self.shl_u32x8(a1, shift))
     }
     #[inline(always)]
-    fn shr_u32x16(self, a: u32x16<Self>, b: u32) -> u32x16<Self> {
+    fn shr_u32x16(self, a: u32x16<Self>, shift: u32) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
-        self.combine_u32x8(self.shr_u32x8(a0, b), self.shr_u32x8(a1, b))
+        self.combine_u32x8(self.shr_u32x8(a0, shift), self.shr_u32x8(a1, shift))
     }
     #[inline(always)]
     fn shrv_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -4734,8 +4734,8 @@ impl Simd for WasmSimd128 {
         self.combine_f32x8(self.cvt_f32_u32x8(a0), self.cvt_f32_u32x8(a1))
     }
     #[inline(always)]
-    fn splat_mask32x16(self, a: i32) -> mask32x16<Self> {
-        let half = self.splat_mask32x8(a);
+    fn splat_mask32x16(self, val: i32) -> mask32x16<Self> {
+        let half = self.splat_mask32x8(val);
         self.combine_mask32x8(half, half)
     }
     #[inline(always)]
@@ -4811,8 +4811,8 @@ impl Simd for WasmSimd128 {
         (b0.simd_into(self), b1.simd_into(self))
     }
     #[inline(always)]
-    fn splat_f64x8(self, a: f64) -> f64x8<Self> {
-        let half = self.splat_f64x4(a);
+    fn splat_f64x8(self, val: f64) -> f64x8<Self> {
+        let half = self.splat_f64x4(val);
         self.combine_f64x4(half, half)
     }
     #[inline(always)]
@@ -5010,8 +5010,8 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
-    fn splat_mask64x8(self, a: i64) -> mask64x8<Self> {
-        let half = self.splat_mask64x4(a);
+    fn splat_mask64x8(self, val: i64) -> mask64x8<Self> {
+        let half = self.splat_mask64x4(val);
         self.combine_mask64x4(half, half)
     }
     #[inline(always)]

--- a/fearless_simd_gen/src/mk_avx2.rs
+++ b/fearless_simd_gen/src/mk_avx2.rs
@@ -165,11 +165,10 @@ fn make_method(method: &str, sig: OpSig, vec_ty: &VecType) -> TokenStream {
     let ty_name = vec_ty.rust_name();
     let method_name = format!("{method}_{ty_name}");
     let method_ident = Ident::new(&method_name, Span::call_site());
-    let ret_ty = sig.simd_impl_ret_ty(vec_ty);
-    let args = sig.simd_trait_args(vec_ty);
+    let method_sig = sig.simd_trait_method_sig(vec_ty, &method_name);
     let method_sig = quote! {
         #[inline(always)]
-        fn #method_ident(#args) -> #ret_ty
+        #method_sig
     };
 
     if method == "shrv" && scalar_bits < 32 {

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -135,13 +135,12 @@ fn mk_simd_impl() -> TokenStream {
                 continue;
             }
             let method_name = format!("{method}_{ty_name}");
-            let method_ident = Ident::new(&method_name, Span::call_site());
-            let ret_ty = sig.simd_impl_ret_ty(vec_ty);
-            let args = sig.simd_trait_args(vec_ty);
+            let method_sig = sig.simd_trait_method_sig(vec_ty, &method_name);
             let method_sig = quote! {
                 #[inline(always)]
-                fn #method_ident(#args) -> #ret_ty
+                #method_sig
             };
+
             let method = match sig {
                 OpSig::Splat => {
                     let num_elements = vec_ty.len;

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -87,12 +87,10 @@ fn mk_simd_impl(level: Level) -> TokenStream {
                 continue;
             }
             let method_name = format!("{method}_{ty_name}");
-            let method_ident = Ident::new(&method_name, Span::call_site());
-            let ret_ty = sig.simd_impl_ret_ty(vec_ty);
-            let args = sig.simd_trait_args(vec_ty);
+            let method_sig = sig.simd_trait_method_sig(vec_ty, &method_name);
             let method_sig = quote! {
                 #[inline(always)]
-                fn #method_ident(#args) -> #ret_ty
+                #method_sig
             };
 
             let method = match sig {

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::{
@@ -20,13 +20,11 @@ pub(crate) fn mk_simd_trait() -> TokenStream {
         } in &ops_for_type(vec_ty)
         {
             let method_name = format!("{method}_{ty_name}");
-            let method = Ident::new(&method_name, Span::call_site());
-            let args = sig.simd_trait_args(vec_ty);
-            let ret_ty = sig.simd_impl_ret_ty(vec_ty);
+            let method_sig = sig.simd_trait_method_sig(vec_ty, &method_name);
             let doc = sig.format_docstring(doc, TyFlavor::SimdTrait);
             methods.extend(quote! {
                 #[doc = #doc]
-                fn #method(#args) -> #ret_ty;
+                #method_sig;
             });
         }
     }
@@ -217,13 +215,11 @@ fn methods_for_vec_trait(scalar: ScalarType) -> Vec<TokenStream> {
         method, sig, doc, ..
     } in vec_trait_ops_for(scalar)
     {
-        let method_name = Ident::new(method, Span::call_site());
         let doc = sig.format_docstring(doc, TyFlavor::VecImpl);
-        if let Some(args) = sig.vec_trait_args() {
-            let ret_ty = sig.trait_ret_ty();
+        if let Some(method_sig) = sig.vec_trait_method_sig(method) {
             methods.push(quote! {
                 #[doc = #doc]
-                fn #method_name(#args) -> #ret_ty;
+                #method_sig;
             });
         }
     }

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -231,16 +231,14 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
     let splat = generic_op_name("splat", ty);
     let mut methods = vec![];
     for Op { method, sig, .. } in vec_trait_ops_for(ty.scalar) {
-        let method_name = Ident::new(method, Span::call_site());
         let trait_method = generic_op_name(method, ty);
-        if let Some(args) = sig.vec_trait_args() {
-            let ret_ty = sig.trait_ret_ty();
+        if let Some(method_sig) = sig.vec_trait_method_sig(method) {
             let call_args = sig
                 .forwarding_call_args()
                 .expect("this method can be forwarded to a specific Simd function");
             methods.push(quote! {
                 #[inline(always)]
-                fn #method_name(#args) -> #ret_ty {
+                #method_sig {
                     self.simd.#trait_method(#call_args)
                 }
             });

--- a/fearless_simd_gen/src/mk_sse4_2.rs
+++ b/fearless_simd_gen/src/mk_sse4_2.rs
@@ -168,11 +168,10 @@ fn make_method(method: &str, sig: OpSig, vec_ty: &VecType) -> TokenStream {
     let ty_name = vec_ty.rust_name();
     let method_name = format!("{method}_{ty_name}");
     let method_ident = Ident::new(&method_name, Span::call_site());
-    let ret_ty = sig.simd_impl_ret_ty(vec_ty);
-    let args = sig.simd_trait_args(vec_ty);
+    let method_sig = sig.simd_trait_method_sig(vec_ty, &method_name);
     let method_sig = quote! {
         #[inline(always)]
-        fn #method_ident(#args) -> #ret_ty
+        #method_sig
     };
 
     if method == "shrv" {


### PR DESCRIPTION
Instead of exporting functions from `OpSig` to generate the arguments list and return type for each method separately, consolidate everything into methods that return the entire method signature at once.

The only change to the generated code is in the parameter names of the generic split/combine-based methods--they now match the parameter names of the `Simd` trait methods.

I plan to add methods that use const generics as part of the swizzle work, and this is a prerequisite.