### PR TITLE
Optimize `deinterleave()` for AVX2

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -2713,7 +2713,14 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn deinterleave_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> (f32x8<Self>, f32x8<Self>) {
-        (self.unzip_low_f32x8(a, b), self.unzip_high_f32x8(a, b))
+        unsafe {
+            let t1 = _mm256_permutevar8x32_ps(a.into(), _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
+            let t2 = _mm256_permutevar8x32_ps(b.into(), _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
+            (
+                _mm256_permute2f128_ps::<0b0010_0000>(t1, t2).simd_into(self),
+                _mm256_permute2f128_ps::<0b0011_0001>(t1, t2).simd_into(self),
+            )
+        }
     }
     #[inline(always)]
     fn max_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -3081,33 +3088,41 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn unzip_low_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         unsafe {
-            let mask = _mm256_setr_epi8(
-                0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 14, 1,
-                3, 5, 7, 9, 11, 13, 15,
-            );
-            let a_shuffled = _mm256_shuffle_epi8(a.into(), mask);
-            let b_shuffled = _mm256_shuffle_epi8(b.into(), mask);
-            let packed = _mm256_permute2x128_si256::<0b0010_0000>(
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(a_shuffled),
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(b_shuffled),
-            );
-            packed.simd_into(self)
+            let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                a.into(),
+                _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                ),
+            ));
+            let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                b.into(),
+                _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                ),
+            ));
+            _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(self)
         }
     }
     #[inline(always)]
     fn unzip_high_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         unsafe {
-            let mask = _mm256_setr_epi8(
-                0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 14, 1,
-                3, 5, 7, 9, 11, 13, 15,
-            );
-            let a_shuffled = _mm256_shuffle_epi8(a.into(), mask);
-            let b_shuffled = _mm256_shuffle_epi8(b.into(), mask);
-            let packed = _mm256_permute2x128_si256::<0b0011_0001>(
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(a_shuffled),
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(b_shuffled),
-            );
-            packed.simd_into(self)
+            let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                a.into(),
+                _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                ),
+            ));
+            let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                b.into(),
+                _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                ),
+            ));
+            _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(self)
         }
     }
     #[inline(always)]
@@ -3123,7 +3138,26 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn deinterleave_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> (i8x32<Self>, i8x32<Self>) {
-        (self.unzip_low_i8x32(a, b), self.unzip_high_i8x32(a, b))
+        unsafe {
+            let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                a.into(),
+                _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                ),
+            ));
+            let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                b.into(),
+                _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                ),
+            ));
+            (
+                _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(self),
+                _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(self),
+            )
+        }
     }
     #[inline(always)]
     fn select_i8x32(self, a: mask8x32<Self>, b: i8x32<Self>, c: i8x32<Self>) -> i8x32<Self> {
@@ -3381,33 +3415,41 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn unzip_low_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
         unsafe {
-            let mask = _mm256_setr_epi8(
-                0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 14, 1,
-                3, 5, 7, 9, 11, 13, 15,
-            );
-            let a_shuffled = _mm256_shuffle_epi8(a.into(), mask);
-            let b_shuffled = _mm256_shuffle_epi8(b.into(), mask);
-            let packed = _mm256_permute2x128_si256::<0b0010_0000>(
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(a_shuffled),
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(b_shuffled),
-            );
-            packed.simd_into(self)
+            let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                a.into(),
+                _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                ),
+            ));
+            let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                b.into(),
+                _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                ),
+            ));
+            _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(self)
         }
     }
     #[inline(always)]
     fn unzip_high_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
         unsafe {
-            let mask = _mm256_setr_epi8(
-                0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 14, 1,
-                3, 5, 7, 9, 11, 13, 15,
-            );
-            let a_shuffled = _mm256_shuffle_epi8(a.into(), mask);
-            let b_shuffled = _mm256_shuffle_epi8(b.into(), mask);
-            let packed = _mm256_permute2x128_si256::<0b0011_0001>(
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(a_shuffled),
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(b_shuffled),
-            );
-            packed.simd_into(self)
+            let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                a.into(),
+                _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                ),
+            ));
+            let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                b.into(),
+                _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                ),
+            ));
+            _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(self)
         }
     }
     #[inline(always)]
