### PR TITLE
Explicitly `cast_signed` some masks and sign bits on x86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ This release has an [MSRV][] of 1.88.
 - Breaking change: the `Element` type on the `SimdBase` trait is now an associated type instead of a type parameter. This should make it more pleasant to write code that's generic over different vector types. ([#170][] by [@valadaptive][])
 - The `WasmSimd128` token type now wraps the new `crate::core_arch::wasm32::WasmSimd128` type. This doesn't expose any new functionality as WASM SIMD128 can only be enabled statically, but matches all the other backend tokens. ([#176][] by [@valadaptive][])
 - Breaking change: the `SimdFrom::simd_from` method now takes the SIMD token as the first argument instead of the second. This matches the argument order of the `from_slice`, `splat`, and `from_fn` methods on `SimdBase`. ([#180][] by [@valadaptive][])
-- Code generation has been improved for shift argument casting on x86 and for scalar fallback. ([#186][] and [#189][] by [@tomcur][])
 
 ### Removed
 
@@ -171,8 +170,6 @@ No changelog was kept for this release.
 [#176]: https://github.com/linebender/fearless_simd/pull/176
 [#180]: https://github.com/linebender/fearless_simd/pull/180
 [#181]: https://github.com/linebender/fearless_simd/pull/181
-[#186]: https://github.com/linebender/fearless_simd/pull/186
-[#189]: https://github.com/linebender/fearless_simd/pull/189
 
 [Unreleased]: https://github.com/linebender/fearless_simd/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/linebender/fearless_simd/compare/v0.3.0...v0.2.0

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -340,7 +340,7 @@ impl Simd for Avx2 {
                 converted = _mm_add_epi32(converted, excess_converted);
                 converted = _mm_blendv_epi8(
                     converted,
-                    _mm_set1_epi32(u32::MAX as i32),
+                    _mm_set1_epi32(u32::MAX.cast_signed()),
                     exceeds_unsigned_range,
                 );
             }
@@ -573,7 +573,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn splat_u8x16(self, val: u8) -> u8x16<Self> {
-        unsafe { _mm_set1_epi8(val as _).simd_into(self) }
+        unsafe { _mm_set1_epi8(val.cast_signed()).simd_into(self) }
     }
     #[inline(always)]
     fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
@@ -705,7 +705,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn simd_lt_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
         unsafe {
-            let sign_bit = _mm_set1_epi8(0x80u8 as _);
+            let sign_bit = _mm_set1_epi8(0x80u8.cast_signed());
             let a_signed = _mm_xor_si128(a.into(), sign_bit);
             let b_signed = _mm_xor_si128(b.into(), sign_bit);
             _mm_cmpgt_epi8(b_signed, a_signed).simd_into(self)
@@ -722,7 +722,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn simd_gt_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
         unsafe {
-            let sign_bit = _mm_set1_epi8(0x80u8 as _);
+            let sign_bit = _mm_set1_epi8(0x80u8.cast_signed());
             let a_signed = _mm_xor_si128(a.into(), sign_bit);
             let b_signed = _mm_xor_si128(b.into(), sign_bit);
             _mm_cmpgt_epi8(a_signed, b_signed).simd_into(self)
@@ -1063,7 +1063,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn splat_u16x8(self, val: u16) -> u16x8<Self> {
-        unsafe { _mm_set1_epi16(val as _).simd_into(self) }
+        unsafe { _mm_set1_epi16(val.cast_signed()).simd_into(self) }
     }
     #[inline(always)]
     fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
@@ -1170,7 +1170,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn simd_lt_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
         unsafe {
-            let sign_bit = _mm_set1_epi16(0x8000u16 as _);
+            let sign_bit = _mm_set1_epi16(0x8000u16.cast_signed());
             let a_signed = _mm_xor_si128(a.into(), sign_bit);
             let b_signed = _mm_xor_si128(b.into(), sign_bit);
             _mm_cmpgt_epi16(b_signed, a_signed).simd_into(self)
@@ -1187,7 +1187,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn simd_gt_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
         unsafe {
-            let sign_bit = _mm_set1_epi16(0x8000u16 as _);
+            let sign_bit = _mm_set1_epi16(0x8000u16.cast_signed());
             let a_signed = _mm_xor_si128(a.into(), sign_bit);
             let b_signed = _mm_xor_si128(b.into(), sign_bit);
             _mm_cmpgt_epi16(a_signed, b_signed).simd_into(self)
@@ -1530,7 +1530,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn splat_u32x4(self, val: u32) -> u32x4<Self> {
-        unsafe { _mm_set1_epi32(val as _).simd_into(self) }
+        unsafe { _mm_set1_epi32(val.cast_signed()).simd_into(self) }
     }
     #[inline(always)]
     fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
@@ -1637,7 +1637,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn simd_lt_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
         unsafe {
-            let sign_bit = _mm_set1_epi32(0x80000000u32 as _);
+            let sign_bit = _mm_set1_epi32(0x80000000u32.cast_signed());
             let a_signed = _mm_xor_si128(a.into(), sign_bit);
             let b_signed = _mm_xor_si128(b.into(), sign_bit);
             _mm_cmpgt_epi32(b_signed, a_signed).simd_into(self)
@@ -1654,7 +1654,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn simd_gt_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
         unsafe {
-            let sign_bit = _mm_set1_epi32(0x80000000u32 as _);
+            let sign_bit = _mm_set1_epi32(0x80000000u32.cast_signed());
             let a_signed = _mm_xor_si128(a.into(), sign_bit);
             let b_signed = _mm_xor_si128(b.into(), sign_bit);
             _mm_cmpgt_epi32(a_signed, b_signed).simd_into(self)
@@ -2413,7 +2413,7 @@ impl Simd for Avx2 {
                 converted = _mm256_add_epi32(converted, excess_converted);
                 converted = _mm256_blendv_epi8(
                     converted,
-                    _mm256_set1_epi32(u32::MAX as i32),
+                    _mm256_set1_epi32(u32::MAX.cast_signed()),
                     exceeds_unsigned_range,
                 );
             }
@@ -2682,7 +2682,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn splat_u8x32(self, val: u8) -> u8x32<Self> {
-        unsafe { _mm256_set1_epi8(val as _).simd_into(self) }
+        unsafe { _mm256_set1_epi8(val.cast_signed()).simd_into(self) }
     }
     #[inline(always)]
     fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self> {
@@ -2816,7 +2816,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn simd_lt_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> mask8x32<Self> {
         unsafe {
-            let sign_bit = _mm256_set1_epi8(0x80u8 as _);
+            let sign_bit = _mm256_set1_epi8(0x80u8.cast_signed());
             let a_signed = _mm256_xor_si256(a.into(), sign_bit);
             let b_signed = _mm256_xor_si256(b.into(), sign_bit);
             _mm256_cmpgt_epi8(b_signed, a_signed).simd_into(self)
@@ -2833,7 +2833,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn simd_gt_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> mask8x32<Self> {
         unsafe {
-            let sign_bit = _mm256_set1_epi8(0x80u8 as _);
+            let sign_bit = _mm256_set1_epi8(0x80u8.cast_signed());
             let a_signed = _mm256_xor_si256(a.into(), sign_bit);
             let b_signed = _mm256_xor_si256(b.into(), sign_bit);
             _mm256_cmpgt_epi8(a_signed, b_signed).simd_into(self)
@@ -3267,7 +3267,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn splat_u16x16(self, val: u16) -> u16x16<Self> {
-        unsafe { _mm256_set1_epi16(val as _).simd_into(self) }
+        unsafe { _mm256_set1_epi16(val.cast_signed()).simd_into(self) }
     }
     #[inline(always)]
     fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self> {
@@ -3378,7 +3378,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn simd_lt_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> mask16x16<Self> {
         unsafe {
-            let sign_bit = _mm256_set1_epi16(0x8000u16 as _);
+            let sign_bit = _mm256_set1_epi16(0x8000u16.cast_signed());
             let a_signed = _mm256_xor_si256(a.into(), sign_bit);
             let b_signed = _mm256_xor_si256(b.into(), sign_bit);
             _mm256_cmpgt_epi16(b_signed, a_signed).simd_into(self)
@@ -3399,7 +3399,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn simd_gt_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> mask16x16<Self> {
         unsafe {
-            let sign_bit = _mm256_set1_epi16(0x8000u16 as _);
+            let sign_bit = _mm256_set1_epi16(0x8000u16.cast_signed());
             let a_signed = _mm256_xor_si256(a.into(), sign_bit);
             let b_signed = _mm256_xor_si256(b.into(), sign_bit);
             _mm256_cmpgt_epi16(a_signed, b_signed).simd_into(self)
@@ -3832,7 +3832,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn splat_u32x8(self, val: u32) -> u32x8<Self> {
-        unsafe { _mm256_set1_epi32(val as _).simd_into(self) }
+        unsafe { _mm256_set1_epi32(val.cast_signed()).simd_into(self) }
     }
     #[inline(always)]
     fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self> {
@@ -3943,7 +3943,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn simd_lt_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> mask32x8<Self> {
         unsafe {
-            let sign_bit = _mm256_set1_epi32(0x80000000u32 as _);
+            let sign_bit = _mm256_set1_epi32(0x80000000u32.cast_signed());
             let a_signed = _mm256_xor_si256(a.into(), sign_bit);
             let b_signed = _mm256_xor_si256(b.into(), sign_bit);
             _mm256_cmpgt_epi32(b_signed, a_signed).simd_into(self)
@@ -3964,7 +3964,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn simd_gt_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> mask32x8<Self> {
         unsafe {
-            let sign_bit = _mm256_set1_epi32(0x80000000u32 as _);
+            let sign_bit = _mm256_set1_epi32(0x80000000u32.cast_signed());
             let a_signed = _mm256_xor_si256(a.into(), sign_bit);
             let b_signed = _mm256_xor_si256(b.into(), sign_bit);
             _mm256_cmpgt_epi32(a_signed, b_signed).simd_into(self)

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -348,7 +348,7 @@ impl Simd for Sse4_2 {
                 converted = _mm_add_epi32(converted, excess_converted);
                 converted = _mm_blendv_epi8(
                     converted,
-                    _mm_set1_epi32(u32::MAX as i32),
+                    _mm_set1_epi32(u32::MAX.cast_signed()),
                     exceeds_unsigned_range,
                 );
             }
@@ -584,7 +584,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn splat_u8x16(self, val: u8) -> u8x16<Self> {
-        unsafe { _mm_set1_epi8(val as _).simd_into(self) }
+        unsafe { _mm_set1_epi8(val.cast_signed()).simd_into(self) }
     }
     #[inline(always)]
     fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
@@ -716,7 +716,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn simd_lt_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
         unsafe {
-            let sign_bit = _mm_set1_epi8(0x80u8 as _);
+            let sign_bit = _mm_set1_epi8(0x80u8.cast_signed());
             let a_signed = _mm_xor_si128(a.into(), sign_bit);
             let b_signed = _mm_xor_si128(b.into(), sign_bit);
             _mm_cmpgt_epi8(b_signed, a_signed).simd_into(self)
@@ -733,7 +733,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn simd_gt_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
         unsafe {
-            let sign_bit = _mm_set1_epi8(0x80u8 as _);
+            let sign_bit = _mm_set1_epi8(0x80u8.cast_signed());
             let a_signed = _mm_xor_si128(a.into(), sign_bit);
             let b_signed = _mm_xor_si128(b.into(), sign_bit);
             _mm_cmpgt_epi8(a_signed, b_signed).simd_into(self)
@@ -1088,7 +1088,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn splat_u16x8(self, val: u16) -> u16x8<Self> {
-        unsafe { _mm_set1_epi16(val as _).simd_into(self) }
+        unsafe { _mm_set1_epi16(val.cast_signed()).simd_into(self) }
     }
     #[inline(always)]
     fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
@@ -1195,7 +1195,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn simd_lt_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
         unsafe {
-            let sign_bit = _mm_set1_epi16(0x8000u16 as _);
+            let sign_bit = _mm_set1_epi16(0x8000u16.cast_signed());
             let a_signed = _mm_xor_si128(a.into(), sign_bit);
             let b_signed = _mm_xor_si128(b.into(), sign_bit);
             _mm_cmpgt_epi16(b_signed, a_signed).simd_into(self)
@@ -1212,7 +1212,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn simd_gt_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
         unsafe {
-            let sign_bit = _mm_set1_epi16(0x8000u16 as _);
+            let sign_bit = _mm_set1_epi16(0x8000u16.cast_signed());
             let a_signed = _mm_xor_si128(a.into(), sign_bit);
             let b_signed = _mm_xor_si128(b.into(), sign_bit);
             _mm_cmpgt_epi16(a_signed, b_signed).simd_into(self)
@@ -1564,7 +1564,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn splat_u32x4(self, val: u32) -> u32x4<Self> {
-        unsafe { _mm_set1_epi32(val as _).simd_into(self) }
+        unsafe { _mm_set1_epi32(val.cast_signed()).simd_into(self) }
     }
     #[inline(always)]
     fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
@@ -1671,7 +1671,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn simd_lt_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
         unsafe {
-            let sign_bit = _mm_set1_epi32(0x80000000u32 as _);
+            let sign_bit = _mm_set1_epi32(0x80000000u32.cast_signed());
             let a_signed = _mm_xor_si128(a.into(), sign_bit);
             let b_signed = _mm_xor_si128(b.into(), sign_bit);
             _mm_cmpgt_epi32(b_signed, a_signed).simd_into(self)
@@ -1688,7 +1688,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn simd_gt_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
         unsafe {
-            let sign_bit = _mm_set1_epi32(0x80000000u32 as _);
+            let sign_bit = _mm_set1_epi32(0x80000000u32.cast_signed());
             let a_signed = _mm_xor_si128(a.into(), sign_bit);
             let b_signed = _mm_xor_si128(b.into(), sign_bit);
             _mm_cmpgt_epi32(a_signed, b_signed).simd_into(self)

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -187,7 +187,7 @@ impl X86 {
     pub(crate) fn handle_splat(&self, method_sig: TokenStream, vec_ty: &VecType) -> TokenStream {
         let intrinsic = set1_intrinsic(vec_ty);
         let cast = match vec_ty.scalar {
-            ScalarType::Unsigned => quote!(as _),
+            ScalarType::Unsigned => quote!(.cast_signed()),
             _ => quote!(),
         };
         quote! {
@@ -241,7 +241,7 @@ impl X86 {
                         };
 
                         quote! {
-                            let sign_bit = #set(#sign as _);
+                            let sign_bit = #set(#sign.cast_signed());
                             let a_signed = #xor_op(a.into(), sign_bit);
                             let b_signed = #xor_op(b.into(), sign_bit);
 
@@ -1050,7 +1050,7 @@ impl X86 {
 
                                     // Clamp to u32::MAX.
                                     converted = #add_int(converted, excess_converted);
-                                    converted = #blend(converted, #set1_int(u32::MAX as i32), exceeds_unsigned_range);
+                                    converted = #blend(converted, #set1_int(u32::MAX.cast_signed()), exceeds_unsigned_range);
                                 }
 
                                 converted.simd_into(self)


### PR DESCRIPTION
This fixes the remainder of `clippy::cast_possible_wrap` warnings on x86.

Very similarly to https://github.com/linebender/fearless_simd/pull/186, explicitly reinterpret these bit patterns as signed (i.e., this again is explicitly a no-op at the instruction-level, but effectively checks bit width remains the same). Also uses `cast_signed` for splatting on x86, which just takes the bit pattern as a signed numeric type for broadcasting.