### PR TITLE
Run tests under Address Sanitizer on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,7 @@ jobs:
         with:
           toolchain: nightly
           targets: ${{ matrix.platform.target }}
+          components: rust-src
 
       - name: restore cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Without a tool like miri or Address Sanitizer memory safety bugs would go undetected.

We can't run intrinsic-heavy code under miri, but we can and should run it under Address Sanitizer on CI.

[Address Sanitizer documentation](https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#addresssanitizer) describes what kind of issues it will find. The most likely error in unsafe code is out-of-bounds accesses, which it will always flag. It will not flag alignment or aliasing issues, which miri would catch.

miri would also flag reads from uninitialized memory, and there's a different dedicated sanitizer for it we could enable, but `rg uninit` shows zero uses of uninit memory in fearless_simd so it's not needed.