@@ -3423,7 +3465,26 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn deinterleave_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> (u8x32<Self>, u8x32<Self>) {
-        (self.unzip_low_u8x32(a, b), self.unzip_high_u8x32(a, b))
+        unsafe {
+            let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                a.into(),
+                _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                ),
+            ));
+            let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                b.into(),
+                _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                ),
+            ));
+            (
+                _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(self),
+                _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(self),
+            )
+        }
     }
     #[inline(always)]
     fn select_u8x32(self, a: mask8x32<Self>, b: u8x32<Self>, c: u8x32<Self>) -> u8x32<Self> {
@@ -3814,33 +3875,41 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn unzip_low_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         unsafe {
-            let mask = _mm256_setr_epi8(
-                0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13, 2,
-                3, 6, 7, 10, 11, 14, 15,
-            );
-            let a_shuffled = _mm256_shuffle_epi8(a.into(), mask);
-            let b_shuffled = _mm256_shuffle_epi8(b.into(), mask);
-            let packed = _mm256_permute2x128_si256::<0b0010_0000>(
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(a_shuffled),
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(b_shuffled),
-            );
-            packed.simd_into(self)
+            let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                a.into(),
+                _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                ),
+            ));
+            let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                b.into(),
+                _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                ),
+            ));
+            _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(self)
         }
     }
     #[inline(always)]
     fn unzip_high_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         unsafe {
-            let mask = _mm256_setr_epi8(
-                0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13, 2,
-                3, 6, 7, 10, 11, 14, 15,
-            );
-            let a_shuffled = _mm256_shuffle_epi8(a.into(), mask);
-            let b_shuffled = _mm256_shuffle_epi8(b.into(), mask);
-            let packed = _mm256_permute2x128_si256::<0b0011_0001>(
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(a_shuffled),
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(b_shuffled),
-            );
-            packed.simd_into(self)
+            let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                a.into(),
+                _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                ),
+            ));
+            let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                b.into(),
+                _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                ),
+            ));
+            _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(self)
         }
     }
     #[inline(always)]
@@ -3856,7 +3925,26 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn deinterleave_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> (i16x16<Self>, i16x16<Self>) {
-        (self.unzip_low_i16x16(a, b), self.unzip_high_i16x16(a, b))
+        unsafe {
+            let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                a.into(),
+                _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                ),
+            ));
+            let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                b.into(),
+                _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                ),
+            ));
+            (
+                _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(self),
+                _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(self),
+            )
+        }
     }
     #[inline(always)]
     fn select_i16x16(self, a: mask16x16<Self>, b: i16x16<Self>, c: i16x16<Self>) -> i16x16<Self> {
@@ -4095,33 +4183,41 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn unzip_low_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
         unsafe {
-            let mask = _mm256_setr_epi8(
-                0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13, 2,
-                3, 6, 7, 10, 11, 14, 15,
-            );
-            let a_shuffled = _mm256_shuffle_epi8(a.into(), mask);
-            let b_shuffled = _mm256_shuffle_epi8(b.into(), mask);
-            let packed = _mm256_permute2x128_si256::<0b0010_0000>(
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(a_shuffled),
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(b_shuffled),
-            );
-            packed.simd_into(self)
+            let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                a.into(),
+                _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                ),
+            ));
+            let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                b.into(),
+                _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                ),
+            ));
+            _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(self)
         }
     }
     #[inline(always)]
     fn unzip_high_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
         unsafe {
-            let mask = _mm256_setr_epi8(
-                0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13, 2,
-                3, 6, 7, 10, 11, 14, 15,
-            );
-            let a_shuffled = _mm256_shuffle_epi8(a.into(), mask);
-            let b_shuffled = _mm256_shuffle_epi8(b.into(), mask);
-            let packed = _mm256_permute2x128_si256::<0b0011_0001>(
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(a_shuffled),
-                _mm256_permute4x64_epi64::<0b11_01_10_00>(b_shuffled),
-            );
-            packed.simd_into(self)
+            let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                a.into(),
+                _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                ),
+            ));
+            let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                b.into(),
+                _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                ),
+            ));
+            _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(self)
         }
     }
     #[inline(always)]
