### PR TITLE
Fix Aarch64 QEMU CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
           save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: install QEMU
-        run: sudo apt install qemu-user
+        run: sudo apt-get update && sudo apt-get install -y qemu-user
 
       # build the tests outside the emulator, otherwise this job would be very slow
       - name: build tests


### PR DESCRIPTION
run `apt-get update` before installing qemu because apparently the package lists can be outdated, causing the job to fail: https://github.com/linebender/fearless_simd/actions/runs/21815601288/job/62936485469

plus other robustness improvements: `apt-get` instead of `apt` to get a stable command-line interface (apt warns its interface isn't stable and it shouldn't be used from shell scripts) and `-y` to install/update any required dependencies.