### PR TITLE
Prepare v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ No changelog was kept for this release.
 [#181]: https://github.com/linebender/fearless_simd/pull/181
 [#185]: https://github.com/linebender/fearless_simd/pull/185
 [#188]: https://github.com/linebender/fearless_simd/pull/188
+[#206]: https://github.com/linebender/fearless_simd/pull/206
 [#207]: https://github.com/linebender/fearless_simd/pull/207
 [#208]: https://github.com/linebender/fearless_simd/pull/208
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,24 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 -->
 
-The latest published Fearless SIMD release is [0.4.0](#040-2026-02-13) which was released on 2026-02-13.
-You can find its changes [documented below](#040-2026-02-13).
+The latest published Fearless SIMD release is [0.4.1](#041-2026-05-16) which was released on 2026-05-16.
+You can find its changes [documented below](#041-2026-05-16).
 
 ## [Unreleased]
 
 This release has an [MSRV][] of 1.88.
+
+## [0.4.1][] (2026-05-16)
+
+This release has an [MSRV][] of 1.88.
+
+### Added
+
+- The `interleave` and `deinterleave` methods on integer and floating-point SIMD vector types. ([#206][] by [@Shnatsel][])
+
+### Fixed
+
+- `Sse4_2` and `Avx2` now consistently use the x86-64-v2 and x86-64-v3 feature sets for detection, dispatch, and generated `target_feature` attributes. ([#208][] by [@Shnatsel][])
 
 ## [0.4.0][] (2026-02-13)
 
@@ -179,8 +191,11 @@ No changelog was kept for this release.
 [#181]: https://github.com/linebender/fearless_simd/pull/181
 [#185]: https://github.com/linebender/fearless_simd/pull/185
 [#188]: https://github.com/linebender/fearless_simd/pull/188
+[#207]: https://github.com/linebender/fearless_simd/pull/207
+[#208]: https://github.com/linebender/fearless_simd/pull/208
 
-[Unreleased]: https://github.com/linebender/fearless_simd/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/linebender/fearless_simd/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/linebender/fearless_simd/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/linebender/fearless_simd/compare/v0.4.0...v0.3.0
 [0.3.0]: https://github.com/linebender/fearless_simd/compare/v0.3.0...v0.2.0
 [0.2.0]: https://github.com/linebender/fearless_simd/compare/e54304c66fc3e42d9604ddc7775b3345b589ce1a...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,7 +192,6 @@ No changelog was kept for this release.
 [#185]: https://github.com/linebender/fearless_simd/pull/185
 [#188]: https://github.com/linebender/fearless_simd/pull/188
 [#206]: https://github.com/linebender/fearless_simd/pull/206
-[#207]: https://github.com/linebender/fearless_simd/pull/207
 [#208]: https://github.com/linebender/fearless_simd/pull/208
 
 [Unreleased]: https://github.com/linebender/fearless_simd/compare/v0.4.1...HEAD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "fearless_simd"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "libm",
 ]

--- a/fearless_simd/Cargo.toml
+++ b/fearless_simd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fearless_simd"
-version = "0.4.0"
+version = "0.4.1"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
#208 is not breaking because the restrictions already existed, we just forgot to add them everywhere.

I realized that _in theory_ #207 would be breaking because while the `Simd` trait requires `Seal`, `SimdInt` and `SimdBase` currently do not, I think that's an oversight. However, those traits are not intended to be implemented manually anyway, so let's just fix that in a follow-up.