### PR TITLE
Replace by-value transmutes with checked_transmute_copy

### DIFF
--- a/fearless_simd/src/generated.rs
+++ b/fearless_simd/src/generated.rs
@@ -12,8 +12,6 @@
 #![cfg_attr(
     target_arch = "x86_64",
     expect(
-        clippy::missing_transmute_annotations,
-        clippy::useless_transmute,
         clippy::new_without_default,
         reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
     )
@@ -21,8 +19,6 @@
 #![cfg_attr(
     target_arch = "wasm32",
     expect(
-        clippy::missing_transmute_annotations,
-        clippy::useless_transmute,
         clippy::new_without_default,
         reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
     )
@@ -34,8 +30,6 @@
     ),
     expect(
         clippy::missing_safety_doc,
-        clippy::missing_transmute_annotations,
-        clippy::useless_transmute,
         clippy::new_without_default,
         reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
     )

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -116,7 +116,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_f32x4(self, a: f32x4<Self>) -> [f32; 4usize] {
-        unsafe { core::mem::transmute::<__m128, [f32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128, [f32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
@@ -138,20 +138,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x4(self, a: u8x16<Self>) -> f32x4<Self> {
-        unsafe {
-            f32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x4(self, a: f32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -426,7 +422,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_i8x16(self, a: i8x16<Self>) -> [i8; 16usize] {
-        unsafe { core::mem::transmute::<__m128i, [i8; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
@@ -448,20 +444,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x16(self, a: u8x16<Self>) -> i8x16<Self> {
-        unsafe {
-            i8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x16(self, a: i8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -660,7 +652,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_u8x16(self, a: u8x16<Self>) -> [u8; 16usize] {
-        unsafe { core::mem::transmute::<__m128i, [u8; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [u8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
@@ -682,20 +674,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -896,7 +884,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_mask8x16(self, a: mask8x16<Self>) -> [i8; 16usize] {
-        unsafe { core::mem::transmute::<__m128i, [i8; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask8x16(self, bits: u64) -> mask8x16<Self> {
@@ -987,7 +975,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_i16x8(self, a: i16x8<Self>) -> [i16; 8usize] {
-        unsafe { core::mem::transmute::<__m128i, [i16; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
@@ -1009,20 +997,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x8(self, a: u8x16<Self>) -> i16x8<Self> {
-        unsafe {
-            i16x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x8(self, a: i16x8<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1196,7 +1180,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_u16x8(self, a: u16x8<Self>) -> [u16; 8usize] {
-        unsafe { core::mem::transmute::<__m128i, [u16; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [u16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
@@ -1218,20 +1202,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x8(self, a: u8x16<Self>) -> u16x8<Self> {
-        unsafe {
-            u16x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x8(self, a: u16x8<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1407,7 +1387,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_mask16x8(self, a: mask16x8<Self>) -> [i16; 8usize] {
-        unsafe { core::mem::transmute::<__m128i, [i16; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask16x8(self, bits: u64) -> mask16x8<Self> {
@@ -1498,7 +1478,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_i32x4(self, a: i32x4<Self>) -> [i32; 4usize] {
-        unsafe { core::mem::transmute::<__m128i, [i32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
@@ -1520,20 +1500,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x4(self, a: u8x16<Self>) -> i32x4<Self> {
-        unsafe {
-            i32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x4(self, a: i32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1709,7 +1685,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_u32x4(self, a: u32x4<Self>) -> [u32; 4usize] {
-        unsafe { core::mem::transmute::<__m128i, [u32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [u32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
@@ -1731,20 +1707,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x4(self, a: u8x16<Self>) -> u32x4<Self> {
-        unsafe {
-            u32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x4(self, a: u32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1928,7 +1900,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_mask32x4(self, a: mask32x4<Self>) -> [i32; 4usize] {
-        unsafe { core::mem::transmute::<__m128i, [i32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask32x4(self, bits: u64) -> mask32x4<Self> {
@@ -2014,7 +1986,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_f64x2(self, a: f64x2<Self>) -> [f64; 2usize] {
-        unsafe { core::mem::transmute::<__m128d, [f64; 2usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128d, [f64; 2usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
@@ -2036,20 +2008,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x2(self, a: u8x16<Self>) -> f64x2<Self> {
-        unsafe {
-            f64x2 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x2 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x2(self, a: f64x2<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -2249,7 +2217,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_mask64x2(self, a: mask64x2<Self>) -> [i64; 2usize] {
-        unsafe { core::mem::transmute::<__m128i, [i64; 2usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i64; 2usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask64x2(self, bits: u64) -> mask64x2<Self> {
@@ -2335,7 +2303,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_f32x8(self, a: f32x8<Self>) -> [f32; 8usize] {
-        unsafe { core::mem::transmute::<__m256, [f32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m256, [f32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
@@ -2357,20 +2325,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x8(self, a: u8x32<Self>) -> f32x8<Self> {
-        unsafe {
-            f32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x8(self, a: f32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -2708,7 +2672,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_i8x32(self, a: i8x32<Self>) -> [i8; 32usize] {
-        unsafe { core::mem::transmute::<__m256i, [i8; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m256i, [i8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
@@ -2730,20 +2694,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x32(self, a: u8x32<Self>) -> i8x32<Self> {
-        unsafe {
-            i8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x32(self, a: i8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3025,7 +2985,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_u8x32(self, a: u8x32<Self>) -> [u8; 32usize] {
-        unsafe { core::mem::transmute::<__m256i, [u8; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m256i, [u8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
@@ -3047,20 +3007,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3349,7 +3305,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_mask8x32(self, a: mask8x32<Self>) -> [i8; 32usize] {
-        unsafe { core::mem::transmute::<__m256i, [i8; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m256i, [i8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask8x32(self, bits: u64) -> mask8x32<Self> {
@@ -3457,7 +3413,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_i16x16(self, a: i16x16<Self>) -> [i16; 16usize] {
-        unsafe { core::mem::transmute::<__m256i, [i16; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m256i, [i16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
@@ -3479,20 +3435,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x16(self, a: u8x32<Self>) -> i16x16<Self> {
-        unsafe {
-            i16x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x16(self, a: i16x16<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3755,7 +3707,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_u16x16(self, a: u16x16<Self>) -> [u16; 16usize] {
-        unsafe { core::mem::transmute::<__m256i, [u16; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m256i, [u16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
@@ -3777,20 +3729,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x16(self, a: u8x32<Self>) -> u16x16<Self> {
-        unsafe {
-            u16x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x16(self, a: u16x16<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4067,7 +4015,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_mask16x16(self, a: mask16x16<Self>) -> [i16; 16usize] {
-        unsafe { core::mem::transmute::<__m256i, [i16; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m256i, [i16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask16x16(self, bits: u64) -> mask16x16<Self> {
@@ -4086,7 +4034,7 @@ impl Simd for Avx2 {
     fn to_bitmask_mask16x16(self, a: mask16x16<Self>) -> u64 {
         unsafe {
             {
-                let halves: [__m128i; 2usize] = core::mem::transmute(a.val.0);
+                let halves: [__m128i; 2usize] = crate::transmute::checked_transmute_copy(&a.val.0);
                 let packed = _mm_packs_epi16(halves[0], halves[1]);
                 _mm_movemask_epi8(packed) as u32 as u64
             }
@@ -4173,7 +4121,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_i32x8(self, a: i32x8<Self>) -> [i32; 8usize] {
-        unsafe { core::mem::transmute::<__m256i, [i32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m256i, [i32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
@@ -4195,20 +4143,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x8(self, a: u8x32<Self>) -> i32x8<Self> {
-        unsafe {
-            i32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x8(self, a: i32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4445,7 +4389,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_u32x8(self, a: u32x8<Self>) -> [u32; 8usize] {
-        unsafe { core::mem::transmute::<__m256i, [u32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m256i, [u32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
@@ -4467,20 +4411,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x8(self, a: u8x32<Self>) -> u32x8<Self> {
-        unsafe {
-            u32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x8(self, a: u32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4728,7 +4668,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_mask32x8(self, a: mask32x8<Self>) -> [i32; 8usize] {
-        unsafe { core::mem::transmute::<__m256i, [i32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m256i, [i32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask32x8(self, bits: u64) -> mask32x8<Self> {
@@ -4826,7 +4766,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_f64x4(self, a: f64x4<Self>) -> [f64; 4usize] {
-        unsafe { core::mem::transmute::<__m256d, [f64; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m256d, [f64; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
@@ -4848,20 +4788,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x4(self, a: u8x32<Self>) -> f64x4<Self> {
-        unsafe {
-            f64x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x4(self, a: f64x4<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5124,7 +5060,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_mask64x4(self, a: mask64x4<Self>) -> [i64; 4usize] {
-        unsafe { core::mem::transmute::<__m256i, [i64; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m256i, [i64; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask64x4(self, bits: u64) -> mask64x4<Self> {
@@ -5223,7 +5159,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_f32x16(self, a: f32x16<Self>) -> [f32; 16usize] {
-        unsafe { core::mem::transmute::<[__m256; 2usize], [f32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m256; 2usize], [f32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
@@ -5245,20 +5181,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x16(self, a: u8x64<Self>) -> f32x16<Self> {
-        unsafe {
-            f32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x16(self, a: f32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5650,7 +5582,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_i8x64(self, a: i8x64<Self>) -> [i8; 64usize] {
-        unsafe { core::mem::transmute::<[__m256i; 2usize], [i8; 64usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
@@ -5672,20 +5604,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x64(self, a: u8x64<Self>) -> i8x64<Self> {
-        unsafe {
-            i8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x64(self, a: i8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5932,7 +5860,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_u8x64(self, a: u8x64<Self>) -> [u8; 64usize] {
-        unsafe { core::mem::transmute::<[__m256i; 2usize], [u8; 64usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [u8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
@@ -5954,20 +5882,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6259,7 +6183,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_mask8x64(self, a: mask8x64<Self>) -> [i8; 64usize] {
-        unsafe { core::mem::transmute::<[__m256i; 2usize], [i8; 64usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask8x64(self, bits: u64) -> mask8x64<Self> {
@@ -6403,7 +6327,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_i16x32(self, a: i16x32<Self>) -> [i16; 32usize] {
-        unsafe { core::mem::transmute::<[__m256i; 2usize], [i16; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
@@ -6425,20 +6349,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x32(self, a: u8x64<Self>) -> i16x32<Self> {
-        unsafe {
-            i16x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x32(self, a: i16x32<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6694,7 +6614,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_u16x32(self, a: u16x32<Self>) -> [u16; 32usize] {
-        unsafe { core::mem::transmute::<[__m256i; 2usize], [u16; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [u16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
@@ -6716,20 +6636,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x32(self, a: u8x64<Self>) -> u16x32<Self> {
-        unsafe {
-            u16x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x32(self, a: u16x32<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7048,7 +6964,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_mask16x32(self, a: mask16x32<Self>) -> [i16; 32usize] {
-        unsafe { core::mem::transmute::<[__m256i; 2usize], [i16; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask16x32(self, bits: u64) -> mask16x32<Self> {
@@ -7169,7 +7085,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_i32x16(self, a: i32x16<Self>) -> [i32; 16usize] {
-        unsafe { core::mem::transmute::<[__m256i; 2usize], [i32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
@@ -7191,20 +7107,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x16(self, a: u8x64<Self>) -> i32x16<Self> {
-        unsafe {
-            i32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x16(self, a: i32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7456,7 +7368,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_u32x16(self, a: u32x16<Self>) -> [u32; 16usize] {
-        unsafe { core::mem::transmute::<[__m256i; 2usize], [u32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [u32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
@@ -7478,20 +7390,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x16(self, a: u8x64<Self>) -> u32x16<Self> {
-        unsafe {
-            u32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x16(self, a: u32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7775,7 +7683,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_mask32x16(self, a: mask32x16<Self>) -> [i32; 16usize] {
-        unsafe { core::mem::transmute::<[__m256i; 2usize], [i32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask32x16(self, bits: u64) -> mask32x16<Self> {
@@ -7904,7 +7812,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_f64x8(self, a: f64x8<Self>) -> [f64; 8usize] {
-        unsafe { core::mem::transmute::<[__m256d; 2usize], [f64; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m256d; 2usize], [f64; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
@@ -7926,20 +7834,16 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x8(self, a: u8x64<Self>) -> f64x8<Self> {
-        unsafe {
-            f64x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x8(self, a: f64x8<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -8225,7 +8129,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_mask64x8(self, a: mask64x8<Self>) -> [i64; 8usize] {
-        unsafe { core::mem::transmute::<[__m256i; 2usize], [i64; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i64; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask64x8(self, bits: u64) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -187,20 +187,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x4(self, a: u8x16<Self>) -> f32x4<Self> {
-        unsafe {
-            f32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x4(self, a: f32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -587,20 +583,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x16(self, a: u8x16<Self>) -> i8x16<Self> {
-        unsafe {
-            i8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x16(self, a: i8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1216,20 +1208,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -2160,20 +2148,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x8(self, a: u8x16<Self>) -> i16x8<Self> {
-        unsafe {
-            i16x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x8(self, a: i16x8<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -2590,20 +2574,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x8(self, a: u8x16<Self>) -> u16x8<Self> {
-        unsafe {
-            u16x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x8(self, a: u16x8<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3213,20 +3193,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x4(self, a: u8x16<Self>) -> i32x4<Self> {
-        unsafe {
-            i32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x4(self, a: i32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3545,20 +3521,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x4(self, a: u8x16<Self>) -> u32x4<Self> {
-        unsafe {
-            u32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x4(self, a: u32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4002,20 +3974,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x2(self, a: u8x16<Self>) -> f64x2<Self> {
-        unsafe {
-            f64x2 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x2 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x2(self, a: f64x2<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4396,20 +4364,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x8(self, a: u8x32<Self>) -> f32x8<Self> {
-        unsafe {
-            f32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x8(self, a: f32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4757,20 +4721,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x32(self, a: u8x32<Self>) -> i8x32<Self> {
-        unsafe {
-            i8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x32(self, a: i8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5025,20 +4985,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5396,20 +5352,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x16(self, a: u8x32<Self>) -> i16x16<Self> {
-        unsafe {
-            i16x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x16(self, a: i16x16<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5664,20 +5616,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x16(self, a: u8x32<Self>) -> u16x16<Self> {
-        unsafe {
-            u16x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x16(self, a: u16x16<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6057,20 +6005,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x8(self, a: u8x32<Self>) -> i32x8<Self> {
-        unsafe {
-            i32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x8(self, a: i32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6330,20 +6274,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x8(self, a: u8x32<Self>) -> u32x8<Self> {
-        unsafe {
-            u32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x8(self, a: u32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6698,20 +6638,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x4(self, a: u8x32<Self>) -> f64x4<Self> {
-        unsafe {
-            f64x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x4(self, a: f64x4<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7120,20 +7056,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x16(self, a: u8x64<Self>) -> f32x16<Self> {
-        unsafe {
-            f32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x16(self, a: f32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7504,20 +7436,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x64(self, a: u8x64<Self>) -> i8x64<Self> {
-        unsafe {
-            i8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x64(self, a: i8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7765,20 +7693,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -8202,20 +8126,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x32(self, a: u8x64<Self>) -> i16x32<Self> {
-        unsafe {
-            i16x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x32(self, a: i16x32<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -8472,20 +8392,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x32(self, a: u8x64<Self>) -> u16x32<Self> {
-        unsafe {
-            u16x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x32(self, a: u16x32<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -8894,20 +8810,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x16(self, a: u8x64<Self>) -> i32x16<Self> {
-        unsafe {
-            i32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x16(self, a: i32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -9160,20 +9072,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x16(self, a: u8x64<Self>) -> u32x16<Self> {
-        unsafe {
-            u32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x16(self, a: u32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -9544,20 +9452,16 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x8(self, a: u8x64<Self>) -> f64x8<Self> {
-        unsafe {
-            f64x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x8(self, a: f64x8<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -106,7 +106,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_f32x4(self, a: f32x4<Self>) -> [f32; 4usize] {
-        unsafe { core::mem::transmute::<float32x4_t, [f32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<float32x4_t, [f32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
@@ -128,20 +128,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x4(self, a: u8x16<Self>) -> f32x4<Self> {
-        unsafe {
-            f32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x4(self, a: f32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -371,7 +367,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_i8x16(self, a: i8x16<Self>) -> [i8; 16usize] {
-        unsafe { core::mem::transmute::<int8x16_t, [i8; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int8x16_t, [i8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
@@ -393,20 +389,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x16(self, a: u8x16<Self>) -> i8x16<Self> {
-        unsafe {
-            i8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x16(self, a: i8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -581,7 +573,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_u8x16(self, a: u8x16<Self>) -> [u8; 16usize] {
-        unsafe { core::mem::transmute::<uint8x16_t, [u8; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<uint8x16_t, [u8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
@@ -603,20 +595,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -787,7 +775,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_mask8x16(self, a: mask8x16<Self>) -> [i8; 16usize] {
-        unsafe { core::mem::transmute::<int8x16_t, [i8; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int8x16_t, [i8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask8x16(self, bits: u64) -> mask8x16<Self> {
@@ -887,7 +875,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_i16x8(self, a: i16x8<Self>) -> [i16; 8usize] {
-        unsafe { core::mem::transmute::<int16x8_t, [i16; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int16x8_t, [i16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
@@ -909,20 +897,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x8(self, a: u8x16<Self>) -> i16x8<Self> {
-        unsafe {
-            i16x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x8(self, a: i16x8<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1097,7 +1081,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_u16x8(self, a: u16x8<Self>) -> [u16; 8usize] {
-        unsafe { core::mem::transmute::<uint16x8_t, [u16; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<uint16x8_t, [u16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
@@ -1119,20 +1103,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x8(self, a: u8x16<Self>) -> u16x8<Self> {
-        unsafe {
-            u16x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x8(self, a: u16x8<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1299,7 +1279,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_mask16x8(self, a: mask16x8<Self>) -> [i16; 8usize] {
-        unsafe { core::mem::transmute::<int16x8_t, [i16; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int16x8_t, [i16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask16x8(self, bits: u64) -> mask16x8<Self> {
@@ -1390,7 +1370,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_i32x4(self, a: i32x4<Self>) -> [i32; 4usize] {
-        unsafe { core::mem::transmute::<int32x4_t, [i32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int32x4_t, [i32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
@@ -1412,20 +1392,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x4(self, a: u8x16<Self>) -> i32x4<Self> {
-        unsafe {
-            i32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x4(self, a: i32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1604,7 +1580,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_u32x4(self, a: u32x4<Self>) -> [u32; 4usize] {
-        unsafe { core::mem::transmute::<uint32x4_t, [u32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<uint32x4_t, [u32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
@@ -1626,20 +1602,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x4(self, a: u8x16<Self>) -> u32x4<Self> {
-        unsafe {
-            u32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x4(self, a: u32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1806,7 +1778,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_mask32x4(self, a: mask32x4<Self>) -> [i32; 4usize] {
-        unsafe { core::mem::transmute::<int32x4_t, [i32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int32x4_t, [i32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask32x4(self, bits: u64) -> mask32x4<Self> {
@@ -1897,7 +1869,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_f64x2(self, a: f64x2<Self>) -> [f64; 2usize] {
-        unsafe { core::mem::transmute::<float64x2_t, [f64; 2usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<float64x2_t, [f64; 2usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
@@ -1919,20 +1891,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x2(self, a: u8x16<Self>) -> f64x2<Self> {
-        unsafe {
-            f64x2 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x2 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x2(self, a: f64x2<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -2130,7 +2098,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_mask64x2(self, a: mask64x2<Self>) -> [i64; 2usize] {
-        unsafe { core::mem::transmute::<int64x2_t, [i64; 2usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int64x2_t, [i64; 2usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask64x2(self, bits: u64) -> mask64x2<Self> {
@@ -2222,7 +2190,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_f32x8(self, a: f32x8<Self>) -> [f32; 8usize] {
-        unsafe { core::mem::transmute::<float32x4x2_t, [f32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<float32x4x2_t, [f32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
@@ -2244,20 +2212,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x8(self, a: u8x32<Self>) -> f32x8<Self> {
-        unsafe {
-            f32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x8(self, a: f32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -2626,7 +2590,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_i8x32(self, a: i8x32<Self>) -> [i8; 32usize] {
-        unsafe { core::mem::transmute::<int8x16x2_t, [i8; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int8x16x2_t, [i8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
@@ -2648,20 +2612,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x32(self, a: u8x32<Self>) -> i8x32<Self> {
-        unsafe {
-            i8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x32(self, a: i8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -2937,7 +2897,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_u8x32(self, a: u8x32<Self>) -> [u8; 32usize] {
-        unsafe { core::mem::transmute::<uint8x16x2_t, [u8; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<uint8x16x2_t, [u8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
@@ -2959,20 +2919,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3236,7 +3192,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_mask8x32(self, a: mask8x32<Self>) -> [i8; 32usize] {
-        unsafe { core::mem::transmute::<int8x16x2_t, [i8; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int8x16x2_t, [i8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask8x32(self, bits: u64) -> mask8x32<Self> {
@@ -3358,7 +3314,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_i16x16(self, a: i16x16<Self>) -> [i16; 16usize] {
-        unsafe { core::mem::transmute::<int16x8x2_t, [i16; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int16x8x2_t, [i16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
@@ -3380,20 +3336,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x16(self, a: u8x32<Self>) -> i16x16<Self> {
-        unsafe {
-            i16x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x16(self, a: i16x16<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3669,7 +3621,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_u16x16(self, a: u16x16<Self>) -> [u16; 16usize] {
-        unsafe { core::mem::transmute::<uint16x8x2_t, [u16; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<uint16x8x2_t, [u16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
@@ -3691,20 +3643,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x16(self, a: u8x32<Self>) -> u16x16<Self> {
-        unsafe {
-            u16x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x16(self, a: u16x16<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3977,7 +3925,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_mask16x16(self, a: mask16x16<Self>) -> [i16; 16usize] {
-        unsafe { core::mem::transmute::<int16x8x2_t, [i16; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int16x8x2_t, [i16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask16x16(self, bits: u64) -> mask16x16<Self> {
@@ -4099,7 +4047,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_i32x8(self, a: i32x8<Self>) -> [i32; 8usize] {
-        unsafe { core::mem::transmute::<int32x4x2_t, [i32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int32x4x2_t, [i32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
@@ -4121,20 +4069,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x8(self, a: u8x32<Self>) -> i32x8<Self> {
-        unsafe {
-            i32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x8(self, a: i32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4415,7 +4359,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_u32x8(self, a: u32x8<Self>) -> [u32; 8usize] {
-        unsafe { core::mem::transmute::<uint32x4x2_t, [u32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<uint32x4x2_t, [u32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
@@ -4437,20 +4381,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x8(self, a: u8x32<Self>) -> u32x8<Self> {
-        unsafe {
-            u32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x8(self, a: u32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4711,7 +4651,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_mask32x8(self, a: mask32x8<Self>) -> [i32; 8usize] {
-        unsafe { core::mem::transmute::<int32x4x2_t, [i32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int32x4x2_t, [i32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask32x8(self, bits: u64) -> mask32x8<Self> {
@@ -4833,7 +4773,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_f64x4(self, a: f64x4<Self>) -> [f64; 4usize] {
-        unsafe { core::mem::transmute::<float64x2x2_t, [f64; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<float64x2x2_t, [f64; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
@@ -4855,20 +4795,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x4(self, a: u8x32<Self>) -> f64x4<Self> {
-        unsafe {
-            f64x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x4(self, a: f64x4<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5183,7 +5119,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_mask64x4(self, a: mask64x4<Self>) -> [i64; 4usize] {
-        unsafe { core::mem::transmute::<int64x2x2_t, [i64; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int64x2x2_t, [i64; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask64x4(self, bits: u64) -> mask64x4<Self> {
@@ -5305,7 +5241,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_f32x16(self, a: f32x16<Self>) -> [f32; 16usize] {
-        unsafe { core::mem::transmute::<float32x4x4_t, [f32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<float32x4x4_t, [f32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
@@ -5327,20 +5263,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x16(self, a: u8x64<Self>) -> f32x16<Self> {
-        unsafe {
-            f32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x16(self, a: f32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5726,7 +5658,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_i8x64(self, a: i8x64<Self>) -> [i8; 64usize] {
-        unsafe { core::mem::transmute::<int8x16x4_t, [i8; 64usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int8x16x4_t, [i8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
@@ -5748,20 +5680,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x64(self, a: u8x64<Self>) -> i8x64<Self> {
-        unsafe {
-            i8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x64(self, a: i8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6046,7 +5974,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_u8x64(self, a: u8x64<Self>) -> [u8; 64usize] {
-        unsafe { core::mem::transmute::<uint8x16x4_t, [u8; 64usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<uint8x16x4_t, [u8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
@@ -6068,20 +5996,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6357,7 +6281,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_mask8x64(self, a: mask8x64<Self>) -> [i8; 64usize] {
-        unsafe { core::mem::transmute::<int8x16x4_t, [i8; 64usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int8x16x4_t, [i8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask8x64(self, bits: u64) -> mask8x64<Self> {
@@ -6470,7 +6394,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_i16x32(self, a: i16x32<Self>) -> [i16; 32usize] {
-        unsafe { core::mem::transmute::<int16x8x4_t, [i16; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int16x8x4_t, [i16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
@@ -6492,20 +6416,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x32(self, a: u8x64<Self>) -> i16x32<Self> {
-        unsafe {
-            i16x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x32(self, a: i16x32<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6799,7 +6719,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_u16x32(self, a: u16x32<Self>) -> [u16; 32usize] {
-        unsafe { core::mem::transmute::<uint16x8x4_t, [u16; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<uint16x8x4_t, [u16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
@@ -6821,20 +6741,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x32(self, a: u8x64<Self>) -> u16x32<Self> {
-        unsafe {
-            u16x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x32(self, a: u16x32<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7129,7 +7045,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_mask16x32(self, a: mask16x32<Self>) -> [i16; 32usize] {
-        unsafe { core::mem::transmute::<int16x8x4_t, [i16; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int16x8x4_t, [i16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask16x32(self, bits: u64) -> mask16x32<Self> {
@@ -7245,7 +7161,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_i32x16(self, a: i32x16<Self>) -> [i32; 16usize] {
-        unsafe { core::mem::transmute::<int32x4x4_t, [i32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int32x4x4_t, [i32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
@@ -7267,20 +7183,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x16(self, a: u8x64<Self>) -> i32x16<Self> {
-        unsafe {
-            i32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x16(self, a: i32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7570,7 +7482,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_u32x16(self, a: u32x16<Self>) -> [u32; 16usize] {
-        unsafe { core::mem::transmute::<uint32x4x4_t, [u32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<uint32x4x4_t, [u32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
@@ -7592,20 +7504,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x16(self, a: u8x64<Self>) -> u32x16<Self> {
-        unsafe {
-            u32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x16(self, a: u32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7883,7 +7791,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_mask32x16(self, a: mask32x16<Self>) -> [i32; 16usize] {
-        unsafe { core::mem::transmute::<int32x4x4_t, [i32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int32x4x4_t, [i32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask32x16(self, bits: u64) -> mask32x16<Self> {
@@ -7996,7 +7904,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_f64x8(self, a: f64x8<Self>) -> [f64; 8usize] {
-        unsafe { core::mem::transmute::<float64x2x4_t, [f64; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<float64x2x4_t, [f64; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
@@ -8018,20 +7926,16 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x8(self, a: u8x64<Self>) -> f64x8<Self> {
-        unsafe {
-            f64x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x8(self, a: f64x8<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -8355,7 +8259,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_mask64x8(self, a: mask64x8<Self>) -> [i64; 8usize] {
-        unsafe { core::mem::transmute::<int64x2x4_t, [i64; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<int64x2x4_t, [i64; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask64x8(self, bits: u64) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -142,7 +142,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_f32x4(self, a: f32x4<Self>) -> [f32; 4usize] {
-        unsafe { core::mem::transmute::<__m128, [f32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128, [f32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
@@ -164,20 +164,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x4(self, a: u8x16<Self>) -> f32x4<Self> {
-        unsafe {
-            f32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x4(self, a: f32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -455,7 +451,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_i8x16(self, a: i8x16<Self>) -> [i8; 16usize] {
-        unsafe { core::mem::transmute::<__m128i, [i8; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
@@ -477,20 +473,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x16(self, a: u8x16<Self>) -> i8x16<Self> {
-        unsafe {
-            i8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x16(self, a: i8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -692,7 +684,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_u8x16(self, a: u8x16<Self>) -> [u8; 16usize] {
-        unsafe { core::mem::transmute::<__m128i, [u8; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [u8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
@@ -714,20 +706,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -936,7 +924,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_mask8x16(self, a: mask8x16<Self>) -> [i8; 16usize] {
-        unsafe { core::mem::transmute::<__m128i, [i8; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask8x16(self, bits: u64) -> mask8x16<Self> {
@@ -1030,7 +1018,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_i16x8(self, a: i16x8<Self>) -> [i16; 8usize] {
-        unsafe { core::mem::transmute::<__m128i, [i16; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
@@ -1052,20 +1040,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x8(self, a: u8x16<Self>) -> i16x8<Self> {
-        unsafe {
-            i16x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x8(self, a: i16x8<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1242,7 +1226,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_u16x8(self, a: u16x8<Self>) -> [u16; 8usize] {
-        unsafe { core::mem::transmute::<__m128i, [u16; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [u16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
@@ -1264,20 +1248,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x8(self, a: u8x16<Self>) -> u16x8<Self> {
-        unsafe {
-            u16x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x8(self, a: u16x8<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1456,7 +1436,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_mask16x8(self, a: mask16x8<Self>) -> [i16; 8usize] {
-        unsafe { core::mem::transmute::<__m128i, [i16; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask16x8(self, bits: u64) -> mask16x8<Self> {
@@ -1550,7 +1530,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_i32x4(self, a: i32x4<Self>) -> [i32; 4usize] {
-        unsafe { core::mem::transmute::<__m128i, [i32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
@@ -1572,20 +1552,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x4(self, a: u8x16<Self>) -> i32x4<Self> {
-        unsafe {
-            i32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x4(self, a: i32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1764,7 +1740,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_u32x4(self, a: u32x4<Self>) -> [u32; 4usize] {
-        unsafe { core::mem::transmute::<__m128i, [u32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [u32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
@@ -1786,20 +1762,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x4(self, a: u8x16<Self>) -> u32x4<Self> {
-        unsafe {
-            u32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x4(self, a: u32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1986,7 +1958,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_mask32x4(self, a: mask32x4<Self>) -> [i32; 4usize] {
-        unsafe { core::mem::transmute::<__m128i, [i32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask32x4(self, bits: u64) -> mask32x4<Self> {
@@ -2075,7 +2047,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_f64x2(self, a: f64x2<Self>) -> [f64; 2usize] {
-        unsafe { core::mem::transmute::<__m128d, [f64; 2usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128d, [f64; 2usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
@@ -2097,20 +2069,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x2(self, a: u8x16<Self>) -> f64x2<Self> {
-        unsafe {
-            f64x2 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x2 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x2(self, a: f64x2<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -2313,7 +2281,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_mask64x2(self, a: mask64x2<Self>) -> [i64; 2usize] {
-        unsafe { core::mem::transmute::<__m128i, [i64; 2usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<__m128i, [i64; 2usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask64x2(self, bits: u64) -> mask64x2<Self> {
@@ -2403,7 +2371,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_f32x8(self, a: f32x8<Self>) -> [f32; 8usize] {
-        unsafe { core::mem::transmute::<[__m128; 2usize], [f32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128; 2usize], [f32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
@@ -2425,20 +2393,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x8(self, a: u8x32<Self>) -> f32x8<Self> {
-        unsafe {
-            f32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x8(self, a: f32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -2785,7 +2749,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_i8x32(self, a: i8x32<Self>) -> [i8; 32usize] {
-        unsafe { core::mem::transmute::<[__m128i; 2usize], [i8; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
@@ -2807,20 +2771,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x32(self, a: u8x32<Self>) -> i8x32<Self> {
-        unsafe {
-            i8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x32(self, a: i8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3074,7 +3034,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_u8x32(self, a: u8x32<Self>) -> [u8; 32usize] {
-        unsafe { core::mem::transmute::<[__m128i; 2usize], [u8; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [u8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
@@ -3096,20 +3056,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3351,7 +3307,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_mask8x32(self, a: mask8x32<Self>) -> [i8; 32usize] {
-        unsafe { core::mem::transmute::<[__m128i; 2usize], [i8; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask8x32(self, bits: u64) -> mask8x32<Self> {
@@ -3471,7 +3427,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_i16x16(self, a: i16x16<Self>) -> [i16; 16usize] {
-        unsafe { core::mem::transmute::<[__m128i; 2usize], [i16; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
@@ -3493,20 +3449,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x16(self, a: u8x32<Self>) -> i16x16<Self> {
-        unsafe {
-            i16x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x16(self, a: i16x16<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3760,7 +3712,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_u16x16(self, a: u16x16<Self>) -> [u16; 16usize] {
-        unsafe { core::mem::transmute::<[__m128i; 2usize], [u16; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [u16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
@@ -3782,20 +3734,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x16(self, a: u8x32<Self>) -> u16x16<Self> {
-        unsafe {
-            u16x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x16(self, a: u16x16<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4048,7 +3996,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_mask16x16(self, a: mask16x16<Self>) -> [i16; 16usize] {
-        unsafe { core::mem::transmute::<[__m128i; 2usize], [i16; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask16x16(self, bits: u64) -> mask16x16<Self> {
@@ -4170,7 +4118,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_i32x8(self, a: i32x8<Self>) -> [i32; 8usize] {
-        unsafe { core::mem::transmute::<[__m128i; 2usize], [i32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
@@ -4192,20 +4140,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x8(self, a: u8x32<Self>) -> i32x8<Self> {
-        unsafe {
-            i32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x8(self, a: i32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4464,7 +4408,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_u32x8(self, a: u32x8<Self>) -> [u32; 8usize] {
-        unsafe { core::mem::transmute::<[__m128i; 2usize], [u32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [u32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
@@ -4486,20 +4430,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x8(self, a: u8x32<Self>) -> u32x8<Self> {
-        unsafe {
-            u32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x8(self, a: u32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4738,7 +4678,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_mask32x8(self, a: mask32x8<Self>) -> [i32; 8usize] {
-        unsafe { core::mem::transmute::<[__m128i; 2usize], [i32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask32x8(self, bits: u64) -> mask32x8<Self> {
@@ -4858,7 +4798,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_f64x4(self, a: f64x4<Self>) -> [f64; 4usize] {
-        unsafe { core::mem::transmute::<[__m128d; 2usize], [f64; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128d; 2usize], [f64; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
@@ -4880,20 +4820,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x4(self, a: u8x32<Self>) -> f64x4<Self> {
-        unsafe {
-            f64x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x4(self, a: f64x4<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5186,7 +5122,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_mask64x4(self, a: mask64x4<Self>) -> [i64; 4usize] {
-        unsafe { core::mem::transmute::<[__m128i; 2usize], [i64; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i64; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask64x4(self, bits: u64) -> mask64x4<Self> {
@@ -5306,7 +5242,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_f32x16(self, a: f32x16<Self>) -> [f32; 16usize] {
-        unsafe { core::mem::transmute::<[__m128; 4usize], [f32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128; 4usize], [f32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
@@ -5328,20 +5264,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x16(self, a: u8x64<Self>) -> f32x16<Self> {
-        unsafe {
-            f32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x16(self, a: f32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5733,7 +5665,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_i8x64(self, a: i8x64<Self>) -> [i8; 64usize] {
-        unsafe { core::mem::transmute::<[__m128i; 4usize], [i8; 64usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
@@ -5755,20 +5687,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x64(self, a: u8x64<Self>) -> i8x64<Self> {
-        unsafe {
-            i8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x64(self, a: i8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6015,7 +5943,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_u8x64(self, a: u8x64<Self>) -> [u8; 64usize] {
-        unsafe { core::mem::transmute::<[__m128i; 4usize], [u8; 64usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [u8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
@@ -6037,20 +5965,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6342,7 +6266,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_mask8x64(self, a: mask8x64<Self>) -> [i8; 64usize] {
-        unsafe { core::mem::transmute::<[__m128i; 4usize], [i8; 64usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask8x64(self, bits: u64) -> mask8x64<Self> {
@@ -6492,7 +6416,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_i16x32(self, a: i16x32<Self>) -> [i16; 32usize] {
-        unsafe { core::mem::transmute::<[__m128i; 4usize], [i16; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
@@ -6514,20 +6438,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x32(self, a: u8x64<Self>) -> i16x32<Self> {
-        unsafe {
-            i16x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x32(self, a: i16x32<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6783,7 +6703,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_u16x32(self, a: u16x32<Self>) -> [u16; 32usize] {
-        unsafe { core::mem::transmute::<[__m128i; 4usize], [u16; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [u16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
@@ -6805,20 +6725,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x32(self, a: u8x64<Self>) -> u16x32<Self> {
-        unsafe {
-            u16x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x32(self, a: u16x32<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7129,7 +7045,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_mask16x32(self, a: mask16x32<Self>) -> [i16; 32usize] {
-        unsafe { core::mem::transmute::<[__m128i; 4usize], [i16; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask16x32(self, bits: u64) -> mask16x32<Self> {
@@ -7250,7 +7166,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_i32x16(self, a: i32x16<Self>) -> [i32; 16usize] {
-        unsafe { core::mem::transmute::<[__m128i; 4usize], [i32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
@@ -7272,20 +7188,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x16(self, a: u8x64<Self>) -> i32x16<Self> {
-        unsafe {
-            i32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x16(self, a: i32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7537,7 +7449,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_u32x16(self, a: u32x16<Self>) -> [u32; 16usize] {
-        unsafe { core::mem::transmute::<[__m128i; 4usize], [u32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [u32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
@@ -7559,20 +7471,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x16(self, a: u8x64<Self>) -> u32x16<Self> {
-        unsafe {
-            u32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x16(self, a: u32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7856,7 +7764,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_mask32x16(self, a: mask32x16<Self>) -> [i32; 16usize] {
-        unsafe { core::mem::transmute::<[__m128i; 4usize], [i32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask32x16(self, bits: u64) -> mask32x16<Self> {
@@ -7969,7 +7877,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_f64x8(self, a: f64x8<Self>) -> [f64; 8usize] {
-        unsafe { core::mem::transmute::<[__m128d; 4usize], [f64; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128d; 4usize], [f64; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
@@ -7991,20 +7899,16 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x8(self, a: u8x64<Self>) -> f64x8<Self> {
-        unsafe {
-            f64x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x8(self, a: f64x8<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -8290,7 +8194,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_mask64x8(self, a: mask64x8<Self>) -> [i64; 8usize] {
-        unsafe { core::mem::transmute::<[__m128i; 4usize], [i64; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i64; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask64x8(self, bits: u64) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -105,7 +105,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_f32x4(self, a: f32x4<Self>) -> [f32; 4usize] {
-        unsafe { core::mem::transmute::<v128, [f32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<v128, [f32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
@@ -127,20 +127,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x4(self, a: u8x16<Self>) -> f32x4<Self> {
-        unsafe {
-            f32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x4(self, a: f32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -411,7 +407,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_i8x16(self, a: i8x16<Self>) -> [i8; 16usize] {
-        unsafe { core::mem::transmute::<v128, [i8; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<v128, [i8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
@@ -433,20 +429,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x16(self, a: u8x16<Self>) -> i8x16<Self> {
-        unsafe {
-            i8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x16(self, a: i8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -636,7 +628,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_u8x16(self, a: u8x16<Self>) -> [u8; 16usize] {
-        unsafe { core::mem::transmute::<v128, [u8; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<v128, [u8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
@@ -658,20 +650,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -853,7 +841,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_mask8x16(self, a: mask8x16<Self>) -> [i8; 16usize] {
-        unsafe { core::mem::transmute::<v128, [i8; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<v128, [i8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask8x16(self, bits: u64) -> mask8x16<Self> {
@@ -947,7 +935,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_i16x8(self, a: i16x8<Self>) -> [i16; 8usize] {
-        unsafe { core::mem::transmute::<v128, [i16; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<v128, [i16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
@@ -969,20 +957,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x8(self, a: u8x16<Self>) -> i16x8<Self> {
-        unsafe {
-            i16x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x8(self, a: i16x8<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1156,7 +1140,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_u16x8(self, a: u16x8<Self>) -> [u16; 8usize] {
-        unsafe { core::mem::transmute::<v128, [u16; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<v128, [u16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
@@ -1178,20 +1162,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x8(self, a: u8x16<Self>) -> u16x8<Self> {
-        unsafe {
-            u16x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x8(self, a: u16x8<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1355,7 +1335,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_mask16x8(self, a: mask16x8<Self>) -> [i16; 8usize] {
-        unsafe { core::mem::transmute::<v128, [i16; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<v128, [i16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask16x8(self, bits: u64) -> mask16x8<Self> {
@@ -1447,7 +1427,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_i32x4(self, a: i32x4<Self>) -> [i32; 4usize] {
-        unsafe { core::mem::transmute::<v128, [i32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<v128, [i32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
@@ -1469,20 +1449,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x4(self, a: u8x16<Self>) -> i32x4<Self> {
-        unsafe {
-            i32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x4(self, a: i32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1660,7 +1636,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_u32x4(self, a: u32x4<Self>) -> [u32; 4usize] {
-        unsafe { core::mem::transmute::<v128, [u32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<v128, [u32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
@@ -1682,20 +1658,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x4(self, a: u8x16<Self>) -> u32x4<Self> {
-        unsafe {
-            u32x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x4(self, a: u32x4<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -1859,7 +1831,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_mask32x4(self, a: mask32x4<Self>) -> [i32; 4usize] {
-        unsafe { core::mem::transmute::<v128, [i32; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<v128, [i32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask32x4(self, bits: u64) -> mask32x4<Self> {
@@ -1951,7 +1923,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_f64x2(self, a: f64x2<Self>) -> [f64; 2usize] {
-        unsafe { core::mem::transmute::<v128, [f64; 2usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<v128, [f64; 2usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
@@ -1973,20 +1945,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x2(self, a: u8x16<Self>) -> f64x2<Self> {
-        unsafe {
-            f64x2 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x2 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x2(self, a: f64x2<Self>) -> u8x16<Self> {
-        unsafe {
-            u8x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -2209,7 +2177,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_mask64x2(self, a: mask64x2<Self>) -> [i64; 2usize] {
-        unsafe { core::mem::transmute::<v128, [i64; 2usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<v128, [i64; 2usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask64x2(self, bits: u64) -> mask64x2<Self> {
@@ -2302,7 +2270,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_f32x8(self, a: f32x8<Self>) -> [f32; 8usize] {
-        unsafe { core::mem::transmute::<[v128; 2usize], [f32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 2usize], [f32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
@@ -2324,20 +2292,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x8(self, a: u8x32<Self>) -> f32x8<Self> {
-        unsafe {
-            f32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x8(self, a: f32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -2684,7 +2648,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_i8x32(self, a: i8x32<Self>) -> [i8; 32usize] {
-        unsafe { core::mem::transmute::<[v128; 2usize], [i8; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
@@ -2706,20 +2670,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x32(self, a: u8x32<Self>) -> i8x32<Self> {
-        unsafe {
-            i8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x32(self, a: i8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -2973,7 +2933,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_u8x32(self, a: u8x32<Self>) -> [u8; 32usize] {
-        unsafe { core::mem::transmute::<[v128; 2usize], [u8; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 2usize], [u8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
@@ -2995,20 +2955,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3250,7 +3206,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_mask8x32(self, a: mask8x32<Self>) -> [i8; 32usize] {
-        unsafe { core::mem::transmute::<[v128; 2usize], [i8; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask8x32(self, bits: u64) -> mask8x32<Self> {
@@ -3370,7 +3326,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_i16x16(self, a: i16x16<Self>) -> [i16; 16usize] {
-        unsafe { core::mem::transmute::<[v128; 2usize], [i16; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
@@ -3392,20 +3348,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x16(self, a: u8x32<Self>) -> i16x16<Self> {
-        unsafe {
-            i16x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x16(self, a: i16x16<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3659,7 +3611,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_u16x16(self, a: u16x16<Self>) -> [u16; 16usize] {
-        unsafe { core::mem::transmute::<[v128; 2usize], [u16; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 2usize], [u16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
@@ -3681,20 +3633,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x16(self, a: u8x32<Self>) -> u16x16<Self> {
-        unsafe {
-            u16x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x16(self, a: u16x16<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -3945,7 +3893,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_mask16x16(self, a: mask16x16<Self>) -> [i16; 16usize] {
-        unsafe { core::mem::transmute::<[v128; 2usize], [i16; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask16x16(self, bits: u64) -> mask16x16<Self> {
@@ -4065,7 +4013,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_i32x8(self, a: i32x8<Self>) -> [i32; 8usize] {
-        unsafe { core::mem::transmute::<[v128; 2usize], [i32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
@@ -4087,20 +4035,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x8(self, a: u8x32<Self>) -> i32x8<Self> {
-        unsafe {
-            i32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x8(self, a: i32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4359,7 +4303,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_u32x8(self, a: u32x8<Self>) -> [u32; 8usize] {
-        unsafe { core::mem::transmute::<[v128; 2usize], [u32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 2usize], [u32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
@@ -4381,20 +4325,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x8(self, a: u8x32<Self>) -> u32x8<Self> {
-        unsafe {
-            u32x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x8(self, a: u32x8<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -4633,7 +4573,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_mask32x8(self, a: mask32x8<Self>) -> [i32; 8usize] {
-        unsafe { core::mem::transmute::<[v128; 2usize], [i32; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask32x8(self, bits: u64) -> mask32x8<Self> {
@@ -4753,7 +4693,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_f64x4(self, a: f64x4<Self>) -> [f64; 4usize] {
-        unsafe { core::mem::transmute::<[v128; 2usize], [f64; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 2usize], [f64; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
@@ -4775,20 +4715,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x4(self, a: u8x32<Self>) -> f64x4<Self> {
-        unsafe {
-            f64x4 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x4(self, a: f64x4<Self>) -> u8x32<Self> {
-        unsafe {
-            u8x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5081,7 +5017,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_mask64x4(self, a: mask64x4<Self>) -> [i64; 4usize] {
-        unsafe { core::mem::transmute::<[v128; 2usize], [i64; 4usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i64; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask64x4(self, bits: u64) -> mask64x4<Self> {
@@ -5201,7 +5137,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_f32x16(self, a: f32x16<Self>) -> [f32; 16usize] {
-        unsafe { core::mem::transmute::<[v128; 4usize], [f32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 4usize], [f32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
@@ -5223,20 +5159,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x16(self, a: u8x64<Self>) -> f32x16<Self> {
-        unsafe {
-            f32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f32x16(self, a: f32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5621,7 +5553,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_i8x64(self, a: i8x64<Self>) -> [i8; 64usize] {
-        unsafe { core::mem::transmute::<[v128; 4usize], [i8; 64usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
@@ -5643,20 +5575,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x64(self, a: u8x64<Self>) -> i8x64<Self> {
-        unsafe {
-            i8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i8x64(self, a: i8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -5903,7 +5831,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_u8x64(self, a: u8x64<Self>) -> [u8; 64usize] {
-        unsafe { core::mem::transmute::<[v128; 4usize], [u8; 64usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 4usize], [u8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
@@ -5925,20 +5853,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6237,7 +6161,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_mask8x64(self, a: mask8x64<Self>) -> [i8; 64usize] {
-        unsafe { core::mem::transmute::<[v128; 4usize], [i8; 64usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask8x64(self, bits: u64) -> mask8x64<Self> {
@@ -6350,7 +6274,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_i16x32(self, a: i16x32<Self>) -> [i16; 32usize] {
-        unsafe { core::mem::transmute::<[v128; 4usize], [i16; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
@@ -6372,20 +6296,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x32(self, a: u8x64<Self>) -> i16x32<Self> {
-        unsafe {
-            i16x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i16x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i16x32(self, a: i16x32<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6641,7 +6561,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_u16x32(self, a: u16x32<Self>) -> [u16; 32usize] {
-        unsafe { core::mem::transmute::<[v128; 4usize], [u16; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 4usize], [u16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
@@ -6663,20 +6583,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x32(self, a: u8x64<Self>) -> u16x32<Self> {
-        unsafe {
-            u16x32 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u16x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u16x32(self, a: u16x32<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -6970,7 +6886,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_mask16x32(self, a: mask16x32<Self>) -> [i16; 32usize] {
-        unsafe { core::mem::transmute::<[v128; 4usize], [i16; 32usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask16x32(self, bits: u64) -> mask16x32<Self> {
@@ -7086,7 +7002,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_i32x16(self, a: i32x16<Self>) -> [i32; 16usize] {
-        unsafe { core::mem::transmute::<[v128; 4usize], [i32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
@@ -7108,20 +7024,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x16(self, a: u8x64<Self>) -> i32x16<Self> {
-        unsafe {
-            i32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        i32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_i32x16(self, a: i32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7373,7 +7285,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_u32x16(self, a: u32x16<Self>) -> [u32; 16usize] {
-        unsafe { core::mem::transmute::<[v128; 4usize], [u32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 4usize], [u32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
@@ -7395,20 +7307,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x16(self, a: u8x64<Self>) -> u32x16<Self> {
-        unsafe {
-            u32x16 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u32x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_u32x16(self, a: u32x16<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -7685,7 +7593,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_mask32x16(self, a: mask32x16<Self>) -> [i32; 16usize] {
-        unsafe { core::mem::transmute::<[v128; 4usize], [i32; 16usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask32x16(self, bits: u64) -> mask32x16<Self> {
@@ -7798,7 +7706,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_f64x8(self, a: f64x8<Self>) -> [f64; 8usize] {
-        unsafe { core::mem::transmute::<[v128; 4usize], [f64; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 4usize], [f64; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
@@ -7820,20 +7728,16 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x8(self, a: u8x64<Self>) -> f64x8<Self> {
-        unsafe {
-            f64x8 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        f64x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
     fn cvt_to_bytes_f64x8(self, a: f64x8<Self>) -> u8x64<Self> {
-        unsafe {
-            u8x64 {
-                val: core::mem::transmute(a.val),
-                simd: self,
-            }
+        u8x64 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
         }
     }
     #[inline(always)]
@@ -8119,7 +8023,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_mask64x8(self, a: mask64x8<Self>) -> [i64; 8usize] {
-        unsafe { core::mem::transmute::<[v128; 4usize], [i64; 8usize]>(a.val.0) }
+        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i64; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn from_bitmask_mask64x8(self, bits: u64) -> mask64x8<Self> {

--- a/fearless_simd/src/transmute.rs
+++ b/fearless_simd/src/transmute.rs
@@ -222,18 +222,6 @@ impl_aligned_simd_pod!(
 /// Like [`core::mem::transmute_copy`], but statically rejects differently-sized
 /// types and only accepts this crate's SIMD plain-old-data storage types.
 #[inline(always)]
-#[cfg_attr(
-    not(any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        all(target_arch = "wasm32", target_feature = "simd128")
-    )),
-    expect(
-        dead_code,
-        reason = "native vector conversions are not used by scalar-only builds"
-    )
-)]
 #[allow(
     clippy::disallowed_methods,
     reason = "This is the central checked wrapper around transmute_copy"

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -213,11 +213,15 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
             block_count,
         } => {
             let split_len = (block_size * block_count) as usize / (ty.scalar_bits * 2);
+            let ty_rust = ty.rust();
             quote! {
                 #method_sig {
                     let (chunks, _) = src.as_chunks::<#split_len>();
-                    unsafe {
-                        core::mem::transmute([self.#do_half(&chunks[0]), self.#do_half(&chunks[1])])
+                    let lo = self.#do_half(&chunks[0]);
+                    let hi = self.#do_half(&chunks[1]);
+                    #ty_rust {
+                        val: crate::transmute::checked_transmute_copy(&[lo.val, hi.val]),
+                        simd: self,
                     }
                 }
             }
@@ -397,21 +401,30 @@ pub(crate) fn generic_as_array<T: ToTokens>(
     let rust_scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
     let num_scalars = vec_ty.len;
 
-    let ref_tok = kind.token();
     let native_ty =
         vec_ty.wrapped_native_ty(|vec_ty| arch_ty(vec_ty).into_token_stream(), max_block_size);
 
-    quote! {
-        #method_sig {
-            unsafe {
-                // Safety: The native vector type backing any implementation will be:
-                // - A `#[repr(simd)]` type, which has the same layout as an array of scalars
-                // - An array of `#[repr(simd)]` types
-                // - For AArch64 specifically, a `#[repr(C)]` tuple of `#[repr(simd)]` types
-                //
-                // Not only do these all have the same layout as a flat array of the corresponding scalars, but they
-                // wrap primitives where all bit patterns are valid (ints and floats).
-                core::mem::transmute::<#ref_tok #native_ty, #ref_tok [#rust_scalar; #num_scalars]>(#ref_tok a.val.0)
+    match kind {
+        RefKind::Value => quote! {
+            #method_sig {
+                crate::transmute::checked_transmute_copy::<#native_ty, [#rust_scalar; #num_scalars]>(&a.val.0)
+            }
+        },
+        RefKind::Ref | RefKind::Mut => {
+            let ref_tok = kind.token();
+            quote! {
+                #method_sig {
+                    unsafe {
+                        // Safety: The native vector type backing any implementation will be:
+                        // - A `#[repr(simd)]` type, which has the same layout as an array of scalars
+                        // - An array of `#[repr(simd)]` types
+                        // - For AArch64 specifically, a `#[repr(C)]` tuple of `#[repr(simd)]` types
+                        //
+                        // Not only do these all have the same layout as a flat array of the corresponding scalars, but they
+                        // wrap primitives where all bit patterns are valid (ints and floats).
+                        core::mem::transmute::<#ref_tok #native_ty, #ref_tok [#rust_scalar; #num_scalars]>(#ref_tok a.val.0)
+                    }
+                }
             }
         }
     }
@@ -445,9 +458,7 @@ pub(crate) fn generic_to_bytes(method_sig: TokenStream, vec_ty: &VecType) -> Tok
     let bytes_ty = vec_ty.reinterpret(ScalarType::Unsigned, 8).rust();
     quote! {
         #method_sig {
-            unsafe {
-                #bytes_ty { val: core::mem::transmute(a.val), simd: self }
-            }
+            #bytes_ty { val: crate::transmute::checked_transmute_copy(&a.val), simd: self }
         }
     }
 }
@@ -456,11 +467,7 @@ pub(crate) fn generic_from_bytes(method_sig: TokenStream, vec_ty: &VecType) -> T
     let ty = vec_ty.rust();
     quote! {
         #method_sig {
-            unsafe {
-                // Safety: All values are wrapped in alignment wrappers (`Aligned128`, `Aligned256`, `Aligned512`), so
-                // we're transmuting between types with all valid bit patterns and the same size and alignment.
-                #ty { val: core::mem::transmute(a.val), simd: self }
-            }
+            #ty { val: crate::transmute::checked_transmute_copy(&a.val), simd: self }
         }
     }
 }

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -517,7 +517,7 @@ fn mask_to_bitmask_words(native_width: usize, vec_ty: &VecType) -> TokenStream {
         },
         (256, 256) => quote! {
             {
-                let halves: [__m128i; 2usize] = core::mem::transmute(a.val.0);
+                let halves: [__m128i; 2usize] = crate::transmute::checked_transmute_copy(&a.val.0);
                 let packed = _mm_packs_epi16(halves[0], halves[1]);
                 _mm_movemask_epi8(packed) as u32 as u64
             }


### PR DESCRIPTION
A big safety win - a lot less bespoke `unsafe` to worry about. 

No difference in codegen in spot-checked assembly.

### Why not wrap `transmute` instead of using `transmute_copy`?

It's not possible to create a generic wrapper for by-value transmutes. rustc rejects it because it cannot prove they have the same sizes for all possible instantiations.

This is a genuine fundamental limitation. Even `bytemuck` implements its by-value transmute in terms of `transmute_copy`: https://github.com/Lokathor/bytemuck/blob/164cedda0eae131bc6cb67902599f4ec253642ca/src/lib.rs#L126

So we are on a well-trodden path for the optimizer, at least.