### PR TITLE
Correctly feature-gate x86 intrinsics on the `safe_wrappers` feature

### DIFF
--- a/fearless_simd/src/core_arch/x86/avx.rs
+++ b/fearless_simd/src/core_arch/x86/avx.rs
@@ -3,12 +3,14 @@
 
 //! Access to AVX intrinsics.
 
+#[cfg(feature = "safe_wrappers")]
 use crate::impl_macros::delegate;
-#[cfg(target_arch = "x86")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86"))]
 use core::arch::x86 as arch;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86_64"))]
 use core::arch::x86_64 as arch;
 
+#[cfg(feature = "safe_wrappers")]
 use arch::*;
 
 /// A token for AVX intrinsics on `x86` and `x86_64`.
@@ -17,10 +19,6 @@ pub struct Avx {
     _private: (),
 }
 
-#[expect(
-    clippy::missing_safety_doc,
-    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
-)]
 impl Avx {
     /// Create a SIMD token.
     ///
@@ -31,7 +29,14 @@ impl Avx {
     pub const unsafe fn new_unchecked() -> Self {
         Self { _private: () }
     }
+}
 
+#[cfg(feature = "safe_wrappers")]
+#[expect(
+    clippy::missing_safety_doc,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+impl Avx {
     delegate! { arch:
         fn _mm256_add_pd(a: __m256d, b: __m256d) -> __m256d;
         fn _mm256_add_ps(a: __m256, b: __m256) -> __m256;

--- a/fearless_simd/src/core_arch/x86/avx2.rs
+++ b/fearless_simd/src/core_arch/x86/avx2.rs
@@ -8,12 +8,14 @@
 
 //! Access to AVX2 intrinsics.
 
+#[cfg(feature = "safe_wrappers")]
 use crate::impl_macros::delegate;
-#[cfg(target_arch = "x86")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86"))]
 use core::arch::x86 as arch;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86_64"))]
 use core::arch::x86_64 as arch;
 
+#[cfg(feature = "safe_wrappers")]
 use arch::*;
 
 /// A token for AVX2 intrinsics on `x86` and `x86_64`.
@@ -31,7 +33,10 @@ impl Avx2 {
     pub const unsafe fn new_unchecked() -> Self {
         Self { _private: () }
     }
+}
 
+#[cfg(feature = "safe_wrappers")]
+impl Avx2 {
     delegate! { arch:
         fn _mm256_abs_epi32(a: __m256i) -> __m256i;
         fn _mm256_abs_epi16(a: __m256i) -> __m256i;

--- a/fearless_simd/src/core_arch/x86/fma.rs
+++ b/fearless_simd/src/core_arch/x86/fma.rs
@@ -3,12 +3,14 @@
 
 //! Access to FMA intrinsics.
 
+#[cfg(feature = "safe_wrappers")]
 use crate::impl_macros::delegate;
-#[cfg(target_arch = "x86")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86"))]
 use core::arch::x86 as arch;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86_64"))]
 use core::arch::x86_64 as arch;
 
+#[cfg(feature = "safe_wrappers")]
 use arch::*;
 
 /// A token for FMA intrinsics on `x86` and `x86_64`.
@@ -27,7 +29,10 @@ impl Fma {
     pub const unsafe fn new_unchecked() -> Self {
         Self { _private: () }
     }
+}
 
+#[cfg(feature = "safe_wrappers")]
+impl Fma {
     delegate! { arch:
         fn _mm_fmadd_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
         fn _mm256_fmadd_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d;

--- a/fearless_simd/src/core_arch/x86/sse.rs
+++ b/fearless_simd/src/core_arch/x86/sse.rs
@@ -3,12 +3,14 @@
 
 //! Access to SSE intrinsics.
 
+#[cfg(feature = "safe_wrappers")]
 use crate::impl_macros::delegate;
-#[cfg(target_arch = "x86")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86"))]
 use core::arch::x86 as arch;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86_64"))]
 use core::arch::x86_64 as arch;
 
+#[cfg(feature = "safe_wrappers")]
 use arch::*;
 
 /// A token for SSE intrinsics on `x86` and `x86_64`.
@@ -17,10 +19,6 @@ pub struct Sse {
     _private: (),
 }
 
-#[expect(
-    clippy::missing_safety_doc,
-    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
-)]
 impl Sse {
     /// Create a SIMD token.
     ///
@@ -31,7 +29,14 @@ impl Sse {
     pub const unsafe fn new_unchecked() -> Self {
         Self { _private: () }
     }
+}
 
+#[cfg(feature = "safe_wrappers")]
+#[expect(
+    clippy::missing_safety_doc,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+impl Sse {
     delegate! { arch:
         fn _mm_add_ss(a: __m128, b: __m128) -> __m128;
         fn _mm_add_ps(a: __m128, b: __m128) -> __m128;

--- a/fearless_simd/src/core_arch/x86/sse2.rs
+++ b/fearless_simd/src/core_arch/x86/sse2.rs
@@ -3,12 +3,14 @@
 
 //! Access to SSE2 intrinsics.
 
+#[cfg(feature = "safe_wrappers")]
 use crate::impl_macros::delegate;
-#[cfg(target_arch = "x86")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86"))]
 use core::arch::x86 as arch;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86_64"))]
 use core::arch::x86_64 as arch;
 
+#[cfg(feature = "safe_wrappers")]
 use arch::*;
 
 /// A token for SSE2 intrinsics on `x86` and `x86_64`.
@@ -17,10 +19,6 @@ pub struct Sse2 {
     _private: (),
 }
 
-#[expect(
-    clippy::missing_safety_doc,
-    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
-)]
 impl Sse2 {
     /// Create a SIMD token.
     ///
@@ -31,7 +29,14 @@ impl Sse2 {
     pub const unsafe fn new_unchecked() -> Self {
         Self { _private: () }
     }
+}
 
+#[cfg(feature = "safe_wrappers")]
+#[expect(
+    clippy::missing_safety_doc,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+impl Sse2 {
     delegate! { arch:
         fn _mm_pause();
         unsafe fn _mm_clflush(p: *const u8);

--- a/fearless_simd/src/core_arch/x86/sse3.rs
+++ b/fearless_simd/src/core_arch/x86/sse3.rs
@@ -3,12 +3,14 @@
 
 //! Access to SSE3 intrinsics.
 
+#[cfg(feature = "safe_wrappers")]
 use crate::impl_macros::delegate;
-#[cfg(target_arch = "x86")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86"))]
 use core::arch::x86 as arch;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86_64"))]
 use core::arch::x86_64 as arch;
 
+#[cfg(feature = "safe_wrappers")]
 use arch::*;
 
 /// A token for SSE3 intrinsics on `x86` and `x86_64`.
@@ -17,10 +19,6 @@ pub struct Sse3 {
     _private: (),
 }
 
-#[expect(
-    clippy::missing_safety_doc,
-    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
-)]
 impl Sse3 {
     /// Create a SIMD token.
     ///
@@ -31,7 +29,14 @@ impl Sse3 {
     pub const unsafe fn new_unchecked() -> Self {
         Self { _private: () }
     }
+}
 
+#[cfg(feature = "safe_wrappers")]
+#[expect(
+    clippy::missing_safety_doc,
+    reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
+)]
+impl Sse3 {
     delegate! { arch:
         fn _mm_addsub_ps(a: __m128, b: __m128) -> __m128;
         fn _mm_addsub_pd(a: __m128d, b: __m128d) -> __m128d;

--- a/fearless_simd/src/core_arch/x86/sse4_1.rs
+++ b/fearless_simd/src/core_arch/x86/sse4_1.rs
@@ -3,12 +3,14 @@
 
 //! Access to SSE4.1 intrinsics.
 
+#[cfg(feature = "safe_wrappers")]
 use crate::impl_macros::delegate;
-#[cfg(target_arch = "x86")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86"))]
 use core::arch::x86 as arch;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86_64"))]
 use core::arch::x86_64 as arch;
 
+#[cfg(feature = "safe_wrappers")]
 use arch::*;
 
 /// A token for SSE4.1 intrinsics on `x86` and `x86_64`.
@@ -27,7 +29,10 @@ impl Sse4_1 {
     pub const unsafe fn new_unchecked() -> Self {
         Self { _private: () }
     }
+}
 
+#[cfg(feature = "safe_wrappers")]
+impl Sse4_1 {
     delegate! { arch:
         fn _mm_blendv_epi8(a: __m128i, b: __m128i, mask: __m128i) -> __m128i;
         fn _mm_blend_epi16<const IMM8: i32>(a: __m128i, b: __m128i) -> __m128i;

--- a/fearless_simd/src/core_arch/x86/sse4_2.rs
+++ b/fearless_simd/src/core_arch/x86/sse4_2.rs
@@ -3,12 +3,14 @@
 
 //! Access to SSE4.2 intrinsics.
 
+#[cfg(feature = "safe_wrappers")]
 use crate::impl_macros::delegate;
-#[cfg(target_arch = "x86")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86"))]
 use core::arch::x86 as arch;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86_64"))]
 use core::arch::x86_64 as arch;
 
+#[cfg(feature = "safe_wrappers")]
 use arch::*;
 
 /// A token for SSE4.2 intrinsics on `x86` and `x86_64`.
@@ -27,7 +29,10 @@ impl Sse4_2 {
     pub const unsafe fn new_unchecked() -> Self {
         Self { _private: () }
     }
+}
 
+#[cfg(feature = "safe_wrappers")]
+impl Sse4_2 {
     delegate! { arch:
         fn _mm_cmpistrm<const IMM8: i32>(a: __m128i, b: __m128i) -> __m128i;
         fn _mm_cmpistri<const IMM8: i32>(a: __m128i, b: __m128i) -> i32;

--- a/fearless_simd/src/core_arch/x86/ssse3.rs
+++ b/fearless_simd/src/core_arch/x86/ssse3.rs
@@ -3,12 +3,14 @@
 
 //! Access to SSSE3 intrinsics.
 
+#[cfg(feature = "safe_wrappers")]
 use crate::impl_macros::delegate;
-#[cfg(target_arch = "x86")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86"))]
 use core::arch::x86 as arch;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(feature = "safe_wrappers", target_arch = "x86_64"))]
 use core::arch::x86_64 as arch;
 
+#[cfg(feature = "safe_wrappers")]
 use arch::*;
 
 /// A token for SSSE3 intrinsics on `x86` and `x86_64`.
@@ -27,7 +29,10 @@ impl Ssse3 {
     pub const unsafe fn new_unchecked() -> Self {
         Self { _private: () }
     }
+}
 
+#[cfg(feature = "safe_wrappers")]
+impl Ssse3 {
     delegate! { arch:
         fn _mm_abs_epi8(a: __m128i) -> __m128i;
         fn _mm_abs_epi16(a: __m128i) -> __m128i;

--- a/fearless_simd/src/impl_macros.rs
+++ b/fearless_simd/src/impl_macros.rs
@@ -24,6 +24,7 @@ macro_rules! delegate {
             #[inline(always)]
             pub $(unsafe $($placeholder)?)?
             fn $func $(<$(const $generic: $generic_ty),*>)?(self, $($arg: $ty),*) $(-> $ret)? {
+                #[allow(unused_unsafe, reason = "Some delegated intrinsics are safe, while others require unsafe.")]
                 unsafe { $func $(::<$($generic,)*>)?($($arg,)*) }
             }
         )*


### PR DESCRIPTION
Previously that feature was only applied to ARM

This is technically semver-breaking but restores the expected behavior and I don't think anyone's depending on this yet, at least not on crates.io