### PR TITLE
Consistently use the v2 and v3 x86_64 instruction sets everywhere

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -14,7 +14,7 @@ use crate::{
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
-#[doc = "The SIMD token for the \"AVX2\" and \"FMA\" level."]
+#[doc = "The SIMD token for the x86-64-v3 level."]
 #[derive(Clone, Copy, Debug)]
 pub struct Avx2 {
     pub avx2: crate::core_arch::x86::Avx2,
@@ -24,7 +24,9 @@ impl Avx2 {
     #[doc = r""]
     #[doc = r" # Safety"]
     #[doc = r""]
-    #[doc = r" The AVX2 and FMA CPU features must be available."]
+    #[doc = r" The `avx2`, `bmi1`, `bmi2`, `cmpxchg16b`, `f16c`, `fma`,"]
+    #[doc = r" `lzcnt`, `movbe`, `popcnt`, and `xsave` CPU features must"]
+    #[doc = r" be available."]
     #[inline]
     pub const unsafe fn new_unchecked() -> Self {
         Self {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -14,7 +14,7 @@ use crate::{
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
-#[doc = "The SIMD token for the x86-64-v2 (`sse4.2`, `cmpxchg16b`, and `popcnt`) level."]
+#[doc = "The SIMD token for the x86-64-v2 level."]
 #[derive(Clone, Copy, Debug)]
 pub struct Sse4_2 {
     pub sse4_2: crate::core_arch::x86::Sse4_2,

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -14,7 +14,7 @@ use crate::{
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
-#[doc = "The SIMD token for the \"SSE4.2\" level."]
+#[doc = "The SIMD token for the x86-64-v2 (`sse4.2`, `cmpxchg16b`, and `popcnt`) level."]
 #[derive(Clone, Copy, Debug)]
 pub struct Sse4_2 {
     pub sse4_2: crate::core_arch::x86::Sse4_2,
@@ -24,7 +24,8 @@ impl Sse4_2 {
     #[doc = r""]
     #[doc = r" # Safety"]
     #[doc = r""]
-    #[doc = r" The SSE4.2 CPU feature must be available."]
+    #[doc = r" The `sse4.2`, `cmpxchg16b`, and `popcnt` CPU features must"]
+    #[doc = r" be available."]
     #[inline]
     pub const unsafe fn new_unchecked() -> Self {
         Sse4_2 {
@@ -86,9 +87,31 @@ impl Simd for Sse4_2 {
     type mask64s = mask64x2<Self>;
     #[inline(always)]
     fn level(self) -> Level {
-        #[cfg(not(all(target_feature = "avx2", target_feature = "fma")))]
+        #[cfg(not(all(
+            target_feature = "avx2",
+            target_feature = "bmi1",
+            target_feature = "bmi2",
+            target_feature = "cmpxchg16b",
+            target_feature = "f16c",
+            target_feature = "fma",
+            target_feature = "lzcnt",
+            target_feature = "movbe",
+            target_feature = "popcnt",
+            target_feature = "xsave"
+        )))]
         return Level::Sse4_2(self);
-        #[cfg(all(target_feature = "avx2", target_feature = "fma"))]
+        #[cfg(all(
+            target_feature = "avx2",
+            target_feature = "bmi1",
+            target_feature = "bmi2",
+            target_feature = "cmpxchg16b",
+            target_feature = "f16c",
+            target_feature = "fma",
+            target_feature = "lzcnt",
+            target_feature = "movbe",
+            target_feature = "popcnt",
+            target_feature = "xsave"
+        ))]
         {
             Level::baseline()
         }

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -243,8 +243,7 @@ pub enum Level {
         ))
     ))]
     Sse4_2(Sse4_2),
-    /// The AVX2 and FMA instruction set on (32 and 64 bit) x86, plus the other instructions
-    /// guaranteed to be available on AVX2+FMA CPUs. Also known as x86-64-v3.
+    /// The x86-64-v3 instruction set on (32 and 64 bit) x86, including AVX2 and FMA.
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     Avx2(Avx2),
     // If new variants are added, make sure to handle them in `Level::dispatch`
@@ -465,9 +464,8 @@ impl Level {
     #[inline]
     pub fn as_sse4_2(self) -> Option<Sse4_2> {
         match self {
-            // Safety: The Avx2 struct represents the `avx2` and `fma` target features being enabled.
-            // The `avx2` target feature *also* implicitly enables the "sse4.2" target feature, which is
-            // the only target feature required to make our Sse4_2 token.
+            // Safety: The Avx2 struct represents the x86-64-v3 feature set being enabled, which
+            // includes the `sse4.2`, `cmpxchg16b`, and `popcnt` features required by Sse4_2.
             Self::Avx2(_avx) => unsafe { Some(Sse4_2::new_unchecked()) },
             #[cfg(not(all(
                 target_feature = "avx2",
@@ -490,7 +488,8 @@ impl Level {
         }
     }
 
-    /// If this is a proof that AVX2 and FMA (or better) is available, access that instruction set.
+    /// If this is a proof that the x86-64-v3 feature set (or better) is available, access that
+    /// instruction set.
     ///
     /// This method should be preferred over matching against the `AVX2` variant of self,
     /// because if Fearless SIMD gets support for an instruction set which is a superset of AVX2,

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -81,7 +81,18 @@ macro_rules! dispatch {
             // This fallthrough logic is documented at the definition site of `Level`.
             #[cfg(all(
                 any(target_arch = "x86", target_arch = "x86_64"),
-                not(all(target_feature = "avx2", target_feature = "fma"))
+                not(all(
+                    target_feature = "avx2",
+                    target_feature = "bmi1",
+                    target_feature = "bmi2",
+                    target_feature = "cmpxchg16b",
+                    target_feature = "f16c",
+                    target_feature = "fma",
+                    target_feature = "lzcnt",
+                    target_feature = "movbe",
+                    target_feature = "popcnt",
+                    target_feature = "xsave"
+                ))
             ))]
             $crate::Level::Sse4_2(sse4_2) => {
                 let $simd = launder(sse4_2);
@@ -104,7 +115,11 @@ macro_rules! dispatch {
                 all(target_arch = "aarch64", not(target_feature = "neon")),
                 all(
                     any(target_arch = "x86", target_arch = "x86_64"),
-                    not(target_feature = "sse4.2")
+                    not(all(
+                        target_feature = "sse4.2",
+                        target_feature = "cmpxchg16b",
+                        target_feature = "popcnt"
+                    ))
                 ),
                 all(target_arch = "wasm32", not(target_feature = "simd128")),
                 not(any(

--- a/fearless_simd_dev_macros/src/lib.rs
+++ b/fearless_simd_dev_macros/src/lib.rs
@@ -78,7 +78,10 @@ pub fn simd_test(_: TokenStream, item: TokenStream) -> TokenStream {
         #[test]
         #ignore_sse4
         fn #sse4_name() {
-            if std::arch::is_x86_feature_detected!("sse4.2") {
+            if std::arch::is_x86_feature_detected!("sse4.2")
+                && std::arch::is_x86_feature_detected!("cmpxchg16b")
+                && std::arch::is_x86_feature_detected!("popcnt")
+            {
                 let sse4 = unsafe { fearless_simd::x86::Sse4_2::new_unchecked() };
                 sse4.vectorize(
                     #[inline(always)]
@@ -94,7 +97,15 @@ pub fn simd_test(_: TokenStream, item: TokenStream) -> TokenStream {
         #ignore_avx2
         fn #avx2_name() {
             if std::arch::is_x86_feature_detected!("avx2")
+                && std::arch::is_x86_feature_detected!("bmi1")
+                && std::arch::is_x86_feature_detected!("bmi2")
+                && std::arch::is_x86_feature_detected!("cmpxchg16b")
+                && std::arch::is_x86_feature_detected!("f16c")
                 && std::arch::is_x86_feature_detected!("fma")
+                && std::arch::is_x86_feature_detected!("lzcnt")
+                && std::arch::is_x86_feature_detected!("movbe")
+                && std::arch::is_x86_feature_detected!("popcnt")
+                && std::arch::is_x86_feature_detected!("xsave")
             {
                 let avx2 = unsafe { fearless_simd::x86::Avx2::new_unchecked() };
                 avx2.vectorize(

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -61,9 +61,7 @@ impl Level for X86 {
 
     fn token_doc(&self) -> &'static str {
         match self {
-            Self::Sse4_2 => {
-                "The SIMD token for the x86-64-v2 level."
-            }
+            Self::Sse4_2 => "The SIMD token for the x86-64-v2 level.",
             Self::Avx2 => "The SIMD token for the x86-64-v3 level.",
         }
     }

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -61,8 +61,10 @@ impl Level for X86 {
 
     fn token_doc(&self) -> &'static str {
         match self {
-            Self::Sse4_2 => r#"The SIMD token for the "SSE4.2" level."#,
-            Self::Avx2 => r#"The SIMD token for the "AVX2" and "FMA" level."#,
+            Self::Sse4_2 => {
+                "The SIMD token for the x86-64-v2 (`sse4.2`, `cmpxchg16b`, and `popcnt`) level."
+            }
+            Self::Avx2 => "The SIMD token for the x86-64-v3 level.",
         }
     }
 
@@ -99,9 +101,31 @@ impl Level for X86 {
         let level_tok = self.token();
         match self {
             Self::Sse4_2 => quote! {
-                #[cfg(not(all(target_feature = "avx2", target_feature = "fma")))]
+                #[cfg(not(all(
+                    target_feature = "avx2",
+                    target_feature = "bmi1",
+                    target_feature = "bmi2",
+                    target_feature = "cmpxchg16b",
+                    target_feature = "f16c",
+                    target_feature = "fma",
+                    target_feature = "lzcnt",
+                    target_feature = "movbe",
+                    target_feature = "popcnt",
+                    target_feature = "xsave"
+                )))]
                 return Level::#level_tok(self);
-                #[cfg(all(target_feature = "avx2", target_feature = "fma"))]
+                #[cfg(all(
+                    target_feature = "avx2",
+                    target_feature = "bmi1",
+                    target_feature = "bmi2",
+                    target_feature = "cmpxchg16b",
+                    target_feature = "f16c",
+                    target_feature = "fma",
+                    target_feature = "lzcnt",
+                    target_feature = "movbe",
+                    target_feature = "popcnt",
+                    target_feature = "xsave"
+                ))]
                 {
                     Level::baseline()
                 }
@@ -119,7 +143,8 @@ impl Level for X86 {
                 ///
                 /// # Safety
                 ///
-                /// The SSE4.2 CPU feature must be available.
+                /// The `sse4.2`, `cmpxchg16b`, and `popcnt` CPU features must
+                /// be available.
                 #[inline]
                 pub const unsafe fn new_unchecked() -> Self {
                     Sse4_2 {
@@ -132,7 +157,9 @@ impl Level for X86 {
                 ///
                 /// # Safety
                 ///
-                /// The AVX2 and FMA CPU features must be available.
+                /// The `avx2`, `bmi1`, `bmi2`, `cmpxchg16b`, `f16c`, `fma`,
+                /// `lzcnt`, `movbe`, `popcnt`, and `xsave` CPU features must
+                /// be available.
                 #[inline]
                 pub const unsafe fn new_unchecked() -> Self {
                     Self {

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -62,7 +62,7 @@ impl Level for X86 {
     fn token_doc(&self) -> &'static str {
         match self {
             Self::Sse4_2 => {
-                "The SIMD token for the x86-64-v2 (`sse4.2`, `cmpxchg16b`, and `popcnt`) level."
+                "The SIMD token for the x86-64-v2 level."
             }
             Self::Avx2 => "The SIMD token for the x86-64-v3 level.",
         }


### PR DESCRIPTION
This shouldn't be an issue on real hardware, but certain emulators with feature combinations that never existed in silicon might complain. Tighten things up just to be sure.