### PR TITLE
Make our READMEs consistent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           tool: cargo-rdme
 
       - name: Run cargo rdme (fearless_simd)
-        run: cargo rdme --check --heading-base-level=0 --workspace-project=fearless_simd
+        run: cargo rdme --check --workspace-project=fearless_simd
 
   clippy-stable:
     name: cargo clippy

--- a/fearless_simd/README.md
+++ b/fearless_simd/README.md
@@ -22,7 +22,7 @@
 
 <!-- We use cargo-rdme to update the README with the contents of lib.rs.
 To edit the following section, update it in lib.rs, then run:
-cargo rdme --workspace-project=fearless_simd --heading-base-level=0
+cargo rdme --workspace-project=fearless_simd
 Full documentation at https://github.com/orium/cargo-rdme -->
 
 <!-- Intra-doc links used in lib.rs should be evaluated here. 
@@ -82,7 +82,7 @@ If you are writing an application, you should create this once (using [`Level::n
 This type stores which instruction sets are available for the current process, which is used
 in the macro to dispatch to the most optimal variant of the supplied function for this process.
 
-# Inlining
+## Inlining
 
 Fearless SIMD relies heavily on Rust's inlining support to create functions which have the
 given target features enabled.
@@ -109,11 +109,11 @@ E.g. We might want names for these, e.g.:
 TODO: Talk about writing versions of functions which can be called in other `S: Simd` functions.
 -->
 
-# Platform-specific intrinsics
+## Platform-specific intrinsics
 
 If the portable APIs are not enough, you can safely invoke platform-specific intrinsics via the [`kernel!()`](kernel) macro.
 
-# WebAssembly
+## WebAssembly
 
 WASM SIMD doesn't have feature detection, and so you need to compile two versions of your bundle for WASM, one with SIMD and one without,
 then select the appropriate one for your user's browser. This can be done via [the `wasm-feature-detect`
@@ -133,7 +133,7 @@ If you want to compile both SIMD and non-SIMD versions of your WebAssembly libra
 that builds it once with the `RUSTFLAGS` specified, and once without. [Cargo currently does not allow specifying compiler flags
 per-profile.](https://github.com/rust-lang/cargo/issues/10271)
 
-## Relaxed SIMD
+### Relaxed SIMD
 
 Fearless SIMD can make use of the [relaxed SIMD](https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md)
 WebAssembly instructions, if the requisite target feature is enabled. These instructions can return implementation-dependent results
@@ -143,12 +143,12 @@ At the time of writing, relaxed SIMD is only supported in Chrome. To make use of
 with relaxed SIMD enabled (`RUSTFLAGS="-Ctarget-feature=+simd128,+relaxed-simd"`) and one with it disabled, and then feature-detect at
 runtime.
 
-# Credits
+## Credits
 
 This crate was inspired by [`pulp`], [`std::simd`], among others in the Rust ecosystem, though makes many decisions differently.
 It benefited from conversations with Luca Versari, though he is not responsible for any of the mistakes or bad decisions.
 
-# Feature Flags
+## Feature Flags
 
 The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) are available:
 

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -1,6 +1,9 @@
 // Copyright 2024 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+// After you edit the crate's doc comment, run this command, then check README.md for any missing links
+// cargo rdme --workspace-project=fearless_simd
+
 //! A helper library to make SIMD more friendly.
 //!
 //! Fearless SIMD exposes safe SIMD with ergonomic multi-versioning in Rust.


### PR DESCRIPTION
Document how to run `cargo rdme` in the lib.rs files.
Also change the base level now that we use level 1 headings in our docs