### PR TITLE
Safe transmute_copy()

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -8,3 +8,8 @@
 trivial-copy-size-limit = 16
 
 # END LINEBENDER LINT SET
+
+disallowed-methods = [
+    { path = "core::mem::transmute_copy", reason = "Use crate::transmute::checked_transmute_copy so that safety preconditions are verified at compile time." },
+    { path = "std::mem::transmute_copy", reason = "Use crate::transmute::checked_transmute_copy so that safety preconditions are verified at compile time." },
+]

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -10,6 +10,6 @@ trivial-copy-size-limit = 16
 # END LINEBENDER LINT SET
 
 disallowed-methods = [
-    { path = "core::mem::transmute_copy", reason = "Use crate::transmute::checked_transmute_copy so that safety preconditions are verified at compile time." },
-    { path = "std::mem::transmute_copy", reason = "Use crate::transmute::checked_transmute_copy so that safety preconditions are verified at compile time." },
+  { path = "core::mem::transmute_copy", reason = "Use crate::transmute::checked_transmute_copy so that safety preconditions are verified at compile time." },
+  { path = "std::mem::transmute_copy", reason = "Use crate::transmute::checked_transmute_copy so that safety preconditions are verified at compile time." },
 ]

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -103,14 +103,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_f32x4(self, val: [f32; 4usize]) -> f32x4<Self> {
         f32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f32x4(self, val: &[f32; 4usize]) -> f32x4<Self> {
         f32x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -413,14 +413,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_i8x16(self, val: [i8; 16usize]) -> i8x16<Self> {
         i8x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i8x16(self, val: &[i8; 16usize]) -> i8x16<Self> {
         i8x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -647,14 +647,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
         u8x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u8x16(self, val: &[u8; 16usize]) -> u8x16<Self> {
         u8x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -890,7 +890,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_mask8x16(self, val: [i8; 16usize]) -> mask8x16<Self> {
         mask8x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -974,14 +974,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_i16x8(self, val: [i16; 8usize]) -> i16x8<Self> {
         i16x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i16x8(self, val: &[i16; 8usize]) -> i16x8<Self> {
         i16x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1183,14 +1183,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
         u16x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u16x8(self, val: &[u16; 8usize]) -> u16x8<Self> {
         u16x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1401,7 +1401,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_mask16x8(self, val: [i16; 8usize]) -> mask16x8<Self> {
         mask16x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -1485,14 +1485,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_i32x4(self, val: [i32; 4usize]) -> i32x4<Self> {
         i32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i32x4(self, val: &[i32; 4usize]) -> i32x4<Self> {
         i32x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1696,14 +1696,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
         u32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u32x4(self, val: &[u32; 4usize]) -> u32x4<Self> {
         u32x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1922,7 +1922,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_mask32x4(self, val: [i32; 4usize]) -> mask32x4<Self> {
         mask32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -2001,14 +2001,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_f64x2(self, val: [f64; 2usize]) -> f64x2<Self> {
         f64x2 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f64x2(self, val: &[f64; 2usize]) -> f64x2<Self> {
         f64x2 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -2243,7 +2243,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_mask64x2(self, val: [i64; 2usize]) -> mask64x2<Self> {
         mask64x2 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -2322,14 +2322,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_f32x8(self, val: [f32; 8usize]) -> f32x8<Self> {
         f32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f32x8(self, val: &[f32; 8usize]) -> f32x8<Self> {
         f32x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -2695,14 +2695,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_i8x32(self, val: [i8; 32usize]) -> i8x32<Self> {
         i8x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i8x32(self, val: &[i8; 32usize]) -> i8x32<Self> {
         i8x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -3012,14 +3012,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self> {
         u8x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u8x32(self, val: &[u8; 32usize]) -> u8x32<Self> {
         u8x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -3343,7 +3343,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_mask8x32(self, val: [i8; 32usize]) -> mask8x32<Self> {
         mask8x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -3444,14 +3444,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_i16x16(self, val: [i16; 16usize]) -> i16x16<Self> {
         i16x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i16x16(self, val: &[i16; 16usize]) -> i16x16<Self> {
         i16x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -3742,14 +3742,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self> {
         u16x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u16x16(self, val: &[u16; 16usize]) -> u16x16<Self> {
         u16x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -4061,7 +4061,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_mask16x16(self, val: [i16; 16usize]) -> mask16x16<Self> {
         mask16x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -4160,14 +4160,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_i32x8(self, val: [i32; 8usize]) -> i32x8<Self> {
         i32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i32x8(self, val: &[i32; 8usize]) -> i32x8<Self> {
         i32x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -4432,14 +4432,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self> {
         u32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u32x8(self, val: &[u32; 8usize]) -> u32x8<Self> {
         u32x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -4722,7 +4722,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_mask32x8(self, val: [i32; 8usize]) -> mask32x8<Self> {
         mask32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -4813,14 +4813,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_f64x4(self, val: [f64; 4usize]) -> f64x4<Self> {
         f64x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f64x4(self, val: &[f64; 4usize]) -> f64x4<Self> {
         f64x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -5118,7 +5118,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_mask64x4(self, val: [i64; 4usize]) -> mask64x4<Self> {
         mask64x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -5210,14 +5210,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_f32x16(self, val: [f32; 16usize]) -> f32x16<Self> {
         f32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f32x16(self, val: &[f32; 16usize]) -> f32x16<Self> {
         f32x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -5630,14 +5630,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_i8x64(self, val: [i8; 64usize]) -> i8x64<Self> {
         i8x64 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i8x64(self, val: &[i8; 64usize]) -> i8x64<Self> {
         i8x64 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -5912,14 +5912,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_u8x64(self, val: [u8; 64usize]) -> u8x64<Self> {
         u8x64 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u8x64(self, val: &[u8; 64usize]) -> u8x64<Self> {
         u8x64 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -6239,7 +6239,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_mask8x64(self, val: [i8; 64usize]) -> mask8x64<Self> {
         mask8x64 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -6376,14 +6376,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_i16x32(self, val: [i16; 32usize]) -> i16x32<Self> {
         i16x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i16x32(self, val: &[i16; 32usize]) -> i16x32<Self> {
         i16x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -6667,14 +6667,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_u16x32(self, val: [u16; 32usize]) -> u16x32<Self> {
         u16x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u16x32(self, val: &[u16; 32usize]) -> u16x32<Self> {
         u16x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -7021,7 +7021,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_mask16x32(self, val: [i16; 32usize]) -> mask16x32<Self> {
         mask16x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -7135,14 +7135,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_i32x16(self, val: [i32; 16usize]) -> i32x16<Self> {
         i32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i32x16(self, val: &[i32; 16usize]) -> i32x16<Self> {
         i32x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -7422,14 +7422,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_u32x16(self, val: [u32; 16usize]) -> u32x16<Self> {
         u32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u32x16(self, val: &[u32; 16usize]) -> u32x16<Self> {
         u32x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -7741,7 +7741,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_mask32x16(self, val: [i32; 16usize]) -> mask32x16<Self> {
         mask32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -7863,14 +7863,14 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_f64x8(self, val: [f64; 8usize]) -> f64x8<Self> {
         f64x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f64x8(self, val: &[f64; 8usize]) -> f64x8<Self> {
         f64x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -8191,7 +8191,7 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn load_array_mask64x8(self, val: [i64; 8usize]) -> mask64x8<Self> {
         mask64x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -8309,7 +8309,7 @@ impl<S: Simd> SimdFrom<__m256, S> for f32x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m256) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8317,14 +8317,14 @@ impl<S: Simd> SimdFrom<__m256, S> for f32x8<S> {
 impl<S: Simd> From<f32x8<S>> for __m256 {
     #[inline(always)]
     fn from(value: f32x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m256i, S> for i8x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m256i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8332,14 +8332,14 @@ impl<S: Simd> SimdFrom<__m256i, S> for i8x32<S> {
 impl<S: Simd> From<i8x32<S>> for __m256i {
     #[inline(always)]
     fn from(value: i8x32<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m256i, S> for u8x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m256i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8347,14 +8347,14 @@ impl<S: Simd> SimdFrom<__m256i, S> for u8x32<S> {
 impl<S: Simd> From<u8x32<S>> for __m256i {
     #[inline(always)]
     fn from(value: u8x32<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m256i, S> for mask8x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m256i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8362,14 +8362,14 @@ impl<S: Simd> SimdFrom<__m256i, S> for mask8x32<S> {
 impl<S: Simd> From<mask8x32<S>> for __m256i {
     #[inline(always)]
     fn from(value: mask8x32<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m256i, S> for i16x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m256i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8377,14 +8377,14 @@ impl<S: Simd> SimdFrom<__m256i, S> for i16x16<S> {
 impl<S: Simd> From<i16x16<S>> for __m256i {
     #[inline(always)]
     fn from(value: i16x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m256i, S> for u16x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m256i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8392,14 +8392,14 @@ impl<S: Simd> SimdFrom<__m256i, S> for u16x16<S> {
 impl<S: Simd> From<u16x16<S>> for __m256i {
     #[inline(always)]
     fn from(value: u16x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m256i, S> for mask16x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m256i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8407,14 +8407,14 @@ impl<S: Simd> SimdFrom<__m256i, S> for mask16x16<S> {
 impl<S: Simd> From<mask16x16<S>> for __m256i {
     #[inline(always)]
     fn from(value: mask16x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m256i, S> for i32x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m256i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8422,14 +8422,14 @@ impl<S: Simd> SimdFrom<__m256i, S> for i32x8<S> {
 impl<S: Simd> From<i32x8<S>> for __m256i {
     #[inline(always)]
     fn from(value: i32x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m256i, S> for u32x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m256i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8437,14 +8437,14 @@ impl<S: Simd> SimdFrom<__m256i, S> for u32x8<S> {
 impl<S: Simd> From<u32x8<S>> for __m256i {
     #[inline(always)]
     fn from(value: u32x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m256i, S> for mask32x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m256i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8452,14 +8452,14 @@ impl<S: Simd> SimdFrom<__m256i, S> for mask32x8<S> {
 impl<S: Simd> From<mask32x8<S>> for __m256i {
     #[inline(always)]
     fn from(value: mask32x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m256d, S> for f64x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m256d) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8467,14 +8467,14 @@ impl<S: Simd> SimdFrom<__m256d, S> for f64x4<S> {
 impl<S: Simd> From<f64x4<S>> for __m256d {
     #[inline(always)]
     fn from(value: f64x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m256i, S> for mask64x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m256i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8482,7 +8482,7 @@ impl<S: Simd> SimdFrom<__m256i, S> for mask64x4<S> {
 impl<S: Simd> From<mask64x4<S>> for __m256i {
     #[inline(always)]
     fn from(value: mask64x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 #[doc = r" This is a version of the `alignr` intrinsic that takes a non-const shift argument. The shift is still"]

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -93,14 +93,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_f32x4(self, val: [f32; 4usize]) -> f32x4<Self> {
         f32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f32x4(self, val: &[f32; 4usize]) -> f32x4<Self> {
         f32x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -358,14 +358,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_i8x16(self, val: [i8; 16usize]) -> i8x16<Self> {
         i8x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i8x16(self, val: &[i8; 16usize]) -> i8x16<Self> {
         i8x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -568,14 +568,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
         u8x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u8x16(self, val: &[u8; 16usize]) -> u8x16<Self> {
         u8x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -781,7 +781,7 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_mask8x16(self, val: [i8; 16usize]) -> mask8x16<Self> {
         mask8x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -874,14 +874,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_i16x8(self, val: [i16; 8usize]) -> i16x8<Self> {
         i16x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i16x8(self, val: &[i16; 8usize]) -> i16x8<Self> {
         i16x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1084,14 +1084,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
         u16x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u16x8(self, val: &[u16; 8usize]) -> u16x8<Self> {
         u16x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1293,7 +1293,7 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_mask16x8(self, val: [i16; 8usize]) -> mask16x8<Self> {
         mask16x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -1377,14 +1377,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_i32x4(self, val: [i32; 4usize]) -> i32x4<Self> {
         i32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i32x4(self, val: &[i32; 4usize]) -> i32x4<Self> {
         i32x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1591,14 +1591,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
         u32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u32x4(self, val: &[u32; 4usize]) -> u32x4<Self> {
         u32x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1800,7 +1800,7 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_mask32x4(self, val: [i32; 4usize]) -> mask32x4<Self> {
         mask32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -1884,14 +1884,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_f64x2(self, val: [f64; 2usize]) -> f64x2<Self> {
         f64x2 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f64x2(self, val: &[f64; 2usize]) -> f64x2<Self> {
         f64x2 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -2124,7 +2124,7 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_mask64x2(self, val: [i64; 2usize]) -> mask64x2<Self> {
         mask64x2 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -2209,14 +2209,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_f32x8(self, val: [f32; 8usize]) -> f32x8<Self> {
         f32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f32x8(self, val: &[f32; 8usize]) -> f32x8<Self> {
         f32x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -2613,14 +2613,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_i8x32(self, val: [i8; 32usize]) -> i8x32<Self> {
         i8x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i8x32(self, val: &[i8; 32usize]) -> i8x32<Self> {
         i8x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -2924,14 +2924,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self> {
         u8x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u8x32(self, val: &[u8; 32usize]) -> u8x32<Self> {
         u8x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -3230,7 +3230,7 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_mask8x32(self, val: [i8; 32usize]) -> mask8x32<Self> {
         mask8x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -3345,14 +3345,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_i16x16(self, val: [i16; 16usize]) -> i16x16<Self> {
         i16x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i16x16(self, val: &[i16; 16usize]) -> i16x16<Self> {
         i16x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -3656,14 +3656,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self> {
         u16x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u16x16(self, val: &[u16; 16usize]) -> u16x16<Self> {
         u16x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -3971,7 +3971,7 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_mask16x16(self, val: [i16; 16usize]) -> mask16x16<Self> {
         mask16x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -4086,14 +4086,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_i32x8(self, val: [i32; 8usize]) -> i32x8<Self> {
         i32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i32x8(self, val: &[i32; 8usize]) -> i32x8<Self> {
         i32x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -4402,14 +4402,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self> {
         u32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u32x8(self, val: &[u32; 8usize]) -> u32x8<Self> {
         u32x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -4705,7 +4705,7 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_mask32x8(self, val: [i32; 8usize]) -> mask32x8<Self> {
         mask32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -4820,14 +4820,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_f64x4(self, val: [f64; 4usize]) -> f64x4<Self> {
         f64x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f64x4(self, val: &[f64; 4usize]) -> f64x4<Self> {
         f64x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -5177,7 +5177,7 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_mask64x4(self, val: [i64; 4usize]) -> mask64x4<Self> {
         mask64x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -5292,14 +5292,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_f32x16(self, val: [f32; 16usize]) -> f32x16<Self> {
         f32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f32x16(self, val: &[f32; 16usize]) -> f32x16<Self> {
         f32x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -5713,14 +5713,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_i8x64(self, val: [i8; 64usize]) -> i8x64<Self> {
         i8x64 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i8x64(self, val: &[i8; 64usize]) -> i8x64<Self> {
         i8x64 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -6033,14 +6033,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_u8x64(self, val: [u8; 64usize]) -> u8x64<Self> {
         u8x64 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u8x64(self, val: &[u8; 64usize]) -> u8x64<Self> {
         u8x64 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -6351,7 +6351,7 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_mask8x64(self, val: [i8; 64usize]) -> mask8x64<Self> {
         mask8x64 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -6457,14 +6457,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_i16x32(self, val: [i16; 32usize]) -> i16x32<Self> {
         i16x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i16x32(self, val: &[i16; 32usize]) -> i16x32<Self> {
         i16x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -6786,14 +6786,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_u16x32(self, val: [u16; 32usize]) -> u16x32<Self> {
         u16x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u16x32(self, val: &[u16; 32usize]) -> u16x32<Self> {
         u16x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -7123,7 +7123,7 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_mask16x32(self, val: [i16; 32usize]) -> mask16x32<Self> {
         mask16x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -7232,14 +7232,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_i32x16(self, val: [i32; 16usize]) -> i32x16<Self> {
         i32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i32x16(self, val: &[i32; 16usize]) -> i32x16<Self> {
         i32x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -7557,14 +7557,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_u32x16(self, val: [u32; 16usize]) -> u32x16<Self> {
         u32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u32x16(self, val: &[u32; 16usize]) -> u32x16<Self> {
         u32x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -7877,7 +7877,7 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_mask32x16(self, val: [i32; 16usize]) -> mask32x16<Self> {
         mask32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -7983,14 +7983,14 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_f64x8(self, val: [f64; 8usize]) -> f64x8<Self> {
         f64x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f64x8(self, val: &[f64; 8usize]) -> f64x8<Self> {
         f64x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -8349,7 +8349,7 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_array_mask64x8(self, val: [i64; 8usize]) -> mask64x8<Self> {
         mask64x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -8452,7 +8452,7 @@ impl<S: Simd> SimdFrom<float32x4_t, S> for f32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: float32x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8460,14 +8460,14 @@ impl<S: Simd> SimdFrom<float32x4_t, S> for f32x4<S> {
 impl<S: Simd> From<f32x4<S>> for float32x4_t {
     #[inline(always)]
     fn from(value: f32x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int8x16_t, S> for i8x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int8x16_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8475,14 +8475,14 @@ impl<S: Simd> SimdFrom<int8x16_t, S> for i8x16<S> {
 impl<S: Simd> From<i8x16<S>> for int8x16_t {
     #[inline(always)]
     fn from(value: i8x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<uint8x16_t, S> for u8x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: uint8x16_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8490,14 +8490,14 @@ impl<S: Simd> SimdFrom<uint8x16_t, S> for u8x16<S> {
 impl<S: Simd> From<u8x16<S>> for uint8x16_t {
     #[inline(always)]
     fn from(value: u8x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int8x16_t, S> for mask8x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int8x16_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8505,14 +8505,14 @@ impl<S: Simd> SimdFrom<int8x16_t, S> for mask8x16<S> {
 impl<S: Simd> From<mask8x16<S>> for int8x16_t {
     #[inline(always)]
     fn from(value: mask8x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int16x8_t, S> for i16x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int16x8_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8520,14 +8520,14 @@ impl<S: Simd> SimdFrom<int16x8_t, S> for i16x8<S> {
 impl<S: Simd> From<i16x8<S>> for int16x8_t {
     #[inline(always)]
     fn from(value: i16x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<uint16x8_t, S> for u16x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: uint16x8_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8535,14 +8535,14 @@ impl<S: Simd> SimdFrom<uint16x8_t, S> for u16x8<S> {
 impl<S: Simd> From<u16x8<S>> for uint16x8_t {
     #[inline(always)]
     fn from(value: u16x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int16x8_t, S> for mask16x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int16x8_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8550,14 +8550,14 @@ impl<S: Simd> SimdFrom<int16x8_t, S> for mask16x8<S> {
 impl<S: Simd> From<mask16x8<S>> for int16x8_t {
     #[inline(always)]
     fn from(value: mask16x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int32x4_t, S> for i32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int32x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8565,14 +8565,14 @@ impl<S: Simd> SimdFrom<int32x4_t, S> for i32x4<S> {
 impl<S: Simd> From<i32x4<S>> for int32x4_t {
     #[inline(always)]
     fn from(value: i32x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<uint32x4_t, S> for u32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: uint32x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8580,14 +8580,14 @@ impl<S: Simd> SimdFrom<uint32x4_t, S> for u32x4<S> {
 impl<S: Simd> From<u32x4<S>> for uint32x4_t {
     #[inline(always)]
     fn from(value: u32x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int32x4_t, S> for mask32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int32x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8595,14 +8595,14 @@ impl<S: Simd> SimdFrom<int32x4_t, S> for mask32x4<S> {
 impl<S: Simd> From<mask32x4<S>> for int32x4_t {
     #[inline(always)]
     fn from(value: mask32x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<float64x2_t, S> for f64x2<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: float64x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8610,14 +8610,14 @@ impl<S: Simd> SimdFrom<float64x2_t, S> for f64x2<S> {
 impl<S: Simd> From<f64x2<S>> for float64x2_t {
     #[inline(always)]
     fn from(value: f64x2<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int64x2_t, S> for mask64x2<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int64x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8625,14 +8625,14 @@ impl<S: Simd> SimdFrom<int64x2_t, S> for mask64x2<S> {
 impl<S: Simd> From<mask64x2<S>> for int64x2_t {
     #[inline(always)]
     fn from(value: mask64x2<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<float32x4x2_t, S> for f32x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: float32x4x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8640,14 +8640,14 @@ impl<S: Simd> SimdFrom<float32x4x2_t, S> for f32x8<S> {
 impl<S: Simd> From<f32x8<S>> for float32x4x2_t {
     #[inline(always)]
     fn from(value: f32x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int8x16x2_t, S> for i8x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int8x16x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8655,14 +8655,14 @@ impl<S: Simd> SimdFrom<int8x16x2_t, S> for i8x32<S> {
 impl<S: Simd> From<i8x32<S>> for int8x16x2_t {
     #[inline(always)]
     fn from(value: i8x32<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<uint8x16x2_t, S> for u8x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: uint8x16x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8670,14 +8670,14 @@ impl<S: Simd> SimdFrom<uint8x16x2_t, S> for u8x32<S> {
 impl<S: Simd> From<u8x32<S>> for uint8x16x2_t {
     #[inline(always)]
     fn from(value: u8x32<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int8x16x2_t, S> for mask8x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int8x16x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8685,14 +8685,14 @@ impl<S: Simd> SimdFrom<int8x16x2_t, S> for mask8x32<S> {
 impl<S: Simd> From<mask8x32<S>> for int8x16x2_t {
     #[inline(always)]
     fn from(value: mask8x32<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int16x8x2_t, S> for i16x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int16x8x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8700,14 +8700,14 @@ impl<S: Simd> SimdFrom<int16x8x2_t, S> for i16x16<S> {
 impl<S: Simd> From<i16x16<S>> for int16x8x2_t {
     #[inline(always)]
     fn from(value: i16x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<uint16x8x2_t, S> for u16x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: uint16x8x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8715,14 +8715,14 @@ impl<S: Simd> SimdFrom<uint16x8x2_t, S> for u16x16<S> {
 impl<S: Simd> From<u16x16<S>> for uint16x8x2_t {
     #[inline(always)]
     fn from(value: u16x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int16x8x2_t, S> for mask16x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int16x8x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8730,14 +8730,14 @@ impl<S: Simd> SimdFrom<int16x8x2_t, S> for mask16x16<S> {
 impl<S: Simd> From<mask16x16<S>> for int16x8x2_t {
     #[inline(always)]
     fn from(value: mask16x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int32x4x2_t, S> for i32x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int32x4x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8745,14 +8745,14 @@ impl<S: Simd> SimdFrom<int32x4x2_t, S> for i32x8<S> {
 impl<S: Simd> From<i32x8<S>> for int32x4x2_t {
     #[inline(always)]
     fn from(value: i32x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<uint32x4x2_t, S> for u32x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: uint32x4x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8760,14 +8760,14 @@ impl<S: Simd> SimdFrom<uint32x4x2_t, S> for u32x8<S> {
 impl<S: Simd> From<u32x8<S>> for uint32x4x2_t {
     #[inline(always)]
     fn from(value: u32x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int32x4x2_t, S> for mask32x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int32x4x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8775,14 +8775,14 @@ impl<S: Simd> SimdFrom<int32x4x2_t, S> for mask32x8<S> {
 impl<S: Simd> From<mask32x8<S>> for int32x4x2_t {
     #[inline(always)]
     fn from(value: mask32x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<float64x2x2_t, S> for f64x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: float64x2x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8790,14 +8790,14 @@ impl<S: Simd> SimdFrom<float64x2x2_t, S> for f64x4<S> {
 impl<S: Simd> From<f64x4<S>> for float64x2x2_t {
     #[inline(always)]
     fn from(value: f64x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int64x2x2_t, S> for mask64x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int64x2x2_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8805,14 +8805,14 @@ impl<S: Simd> SimdFrom<int64x2x2_t, S> for mask64x4<S> {
 impl<S: Simd> From<mask64x4<S>> for int64x2x2_t {
     #[inline(always)]
     fn from(value: mask64x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<float32x4x4_t, S> for f32x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: float32x4x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8820,14 +8820,14 @@ impl<S: Simd> SimdFrom<float32x4x4_t, S> for f32x16<S> {
 impl<S: Simd> From<f32x16<S>> for float32x4x4_t {
     #[inline(always)]
     fn from(value: f32x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int8x16x4_t, S> for i8x64<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int8x16x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8835,14 +8835,14 @@ impl<S: Simd> SimdFrom<int8x16x4_t, S> for i8x64<S> {
 impl<S: Simd> From<i8x64<S>> for int8x16x4_t {
     #[inline(always)]
     fn from(value: i8x64<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<uint8x16x4_t, S> for u8x64<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: uint8x16x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8850,14 +8850,14 @@ impl<S: Simd> SimdFrom<uint8x16x4_t, S> for u8x64<S> {
 impl<S: Simd> From<u8x64<S>> for uint8x16x4_t {
     #[inline(always)]
     fn from(value: u8x64<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int8x16x4_t, S> for mask8x64<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int8x16x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8865,14 +8865,14 @@ impl<S: Simd> SimdFrom<int8x16x4_t, S> for mask8x64<S> {
 impl<S: Simd> From<mask8x64<S>> for int8x16x4_t {
     #[inline(always)]
     fn from(value: mask8x64<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int16x8x4_t, S> for i16x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int16x8x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8880,14 +8880,14 @@ impl<S: Simd> SimdFrom<int16x8x4_t, S> for i16x32<S> {
 impl<S: Simd> From<i16x32<S>> for int16x8x4_t {
     #[inline(always)]
     fn from(value: i16x32<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<uint16x8x4_t, S> for u16x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: uint16x8x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8895,14 +8895,14 @@ impl<S: Simd> SimdFrom<uint16x8x4_t, S> for u16x32<S> {
 impl<S: Simd> From<u16x32<S>> for uint16x8x4_t {
     #[inline(always)]
     fn from(value: u16x32<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int16x8x4_t, S> for mask16x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int16x8x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8910,14 +8910,14 @@ impl<S: Simd> SimdFrom<int16x8x4_t, S> for mask16x32<S> {
 impl<S: Simd> From<mask16x32<S>> for int16x8x4_t {
     #[inline(always)]
     fn from(value: mask16x32<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int32x4x4_t, S> for i32x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int32x4x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8925,14 +8925,14 @@ impl<S: Simd> SimdFrom<int32x4x4_t, S> for i32x16<S> {
 impl<S: Simd> From<i32x16<S>> for int32x4x4_t {
     #[inline(always)]
     fn from(value: i32x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<uint32x4x4_t, S> for u32x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: uint32x4x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8940,14 +8940,14 @@ impl<S: Simd> SimdFrom<uint32x4x4_t, S> for u32x16<S> {
 impl<S: Simd> From<u32x16<S>> for uint32x4x4_t {
     #[inline(always)]
     fn from(value: u32x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int32x4x4_t, S> for mask32x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int32x4x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8955,14 +8955,14 @@ impl<S: Simd> SimdFrom<int32x4x4_t, S> for mask32x16<S> {
 impl<S: Simd> From<mask32x16<S>> for int32x4x4_t {
     #[inline(always)]
     fn from(value: mask32x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<float64x2x4_t, S> for f64x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: float64x2x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8970,14 +8970,14 @@ impl<S: Simd> SimdFrom<float64x2x4_t, S> for f64x8<S> {
 impl<S: Simd> From<f64x8<S>> for float64x2x4_t {
     #[inline(always)]
     fn from(value: f64x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<int64x2x4_t, S> for mask64x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: int64x2x4_t) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8985,7 +8985,7 @@ impl<S: Simd> SimdFrom<int64x2x4_t, S> for mask64x8<S> {
 impl<S: Simd> From<mask64x8<S>> for int64x2x4_t {
     #[inline(always)]
     fn from(value: mask64x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 #[doc = r" This is a version of the `vext` intrinsic that takes a non-const shift argument. The shift is still"]

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -2712,47 +2712,48 @@ pub trait Simd:
     fn split_mask64x8(self, a: mask64x8<Self>) -> (mask64x4<Self>, mask64x4<Self>);
 }
 pub(crate) mod arch_types {
+    use crate::transmute::SimdPod;
     #[expect(
         unnameable_types,
         reason = "The native vector types that back a `Simd` implementation are an internal implementation detail, and intentionally kept private"
     )]
     pub trait ArchTypes {
-        type f32x4: Copy + Send + Sync;
-        type i8x16: Copy + Send + Sync;
-        type u8x16: Copy + Send + Sync;
-        type mask8x16: Copy + Send + Sync;
-        type i16x8: Copy + Send + Sync;
-        type u16x8: Copy + Send + Sync;
-        type mask16x8: Copy + Send + Sync;
-        type i32x4: Copy + Send + Sync;
-        type u32x4: Copy + Send + Sync;
-        type mask32x4: Copy + Send + Sync;
-        type f64x2: Copy + Send + Sync;
-        type mask64x2: Copy + Send + Sync;
-        type f32x8: Copy + Send + Sync;
-        type i8x32: Copy + Send + Sync;
-        type u8x32: Copy + Send + Sync;
-        type mask8x32: Copy + Send + Sync;
-        type i16x16: Copy + Send + Sync;
-        type u16x16: Copy + Send + Sync;
-        type mask16x16: Copy + Send + Sync;
-        type i32x8: Copy + Send + Sync;
-        type u32x8: Copy + Send + Sync;
-        type mask32x8: Copy + Send + Sync;
-        type f64x4: Copy + Send + Sync;
-        type mask64x4: Copy + Send + Sync;
-        type f32x16: Copy + Send + Sync;
-        type i8x64: Copy + Send + Sync;
-        type u8x64: Copy + Send + Sync;
-        type mask8x64: Copy + Send + Sync;
-        type i16x32: Copy + Send + Sync;
-        type u16x32: Copy + Send + Sync;
-        type mask16x32: Copy + Send + Sync;
-        type i32x16: Copy + Send + Sync;
-        type u32x16: Copy + Send + Sync;
-        type mask32x16: Copy + Send + Sync;
-        type f64x8: Copy + Send + Sync;
-        type mask64x8: Copy + Send + Sync;
+        type f32x4: Copy + Send + Sync + SimdPod;
+        type i8x16: Copy + Send + Sync + SimdPod;
+        type u8x16: Copy + Send + Sync + SimdPod;
+        type mask8x16: Copy + Send + Sync + SimdPod;
+        type i16x8: Copy + Send + Sync + SimdPod;
+        type u16x8: Copy + Send + Sync + SimdPod;
+        type mask16x8: Copy + Send + Sync + SimdPod;
+        type i32x4: Copy + Send + Sync + SimdPod;
+        type u32x4: Copy + Send + Sync + SimdPod;
+        type mask32x4: Copy + Send + Sync + SimdPod;
+        type f64x2: Copy + Send + Sync + SimdPod;
+        type mask64x2: Copy + Send + Sync + SimdPod;
+        type f32x8: Copy + Send + Sync + SimdPod;
+        type i8x32: Copy + Send + Sync + SimdPod;
+        type u8x32: Copy + Send + Sync + SimdPod;
+        type mask8x32: Copy + Send + Sync + SimdPod;
+        type i16x16: Copy + Send + Sync + SimdPod;
+        type u16x16: Copy + Send + Sync + SimdPod;
+        type mask16x16: Copy + Send + Sync + SimdPod;
+        type i32x8: Copy + Send + Sync + SimdPod;
+        type u32x8: Copy + Send + Sync + SimdPod;
+        type mask32x8: Copy + Send + Sync + SimdPod;
+        type f64x4: Copy + Send + Sync + SimdPod;
+        type mask64x4: Copy + Send + Sync + SimdPod;
+        type f32x16: Copy + Send + Sync + SimdPod;
+        type i8x64: Copy + Send + Sync + SimdPod;
+        type u8x64: Copy + Send + Sync + SimdPod;
+        type mask8x64: Copy + Send + Sync + SimdPod;
+        type i16x32: Copy + Send + Sync + SimdPod;
+        type u16x32: Copy + Send + Sync + SimdPod;
+        type mask16x32: Copy + Send + Sync + SimdPod;
+        type i32x16: Copy + Send + Sync + SimdPod;
+        type u32x16: Copy + Send + Sync + SimdPod;
+        type mask32x16: Copy + Send + Sync + SimdPod;
+        type f64x8: Copy + Send + Sync + SimdPod;
+        type mask64x8: Copy + Send + Sync + SimdPod;
     }
 }
 #[doc = r" Base functionality implemented by all SIMD vectors."]

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -129,14 +129,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_f32x4(self, val: [f32; 4usize]) -> f32x4<Self> {
         f32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f32x4(self, val: &[f32; 4usize]) -> f32x4<Self> {
         f32x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -442,14 +442,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_i8x16(self, val: [i8; 16usize]) -> i8x16<Self> {
         i8x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i8x16(self, val: &[i8; 16usize]) -> i8x16<Self> {
         i8x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -679,14 +679,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
         u8x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u8x16(self, val: &[u8; 16usize]) -> u8x16<Self> {
         u8x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -930,7 +930,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_mask8x16(self, val: [i8; 16usize]) -> mask8x16<Self> {
         mask8x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -1017,14 +1017,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_i16x8(self, val: [i16; 8usize]) -> i16x8<Self> {
         i16x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i16x8(self, val: &[i16; 8usize]) -> i16x8<Self> {
         i16x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1229,14 +1229,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
         u16x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u16x8(self, val: &[u16; 8usize]) -> u16x8<Self> {
         u16x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1450,7 +1450,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_mask16x8(self, val: [i16; 8usize]) -> mask16x8<Self> {
         mask16x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -1537,14 +1537,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_i32x4(self, val: [i32; 4usize]) -> i32x4<Self> {
         i32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i32x4(self, val: &[i32; 4usize]) -> i32x4<Self> {
         i32x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1751,14 +1751,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
         u32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u32x4(self, val: &[u32; 4usize]) -> u32x4<Self> {
         u32x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1980,7 +1980,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_mask32x4(self, val: [i32; 4usize]) -> mask32x4<Self> {
         mask32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -2062,14 +2062,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_f64x2(self, val: [f64; 2usize]) -> f64x2<Self> {
         f64x2 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f64x2(self, val: &[f64; 2usize]) -> f64x2<Self> {
         f64x2 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -2307,7 +2307,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_mask64x2(self, val: [i64; 2usize]) -> mask64x2<Self> {
         mask64x2 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -2390,14 +2390,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_f32x8(self, val: [f32; 8usize]) -> f32x8<Self> {
         f32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f32x8(self, val: &[f32; 8usize]) -> f32x8<Self> {
         f32x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -2772,14 +2772,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_i8x32(self, val: [i8; 32usize]) -> i8x32<Self> {
         i8x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i8x32(self, val: &[i8; 32usize]) -> i8x32<Self> {
         i8x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -3061,14 +3061,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self> {
         u8x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u8x32(self, val: &[u8; 32usize]) -> u8x32<Self> {
         u8x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -3345,7 +3345,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_mask8x32(self, val: [i8; 32usize]) -> mask8x32<Self> {
         mask8x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -3458,14 +3458,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_i16x16(self, val: [i16; 16usize]) -> i16x16<Self> {
         i16x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i16x16(self, val: &[i16; 16usize]) -> i16x16<Self> {
         i16x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -3747,14 +3747,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self> {
         u16x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u16x16(self, val: &[u16; 16usize]) -> u16x16<Self> {
         u16x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -4042,7 +4042,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_mask16x16(self, val: [i16; 16usize]) -> mask16x16<Self> {
         mask16x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -4157,14 +4157,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_i32x8(self, val: [i32; 8usize]) -> i32x8<Self> {
         i32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i32x8(self, val: &[i32; 8usize]) -> i32x8<Self> {
         i32x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -4451,14 +4451,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self> {
         u32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u32x8(self, val: &[u32; 8usize]) -> u32x8<Self> {
         u32x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -4732,7 +4732,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_mask32x8(self, val: [i32; 8usize]) -> mask32x8<Self> {
         mask32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -4845,14 +4845,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_f64x4(self, val: [f64; 4usize]) -> f64x4<Self> {
         f64x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f64x4(self, val: &[f64; 4usize]) -> f64x4<Self> {
         f64x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -5180,7 +5180,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_mask64x4(self, val: [i64; 4usize]) -> mask64x4<Self> {
         mask64x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -5293,14 +5293,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_f32x16(self, val: [f32; 16usize]) -> f32x16<Self> {
         f32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f32x16(self, val: &[f32; 16usize]) -> f32x16<Self> {
         f32x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -5713,14 +5713,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_i8x64(self, val: [i8; 64usize]) -> i8x64<Self> {
         i8x64 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i8x64(self, val: &[i8; 64usize]) -> i8x64<Self> {
         i8x64 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -5995,14 +5995,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_u8x64(self, val: [u8; 64usize]) -> u8x64<Self> {
         u8x64 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u8x64(self, val: &[u8; 64usize]) -> u8x64<Self> {
         u8x64 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -6322,7 +6322,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_mask8x64(self, val: [i8; 64usize]) -> mask8x64<Self> {
         mask8x64 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -6465,14 +6465,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_i16x32(self, val: [i16; 32usize]) -> i16x32<Self> {
         i16x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i16x32(self, val: &[i16; 32usize]) -> i16x32<Self> {
         i16x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -6756,14 +6756,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_u16x32(self, val: [u16; 32usize]) -> u16x32<Self> {
         u16x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u16x32(self, val: &[u16; 32usize]) -> u16x32<Self> {
         u16x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -7102,7 +7102,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_mask16x32(self, val: [i16; 32usize]) -> mask16x32<Self> {
         mask16x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -7216,14 +7216,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_i32x16(self, val: [i32; 16usize]) -> i32x16<Self> {
         i32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i32x16(self, val: &[i32; 16usize]) -> i32x16<Self> {
         i32x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -7503,14 +7503,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_u32x16(self, val: [u32; 16usize]) -> u32x16<Self> {
         u32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u32x16(self, val: &[u32; 16usize]) -> u32x16<Self> {
         u32x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -7822,7 +7822,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_mask32x16(self, val: [i32; 16usize]) -> mask32x16<Self> {
         mask32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -7928,14 +7928,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_f64x8(self, val: [f64; 8usize]) -> f64x8<Self> {
         f64x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f64x8(self, val: &[f64; 8usize]) -> f64x8<Self> {
         f64x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -8256,7 +8256,7 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn load_array_mask64x8(self, val: [i64; 8usize]) -> mask64x8<Self> {
         mask64x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -8359,7 +8359,7 @@ impl<S: Simd> SimdFrom<__m128, S> for f32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8367,14 +8367,14 @@ impl<S: Simd> SimdFrom<__m128, S> for f32x4<S> {
 impl<S: Simd> From<f32x4<S>> for __m128 {
     #[inline(always)]
     fn from(value: f32x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m128i, S> for i8x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m128i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8382,14 +8382,14 @@ impl<S: Simd> SimdFrom<__m128i, S> for i8x16<S> {
 impl<S: Simd> From<i8x16<S>> for __m128i {
     #[inline(always)]
     fn from(value: i8x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m128i, S> for u8x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m128i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8397,14 +8397,14 @@ impl<S: Simd> SimdFrom<__m128i, S> for u8x16<S> {
 impl<S: Simd> From<u8x16<S>> for __m128i {
     #[inline(always)]
     fn from(value: u8x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m128i, S> for mask8x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m128i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8412,14 +8412,14 @@ impl<S: Simd> SimdFrom<__m128i, S> for mask8x16<S> {
 impl<S: Simd> From<mask8x16<S>> for __m128i {
     #[inline(always)]
     fn from(value: mask8x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m128i, S> for i16x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m128i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8427,14 +8427,14 @@ impl<S: Simd> SimdFrom<__m128i, S> for i16x8<S> {
 impl<S: Simd> From<i16x8<S>> for __m128i {
     #[inline(always)]
     fn from(value: i16x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m128i, S> for u16x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m128i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8442,14 +8442,14 @@ impl<S: Simd> SimdFrom<__m128i, S> for u16x8<S> {
 impl<S: Simd> From<u16x8<S>> for __m128i {
     #[inline(always)]
     fn from(value: u16x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m128i, S> for mask16x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m128i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8457,14 +8457,14 @@ impl<S: Simd> SimdFrom<__m128i, S> for mask16x8<S> {
 impl<S: Simd> From<mask16x8<S>> for __m128i {
     #[inline(always)]
     fn from(value: mask16x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m128i, S> for i32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m128i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8472,14 +8472,14 @@ impl<S: Simd> SimdFrom<__m128i, S> for i32x4<S> {
 impl<S: Simd> From<i32x4<S>> for __m128i {
     #[inline(always)]
     fn from(value: i32x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m128i, S> for u32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m128i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8487,14 +8487,14 @@ impl<S: Simd> SimdFrom<__m128i, S> for u32x4<S> {
 impl<S: Simd> From<u32x4<S>> for __m128i {
     #[inline(always)]
     fn from(value: u32x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m128i, S> for mask32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m128i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8502,14 +8502,14 @@ impl<S: Simd> SimdFrom<__m128i, S> for mask32x4<S> {
 impl<S: Simd> From<mask32x4<S>> for __m128i {
     #[inline(always)]
     fn from(value: mask32x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m128d, S> for f64x2<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m128d) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8517,14 +8517,14 @@ impl<S: Simd> SimdFrom<__m128d, S> for f64x2<S> {
 impl<S: Simd> From<f64x2<S>> for __m128d {
     #[inline(always)]
     fn from(value: f64x2<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<__m128i, S> for mask64x2<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: __m128i) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8532,7 +8532,7 @@ impl<S: Simd> SimdFrom<__m128i, S> for mask64x2<S> {
 impl<S: Simd> From<mask64x2<S>> for __m128i {
     #[inline(always)]
     fn from(value: mask64x2<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 #[doc = r" This is a version of the `alignr` intrinsic that takes a non-const shift argument. The shift is still"]

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -92,14 +92,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_f32x4(self, val: [f32; 4usize]) -> f32x4<Self> {
         f32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f32x4(self, val: &[f32; 4usize]) -> f32x4<Self> {
         f32x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -398,14 +398,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_i8x16(self, val: [i8; 16usize]) -> i8x16<Self> {
         i8x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i8x16(self, val: &[i8; 16usize]) -> i8x16<Self> {
         i8x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -623,14 +623,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
         u8x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u8x16(self, val: &[u8; 16usize]) -> u8x16<Self> {
         u8x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -847,7 +847,7 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_mask8x16(self, val: [i8; 16usize]) -> mask8x16<Self> {
         mask8x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -934,14 +934,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_i16x8(self, val: [i16; 8usize]) -> i16x8<Self> {
         i16x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i16x8(self, val: &[i16; 8usize]) -> i16x8<Self> {
         i16x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1143,14 +1143,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
         u16x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u16x8(self, val: &[u16; 8usize]) -> u16x8<Self> {
         u16x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1349,7 +1349,7 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_mask16x8(self, val: [i16; 8usize]) -> mask16x8<Self> {
         mask16x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -1434,14 +1434,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_i32x4(self, val: [i32; 4usize]) -> i32x4<Self> {
         i32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i32x4(self, val: &[i32; 4usize]) -> i32x4<Self> {
         i32x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1647,14 +1647,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
         u32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u32x4(self, val: &[u32; 4usize]) -> u32x4<Self> {
         u32x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -1853,7 +1853,7 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_mask32x4(self, val: [i32; 4usize]) -> mask32x4<Self> {
         mask32x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -1938,14 +1938,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_f64x2(self, val: [f64; 2usize]) -> f64x2<Self> {
         f64x2 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f64x2(self, val: &[f64; 2usize]) -> f64x2<Self> {
         f64x2 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -2203,7 +2203,7 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_mask64x2(self, val: [i64; 2usize]) -> mask64x2<Self> {
         mask64x2 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -2289,14 +2289,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_f32x8(self, val: [f32; 8usize]) -> f32x8<Self> {
         f32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f32x8(self, val: &[f32; 8usize]) -> f32x8<Self> {
         f32x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -2671,14 +2671,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_i8x32(self, val: [i8; 32usize]) -> i8x32<Self> {
         i8x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i8x32(self, val: &[i8; 32usize]) -> i8x32<Self> {
         i8x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -2960,14 +2960,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self> {
         u8x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u8x32(self, val: &[u8; 32usize]) -> u8x32<Self> {
         u8x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -3244,7 +3244,7 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_mask8x32(self, val: [i8; 32usize]) -> mask8x32<Self> {
         mask8x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -3357,14 +3357,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_i16x16(self, val: [i16; 16usize]) -> i16x16<Self> {
         i16x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i16x16(self, val: &[i16; 16usize]) -> i16x16<Self> {
         i16x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -3646,14 +3646,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self> {
         u16x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u16x16(self, val: &[u16; 16usize]) -> u16x16<Self> {
         u16x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -3939,7 +3939,7 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_mask16x16(self, val: [i16; 16usize]) -> mask16x16<Self> {
         mask16x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -4052,14 +4052,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_i32x8(self, val: [i32; 8usize]) -> i32x8<Self> {
         i32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i32x8(self, val: &[i32; 8usize]) -> i32x8<Self> {
         i32x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -4346,14 +4346,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self> {
         u32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u32x8(self, val: &[u32; 8usize]) -> u32x8<Self> {
         u32x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -4627,7 +4627,7 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_mask32x8(self, val: [i32; 8usize]) -> mask32x8<Self> {
         mask32x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -4740,14 +4740,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_f64x4(self, val: [f64; 4usize]) -> f64x4<Self> {
         f64x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f64x4(self, val: &[f64; 4usize]) -> f64x4<Self> {
         f64x4 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -5075,7 +5075,7 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_mask64x4(self, val: [i64; 4usize]) -> mask64x4<Self> {
         mask64x4 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -5188,14 +5188,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_f32x16(self, val: [f32; 16usize]) -> f32x16<Self> {
         f32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f32x16(self, val: &[f32; 16usize]) -> f32x16<Self> {
         f32x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -5605,14 +5605,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_i8x64(self, val: [i8; 64usize]) -> i8x64<Self> {
         i8x64 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i8x64(self, val: &[i8; 64usize]) -> i8x64<Self> {
         i8x64 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -5887,14 +5887,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_u8x64(self, val: [u8; 64usize]) -> u8x64<Self> {
         u8x64 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u8x64(self, val: &[u8; 64usize]) -> u8x64<Self> {
         u8x64 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -6225,7 +6225,7 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_mask8x64(self, val: [i8; 64usize]) -> mask8x64<Self> {
         mask8x64 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -6331,14 +6331,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_i16x32(self, val: [i16; 32usize]) -> i16x32<Self> {
         i16x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i16x32(self, val: &[i16; 32usize]) -> i16x32<Self> {
         i16x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -6622,14 +6622,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_u16x32(self, val: [u16; 32usize]) -> u16x32<Self> {
         u16x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u16x32(self, val: &[u16; 32usize]) -> u16x32<Self> {
         u16x32 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -6955,7 +6955,7 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_mask16x32(self, val: [i16; 32usize]) -> mask16x32<Self> {
         mask16x32 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -7064,14 +7064,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_i32x16(self, val: [i32; 16usize]) -> i32x16<Self> {
         i32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_i32x16(self, val: &[i32; 16usize]) -> i32x16<Self> {
         i32x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -7351,14 +7351,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_u32x16(self, val: [u32; 16usize]) -> u32x16<Self> {
         u32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_u32x16(self, val: &[u32; 16usize]) -> u32x16<Self> {
         u32x16 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -7667,7 +7667,7 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_mask32x16(self, val: [i32; 16usize]) -> mask32x16<Self> {
         mask32x16 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -7773,14 +7773,14 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_f64x8(self, val: [f64; 8usize]) -> f64x8<Self> {
         f64x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
     #[inline(always)]
     fn load_array_ref_f64x8(self, val: &[f64; 8usize]) -> f64x8<Self> {
         f64x8 {
-            val: unsafe { core::mem::transmute_copy(val) },
+            val: crate::transmute::checked_transmute_copy(val),
             simd: self,
         }
     }
@@ -8101,7 +8101,7 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn load_array_mask64x8(self, val: [i64; 8usize]) -> mask64x8<Self> {
         mask64x8 {
-            val: unsafe { core::mem::transmute_copy(&val) },
+            val: crate::transmute::checked_transmute_copy(&val),
             simd: self,
         }
     }
@@ -8204,7 +8204,7 @@ impl<S: Simd> SimdFrom<v128, S> for f32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: v128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8212,14 +8212,14 @@ impl<S: Simd> SimdFrom<v128, S> for f32x4<S> {
 impl<S: Simd> From<f32x4<S>> for v128 {
     #[inline(always)]
     fn from(value: f32x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<v128, S> for i8x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: v128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8227,14 +8227,14 @@ impl<S: Simd> SimdFrom<v128, S> for i8x16<S> {
 impl<S: Simd> From<i8x16<S>> for v128 {
     #[inline(always)]
     fn from(value: i8x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<v128, S> for u8x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: v128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8242,14 +8242,14 @@ impl<S: Simd> SimdFrom<v128, S> for u8x16<S> {
 impl<S: Simd> From<u8x16<S>> for v128 {
     #[inline(always)]
     fn from(value: u8x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<v128, S> for mask8x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: v128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8257,14 +8257,14 @@ impl<S: Simd> SimdFrom<v128, S> for mask8x16<S> {
 impl<S: Simd> From<mask8x16<S>> for v128 {
     #[inline(always)]
     fn from(value: mask8x16<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<v128, S> for i16x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: v128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8272,14 +8272,14 @@ impl<S: Simd> SimdFrom<v128, S> for i16x8<S> {
 impl<S: Simd> From<i16x8<S>> for v128 {
     #[inline(always)]
     fn from(value: i16x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<v128, S> for u16x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: v128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8287,14 +8287,14 @@ impl<S: Simd> SimdFrom<v128, S> for u16x8<S> {
 impl<S: Simd> From<u16x8<S>> for v128 {
     #[inline(always)]
     fn from(value: u16x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<v128, S> for mask16x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: v128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8302,14 +8302,14 @@ impl<S: Simd> SimdFrom<v128, S> for mask16x8<S> {
 impl<S: Simd> From<mask16x8<S>> for v128 {
     #[inline(always)]
     fn from(value: mask16x8<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<v128, S> for i32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: v128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8317,14 +8317,14 @@ impl<S: Simd> SimdFrom<v128, S> for i32x4<S> {
 impl<S: Simd> From<i32x4<S>> for v128 {
     #[inline(always)]
     fn from(value: i32x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<v128, S> for u32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: v128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8332,14 +8332,14 @@ impl<S: Simd> SimdFrom<v128, S> for u32x4<S> {
 impl<S: Simd> From<u32x4<S>> for v128 {
     #[inline(always)]
     fn from(value: u32x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<v128, S> for mask32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: v128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8347,14 +8347,14 @@ impl<S: Simd> SimdFrom<v128, S> for mask32x4<S> {
 impl<S: Simd> From<mask32x4<S>> for v128 {
     #[inline(always)]
     fn from(value: mask32x4<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<v128, S> for f64x2<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: v128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8362,14 +8362,14 @@ impl<S: Simd> SimdFrom<v128, S> for f64x2<S> {
 impl<S: Simd> From<f64x2<S>> for v128 {
     #[inline(always)]
     fn from(value: f64x2<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> SimdFrom<v128, S> for mask64x2<S> {
     #[inline(always)]
     fn simd_from(simd: S, arch: v128) -> Self {
         Self {
-            val: unsafe { core::mem::transmute_copy(&arch) },
+            val: crate::transmute::checked_transmute_copy(&arch),
             simd,
         }
     }
@@ -8377,7 +8377,7 @@ impl<S: Simd> SimdFrom<v128, S> for mask64x2<S> {
 impl<S: Simd> From<mask64x2<S>> for v128 {
     #[inline(always)]
     fn from(value: mask64x2<S>) -> Self {
-        unsafe { core::mem::transmute_copy(&value.val) }
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 #[doc = r" This is a vector extend, like `vext` on ARM or `alignr` on x86, that takes a non-const shift argument."]

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -154,6 +154,7 @@ mod kernel_macros;
 mod macros;
 mod support;
 mod traits;
+mod transmute;
 
 pub use generated::*;
 pub use traits::*;

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -131,6 +131,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 // These lints shouldn't apply to examples.
 #![warn(clippy::print_stdout, clippy::print_stderr)]
+#![cfg_attr(not(test), deny(clippy::disallowed_methods))]
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -131,10 +131,10 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 // These lints shouldn't apply to examples.
 #![warn(clippy::print_stdout, clippy::print_stderr)]
-#![cfg_attr(not(test), deny(clippy::disallowed_methods))]
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
+#![cfg_attr(not(test), deny(clippy::disallowed_methods))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(non_camel_case_types, reason = "TODO")]
 #![expect(clippy::unused_unit, reason = "easier for code generation")]

--- a/fearless_simd/src/transmute.rs
+++ b/fearless_simd/src/transmute.rs
@@ -106,8 +106,16 @@ impl_aligned_simd_pod!(
     Aligned512<[u32; 16]>,
 );
 
+// the `const` is just to only use a single cfg annotation, nothing to do with const evalulation
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 const _: () = {
+    // SAFETY: std docs clearly state:
+    // > The in-memory representation of this type is the same as the one of an equivalent array
+    // > (i.e. the in-memory order of elements is the same,
+    // and there is no padding between two consecutive elements);
+    // > however, the alignment is different and equal to the size of the type.
+    // at https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m256.html and the other structs
+    // Fortunately for us, transmute_copy() does not care about alignment
     unsafe impl SimdPod for __m128 {}
     unsafe impl SimdPod for __m128d {}
     unsafe impl SimdPod for __m128i {}
@@ -121,6 +129,9 @@ unsafe impl SimdPod for v128 {}
 
 #[cfg(target_arch = "aarch64")]
 const _: () = {
+    // SAFETY:
+    // Compound types like float32x4x4_t are defined as #[repr(C)] tuples of basic types,
+    // see e.g. https://doc.rust-lang.org/stable/core/arch/aarch64/struct.float32x4x4_t.html
     unsafe impl SimdPod for float32x4_t {}
     unsafe impl SimdPod for float32x4x2_t {}
     unsafe impl SimdPod for float32x4x4_t {}

--- a/fearless_simd/src/transmute.rs
+++ b/fearless_simd/src/transmute.rs
@@ -1,0 +1,231 @@
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! We have bytemuck at home
+//!
+//! This all serves a single `checked_transmute_copy` function,
+//! if we find this growing in complexity we should probably just use the real bytemuck
+
+use core::mem::size_of;
+
+use crate::support::{Aligned128, Aligned256, Aligned512};
+
+#[cfg(target_arch = "aarch64")]
+use core::arch::aarch64::{
+    float32x4_t, float32x4x2_t, float32x4x4_t, float64x2_t, float64x2x2_t, float64x2x4_t,
+    int8x16_t, int8x16x2_t, int8x16x4_t, int16x8_t, int16x8x2_t, int16x8x4_t, int32x4_t,
+    int32x4x2_t, int32x4x4_t, int64x2_t, int64x2x2_t, int64x2x4_t, uint8x16_t, uint8x16x2_t,
+    uint8x16x4_t, uint16x8_t, uint16x8x2_t, uint16x8x4_t, uint32x4_t, uint32x4x2_t, uint32x4x4_t,
+};
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+use core::arch::wasm32::v128;
+#[cfg(target_arch = "x86")]
+use core::arch::x86::{__m128, __m128d, __m128i, __m256, __m256d, __m256i};
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::{__m128, __m128d, __m128i, __m256, __m256d, __m256i};
+
+/// Types that can be safely copied through an arbitrary same-sized bit representation.
+///
+/// This is intentionally narrower than all possible POD types: it only covers scalar and SIMD
+/// storage types used by this crate today.
+///
+/// # Safety
+///
+/// Implementors must be `Copy`, contain no pointers or padding, and every bit pattern must be a
+/// valid value of the type.
+///
+/// See [bytemuck::Pod](https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html)
+/// for the exact requirements and examples.
+#[expect(
+    unnameable_types,
+    reason = "This is an internal trait in a private module"
+)]
+pub unsafe trait SimdPod: Copy {}
+
+// Do not blanket-impl `Aligned*<T: SimdPod>`: alignment wrappers can add
+// trailing padding for undersized `T`, e.g. `Aligned128<u8>`.
+macro_rules! impl_aligned_simd_pod {
+    ($($wrapper:ident<$inner:ty>),+ $(,)?) => {
+        $(
+            // SAFETY: this enforces that the alignment wrapper adds no trailing padding to the
+            // wrapped SIMD storage, preserving the `SimdPod` no-padding invariant.
+            const _: () = assert!(size_of::<$wrapper<$inner>>() == size_of::<$inner>());
+            unsafe impl SimdPod for $wrapper<$inner> {}
+        )+
+    };
+}
+
+unsafe impl SimdPod for f32 {}
+unsafe impl SimdPod for f64 {}
+unsafe impl SimdPod for i8 {}
+unsafe impl SimdPod for u8 {}
+unsafe impl SimdPod for i16 {}
+unsafe impl SimdPod for u16 {}
+unsafe impl SimdPod for i32 {}
+unsafe impl SimdPod for u32 {}
+unsafe impl SimdPod for i64 {}
+unsafe impl SimdPod for u64 {}
+
+unsafe impl<T: SimdPod, const N: usize> SimdPod for [T; N] {}
+
+impl_aligned_simd_pod!(
+    Aligned128<[f32; 4]>,
+    Aligned128<[f64; 2]>,
+    Aligned128<[i8; 16]>,
+    Aligned128<[i16; 8]>,
+    Aligned128<[i32; 4]>,
+    Aligned128<[i64; 2]>,
+    Aligned128<[u8; 16]>,
+    Aligned128<[u16; 8]>,
+    Aligned128<[u32; 4]>,
+    Aligned256<[f32; 8]>,
+    Aligned256<[f64; 4]>,
+    Aligned256<[i8; 32]>,
+    Aligned256<[i16; 16]>,
+    Aligned256<[i32; 8]>,
+    Aligned256<[i64; 4]>,
+    Aligned256<[u8; 32]>,
+    Aligned256<[u16; 16]>,
+    Aligned256<[u32; 8]>,
+    Aligned512<[f32; 16]>,
+    Aligned512<[f64; 8]>,
+    Aligned512<[i8; 64]>,
+    Aligned512<[i16; 32]>,
+    Aligned512<[i32; 16]>,
+    Aligned512<[i64; 8]>,
+    Aligned512<[u8; 64]>,
+    Aligned512<[u16; 32]>,
+    Aligned512<[u32; 16]>,
+);
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+const _: () = {
+    unsafe impl SimdPod for __m128 {}
+    unsafe impl SimdPod for __m128d {}
+    unsafe impl SimdPod for __m128i {}
+    unsafe impl SimdPod for __m256 {}
+    unsafe impl SimdPod for __m256d {}
+    unsafe impl SimdPod for __m256i {}
+};
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+unsafe impl SimdPod for v128 {}
+
+#[cfg(target_arch = "aarch64")]
+const _: () = {
+    unsafe impl SimdPod for float32x4_t {}
+    unsafe impl SimdPod for float32x4x2_t {}
+    unsafe impl SimdPod for float32x4x4_t {}
+    unsafe impl SimdPod for float64x2_t {}
+    unsafe impl SimdPod for float64x2x2_t {}
+    unsafe impl SimdPod for float64x2x4_t {}
+    unsafe impl SimdPod for int8x16_t {}
+    unsafe impl SimdPod for int8x16x2_t {}
+    unsafe impl SimdPod for int8x16x4_t {}
+    unsafe impl SimdPod for int16x8_t {}
+    unsafe impl SimdPod for int16x8x2_t {}
+    unsafe impl SimdPod for int16x8x4_t {}
+    unsafe impl SimdPod for int32x4_t {}
+    unsafe impl SimdPod for int32x4x2_t {}
+    unsafe impl SimdPod for int32x4x4_t {}
+    unsafe impl SimdPod for int64x2_t {}
+    unsafe impl SimdPod for int64x2x2_t {}
+    unsafe impl SimdPod for int64x2x4_t {}
+    unsafe impl SimdPod for uint8x16_t {}
+    unsafe impl SimdPod for uint8x16x2_t {}
+    unsafe impl SimdPod for uint8x16x4_t {}
+    unsafe impl SimdPod for uint16x8_t {}
+    unsafe impl SimdPod for uint16x8x2_t {}
+    unsafe impl SimdPod for uint16x8x4_t {}
+    unsafe impl SimdPod for uint32x4_t {}
+    unsafe impl SimdPod for uint32x4x2_t {}
+    unsafe impl SimdPod for uint32x4x4_t {}
+};
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+impl_aligned_simd_pod!(
+    Aligned128<__m128>,
+    Aligned128<__m128d>,
+    Aligned128<__m128i>,
+    Aligned256<__m256>,
+    Aligned256<__m256d>,
+    Aligned256<__m256i>,
+    Aligned256<[__m128; 2]>,
+    Aligned256<[__m128d; 2]>,
+    Aligned256<[__m128i; 2]>,
+    Aligned512<[__m128; 4]>,
+    Aligned512<[__m128d; 4]>,
+    Aligned512<[__m128i; 4]>,
+    Aligned512<[__m256; 2]>,
+    Aligned512<[__m256d; 2]>,
+    Aligned512<[__m256i; 2]>,
+);
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+impl_aligned_simd_pod!(
+    Aligned128<v128>,
+    Aligned256<[v128; 2]>,
+    Aligned512<[v128; 4]>
+);
+
+#[cfg(target_arch = "aarch64")]
+impl_aligned_simd_pod!(
+    Aligned128<float32x4_t>,
+    Aligned128<float64x2_t>,
+    Aligned128<int8x16_t>,
+    Aligned128<int16x8_t>,
+    Aligned128<int32x4_t>,
+    Aligned128<int64x2_t>,
+    Aligned128<uint8x16_t>,
+    Aligned128<uint16x8_t>,
+    Aligned128<uint32x4_t>,
+    Aligned256<float32x4x2_t>,
+    Aligned256<float64x2x2_t>,
+    Aligned256<int8x16x2_t>,
+    Aligned256<int16x8x2_t>,
+    Aligned256<int32x4x2_t>,
+    Aligned256<int64x2x2_t>,
+    Aligned256<uint8x16x2_t>,
+    Aligned256<uint16x8x2_t>,
+    Aligned256<uint32x4x2_t>,
+    Aligned512<float32x4x4_t>,
+    Aligned512<float64x2x4_t>,
+    Aligned512<int8x16x4_t>,
+    Aligned512<int16x8x4_t>,
+    Aligned512<int32x4x4_t>,
+    Aligned512<int64x2x4_t>,
+    Aligned512<uint8x16x4_t>,
+    Aligned512<uint16x8x4_t>,
+    Aligned512<uint32x4x4_t>,
+);
+
+/// Like [`core::mem::transmute_copy`], but statically rejects differently-sized
+/// types and only accepts this crate's SIMD plain-old-data storage types.
+#[inline(always)]
+#[cfg_attr(
+    not(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        all(target_arch = "wasm32", target_feature = "simd128")
+    )),
+    expect(
+        dead_code,
+        reason = "native vector conversions are not used by scalar-only builds"
+    )
+)]
+#[allow(
+    clippy::disallowed_methods,
+    reason = "This is the central checked wrapper around transmute_copy"
+)]
+pub(crate) fn checked_transmute_copy<Src: SimdPod, Dst: SimdPod>(src: &Src) -> Dst {
+    const {
+        assert!(
+            size_of::<Src>() == size_of::<Dst>(),
+            "checked_transmute_copy requires source and destination to have the same size"
+        );
+    }
+    // Safety: `SimdPod` guarantees source and destination validity for all bit patterns, and
+    // the const assertion above prevents the "destination larger than source" failure mode.
+    unsafe { core::mem::transmute_copy(src) }
+}

--- a/fearless_simd/src/transmute.rs
+++ b/fearless_simd/src/transmute.rs
@@ -107,7 +107,7 @@ impl_aligned_simd_pod!(
     Aligned512<[u32; 16]>,
 );
 
-// the `const` is just to only use a single cfg annotation, nothing to do with const evalulation
+// the `const` is just to only use a single cfg annotation, nothing to do with const evaluation
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 const _: () = {
     // SAFETY: std docs clearly state:

--- a/fearless_simd/src/transmute.rs
+++ b/fearless_simd/src/transmute.rs
@@ -36,9 +36,13 @@ use core::arch::x86_64::{__m128, __m128d, __m128i, __m256, __m256d, __m256i};
 ///
 /// See [bytemuck::Pod](https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html)
 /// for the exact requirements and examples.
-#[expect(
+#[allow(
     unnameable_types,
-    reason = "This is an internal trait in a private module"
+    reason = "This must be `pub` to avoid `private_bounds` warnings on the generated `ArchTypes` trait, but the containing module remains private"
+)]
+#[allow(
+    unreachable_pub,
+    reason = "This must be `pub` to avoid `private_bounds` warnings on the generated `ArchTypes` trait, but the containing module remains private"
 )]
 pub unsafe trait SimdPod: Copy {}
 

--- a/fearless_simd/src/transmute.rs
+++ b/fearless_simd/src/transmute.rs
@@ -46,6 +46,7 @@ use core::arch::x86_64::{__m128, __m128d, __m128i, __m256, __m256d, __m256i};
 )]
 pub unsafe trait SimdPod: Copy {}
 
+#[allow(dead_code, reason = "Not all platforms use safe transmute machinery")]
 fn assert_simd_pod<T: SimdPod>() {}
 
 // Do not blanket-impl `Aligned*<T: SimdPod>`: alignment wrappers can add

--- a/fearless_simd/src/transmute.rs
+++ b/fearless_simd/src/transmute.rs
@@ -46,14 +46,18 @@ use core::arch::x86_64::{__m128, __m128d, __m128i, __m256, __m256d, __m256i};
 )]
 pub unsafe trait SimdPod: Copy {}
 
+fn assert_simd_pod<T: SimdPod>() {}
+
 // Do not blanket-impl `Aligned*<T: SimdPod>`: alignment wrappers can add
 // trailing padding for undersized `T`, e.g. `Aligned128<u8>`.
 macro_rules! impl_aligned_simd_pod {
     ($($wrapper:ident<$inner:ty>),+ $(,)?) => {
         $(
             // SAFETY: this enforces that the alignment wrapper adds no trailing padding to the
-            // wrapped SIMD storage, preserving the `SimdPod` no-padding invariant.
+            // wrapped SIMD storage, preserving the `SimdPod` no-padding invariant,
+            // and that the inner type is also SimdPod
             const _: () = assert!(size_of::<$wrapper<$inner>>() == size_of::<$inner>());
+            const _: fn() = assert_simd_pod::<$inner>;
             unsafe impl SimdPod for $wrapper<$inner> {}
         )+
     };

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -376,19 +376,7 @@ pub(crate) fn generic_from_array(
     // lower to LLVM intrinsics, they will likely not be optimized until much later in the pipeline (if at all),
     // resulting in substantially worse codegen. See https://github.com/linebender/fearless_simd/pull/185.
     let expr = quote! {
-        // Safety: The native vector type backing any implementation will be:
-        // - A `#[repr(simd)]` type, which has the same layout as an array of scalars
-        // - An array of `#[repr(simd)]` types
-        // - For AArch64 specifically, a `#[repr(C)]` tuple of `#[repr(simd)]` types
-        //
-        // These all have the same layout as a flat array of the corresponding scalars. The native vector types probably
-        // have greater alignment requirements than the source array type we're copying from, but that's explicitly
-        // allowed by transmute_copy:
-        //
-        // > This function will unsafely assume the pointer src is valid for size_of::<Dst> bytes by transmuting &Src to
-        // > &Dst and then reading the &Dst **(except that this is done in a way that is correct even when &Dst has
-        // > stricter alignment requirements than &Src).**
-        unsafe { core::mem::transmute_copy(#inner_ref) }
+        crate::transmute::checked_transmute_copy(#inner_ref)
     };
     let vec_rust = vec_ty.rust();
 

--- a/fearless_simd_gen/src/level.rs
+++ b/fearless_simd_gen/src/level.rs
@@ -197,7 +197,7 @@ pub(crate) trait Level {
                     #[inline(always)]
                     fn simd_from(simd: S, arch: #arch) -> Self {
                         Self {
-                            val: unsafe { core::mem::transmute_copy(&arch) },
+                            val: crate::transmute::checked_transmute_copy(&arch),
                             simd
                         }
                     }
@@ -205,7 +205,7 @@ pub(crate) trait Level {
                 impl<S: Simd> From<#simd<S>> for #arch {
                     #[inline(always)]
                     fn from(value: #simd<S>) -> Self {
-                        unsafe { core::mem::transmute_copy(&value.val) }
+                        crate::transmute::checked_transmute_copy(&value.val)
                     }
                 }
             });

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -114,12 +114,14 @@ pub(crate) fn mk_arch_types() -> TokenStream {
     for vec_ty in SIMD_TYPES {
         let ty_name = vec_ty.rust();
         types.push(quote! {
-            type #ty_name: Copy + Send + Sync;
+            type #ty_name: Copy + Send + Sync + SimdPod;
         });
     }
 
     quote! {
         pub(crate) mod arch_types {
+            use crate::transmute::SimdPod;
+
             #[expect(
                 unnameable_types,
                 reason = "The native vector types that back a `Simd` implementation are an internal implementation detail, and intentionally kept private"


### PR DESCRIPTION
"we have `bytemuck` at home"

These are the `transmute_copy()` safety improvements from #231 taken one step further: on top of checking the sizes match at compile time and that both types are `Copy`, we also add a marker trait to types that are safe to transmute and require it in `checked_transmute_copy()`, making that function fully safe to call.

The design follows the `bytemuck` crate closely. We could just use `bytemuck`, but it would pull in `syn` and other proc macro machinery, and we would still have to write the `impl_aligned_simd_pod!` macro because bytemuck rightfully refuses to derive `Pod` on generic wrappers like `Aligned128<T>` because they may introduce padding depending on the `T`. So the amount of code it saves us is minimal.

Rebasing #231 on top of this would be hellish, but a merge commit probably wouldn't be too bad.