### PR TITLE
Inline `float_from` and `truncate_from`

### DIFF
--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -220,11 +220,13 @@ impl<S: Simd> crate::SimdFloat<f32, S> for f32x4<S> {
     }
 }
 impl<S: Simd> SimdCvtFloat<u32x4<S>> for f32x4<S> {
+    #[inline(always)]
     fn float_from(x: u32x4<S>) -> Self {
         x.simd.cvt_f32_u32x4(x)
     }
 }
 impl<S: Simd> SimdCvtFloat<i32x4<S>> for f32x4<S> {
+    #[inline(always)]
     fn float_from(x: i32x4<S>) -> Self {
         x.simd.cvt_f32_i32x4(x)
     }
@@ -1464,6 +1466,7 @@ impl<S: Simd> crate::SimdInt<i32, S> for i32x4<S> {
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x4<S>> for i32x4<S> {
+    #[inline(always)]
     fn truncate_from(x: f32x4<S>) -> Self {
         x.simd.cvt_i32_f32x4(x)
     }
@@ -1641,6 +1644,7 @@ impl<S: Simd> crate::SimdInt<u32, S> for u32x4<S> {
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x4<S>> for u32x4<S> {
+    #[inline(always)]
     fn truncate_from(x: f32x4<S>) -> Self {
         x.simd.cvt_u32_f32x4(x)
     }
@@ -2395,11 +2399,13 @@ impl<S: Simd> crate::SimdFloat<f32, S> for f32x8<S> {
     }
 }
 impl<S: Simd> SimdCvtFloat<u32x8<S>> for f32x8<S> {
+    #[inline(always)]
     fn float_from(x: u32x8<S>) -> Self {
         x.simd.cvt_f32_u32x8(x)
     }
 }
 impl<S: Simd> SimdCvtFloat<i32x8<S>> for f32x8<S> {
+    #[inline(always)]
     fn float_from(x: i32x8<S>) -> Self {
         x.simd.cvt_f32_i32x8(x)
     }
@@ -3769,6 +3775,7 @@ impl<S: Simd> crate::SimdInt<i32, S> for i32x8<S> {
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x8<S>> for i32x8<S> {
+    #[inline(always)]
     fn truncate_from(x: f32x8<S>) -> Self {
         x.simd.cvt_i32_f32x8(x)
     }
@@ -3962,6 +3969,7 @@ impl<S: Simd> crate::SimdInt<u32, S> for u32x8<S> {
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x8<S>> for u32x8<S> {
+    #[inline(always)]
     fn truncate_from(x: f32x8<S>) -> Self {
         x.simd.cvt_u32_f32x8(x)
     }
@@ -4762,11 +4770,13 @@ impl<S: Simd> crate::SimdFloat<f32, S> for f32x16<S> {
     }
 }
 impl<S: Simd> SimdCvtFloat<u32x16<S>> for f32x16<S> {
+    #[inline(always)]
     fn float_from(x: u32x16<S>) -> Self {
         x.simd.cvt_f32_u32x16(x)
     }
 }
 impl<S: Simd> SimdCvtFloat<i32x16<S>> for f32x16<S> {
+    #[inline(always)]
     fn float_from(x: i32x16<S>) -> Self {
         x.simd.cvt_f32_i32x16(x)
     }
@@ -6246,6 +6256,7 @@ impl<S: Simd> crate::SimdInt<i32, S> for i32x16<S> {
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x16<S>> for i32x16<S> {
+    #[inline(always)]
     fn truncate_from(x: f32x16<S>) -> Self {
         x.simd.cvt_i32_f32x16(x)
     }
@@ -6441,6 +6452,7 @@ impl<S: Simd> crate::SimdInt<u32, S> for u32x16<S> {
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x16<S>> for u32x16<S> {
+    #[inline(always)]
     fn truncate_from(x: f32x16<S>) -> Self {
         x.simd.cvt_u32_f32x16(x)
     }

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -73,6 +73,7 @@ pub(crate) fn mk_simd_types() -> TokenStream {
                     let src_ty = src_ty.rust();
                     conditional_impls.push(quote! {
                         impl<S: Simd> SimdCvtFloat<#src_ty<S>> for #name<S> {
+                            #[inline(always)]
                             fn float_from(x: #src_ty<S>) -> Self {
                                 x.simd.#method(x)
                             }
@@ -93,6 +94,7 @@ pub(crate) fn mk_simd_types() -> TokenStream {
                 let src_ty = src_ty.rust();
                 conditional_impls.push(quote! {
                     impl<S: Simd> SimdCvtTruncate<#src_ty<S>> for #name<S> {
+                        #[inline(always)]
                         fn truncate_from(x: #src_ty<S>) -> Self {
                             x.simd.#method(x)
                         }


### PR DESCRIPTION
These weren't marked as `#[inline]`, but previously seemed to be getting inlined anyway. After updating rustc and fearless_simd, some inlining heuristic must have changed, because they stopped getting inlined and everything became much slower.