### PR TITLE
Add fast approximate reciprocal methods for float vectors

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -192,6 +192,10 @@ impl Simd for Avx2 {
         unsafe { _mm_sqrt_ps(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        unsafe { _mm_rcp_ps(a.into()).simd_into(self) }
+    }
+    #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         unsafe { _mm_add_ps(a.into(), b.into()).simd_into(self) }
     }
@@ -2182,6 +2186,10 @@ impl Simd for Avx2 {
         unsafe { _mm_sqrt_pd(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        self.splat_f64x2(1.0) / a
+    }
+    #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         unsafe { _mm_add_pd(a.into(), b.into()).simd_into(self) }
     }
@@ -2556,6 +2564,10 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         unsafe { _mm256_sqrt_ps(a.into()).simd_into(self) }
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        unsafe { _mm256_rcp_ps(a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -4990,6 +5002,10 @@ impl Simd for Avx2 {
         unsafe { _mm256_sqrt_pd(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        self.splat_f64x4(1.0) / a
+    }
+    #[inline(always)]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
         unsafe { _mm256_add_pd(a.into(), b.into()).simd_into(self) }
     }
@@ -5421,6 +5437,14 @@ impl Simd for Avx2 {
     fn sqrt_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.sqrt_f32x8(a0), self.sqrt_f32x8(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_f32x8(
+            self.approximate_recip_f32x8(a0),
+            self.approximate_recip_f32x8(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x16(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -8024,6 +8048,14 @@ impl Simd for Avx2 {
     fn sqrt_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
         self.combine_f64x4(self.sqrt_f64x4(a0), self.sqrt_f64x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f64x4(
+            self.approximate_recip_f64x4(a0),
+            self.approximate_recip_f64x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f64x8(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -192,6 +192,10 @@ impl Simd for Avx2 {
         unsafe { _mm_sqrt_ps(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        unsafe { _mm_rcp_ps(a.into()).simd_into(self) }
+    }
+    #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         unsafe { _mm_add_ps(a.into(), b.into()).simd_into(self) }
     }
@@ -2031,6 +2035,10 @@ impl Simd for Avx2 {
         unsafe { _mm_sqrt_pd(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        self.splat_f64x2(1.0) / a
+    }
+    #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         unsafe { _mm_add_pd(a.into(), b.into()).simd_into(self) }
     }
@@ -2344,6 +2352,10 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         unsafe { _mm256_sqrt_ps(a.into()).simd_into(self) }
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        unsafe { _mm256_rcp_ps(a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -4770,6 +4782,10 @@ impl Simd for Avx2 {
         unsafe { _mm256_sqrt_pd(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        self.splat_f64x4(1.0) / a
+    }
+    #[inline(always)]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
         unsafe { _mm256_add_pd(a.into(), b.into()).simd_into(self) }
     }
@@ -5141,6 +5157,14 @@ impl Simd for Avx2 {
     fn sqrt_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.sqrt_f32x8(a0), self.sqrt_f32x8(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_f32x8(
+            self.approximate_recip_f32x8(a0),
+            self.approximate_recip_f32x8(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x16(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -7695,6 +7719,14 @@ impl Simd for Avx2 {
     fn sqrt_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
         self.combine_f64x4(self.sqrt_f64x4(a0), self.sqrt_f64x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f64x4(
+            self.approximate_recip_f64x4(a0),
+            self.approximate_recip_f64x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f64x8(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -2036,7 +2036,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
-        self.splat_f64x2(1.0) / a
+        1.0 / a
     }
     #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
@@ -4783,7 +4783,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
-        self.splat_f64x4(1.0) / a
+        1.0 / a
     }
     #[inline(always)]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -251,6 +251,10 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        self.splat_f32x4(1.0) / a
+    }
+    #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         [
             f32::add(a[0usize], &b[0usize]),
@@ -3816,6 +3820,10 @@ impl Simd for Fallback {
         [f64::sqrt(a[0usize]), f64::sqrt(a[1usize])].simd_into(self)
     }
     #[inline(always)]
+    fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        self.splat_f64x2(1.0) / a
+    }
+    #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         [
             f64::add(a[0usize], &b[0usize]),
@@ -4224,6 +4232,14 @@ impl Simd for Fallback {
     fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f32x4(self.sqrt_f32x4(a0), self.sqrt_f32x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(
+            self.approximate_recip_f32x4(a0),
+            self.approximate_recip_f32x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -6482,6 +6498,14 @@ impl Simd for Fallback {
         self.combine_f64x2(self.sqrt_f64x2(a0), self.sqrt_f64x2(a1))
     }
     #[inline(always)]
+    fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        self.combine_f64x2(
+            self.approximate_recip_f64x2(a0),
+            self.approximate_recip_f64x2(a1),
+        )
+    }
+    #[inline(always)]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f64x4(a);
         let (b0, b1) = self.split_f64x4(b);
@@ -6916,6 +6940,14 @@ impl Simd for Fallback {
     fn sqrt_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.sqrt_f32x8(a0), self.sqrt_f32x8(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_f32x8(
+            self.approximate_recip_f32x8(a0),
+            self.approximate_recip_f32x8(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x16(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -9294,6 +9326,14 @@ impl Simd for Fallback {
     fn sqrt_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
         self.combine_f64x4(self.sqrt_f64x4(a0), self.sqrt_f64x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f64x4(
+            self.approximate_recip_f64x4(a0),
+            self.approximate_recip_f64x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f64x8(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -250,7 +250,7 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
-        self.splat_f32x4(1.0) / a
+        1.0 / a
     }
     #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
@@ -3990,7 +3990,7 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
-        self.splat_f64x2(1.0) / a
+        1.0 / a
     }
     #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -249,6 +249,10 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        self.splat_f32x4(1.0) / a
+    }
+    #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         [
             f32::add(a[0usize], &b[0usize]),
@@ -3985,6 +3989,10 @@ impl Simd for Fallback {
         [f64::sqrt(a[0usize]), f64::sqrt(a[1usize])].simd_into(self)
     }
     #[inline(always)]
+    fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        self.splat_f64x2(1.0) / a
+    }
+    #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         [
             f64::add(a[0usize], &b[0usize]),
@@ -4362,6 +4370,14 @@ impl Simd for Fallback {
     fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f32x4(self.sqrt_f32x4(a0), self.sqrt_f32x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(
+            self.approximate_recip_f32x4(a0),
+            self.approximate_recip_f32x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -6619,6 +6635,14 @@ impl Simd for Fallback {
         self.combine_f64x2(self.sqrt_f64x2(a0), self.sqrt_f64x2(a1))
     }
     #[inline(always)]
+    fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        self.combine_f64x2(
+            self.approximate_recip_f64x2(a0),
+            self.approximate_recip_f64x2(a1),
+        )
+    }
+    #[inline(always)]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f64x4(a);
         let (b0, b1) = self.split_f64x4(b);
@@ -7018,6 +7042,14 @@ impl Simd for Fallback {
     fn sqrt_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.sqrt_f32x8(a0), self.sqrt_f32x8(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_f32x8(
+            self.approximate_recip_f32x8(a0),
+            self.approximate_recip_f32x8(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x16(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -9395,6 +9427,14 @@ impl Simd for Fallback {
     fn sqrt_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
         self.combine_f64x4(self.sqrt_f64x4(a0), self.sqrt_f64x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f64x4(
+            self.approximate_recip_f64x4(a0),
+            self.approximate_recip_f64x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f64x8(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -184,6 +184,10 @@ impl Simd for Neon {
         unsafe { vsqrtq_f32(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        unsafe { vrecpeq_f32(a.into()).simd_into(self) }
+    }
+    #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         unsafe { vaddq_f32(a.into(), b.into()).simd_into(self) }
     }
@@ -2062,6 +2066,10 @@ impl Simd for Neon {
         unsafe { vsqrtq_f64(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        unsafe { vrecpeq_f64(a.into()).simd_into(self) }
+    }
+    #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         unsafe { vaddq_f64(a.into(), b.into()).simd_into(self) }
     }
@@ -2453,6 +2461,14 @@ impl Simd for Neon {
     fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f32x4(self.sqrt_f32x4(a0), self.sqrt_f32x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(
+            self.approximate_recip_f32x4(a0),
+            self.approximate_recip_f32x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -5128,6 +5144,14 @@ impl Simd for Neon {
         self.combine_f64x2(self.sqrt_f64x2(a0), self.sqrt_f64x2(a1))
     }
     #[inline(always)]
+    fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        self.combine_f64x2(
+            self.approximate_recip_f64x2(a0),
+            self.approximate_recip_f64x2(a1),
+        )
+    }
+    #[inline(always)]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f64x4(a);
         let (b0, b1) = self.split_f64x4(b);
@@ -5666,6 +5690,14 @@ impl Simd for Neon {
     fn sqrt_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.sqrt_f32x8(a0), self.sqrt_f32x8(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_f32x8(
+            self.approximate_recip_f32x8(a0),
+            self.approximate_recip_f32x8(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x16(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -8473,6 +8505,14 @@ impl Simd for Neon {
     fn sqrt_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
         self.combine_f64x4(self.sqrt_f64x4(a0), self.sqrt_f64x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f64x4(
+            self.approximate_recip_f64x4(a0),
+            self.approximate_recip_f64x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f64x8(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -182,6 +182,10 @@ impl Simd for Neon {
         unsafe { vsqrtq_f32(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        unsafe { vrecpeq_f32(a.into()).simd_into(self) }
+    }
+    #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         unsafe { vaddq_f32(a.into(), b.into()).simd_into(self) }
     }
@@ -1909,6 +1913,10 @@ impl Simd for Neon {
         unsafe { vsqrtq_f64(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        unsafe { vrecpeq_f64(a.into()).simd_into(self) }
+    }
+    #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         unsafe { vaddq_f64(a.into(), b.into()).simd_into(self) }
     }
@@ -2239,6 +2247,14 @@ impl Simd for Neon {
     fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f32x4(self.sqrt_f32x4(a0), self.sqrt_f32x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(
+            self.approximate_recip_f32x4(a0),
+            self.approximate_recip_f32x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -4805,6 +4821,14 @@ impl Simd for Neon {
         self.combine_f64x2(self.sqrt_f64x2(a0), self.sqrt_f64x2(a1))
     }
     #[inline(always)]
+    fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        self.combine_f64x2(
+            self.approximate_recip_f64x2(a0),
+            self.approximate_recip_f64x2(a1),
+        )
+    }
+    #[inline(always)]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f64x4(a);
         let (b0, b1) = self.split_f64x4(b);
@@ -5272,6 +5296,14 @@ impl Simd for Neon {
     fn sqrt_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.sqrt_f32x8(a0), self.sqrt_f32x8(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_f32x8(
+            self.approximate_recip_f32x8(a0),
+            self.approximate_recip_f32x8(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x16(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -7916,6 +7948,14 @@ impl Simd for Neon {
     fn sqrt_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
         self.combine_f64x4(self.sqrt_f64x4(a0), self.sqrt_f64x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f64x4(
+            self.approximate_recip_f64x4(a0),
+            self.approximate_recip_f64x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f64x8(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -152,6 +152,8 @@ pub trait Simd:
     fn neg_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Add two vectors element-wise."]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Subtract two vectors element-wise."]
@@ -901,6 +903,8 @@ pub trait Simd:
     fn neg_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Add two vectors element-wise."]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Subtract two vectors element-wise."]
@@ -1046,6 +1050,8 @@ pub trait Simd:
     fn neg_f32x8(self, a: f32x8<Self>) -> f32x8<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self>;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip_f32x8(self, a: f32x8<Self>) -> f32x8<Self>;
     #[doc = "Add two vectors element-wise."]
     fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self>;
     #[doc = "Subtract two vectors element-wise."]
@@ -1817,6 +1823,8 @@ pub trait Simd:
     fn neg_f64x4(self, a: f64x4<Self>) -> f64x4<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt_f64x4(self, a: f64x4<Self>) -> f64x4<Self>;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self>;
     #[doc = "Add two vectors element-wise."]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self>;
     #[doc = "Subtract two vectors element-wise."]
@@ -1966,6 +1974,8 @@ pub trait Simd:
     fn neg_f32x16(self, a: f32x16<Self>) -> f32x16<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt_f32x16(self, a: f32x16<Self>) -> f32x16<Self>;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip_f32x16(self, a: f32x16<Self>) -> f32x16<Self>;
     #[doc = "Add two vectors element-wise."]
     fn add_f32x16(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self>;
     #[doc = "Subtract two vectors element-wise."]
@@ -2731,6 +2741,8 @@ pub trait Simd:
     fn neg_f64x8(self, a: f64x8<Self>) -> f64x8<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt_f64x8(self, a: f64x8<Self>) -> f64x8<Self>;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip_f64x8(self, a: f64x8<Self>) -> f64x8<Self>;
     #[doc = "Add two vectors element-wise."]
     fn add_f64x8(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self>;
     #[doc = "Subtract two vectors element-wise."]
@@ -2996,6 +3008,8 @@ pub trait SimdFloat<S: Simd>:
     fn abs(self) -> Self;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt(self) -> Self;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip(self) -> Self;
     #[doc = "Return a vector with the magnitude of `self` and the sign of `rhs` for each element.\n\nThis operation copies the sign bit, so if an input element is NaN, the output element will be a NaN with the same payload and a copied sign bit."]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Compare two vectors element-wise for equality.\n\nReturns a mask where each element is all ones if the corresponding elements are equal, and all zeroes if not."]

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -150,6 +150,8 @@ pub trait Simd:
     fn neg_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Add two vectors element-wise."]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Subtract two vectors element-wise."]
@@ -855,6 +857,8 @@ pub trait Simd:
     fn neg_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Add two vectors element-wise."]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Subtract two vectors element-wise."]
@@ -980,6 +984,8 @@ pub trait Simd:
     fn neg_f32x8(self, a: f32x8<Self>) -> f32x8<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self>;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip_f32x8(self, a: f32x8<Self>) -> f32x8<Self>;
     #[doc = "Add two vectors element-wise."]
     fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self>;
     #[doc = "Subtract two vectors element-wise."]
@@ -1707,6 +1713,8 @@ pub trait Simd:
     fn neg_f64x4(self, a: f64x4<Self>) -> f64x4<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt_f64x4(self, a: f64x4<Self>) -> f64x4<Self>;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self>;
     #[doc = "Add two vectors element-wise."]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self>;
     #[doc = "Subtract two vectors element-wise."]
@@ -1836,6 +1844,8 @@ pub trait Simd:
     fn neg_f32x16(self, a: f32x16<Self>) -> f32x16<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt_f32x16(self, a: f32x16<Self>) -> f32x16<Self>;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip_f32x16(self, a: f32x16<Self>) -> f32x16<Self>;
     #[doc = "Add two vectors element-wise."]
     fn add_f32x16(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self>;
     #[doc = "Subtract two vectors element-wise."]
@@ -2557,6 +2567,8 @@ pub trait Simd:
     fn neg_f64x8(self, a: f64x8<Self>) -> f64x8<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt_f64x8(self, a: f64x8<Self>) -> f64x8<Self>;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip_f64x8(self, a: f64x8<Self>) -> f64x8<Self>;
     #[doc = "Add two vectors element-wise."]
     fn add_f64x8(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self>;
     #[doc = "Subtract two vectors element-wise."]
@@ -2801,6 +2813,8 @@ pub trait SimdFloat<S: Simd>:
     fn abs(self) -> Self;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
     fn sqrt(self) -> Self;
+    #[doc = "Compute an approximate reciprocal (`1. / x`) for each element.\n\nThis uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\nOn x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. The precision of this operation may change as new platform support is added."]
+    fn approximate_recip(self) -> Self;
     #[doc = "Return a vector with the magnitude of `self` and the sign of `rhs` for each element.\n\nThis operation copies the sign bit, so if an input element is NaN, the output element will be a NaN with the same payload and a copied sign bit."]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Compare two vectors element-wise for equality.\n\nReturns a mask where each logical lane is true if the corresponding elements are equal, and false if not."]

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -137,6 +137,10 @@ impl<S: Simd> crate::SimdFloat<S> for f32x4<S> {
         self.simd.sqrt_f32x4(self)
     }
     #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f32x4(self)
+    }
+    #[inline(always)]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.copysign_f32x4(self, rhs.simd_into(self.simd))
     }
@@ -1928,6 +1932,10 @@ impl<S: Simd> crate::SimdFloat<S> for f64x2<S> {
         self.simd.sqrt_f64x2(self)
     }
     #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f64x2(self)
+    }
+    #[inline(always)]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.copysign_f64x2(self, rhs.simd_into(self.simd))
     }
@@ -2309,6 +2317,10 @@ impl<S: Simd> crate::SimdFloat<S> for f32x8<S> {
     #[inline(always)]
     fn sqrt(self) -> Self {
         self.simd.sqrt_f32x8(self)
+    }
+    #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f32x8(self)
     }
     #[inline(always)]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -4182,6 +4194,10 @@ impl<S: Simd> crate::SimdFloat<S> for f64x4<S> {
         self.simd.sqrt_f64x4(self)
     }
     #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f64x4(self)
+    }
+    #[inline(always)]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.copysign_f64x4(self, rhs.simd_into(self.simd))
     }
@@ -4583,6 +4599,10 @@ impl<S: Simd> crate::SimdFloat<S> for f32x16<S> {
     #[inline(always)]
     fn sqrt(self) -> Self {
         self.simd.sqrt_f32x16(self)
+    }
+    #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f32x16(self)
     }
     #[inline(always)]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -6404,6 +6424,10 @@ impl<S: Simd> crate::SimdFloat<S> for f64x8<S> {
     #[inline(always)]
     fn sqrt(self) -> Self {
         self.simd.sqrt_f64x8(self)
+    }
+    #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f64x8(self)
     }
     #[inline(always)]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -140,6 +140,10 @@ impl<S: Simd> crate::SimdFloat<S> for f32x4<S> {
         self.simd.sqrt_f32x4(self)
     }
     #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f32x4(self)
+    }
+    #[inline(always)]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.copysign_f32x4(self, rhs.simd_into(self.simd))
     }
@@ -1760,6 +1764,10 @@ impl<S: Simd> crate::SimdFloat<S> for f64x2<S> {
         self.simd.sqrt_f64x2(self)
     }
     #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f64x2(self)
+    }
+    #[inline(always)]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.copysign_f64x2(self, rhs.simd_into(self.simd))
     }
@@ -2072,6 +2080,10 @@ impl<S: Simd> crate::SimdFloat<S> for f32x8<S> {
     #[inline(always)]
     fn sqrt(self) -> Self {
         self.simd.sqrt_f32x8(self)
+    }
+    #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f32x8(self)
     }
     #[inline(always)]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -3755,6 +3767,10 @@ impl<S: Simd> crate::SimdFloat<S> for f64x4<S> {
         self.simd.sqrt_f64x4(self)
     }
     #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f64x4(self)
+    }
+    #[inline(always)]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.copysign_f64x4(self, rhs.simd_into(self.simd))
     }
@@ -4080,6 +4096,10 @@ impl<S: Simd> crate::SimdFloat<S> for f32x16<S> {
     #[inline(always)]
     fn sqrt(self) -> Self {
         self.simd.sqrt_f32x16(self)
+    }
+    #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f32x16(self)
     }
     #[inline(always)]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -5732,6 +5752,10 @@ impl<S: Simd> crate::SimdFloat<S> for f64x8<S> {
     #[inline(always)]
     fn sqrt(self) -> Self {
         self.simd.sqrt_f64x8(self)
+    }
+    #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f64x8(self)
     }
     #[inline(always)]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -197,6 +197,10 @@ impl Simd for Sse4_2 {
         unsafe { _mm_sqrt_ps(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        unsafe { _mm_rcp_ps(a.into()).simd_into(self) }
+    }
+    #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         unsafe { _mm_add_ps(a.into(), b.into()).simd_into(self) }
     }
@@ -2222,6 +2226,10 @@ impl Simd for Sse4_2 {
         unsafe { _mm_sqrt_pd(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        self.splat_f64x2(1.0) / a
+    }
+    #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         unsafe { _mm_add_pd(a.into(), b.into()).simd_into(self) }
     }
@@ -2598,6 +2606,14 @@ impl Simd for Sse4_2 {
     fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f32x4(self.sqrt_f32x4(a0), self.sqrt_f32x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(
+            self.approximate_recip_f32x4(a0),
+            self.approximate_recip_f32x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -5055,6 +5071,14 @@ impl Simd for Sse4_2 {
         self.combine_f64x2(self.sqrt_f64x2(a0), self.sqrt_f64x2(a1))
     }
     #[inline(always)]
+    fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        self.combine_f64x2(
+            self.approximate_recip_f64x2(a0),
+            self.approximate_recip_f64x2(a1),
+        )
+    }
+    #[inline(always)]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f64x4(a);
         let (b0, b1) = self.split_f64x4(b);
@@ -5531,6 +5555,14 @@ impl Simd for Sse4_2 {
     fn sqrt_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.sqrt_f32x8(a0), self.sqrt_f32x8(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_f32x8(
+            self.approximate_recip_f32x8(a0),
+            self.approximate_recip_f32x8(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x16(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -8126,6 +8158,14 @@ impl Simd for Sse4_2 {
     fn sqrt_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
         self.combine_f64x4(self.sqrt_f64x4(a0), self.sqrt_f64x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f64x4(
+            self.approximate_recip_f64x4(a0),
+            self.approximate_recip_f64x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f64x8(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -2097,7 +2097,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
-        self.splat_f64x2(1.0) / a
+        1.0 / a
     }
     #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -218,6 +218,10 @@ impl Simd for Sse4_2 {
         unsafe { _mm_sqrt_ps(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        unsafe { _mm_rcp_ps(a.into()).simd_into(self) }
+    }
+    #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         unsafe { _mm_add_ps(a.into(), b.into()).simd_into(self) }
     }
@@ -2092,6 +2096,10 @@ impl Simd for Sse4_2 {
         unsafe { _mm_sqrt_pd(a.into()).simd_into(self) }
     }
     #[inline(always)]
+    fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        self.splat_f64x2(1.0) / a
+    }
+    #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         unsafe { _mm_add_pd(a.into(), b.into()).simd_into(self) }
     }
@@ -2407,6 +2415,14 @@ impl Simd for Sse4_2 {
     fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f32x4(self.sqrt_f32x4(a0), self.sqrt_f32x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(
+            self.approximate_recip_f32x4(a0),
+            self.approximate_recip_f32x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -4815,6 +4831,14 @@ impl Simd for Sse4_2 {
         self.combine_f64x2(self.sqrt_f64x2(a0), self.sqrt_f64x2(a1))
     }
     #[inline(always)]
+    fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        self.combine_f64x2(
+            self.approximate_recip_f64x2(a0),
+            self.approximate_recip_f64x2(a1),
+        )
+    }
+    #[inline(always)]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f64x4(a);
         let (b0, b1) = self.split_f64x4(b);
@@ -5240,6 +5264,14 @@ impl Simd for Sse4_2 {
     fn sqrt_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.sqrt_f32x8(a0), self.sqrt_f32x8(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_f32x8(
+            self.approximate_recip_f32x8(a0),
+            self.approximate_recip_f32x8(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x16(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -7786,6 +7818,14 @@ impl Simd for Sse4_2 {
     fn sqrt_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
         self.combine_f64x4(self.sqrt_f64x4(a0), self.sqrt_f64x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f64x4(
+            self.approximate_recip_f64x4(a0),
+            self.approximate_recip_f64x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f64x8(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -183,6 +183,10 @@ impl Simd for WasmSimd128 {
         f32x4_sqrt(a.into()).simd_into(self)
     }
     #[inline(always)]
+    fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        self.div_f32x4(self.splat_f32x4(1.0), a)
+    }
+    #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         f32x4_add(a.into(), b.into()).simd_into(self)
     }
@@ -2147,6 +2151,10 @@ impl Simd for WasmSimd128 {
         f64x2_sqrt(a.into()).simd_into(self)
     }
     #[inline(always)]
+    fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        self.div_f64x2(self.splat_f64x2(1.0), a)
+    }
+    #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         f64x2_add(a.into(), b.into()).simd_into(self)
     }
@@ -2552,6 +2560,14 @@ impl Simd for WasmSimd128 {
     fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f32x4(self.sqrt_f32x4(a0), self.sqrt_f32x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(
+            self.approximate_recip_f32x4(a0),
+            self.approximate_recip_f32x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -5007,6 +5023,14 @@ impl Simd for WasmSimd128 {
         self.combine_f64x2(self.sqrt_f64x2(a0), self.sqrt_f64x2(a1))
     }
     #[inline(always)]
+    fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        self.combine_f64x2(
+            self.approximate_recip_f64x2(a0),
+            self.approximate_recip_f64x2(a1),
+        )
+    }
+    #[inline(always)]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f64x4(a);
         let (b0, b1) = self.split_f64x4(b);
@@ -5483,6 +5507,14 @@ impl Simd for WasmSimd128 {
     fn sqrt_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.sqrt_f32x8(a0), self.sqrt_f32x8(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_f32x8(
+            self.approximate_recip_f32x8(a0),
+            self.approximate_recip_f32x8(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x16(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -8070,6 +8102,14 @@ impl Simd for WasmSimd128 {
     fn sqrt_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
         self.combine_f64x4(self.sqrt_f64x4(a0), self.sqrt_f64x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f64x4(
+            self.approximate_recip_f64x4(a0),
+            self.approximate_recip_f64x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f64x8(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -182,7 +182,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
-        self.div_f32x4(self.splat_f32x4(1.0), a)
+        self.div_f32x4(1.0, a)
     }
     #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
@@ -1993,7 +1993,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
-        self.div_f64x2(self.splat_f64x2(1.0), a)
+        self.div_f64x2(1.0, a)
     }
     #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -182,7 +182,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
-        self.div_f32x4(self.splat_f32x4(1.0), a)
+        1.0 / a
     }
     #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
@@ -1993,7 +1993,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
-        self.div_f64x2(self.splat_f64x2(1.0), a)
+        1.0 / a
     }
     #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -182,7 +182,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
-        self.div_f32x4(1.0, a)
+        self.div_f32x4(self.splat_f32x4(1.0), a)
     }
     #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
@@ -1993,7 +1993,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
-        self.div_f64x2(1.0, a)
+        self.div_f64x2(self.splat_f64x2(1.0), a)
     }
     #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -181,6 +181,10 @@ impl Simd for WasmSimd128 {
         f32x4_sqrt(a.into()).simd_into(self)
     }
     #[inline(always)]
+    fn approximate_recip_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        self.div_f32x4(self.splat_f32x4(1.0), a)
+    }
+    #[inline(always)]
     fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         f32x4_add(a.into(), b.into()).simd_into(self)
     }
@@ -1988,6 +1992,10 @@ impl Simd for WasmSimd128 {
         f64x2_sqrt(a.into()).simd_into(self)
     }
     #[inline(always)]
+    fn approximate_recip_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        self.div_f64x2(self.splat_f64x2(1.0), a)
+    }
+    #[inline(always)]
     fn add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         f64x2_add(a.into(), b.into()).simd_into(self)
     }
@@ -2330,6 +2338,14 @@ impl Simd for WasmSimd128 {
     fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f32x4(self.sqrt_f32x4(a0), self.sqrt_f32x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(
+            self.approximate_recip_f32x4(a0),
+            self.approximate_recip_f32x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -4736,6 +4752,14 @@ impl Simd for WasmSimd128 {
         self.combine_f64x2(self.sqrt_f64x2(a0), self.sqrt_f64x2(a1))
     }
     #[inline(always)]
+    fn approximate_recip_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        self.combine_f64x2(
+            self.approximate_recip_f64x2(a0),
+            self.approximate_recip_f64x2(a1),
+        )
+    }
+    #[inline(always)]
     fn add_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f64x4(a);
         let (b0, b1) = self.split_f64x4(b);
@@ -5161,6 +5185,14 @@ impl Simd for WasmSimd128 {
     fn sqrt_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.sqrt_f32x8(a0), self.sqrt_f32x8(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_f32x8(
+            self.approximate_recip_f32x8(a0),
+            self.approximate_recip_f32x8(a1),
+        )
     }
     #[inline(always)]
     fn add_f32x16(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -7699,6 +7731,14 @@ impl Simd for WasmSimd128 {
     fn sqrt_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
         self.combine_f64x4(self.sqrt_f64x4(a0), self.sqrt_f64x4(a1))
+    }
+    #[inline(always)]
+    fn approximate_recip_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f64x4(
+            self.approximate_recip_f64x4(a0),
+            self.approximate_recip_f64x4(a1),
+        )
     }
     #[inline(always)]
     fn add_f64x8(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd_gen/src/arch/neon.rs
+++ b/fearless_simd_gen/src/arch/neon.rs
@@ -69,6 +69,11 @@ pub(crate) fn expr(op: &str, ty: &VecType, args: &[TokenStream]) -> TokenStream 
                 #sub(a.into(), c2)
             }
         }
+        "approximate_recip" => {
+            let vrecpe = simple_intrinsic("vrecpe", ty);
+            let a = &args[0];
+            quote! { #vrecpe(#a) }
+        }
         _ => unimplemented!("missing {op}"),
     }
 }

--- a/fearless_simd_gen/src/arch/x86.rs
+++ b/fearless_simd_gen/src/arch/x86.rs
@@ -90,6 +90,11 @@ pub(crate) fn expr(op: &str, ty: &VecType, args: &[TokenStream]) -> TokenStream 
                     #or(#and(mask, #b), #andnot(mask, #a))
                 }
             }
+            "approximate_recip" => {
+                // f32 only; f64 handled in mk_x86.rs
+                let intrinsic = simple_intrinsic("rcp", ty);
+                quote! { #intrinsic ( #( #args ),* ) }
+            }
             "mul" => {
                 let suffix = op_suffix(ty.scalar, ty.scalar_bits, false);
                 let intrinsic = if matches!(ty.scalar, ScalarType::Int | ScalarType::Unsigned) {

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -149,6 +149,15 @@ impl Level for Fallback {
                 }
             }
             OpSig::Unary => {
+                if method == "approximate_recip" {
+                    let splat_op = generic_op_name("splat", vec_ty);
+                    return quote! {
+                        #method_sig {
+                            self.#splat_op(1.0) / a
+                        }
+                    };
+                }
+
                 let items = make_list(
                     (0..vec_ty.len)
                         .map(|idx| {

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -148,10 +148,9 @@ impl Level for Fallback {
             }
             OpSig::Unary => {
                 if method == "approximate_recip" {
-                    let splat_op = generic_op_name("splat", vec_ty);
                     return quote! {
                         #method_sig {
-                            self.#splat_op(1.0) / a
+                            1.0 / a
                         }
                     };
                 }

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -147,6 +147,15 @@ impl Level for Fallback {
                 }
             }
             OpSig::Unary => {
+                if method == "approximate_recip" {
+                    let splat_op = generic_op_name("splat", vec_ty);
+                    return quote! {
+                        #method_sig {
+                            self.#splat_op(1.0) / a
+                        }
+                    };
+                }
+
                 let items = make_list(
                     (0..vec_ty.len)
                         .map(|idx| {

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -95,6 +95,17 @@ impl Level for WasmSimd128 {
                     quote! {
                         self.#sub(a, self.#trunc(a))
                     }
+                } else if matches!(method, "approximate_recip") {
+                    assert_eq!(
+                        vec_ty.scalar,
+                        ScalarType::Float,
+                        "only float supports approximate_recip"
+                    );
+                    let splat_op = generic_op_name("splat", vec_ty);
+                    let div_op = generic_op_name("div", vec_ty);
+                    quote! {
+                        self.#div_op(self.#splat_op(1.0), a)
+                    }
                 } else {
                     let expr = wasm::expr(method, vec_ty, &args);
                     quote! { #expr.simd_into(self) }

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -100,9 +100,10 @@ impl Level for WasmSimd128 {
                         ScalarType::Float,
                         "only float supports approximate_recip"
                     );
+                    let splat_op = generic_op_name("splat", vec_ty);
                     let div_op = generic_op_name("div", vec_ty);
                     quote! {
-                        self.#div_op(1.0, a)
+                        self.#div_op(self.#splat_op(1.0), a)
                     }
                 } else {
                     let expr = wasm::expr(method, vec_ty, &args);

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -100,10 +100,8 @@ impl Level for WasmSimd128 {
                         ScalarType::Float,
                         "only float supports approximate_recip"
                     );
-                    let splat_op = generic_op_name("splat", vec_ty);
-                    let div_op = generic_op_name("div", vec_ty);
                     quote! {
-                        self.#div_op(self.#splat_op(1.0), a)
+                        1.0 / a
                     }
                 } else {
                     let expr = wasm::expr(method, vec_ty, &args);

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -100,10 +100,9 @@ impl Level for WasmSimd128 {
                         ScalarType::Float,
                         "only float supports approximate_recip"
                     );
-                    let splat_op = generic_op_name("splat", vec_ty);
                     let div_op = generic_op_name("div", vec_ty);
                     quote! {
-                        self.#div_op(self.#splat_op(1.0), a)
+                        self.#div_op(1.0, a)
                     }
                 } else {
                     let expr = wasm::expr(method, vec_ty, &args);

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -94,6 +94,17 @@ impl Level for WasmSimd128 {
                     quote! {
                         self.#sub(a, self.#trunc(a))
                     }
+                } else if matches!(method, "approximate_recip") {
+                    assert_eq!(
+                        vec_ty.scalar,
+                        ScalarType::Float,
+                        "only float supports approximate_recip"
+                    );
+                    let splat_op = generic_op_name("splat", vec_ty);
+                    let div_op = generic_op_name("div", vec_ty);
+                    quote! {
+                        self.#div_op(self.#splat_op(1.0), a)
+                    }
                 } else {
                     let expr = wasm::expr(method, vec_ty, &args);
                     quote! { #expr.simd_into(self) }

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -309,6 +309,14 @@ impl X86 {
                     }
                 }
             }
+            "approximate_recip" if vec_ty.scalar_bits == 64 => {
+                let splat_op = generic_op_name("splat", vec_ty);
+                quote! {
+                    #method_sig {
+                        self.#splat_op(1.0) / a
+                    }
+                }
+            }
             "not" => {
                 quote! {
                     #method_sig {

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -339,10 +339,9 @@ impl X86 {
                 }
             }
             "approximate_recip" if vec_ty.scalar_bits == 64 => {
-                let splat_op = generic_op_name("splat", vec_ty);
                 quote! {
                     #method_sig {
-                        self.#splat_op(1.0) / a
+                        1.0 / a
                     }
                 }
             }

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -338,6 +338,14 @@ impl X86 {
                     }
                 }
             }
+            "approximate_recip" if vec_ty.scalar_bits == 64 => {
+                let splat_op = generic_op_name("splat", vec_ty);
+                quote! {
+                    #method_sig {
+                        self.#splat_op(1.0) / a
+                    }
+                }
+            }
             "not" if vec_ty.scalar == ScalarType::Mask => {
                 let xor_op = generic_op_name("xor", vec_ty);
                 let splat_op = generic_op_name("splat", vec_ty);

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -530,6 +530,16 @@ const FLOAT_OPS: &[Op] = &[
         Negative elements other than `-0.0` will become NaN.",
     ),
     Op::new(
+        "approximate_recip",
+        OpKind::VecTraitMethod,
+        OpSig::Unary,
+        "Compute an approximate reciprocal (`1. / x`) for each element.\n\n\
+         This uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\n\
+         On x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. \
+         On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. \
+         The precision of this operation may change as new platform support is added.",
+    ),
+    Op::new(
         "add",
         OpKind::Overloaded(CoreOpTrait::Add),
         OpSig::Binary,

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -581,6 +581,16 @@ const FLOAT_OPS: &[Op] = &[
         Negative elements other than `-0.0` will become NaN.",
     ),
     Op::new(
+        "approximate_recip",
+        OpKind::VecTraitMethod,
+        OpSig::Unary,
+        "Compute an approximate reciprocal (`1. / x`) for each element.\n\n\
+         This uses a fast hardware estimate where available, and falls back to exact division otherwise.\n\n\
+         On x86 for `f32`, this has a relative error less than `1.5 × 2^-12`. \
+         On AArch64 (`f32` and `f64`), this has a relative error less than `2^-8`. \
+         The precision of this operation may change as new platform support is added.",
+    ),
+    Op::new(
         "add",
         OpKind::Overloaded(CoreOpTrait::Add),
         OpSig::Binary,

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -2666,9 +2666,9 @@ fn sqrt_f64x2<S: Simd>(simd: S) {
 
 #[simd_test]
 fn approximate_recip_f64x2<S: Simd>(simd: S) {
-    let a = f64x2::from_slice(simd, &[1.0, 23.0]);
+    let a = f64x4::from_slice(simd, &[1.0, -2.0, 23.0, 9.0]);
     let result = a.approximate_recip();
-    let expected = [1.0, 1. / 23.];
+    let expected = [1.0, -0.5, 1. / 23., 1. / 9.];
     for i in 0..2 {
         let rel_error = ((result[i] - expected[i]) / expected[i]).abs();
         assert!(

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -55,6 +55,21 @@ fn sqrt_f32x4<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn approximate_recip_f32x4<S: Simd>(simd: S) {
+    let a = f32x4::from_slice(simd, &[1.0, -2.0, 23.0, 9.0]);
+    let result = a.approximate_recip();
+    let expected = [1.0, -0.5, 1. / 23., 1. / 9.];
+    for i in 0..4 {
+        let rel_error = ((result[i] - expected[i]) / expected[i]).abs();
+        assert!(
+            rel_error < 0.005,
+            "approximate_recip({}) rel_error = {rel_error}",
+            a[i]
+        );
+    }
+}
+
+#[simd_test]
 fn div_f32x4<S: Simd>(simd: S) {
     let a = f32x4::from_slice(simd, &[4.0, 2.0, 1.0, 0.0]);
     let b = f32x4::from_slice(simd, &[4.0, 1.0, 3.0, 0.1]);
@@ -2647,6 +2662,21 @@ fn neg_i32x4<S: Simd>(simd: S) {
 fn sqrt_f64x2<S: Simd>(simd: S) {
     let a = f64x2::from_slice(simd, &[4.0, 9.0]);
     assert_eq!(*a.sqrt(), [2.0, 3.0]);
+}
+
+#[simd_test]
+fn approximate_recip_f64x2<S: Simd>(simd: S) {
+    let a = f64x2::from_slice(simd, &[1.0, 23.0]);
+    let result = a.approximate_recip();
+    let expected = [1.0, 1. / 23.];
+    for i in 0..2 {
+        let rel_error = ((result[i] - expected[i]) / expected[i]).abs();
+        assert!(
+            rel_error < 0.005,
+            "approximate_recip({}) rel_error = {rel_error}",
+            a[i]
+        );
+    }
 }
 
 #[simd_test]

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -73,6 +73,21 @@ fn sqrt_f32x4<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn approximate_recip_f32x4<S: Simd>(simd: S) {
+    let a = f32x4::from_slice(simd, &[1.0, -2.0, 23.0, 9.0]);
+    let result = a.approximate_recip();
+    let expected = [1.0, -0.5, 1. / 23., 1. / 9.];
+    for i in 0..4 {
+        let rel_error = ((result[i] - expected[i]) / expected[i]).abs();
+        assert!(
+            rel_error < 0.005,
+            "approximate_recip({}) rel_error = {rel_error}",
+            a[i]
+        );
+    }
+}
+
+#[simd_test]
 fn div_f32x4<S: Simd>(simd: S) {
     let a = f32x4::from_slice(simd, &[4.0, 2.0, 1.0, 0.0]);
     let b = f32x4::from_slice(simd, &[4.0, 1.0, 3.0, 0.1]);
@@ -3194,6 +3209,21 @@ fn neg_i32x4<S: Simd>(simd: S) {
 fn sqrt_f64x2<S: Simd>(simd: S) {
     let a = f64x2::from_slice(simd, &[4.0, 9.0]);
     assert_eq!(*a.sqrt(), [2.0, 3.0]);
+}
+
+#[simd_test]
+fn approximate_recip_f64x2<S: Simd>(simd: S) {
+    let a = f64x2::from_slice(simd, &[1.0, 23.0]);
+    let result = a.approximate_recip();
+    let expected = [1.0, 1. / 23.];
+    for i in 0..2 {
+        let rel_error = ((result[i] - expected[i]) / expected[i]).abs();
+        assert!(
+            rel_error < 0.005,
+            "approximate_recip({}) rel_error = {rel_error}",
+            a[i]
+        );
+    }
 }
 
 #[simd_test]

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -3213,9 +3213,9 @@ fn sqrt_f64x2<S: Simd>(simd: S) {
 
 #[simd_test]
 fn approximate_recip_f64x2<S: Simd>(simd: S) {
-    let a = f64x2::from_slice(simd, &[1.0, 23.0]);
+    let a = f64x4::from_slice(simd, &[1.0, -2.0, 23.0, 9.0]);
     let result = a.approximate_recip();
-    let expected = [1.0, 1. / 23.];
+    let expected = [1.0, -0.5, 1. / 23., 1. / 9.];
     for i in 0..2 {
         let rel_error = ((result[i] - expected[i]) / expected[i]).abs();
         assert!(


### PR DESCRIPTION
x86 and AArch64 have instructions to calculate fast approximate reciprocals, and these can speed up some algorithms quite nicely (e.g. sprinkling this in Vello's `flatten_simd.rs` results in -4% flattening timings for GhostScript Tiger (actually landing that there requires a bit of thought whether the lowered precision is acceptable of course!)).

There is some detail here that this PR as-is doesn't attempt to solve. x86's `rcp` has about 12 bits of precision, AArch64's `vrecpe` about 8 bits. AArch64 has an additional instruction however, `vrecps`, to perform a Newton refinement step, which bumps the precision to 16 bits. That'd look something like the following.

```rust
let x0 = vrecpeq_f32(a);
x0 * vrecpsq_f32(a, x0); // calculates x0 * (2 - x0 * a), roughly doubling the precision of the `x0` estimate
```

Then, AVX512 introduces `rcp14`, which allows calculating to 14-bit precision with (I believe) the same performance as `rcp`, and extends support to `f64`.

In any case, this method does the simplest thing of just exposing the cheapest hardware estimate, similar to e.g. Highway's `ApproximateReciprocal`.