### PR TITLE
For `Token::new_unchecked`, use `target_feature(enable = )` attributes

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -20,15 +20,16 @@ pub struct Avx2 {
     _private: (),
 }
 impl Avx2 {
-    #[doc = r" Create a SIMD token."]
+    #[doc = r" Create a SIMD token, which can be used as future proof that the"]
+    #[doc = r" x86-64-v2 level is available for this run."]
     #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r""]
-    #[doc = r" The `avx2`, `bmi1`, `bmi2`, `cmpxchg16b`, `f16c`, `fma`,"]
+    #[doc = r" As indicated by the required target features to call this function,"]
+    #[doc = r" `avx2`, `bmi1`, `bmi2`, `cmpxchg16b`, `f16c`, `fma`,"]
     #[doc = r" `lzcnt`, `movbe`, `popcnt`, and `xsave` CPU features must"]
     #[doc = r" be available."]
     #[inline]
-    pub const unsafe fn new_unchecked() -> Self {
+    #[target_feature(enable = "avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,lzcnt,movbe,popcnt,xsave")]
+    pub const fn new_unchecked() -> Self {
         Self { _private: () }
     }
 }

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -17,8 +17,14 @@ pub struct Neon {
     _private: (),
 }
 impl Neon {
+    #[doc = r" Create a SIMD token, which can be used as future proof that the"]
+    #[doc = r" neon target feature is available for this run."]
+    #[doc = r""]
+    #[doc = r" As indicated by the required target features to call this function,"]
+    #[doc = r" the `neon` CPU feature must be available."]
     #[inline]
-    pub const unsafe fn new_unchecked() -> Self {
+    #[target_feature(enable = "neon")]
+    pub const fn new_unchecked() -> Self {
         Neon { _private: () }
     }
 }

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -20,14 +20,15 @@ pub struct Sse4_2 {
     _private: (),
 }
 impl Sse4_2 {
-    #[doc = r" Create a SIMD token."]
+    #[doc = r" Create a SIMD token, which can be used as future proof that the"]
+    #[doc = r" x86-64-v2 level is available for this run."]
     #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r""]
-    #[doc = r" The `sse4.2`, `cmpxchg16b`, and `popcnt` CPU features must"]
+    #[doc = r" As indicated by the required target features to call this function,"]
+    #[doc = r" `sse4.2`, `cmpxchg16b`, and `popcnt` CPU features must"]
     #[doc = r" be available."]
+    #[target_feature(enable = "sse4.2,cmpxchg16b,popcnt")]
     #[inline]
-    pub const unsafe fn new_unchecked() -> Self {
+    pub const fn new_unchecked() -> Self {
         Sse4_2 { _private: () }
     }
 }

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -17,6 +17,12 @@ pub struct WasmSimd128 {
     _private: (),
 }
 impl WasmSimd128 {
+    #[doc = r" Create a SIMD token, which can be used as future proof that the"]
+    #[doc = r" simd128 wasm feature is enabled for this run."]
+    #[doc = r""]
+    #[doc = r" As WASM does not allow runtime feature detection, this function"]
+    #[doc = r" is always available if this library is compiled with the simd128"]
+    #[doc = r" feature enabled."]
     #[inline]
     pub const fn new_unchecked() -> Self {
         Self { _private: () }

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -67,9 +67,18 @@ impl Level for Neon {
     }
 
     fn make_impl_body(&self) -> TokenStream {
+        let features = self
+            .enabled_target_features()
+            .expect("Actual impl can't fail.");
         quote! {
+            /// Create a SIMD token, which can be used as future proof that the
+            /// neon target feature is available for this run.
+            ///
+            /// As indicated by the required target features to call this function,
+            /// the `neon` CPU feature must be available.
             #[inline]
-            pub const unsafe fn new_unchecked() -> Self {
+            #[target_feature(enable = #features)]
+            pub const fn new_unchecked() -> Self {
                 Neon { _private: () }
             }
         }

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -57,6 +57,12 @@ impl Level for WasmSimd128 {
 
     fn make_impl_body(&self) -> TokenStream {
         quote! {
+            /// Create a SIMD token, which can be used as future proof that the
+            /// simd128 wasm feature is enabled for this run.
+            ///
+            /// As WASM does not allow runtime feature detection, this function
+            /// is always available if this library is compiled with the simd128
+            /// feature enabled.
             #[inline]
             pub const fn new_unchecked() -> Self {
                 Self { _private: () }

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -133,31 +133,45 @@ impl Level for X86 {
 
     fn make_impl_body(&self) -> TokenStream {
         match self {
-            Self::Sse4_2 => quote! {
-                /// Create a SIMD token.
-                ///
-                /// # Safety
-                ///
-                /// The `sse4.2`, `cmpxchg16b`, and `popcnt` CPU features must
-                /// be available.
-                #[inline]
-                pub const unsafe fn new_unchecked() -> Self {
-                    Sse4_2 { _private: () }
+            Self::Sse4_2 => {
+                let features = self
+                    .enabled_target_features()
+                    .expect("Actual impl can't fail.");
+                quote! {
+                    /// Create a SIMD token, which can be used as future proof that the
+                    /// x86-64-v2 level is available for this run.
+                    ///
+                    /// As indicated by the required target features to call this function,
+                    /// `sse4.2`, `cmpxchg16b`, and `popcnt` CPU features must
+                    /// be available.
+                    // TODO: Why is this const?
+                    // TODO: Do we need to explain why this is const.
+                    #[target_feature(enable = #features)]
+                    #[inline]
+                    pub const fn new_unchecked() -> Self {
+                        Sse4_2 { _private: () }
+                    }
                 }
-            },
-            Self::Avx2 => quote! {
-                /// Create a SIMD token.
-                ///
-                /// # Safety
-                ///
-                /// The `avx2`, `bmi1`, `bmi2`, `cmpxchg16b`, `f16c`, `fma`,
-                /// `lzcnt`, `movbe`, `popcnt`, and `xsave` CPU features must
-                /// be available.
-                #[inline]
-                pub const unsafe fn new_unchecked() -> Self {
-                    Self { _private: () }
+            }
+            Self::Avx2 => {
+                let features = self
+                    .enabled_target_features()
+                    .expect("Actual impl can't fail.");
+                quote! {
+                    /// Create a SIMD token, which can be used as future proof that the
+                    /// x86-64-v2 level is available for this run.
+                    ///
+                    /// As indicated by the required target features to call this function,
+                    /// `avx2`, `bmi1`, `bmi2`, `cmpxchg16b`, `f16c`, `fma`,
+                    /// `lzcnt`, `movbe`, `popcnt`, and `xsave` CPU features must
+                    /// be available.
+                    #[inline]
+                    #[target_feature(enable = #features)]
+                    pub const fn new_unchecked() -> Self {
+                        Self { _private: () }
+                    }
                 }
-            },
+            }
         }
     }
 


### PR DESCRIPTION
This removes some instances of `unsafe` for having target features enabled. It also allows the use of target features 1.1 to transfer into Fearless SIMD safely.


A few unanswered questions:
- Should we rename `new_unchecked` to `new`?
- Does it even make sense for these to be const?
- Does this prevent inlining of these functions?