### PR TITLE
Fix conversion roundtrip tests

### DIFF
--- a/fearless_simd_tests/tests/mod.rs
+++ b/fearless_simd_tests/tests/mod.rs
@@ -140,7 +140,7 @@ fn test_f32_to_u32_exhaustive<S: Simd>(simd: S) {
 
 #[simd_test]
 #[ignore]
-fn test_f32_to_i32<S: Simd>(simd: S) {
+fn test_f32_to_i32_exhaustive<S: Simd>(simd: S) {
     // The vectorize call doesn't affect the outcome of the test, but does make it complete far more quickly
     #[expect(
         clippy::cast_possible_truncation,

--- a/fearless_simd_tests/tests/mod.rs
+++ b/fearless_simd_tests/tests/mod.rs
@@ -74,11 +74,11 @@ fn test_f32_to_i32_exhaustive<S: Simd>(simd: S) {
         || {
             for i in (0..u32::MAX).step_by(4) {
                 let floats = f32x4::from_fn(simd, |n| f32::from_bits(n as u32 + i));
-                let ints = floats.to_int::<i32x4<_>>();
+                let ints = floats.to_int_precise::<i32x4<_>>();
                 let ints_ref = (*floats).map(|f| f as i32);
                 assert_eq!(
                     *ints, ints_ref,
-                    "f32x4::to_int::<i32x4<_>>() returns the same results as Rust's `as i32`"
+                    "f32x4::to_int_precise::<i32x4<_>>() returns the same results as Rust's `as i32`"
                 );
             }
         },
@@ -98,11 +98,11 @@ fn test_f32_to_u32_exhaustive<S: Simd>(simd: S) {
         || {
             for i in (0..u32::MAX).step_by(4) {
                 let floats = f32x4::from_fn(simd, |n| f32::from_bits(n as u32 + i));
-                let ints = floats.to_int::<u32x4<_>>();
+                let ints = floats.to_int_precise::<u32x4<_>>();
                 let ints_ref = (*floats).map(|f| f as u32);
                 assert_eq!(
                     *ints, ints_ref,
-                    "f32x4::to_int::<u32x4<_>>() returns the same results as Rust's `as u32`"
+                    "f32x4::to_int_precise::<u32x4<_>>() returns the same results as Rust's `as u32`"
                 );
             }
         },


### PR DESCRIPTION
Update exhaustive tests to roundtrip precise conversions on all values; out-of-range values are intentionally implementation-defined in the non-precise variants.

Add tests for the non-precise variants that correctly ignore the out-of-range values.

Fixes #202
