### PR TITLE
Run CI tests in Intel SDE with all feature levels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,8 +278,10 @@ jobs:
         run: ${SDE_PKG}/sde64 -hsw -- cargo test $CARGO_TEST_ARGS
 
       - name: run tests on CPU with AVX-512
-        # Github Actions doesn't give us AVX-512 so this is the only way to exercise AVX-512 codepaths on CI
-        # -icl stands for Ice Lake; technically Skylake added AVX-512 first but it's mostly useless there due to downclocking
+        # Github Actions doesn't give us AVX-512 so this is the only way to exercise AVX-512 codepaths on CI.
+        # -icl stands for Ice Lake. Technically Skylake added AVX-512 first, but it's mostly useless there due to
+        # downclocking. When we do eventually add explicit AVX-512 support, we'll likely target the Ice Lake feature
+        # level.
         run: ${SDE_PKG}/sde64 -icl -- cargo test $CARGO_TEST_ARGS
 
   test-nightly-asan:


### PR DESCRIPTION
Runs tests in Intel Software Development Emulator, like `stdarch` does already, to verify we don't accidentally use an AVX2 instruction on SSE4.2 level or some such.

Part of #124

Some NEON instructions are only available on some cores, and have to checked for at runtime via CPU features, but this PR fully covers the x86 side of things: SSE2 (baseline), SSE4.2, AVX2, AVX-512.

Intel SDE is also the only way to test AVX-512 intrinsics on Github Actions hosted runners, so we'll need it for testing AVX-512 when that arrives. We could have used QEMU for the rest, but QEMU does not support AVX-512.