### PR TITLE
Show NEON and WASM docs on docs.rs

### DIFF
--- a/fearless_simd/Cargo.toml
+++ b/fearless_simd/Cargo.toml
@@ -13,9 +13,17 @@ readme = "README.md"
 
 [package.metadata.docs.rs]
 all-features = true
-default-target = "x86_64-unknown-linux-gnu"
-targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu", "aarch64-apple-darwin", "wasm32-unknown-unknown"]
-rustdoc-args = ["--cfg", 'target_feature="simd128"'] # otherwise WASM docs only show the fallback level
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "i686-unknown-linux-gnu",
+  "aarch64-apple-darwin",
+  "wasm32-unknown-unknown",
+]
+rustdoc-args = [
+  "--cfg",
+  'target_feature="simd128"',
+] # otherwise WASM docs only show the fallback level
+
 
 [features]
 default = ["std"]

--- a/fearless_simd/Cargo.toml
+++ b/fearless_simd/Cargo.toml
@@ -13,10 +13,9 @@ readme = "README.md"
 
 [package.metadata.docs.rs]
 all-features = true
-# TODO: Get the right set of targets here. x86 linux, x86-64 linux, arm-macos, wasm
-# default-target = "x86_64-unknown-linux-gnu"
-# targets = []
-
+default-target = "x86_64-unknown-linux-gnu"
+targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu", "aarch64-apple-darwin", "wasm32-unknown-unknown"]
+rustdoc-args = ["--cfg", 'target_feature="simd128"'] # otherwise WASM docs only show the fallback level
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Now that docs.rs [only builds one target by default](https://blog.rust-lang.org/2026/04/04/docsrs-only-default-targets/), we need to explicitly specify the list of targets to show NEON and WASM documentation on docs.rs.

This also enables the `simd128` target feature on docs.rs, which might not match the default local build, but whichever option we pick (enabling simd128 or only showing fallback or having no wasm docs at all) is going to be confusing in some way, so it's a "pick your poison" kind of situation.