### PR TITLE
Use `load_array_ref` to implement `from_slice`

### DIFF
--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -97,7 +97,7 @@ impl<S: Simd> SimdBase<S> for f32x4<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[f32]) -> Self {
-        simd.load_array_f32x4(slice.try_into().unwrap())
+        simd.load_array_ref_f32x4(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [f32]) {
@@ -327,7 +327,7 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i8]) -> Self {
-        simd.load_array_i8x16(slice.try_into().unwrap())
+        simd.load_array_ref_i8x16(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i8]) {
@@ -493,7 +493,7 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u8]) -> Self {
-        simd.load_array_u8x16(slice.try_into().unwrap())
+        simd.load_array_ref_u8x16(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u8]) {
@@ -664,7 +664,7 @@ impl<S: Simd> SimdBase<S> for mask8x16<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i8]) -> Self {
-        simd.load_array_mask8x16(slice.try_into().unwrap())
+        simd.load_array_ref_mask8x16(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i8]) {
@@ -806,7 +806,7 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i16]) -> Self {
-        simd.load_array_i16x8(slice.try_into().unwrap())
+        simd.load_array_ref_i16x8(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i16]) {
@@ -972,7 +972,7 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u16]) -> Self {
-        simd.load_array_u16x8(slice.try_into().unwrap())
+        simd.load_array_ref_u16x8(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u16]) {
@@ -1143,7 +1143,7 @@ impl<S: Simd> SimdBase<S> for mask16x8<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i16]) -> Self {
-        simd.load_array_mask16x8(slice.try_into().unwrap())
+        simd.load_array_ref_mask16x8(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i16]) {
@@ -1285,7 +1285,7 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i32]) -> Self {
-        simd.load_array_i32x4(slice.try_into().unwrap())
+        simd.load_array_ref_i32x4(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i32]) {
@@ -1463,7 +1463,7 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u32]) -> Self {
-        simd.load_array_u32x4(slice.try_into().unwrap())
+        simd.load_array_ref_u32x4(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u32]) {
@@ -1646,7 +1646,7 @@ impl<S: Simd> SimdBase<S> for mask32x4<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i32]) -> Self {
-        simd.load_array_mask32x4(slice.try_into().unwrap())
+        simd.load_array_ref_mask32x4(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i32]) {
@@ -1788,7 +1788,7 @@ impl<S: Simd> SimdBase<S> for f64x2<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[f64]) -> Self {
-        simd.load_array_f64x2(slice.try_into().unwrap())
+        simd.load_array_ref_f64x2(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [f64]) {
@@ -2009,7 +2009,7 @@ impl<S: Simd> SimdBase<S> for mask64x2<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i64]) -> Self {
-        simd.load_array_mask64x2(slice.try_into().unwrap())
+        simd.load_array_ref_mask64x2(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i64]) {
@@ -2151,7 +2151,7 @@ impl<S: Simd> SimdBase<S> for f32x8<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[f32]) -> Self {
-        simd.load_array_f32x8(slice.try_into().unwrap())
+        simd.load_array_ref_f32x8(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [f32]) {
@@ -2388,7 +2388,7 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i8]) -> Self {
-        simd.load_array_i8x32(slice.try_into().unwrap())
+        simd.load_array_ref_i8x32(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i8]) {
@@ -2561,7 +2561,7 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u8]) -> Self {
-        simd.load_array_u8x32(slice.try_into().unwrap())
+        simd.load_array_ref_u8x32(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u8]) {
@@ -2739,7 +2739,7 @@ impl<S: Simd> SimdBase<S> for mask8x32<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i8]) -> Self {
-        simd.load_array_mask8x32(slice.try_into().unwrap())
+        simd.load_array_ref_mask8x32(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i8]) {
@@ -2893,7 +2893,7 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i16]) -> Self {
-        simd.load_array_i16x16(slice.try_into().unwrap())
+        simd.load_array_ref_i16x16(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i16]) {
@@ -3071,7 +3071,7 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u16]) -> Self {
-        simd.load_array_u16x16(slice.try_into().unwrap())
+        simd.load_array_ref_u16x16(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u16]) {
@@ -3249,7 +3249,7 @@ impl<S: Simd> SimdBase<S> for mask16x16<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i16]) -> Self {
-        simd.load_array_mask16x16(slice.try_into().unwrap())
+        simd.load_array_ref_mask16x16(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i16]) {
@@ -3398,7 +3398,7 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i32]) -> Self {
-        simd.load_array_i32x8(slice.try_into().unwrap())
+        simd.load_array_ref_i32x8(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i32]) {
@@ -3583,7 +3583,7 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u32]) -> Self {
-        simd.load_array_u32x8(slice.try_into().unwrap())
+        simd.load_array_ref_u32x8(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u32]) {
@@ -3773,7 +3773,7 @@ impl<S: Simd> SimdBase<S> for mask32x8<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i32]) -> Self {
-        simd.load_array_mask32x8(slice.try_into().unwrap())
+        simd.load_array_ref_mask32x8(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i32]) {
@@ -3922,7 +3922,7 @@ impl<S: Simd> SimdBase<S> for f64x4<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[f64]) -> Self {
-        simd.load_array_f64x4(slice.try_into().unwrap())
+        simd.load_array_ref_f64x4(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [f64]) {
@@ -4150,7 +4150,7 @@ impl<S: Simd> SimdBase<S> for mask64x4<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i64]) -> Self {
-        simd.load_array_mask64x4(slice.try_into().unwrap())
+        simd.load_array_ref_mask64x4(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i64]) {
@@ -4304,7 +4304,7 @@ impl<S: Simd> SimdBase<S> for f32x16<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[f32]) -> Self {
-        simd.load_array_f32x16(slice.try_into().unwrap())
+        simd.load_array_ref_f32x16(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [f32]) {
@@ -4535,7 +4535,7 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i8]) -> Self {
-        simd.load_array_i8x64(slice.try_into().unwrap())
+        simd.load_array_ref_i8x64(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i8]) {
@@ -4702,7 +4702,7 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u8]) -> Self {
-        simd.load_array_u8x64(slice.try_into().unwrap())
+        simd.load_array_ref_u8x64(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u8]) {
@@ -4874,7 +4874,7 @@ impl<S: Simd> SimdBase<S> for mask8x64<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i8]) -> Self {
-        simd.load_array_mask8x64(slice.try_into().unwrap())
+        simd.load_array_ref_mask8x64(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i8]) {
@@ -5022,7 +5022,7 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i16]) -> Self {
-        simd.load_array_i16x32(slice.try_into().unwrap())
+        simd.load_array_ref_i16x32(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i16]) {
@@ -5194,7 +5194,7 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u16]) -> Self {
-        simd.load_array_u16x32(slice.try_into().unwrap())
+        simd.load_array_ref_u16x32(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u16]) {
@@ -5366,7 +5366,7 @@ impl<S: Simd> SimdBase<S> for mask16x32<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i16]) -> Self {
-        simd.load_array_mask16x32(slice.try_into().unwrap())
+        simd.load_array_ref_mask16x32(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i16]) {
@@ -5514,7 +5514,7 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i32]) -> Self {
-        simd.load_array_i32x16(slice.try_into().unwrap())
+        simd.load_array_ref_i32x16(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i32]) {
@@ -5698,7 +5698,7 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u32]) -> Self {
-        simd.load_array_u32x16(slice.try_into().unwrap())
+        simd.load_array_ref_u32x16(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u32]) {
@@ -5882,7 +5882,7 @@ impl<S: Simd> SimdBase<S> for mask32x16<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i32]) -> Self {
-        simd.load_array_mask32x16(slice.try_into().unwrap())
+        simd.load_array_ref_mask32x16(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i32]) {
@@ -6025,7 +6025,7 @@ impl<S: Simd> SimdBase<S> for f64x8<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[f64]) -> Self {
-        simd.load_array_f64x8(slice.try_into().unwrap())
+        simd.load_array_ref_f64x8(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [f64]) {
@@ -6247,7 +6247,7 @@ impl<S: Simd> SimdBase<S> for mask64x8<S> {
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i64]) -> Self {
-        simd.load_array_mask64x8(slice.try_into().unwrap())
+        simd.load_array_ref_mask64x8(slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i64]) {

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -289,6 +289,7 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
         _ => unreachable!(),
     };
     let from_array_op = generic_op_name("load_array", ty);
+    let from_array_ref_op = generic_op_name("load_array_ref", ty);
     let store_array_op = generic_op_name("store_array", ty);
     let as_array_ref_op = generic_op_name("as_array_ref", ty);
     let as_array_mut_op = generic_op_name("as_array_mut", ty);
@@ -317,7 +318,7 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
 
             #[inline(always)]
             fn from_slice(simd: S, slice: &[#scalar]) -> Self {
-                simd.#from_array_op(slice.try_into().unwrap())
+                simd.#from_array_ref_op(slice.try_into().unwrap())
             }
 
             #[inline(always)]


### PR DESCRIPTION
I *meant* to use this method to implement the `from_slice` method, but apparently used `load_array` instead.