### PR TITLE
Make misuse fail in the generator instead of emitting todo!() macros

### DIFF
--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -189,11 +189,7 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
             }
         }
         OpSig::StoreInterleaved { .. } => {
-            quote! {
-                #method_sig {
-                    todo!()
-                }
-            }
+            todo!("The generic fallback is not used for this operation")
         }
         OpSig::Split { .. }
         | OpSig::Combine { .. }

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -189,7 +189,7 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
             }
         }
         OpSig::StoreInterleaved { .. } => {
-            todo!("The generic fallback is not used for this operation")
+            panic!("The generic fallback is not implemented for this operation")
         }
         OpSig::Split { .. }
         | OpSig::Combine { .. }


### PR DESCRIPTION
Fixes https://github.com/linebender/fearless_simd/issues/205

This `todo!()` was never actually emitted into fearless_simd code because all implementations override it and don't use the generic fallback. This is just a minor cleanup to prevent future misuse.