### PR TITLE
Run x86 apple job on x86 hardware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
       matrix:
         platform:
           - { target: aarch64-apple-darwin, os: macos-latest }
-          - { target: x86_64-apple-darwin, os: macos-latest }
+          - { target: x86_64-apple-darwin, os: macos-26-intel }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
           - { target: i686-pc-windows-msvc, os: windows-latest }


### PR DESCRIPTION
`macos-latest` is ARM, and runs x86 binaries through rosetta. We need to specify the Intel runner explicitly to get x86 hardware.

Motivation: https://github.com/linebender/fearless_simd/pull/218#issuecomment-4482607401

Our test suite is now so thorough that it caught a Rosetta bug :sunglasses: 