@@ -4137,7 +4233,26 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn deinterleave_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> (u16x16<Self>, u16x16<Self>) {
-        (self.unzip_low_u16x16(a, b), self.unzip_high_u16x16(a, b))
+        unsafe {
+            let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                a.into(),
+                _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                ),
+            ));
+            let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
+                b.into(),
+                _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                ),
+            ));
+            (
+                _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(self),
+                _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(self),
+            )
+        }
     }
     #[inline(always)]
     fn select_u16x16(self, a: mask16x16<Self>, b: u16x16<Self>, c: u16x16<Self>) -> u16x16<Self> {
@@ -4565,7 +4680,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn deinterleave_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> (i32x8<Self>, i32x8<Self>) {
-        (self.unzip_low_i32x8(a, b), self.unzip_high_i32x8(a, b))
+        unsafe {
+            let t1 =
+                _mm256_permutevar8x32_epi32(a.into(), _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
+            let t2 =
+                _mm256_permutevar8x32_epi32(b.into(), _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
+            (
+                _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(self),
+                _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(self),
+            )
+        }
     }
     #[inline(always)]
     fn select_i32x8(self, a: mask32x8<Self>, b: i32x8<Self>, c: i32x8<Self>) -> i32x8<Self> {
@@ -4838,7 +4962,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn deinterleave_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> (u32x8<Self>, u32x8<Self>) {
-        (self.unzip_low_u32x8(a, b), self.unzip_high_u32x8(a, b))
+        unsafe {
+            let t1 =
+                _mm256_permutevar8x32_epi32(a.into(), _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
+            let t2 =
+                _mm256_permutevar8x32_epi32(b.into(), _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
+            (
+                _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(self),
+                _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(self),
+            )
+        }
     }
     #[inline(always)]
     fn select_u32x8(self, a: mask32x8<Self>, b: u32x8<Self>, c: u32x8<Self>) -> u32x8<Self> {
@@ -5250,7 +5383,14 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn deinterleave_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> (f64x4<Self>, f64x4<Self>) {
-        (self.unzip_low_f64x4(a, b), self.unzip_high_f64x4(a, b))
+        unsafe {
+            let t1 = _mm256_permute4x64_pd::<0b11_01_10_00>(a.into());
+            let t2 = _mm256_permute4x64_pd::<0b11_01_10_00>(b.into());
+            (
+                _mm256_permute2f128_pd::<0b0010_0000>(t1, t2).simd_into(self),
+                _mm256_permute2f128_pd::<0b0011_0001>(t1, t2).simd_into(self),
+            )
+        }
     }
     #[inline(always)]
     fn max_f64x4(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -846,13 +846,90 @@ impl X86 {
         method_sig: TokenStream,
         vec_ty: &VecType,
     ) -> TokenStream {
-        let unzip_low = generic_op_name("unzip_low", vec_ty);
-        let unzip_high = generic_op_name("unzip_high", vec_ty);
-        quote! {
-            #method_sig {
-                (self.#unzip_low(a, b), self.#unzip_high(a, b))
+        match vec_ty.n_bits() {
+            256 => {
+                // Optimized path: compute the per-input shuffles once, then use permute2f128 /
+                // permute2x128 to produce both unzip_low and unzip_high results. This avoids
+                // the redundant shuffle operations that occur when unzip_low and unzip_high are
+                // called separately.
+                let (t1, t2, shuffle) = self.unzip256_intermediates(vec_ty);
+                quote! {
+                    #method_sig {
+                        unsafe {
+                            let t1 = #t1;
+                            let t2 = #t2;
+                            (
+                                #shuffle::<0b0010_0000>(t1, t2).simd_into(self),
+                                #shuffle::<0b0011_0001>(t1, t2).simd_into(self),
+                            )
+                        }
+                    }
+                }
+            }
+            _ => {
+                // For 128-bit vectors, unzip_low/unzip_high are cheap, so there's no
+                // redundancy in calling them separately.
+                let unzip_low = generic_op_name("unzip_low", vec_ty);
+                let unzip_high = generic_op_name("unzip_high", vec_ty);
+                quote! {
+                    #method_sig {
+                        (self.#unzip_low(a, b), self.#unzip_high(a, b))
+                    }
+                }
             }
         }
+    }
+
+    /// Returns `(t1_expr, t2_expr, shuffle_ident)` for 256-bit unzip operations.
+    ///
+    /// `t1` and `t2` are the per-input shuffles that separate even and odd elements.
+    /// `shuffle` is the `permute2f128` / `permute2x128` intrinsic used to select
+    /// the low or high halves via immediate `0b0010_0000` or `0b0011_0001`.
+    fn unzip256_intermediates(&self, vec_ty: &VecType) -> (TokenStream, TokenStream, Ident) {
+        let shuffle = intrinsic_ident(
+            match vec_ty.scalar {
+                ScalarType::Float => "permute2f128",
+                _ => "permute2x128",
+            },
+            coarse_type(vec_ty),
+            256,
+        );
+
+        let (t1, t2) = match vec_ty.scalar_bits {
+            32 | 64 => {
+                let kind = match vec_ty.scalar_bits {
+                    32 => "permutevar8x32",
+                    64 => "permute4x64",
+                    _ => unreachable!(),
+                };
+                let suffix = op_suffix(vec_ty.scalar, vec_ty.scalar_bits, false);
+                let intr = intrinsic_ident(kind, suffix, 256);
+                let shuf = |input: TokenStream| match vec_ty.scalar_bits {
+                    32 => quote! { #intr(#input, _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7)) },
+                    64 => quote! { #intr::<0b11_01_10_00>(#input) },
+                    _ => unreachable!(),
+                };
+                (shuf(quote! { a.into() }), shuf(quote! { b.into() }))
+            }
+            8 | 16 => {
+                let mask = match vec_ty.scalar_bits {
+                    8 => quote! { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 },
+                    16 => quote! { 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15 },
+                    _ => unreachable!(),
+                };
+                let shuf = |input: TokenStream| {
+                    quote! {
+                        _mm256_permute4x64_epi64::<0b11_01_10_00>(
+                            _mm256_shuffle_epi8(#input, _mm256_setr_epi8(#mask, #mask)),
+                        )
+                    }
+                };
+                (shuf(quote! { a.into() }), shuf(quote! { b.into() }))
+            }
+            _ => unreachable!(),
+        };
+
+        (t1, t2, shuffle)
     }
 
     pub(crate) fn handle_unzip(
@@ -923,38 +1000,9 @@ impl X86 {
                     }
                 }
             }
-            (_, 256, 64 | 32) => {
-                // First we perform a lane-crossing shuffle to move the even-indexed elements of each input to the lower
-                // half, and the odd-indexed ones to the upper half.
-                // e.g. [0, 1, 2, 3, 4, 5, 6, 7] becomes [0, 2, 4, 6, 1, 3, 5, 7]).
-                let low_shuffle_kind = match vec_ty.scalar_bits {
-                    32 => "permutevar8x32",
-                    64 => "permute4x64",
-                    _ => unreachable!(),
-                };
-                let low_shuffle_suffix = op_suffix(vec_ty.scalar, vec_ty.scalar_bits, false);
-                let low_shuffle_intrinsic =
-                    intrinsic_ident(low_shuffle_kind, low_shuffle_suffix, 256);
-                let low_shuffle = |input_name: TokenStream| match vec_ty.scalar_bits {
-                    32 => {
-                        quote! { #low_shuffle_intrinsic(#input_name, _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7)) }
-                    }
-                    64 => quote! { #low_shuffle_intrinsic::<0b11_01_10_00>(#input_name) },
-                    _ => unreachable!(),
-                };
-                let shuf_t1 = low_shuffle(quote! { a.into() });
-                let shuf_t2 = low_shuffle(quote! { b.into() });
-
-                // Then we combine the lower or upper halves.
-                let high_shuffle = intrinsic_ident(
-                    match vec_ty.scalar {
-                        ScalarType::Float => "permute2f128",
-                        _ => "permute2x128",
-                    },
-                    coarse_type(vec_ty),
-                    256,
-                );
-                let high_shuffle_immediate = if select_even {
+            (_, 256, _) => {
+                let (t1, t2, shuffle) = self.unzip256_intermediates(vec_ty);
+                let shuffle_immediate = if select_even {
                     quote! { 0b0010_0000 }
                 } else {
                     quote! { 0b0011_0001 }
@@ -962,45 +1010,9 @@ impl X86 {
 
                 quote! {
                     unsafe {
-                        let t1 = #shuf_t1;
-                        let t2 = #shuf_t2;
-
-                        #high_shuffle::<#high_shuffle_immediate>(t1, t2).simd_into(self)
-                    }
-                }
-            }
-            (_, 256, 16 | 8) => {
-                // Separate out the even-indexed and odd-indexed elements within each 128-bit lane
-                let mask = match vec_ty.scalar_bits {
-                    8 => {
-                        quote! { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 }
-                    }
-                    16 => {
-                        quote! { 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15 }
-                    }
-                    _ => unreachable!(),
-                };
-
-                // We then permute the even-indexed and odd-indexed blocks across lanes, and finally do a 2x128 permute to
-                // select either the even- or odd-indexed elements
-                let high_shuffle_immediate = if select_even {
-                    quote! { 0b0010_0000 }
-                } else {
-                    quote! { 0b0011_0001 }
-                };
-
-                quote! {
-                    unsafe {
-                        let mask = _mm256_setr_epi8(#mask, #mask);
-                        let a_shuffled = _mm256_shuffle_epi8(a.into(), mask);
-                        let b_shuffled = _mm256_shuffle_epi8(b.into(), mask);
-
-                        let packed = _mm256_permute2x128_si256::<#high_shuffle_immediate>(
-                            _mm256_permute4x64_epi64::<0b11_01_10_00>(a_shuffled),
-                            _mm256_permute4x64_epi64::<0b11_01_10_00>(b_shuffled)
-                        );
-
-                        packed.simd_into(self)
+                        let t1 = #t1;
+                        let t2 = #t2;
+                        #shuffle::<#shuffle_immediate>(t1, t2).simd_into(self)
                     }
                 }
             }


### PR DESCRIPTION
Follow up to #206

@LaurenzV noted that deinterleaving could be optimized the same way. 

Emitting the proper shuffle is more involved than for zip, but it's already implemented in `handle_unzip()`, so I've simply split it into a helper function and reused it.

This code has good test coverage and all tests pass.