### PR TITLE
Implement safe reference casts

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -10,6 +10,8 @@ trivial-copy-size-limit = 16
 # END LINEBENDER LINT SET
 
 disallowed-methods = [
+  { path = "core::mem::transmute", reason = "Use the checked helpers in fearless_simd/src/transmute.rs: checked_transmute_copy for values, checked_cast_ref for shared references, and checked_cast_mut for mutable references." },
+  { path = "std::mem::transmute", reason = "Use the checked helpers in fearless_simd/src/transmute.rs: checked_transmute_copy for values, checked_cast_ref for shared references, and checked_cast_mut for mutable references." },
   { path = "core::mem::transmute_copy", reason = "Use crate::transmute::checked_transmute_copy so that safety preconditions are verified at compile time." },
   { path = "std::mem::transmute_copy", reason = "Use crate::transmute::checked_transmute_copy so that safety preconditions are verified at compile time." },
 ]

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -120,11 +120,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
-        unsafe { core::mem::transmute::<&__m128, &[f32; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128, [f32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f32x4(self, a: &mut f32x4<Self>) -> &mut [f32; 4usize] {
-        unsafe { core::mem::transmute::<&mut __m128, &mut [f32; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128, [f32; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
@@ -426,11 +426,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
-        unsafe { core::mem::transmute::<&__m128i, &[i8; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128i, [i8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i8x16(self, a: &mut i8x16<Self>) -> &mut [i8; 16usize] {
-        unsafe { core::mem::transmute::<&mut __m128i, &mut [i8; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128i, [i8; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
@@ -656,11 +656,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
-        unsafe { core::mem::transmute::<&__m128i, &[u8; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128i, [u8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u8x16(self, a: &mut u8x16<Self>) -> &mut [u8; 16usize] {
-        unsafe { core::mem::transmute::<&mut __m128i, &mut [u8; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128i, [u8; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
@@ -979,11 +979,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
-        unsafe { core::mem::transmute::<&__m128i, &[i16; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128i, [i16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i16x8(self, a: &mut i16x8<Self>) -> &mut [i16; 8usize] {
-        unsafe { core::mem::transmute::<&mut __m128i, &mut [i16; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128i, [i16; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
@@ -1184,11 +1184,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
-        unsafe { core::mem::transmute::<&__m128i, &[u16; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128i, [u16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u16x8(self, a: &mut u16x8<Self>) -> &mut [u16; 8usize] {
-        unsafe { core::mem::transmute::<&mut __m128i, &mut [u16; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128i, [u16; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
@@ -1482,11 +1482,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
-        unsafe { core::mem::transmute::<&__m128i, &[i32; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128i, [i32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i32x4(self, a: &mut i32x4<Self>) -> &mut [i32; 4usize] {
-        unsafe { core::mem::transmute::<&mut __m128i, &mut [i32; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128i, [i32; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
@@ -1689,11 +1689,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
-        unsafe { core::mem::transmute::<&__m128i, &[u32; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128i, [u32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u32x4(self, a: &mut u32x4<Self>) -> &mut [u32; 4usize] {
-        unsafe { core::mem::transmute::<&mut __m128i, &mut [u32; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128i, [u32; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
@@ -1990,11 +1990,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
-        unsafe { core::mem::transmute::<&__m128d, &[f64; 2usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128d, [f64; 2usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f64x2(self, a: &mut f64x2<Self>) -> &mut [f64; 2usize] {
-        unsafe { core::mem::transmute::<&mut __m128d, &mut [f64; 2usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128d, [f64; 2usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
@@ -2307,11 +2307,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
-        unsafe { core::mem::transmute::<&__m256, &[f32; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m256, [f32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f32x8(self, a: &mut f32x8<Self>) -> &mut [f32; 8usize] {
-        unsafe { core::mem::transmute::<&mut __m256, &mut [f32; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m256, [f32; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
@@ -2676,11 +2676,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
-        unsafe { core::mem::transmute::<&__m256i, &[i8; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m256i, [i8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i8x32(self, a: &mut i8x32<Self>) -> &mut [i8; 32usize] {
-        unsafe { core::mem::transmute::<&mut __m256i, &mut [i8; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m256i, [i8; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
@@ -2989,11 +2989,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
-        unsafe { core::mem::transmute::<&__m256i, &[u8; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m256i, [u8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u8x32(self, a: &mut u8x32<Self>) -> &mut [u8; 32usize] {
-        unsafe { core::mem::transmute::<&mut __m256i, &mut [u8; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m256i, [u8; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
@@ -3417,11 +3417,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
-        unsafe { core::mem::transmute::<&__m256i, &[i16; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m256i, [i16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i16x16(self, a: &mut i16x16<Self>) -> &mut [i16; 16usize] {
-        unsafe { core::mem::transmute::<&mut __m256i, &mut [i16; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m256i, [i16; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
@@ -3711,11 +3711,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
-        unsafe { core::mem::transmute::<&__m256i, &[u16; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m256i, [u16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u16x16(self, a: &mut u16x16<Self>) -> &mut [u16; 16usize] {
-        unsafe { core::mem::transmute::<&mut __m256i, &mut [u16; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m256i, [u16; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
@@ -4125,11 +4125,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
-        unsafe { core::mem::transmute::<&__m256i, &[i32; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m256i, [i32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i32x8(self, a: &mut i32x8<Self>) -> &mut [i32; 8usize] {
-        unsafe { core::mem::transmute::<&mut __m256i, &mut [i32; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m256i, [i32; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
@@ -4393,11 +4393,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
-        unsafe { core::mem::transmute::<&__m256i, &[u32; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m256i, [u32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u32x8(self, a: &mut u32x8<Self>) -> &mut [u32; 8usize] {
-        unsafe { core::mem::transmute::<&mut __m256i, &mut [u32; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m256i, [u32; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
@@ -4770,11 +4770,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
-        unsafe { core::mem::transmute::<&__m256d, &[f64; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m256d, [f64; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f64x4(self, a: &mut f64x4<Self>) -> &mut [f64; 4usize] {
-        unsafe { core::mem::transmute::<&mut __m256d, &mut [f64; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m256d, [f64; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
@@ -5163,11 +5163,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
-        unsafe { core::mem::transmute::<&[__m256; 2usize], &[f32; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m256; 2usize], [f32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f32x16(self, a: &mut f32x16<Self>) -> &mut [f32; 16usize] {
-        unsafe { core::mem::transmute::<&mut [__m256; 2usize], &mut [f32; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m256; 2usize], [f32; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
@@ -5586,11 +5586,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
-        unsafe { core::mem::transmute::<&[__m256i; 2usize], &[i8; 64usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [i8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i8x64(self, a: &mut i8x64<Self>) -> &mut [i8; 64usize] {
-        unsafe { core::mem::transmute::<&mut [__m256i; 2usize], &mut [i8; 64usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [i8; 64usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
@@ -5864,11 +5864,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
-        unsafe { core::mem::transmute::<&[__m256i; 2usize], &[u8; 64usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [u8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u8x64(self, a: &mut u8x64<Self>) -> &mut [u8; 64usize] {
-        unsafe { core::mem::transmute::<&mut [__m256i; 2usize], &mut [u8; 64usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [u8; 64usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
@@ -6331,11 +6331,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
-        unsafe { core::mem::transmute::<&[__m256i; 2usize], &[i16; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [i16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i16x32(self, a: &mut i16x32<Self>) -> &mut [i16; 32usize] {
-        unsafe { core::mem::transmute::<&mut [__m256i; 2usize], &mut [i16; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [i16; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
@@ -6618,11 +6618,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
-        unsafe { core::mem::transmute::<&[__m256i; 2usize], &[u16; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [u16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u16x32(self, a: &mut u16x32<Self>) -> &mut [u16; 32usize] {
-        unsafe { core::mem::transmute::<&mut [__m256i; 2usize], &mut [u16; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [u16; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
@@ -7089,11 +7089,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
-        unsafe { core::mem::transmute::<&[__m256i; 2usize], &[i32; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [i32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i32x16(self, a: &mut i32x16<Self>) -> &mut [i32; 16usize] {
-        unsafe { core::mem::transmute::<&mut [__m256i; 2usize], &mut [i32; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [i32; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
@@ -7372,11 +7372,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
-        unsafe { core::mem::transmute::<&[__m256i; 2usize], &[u32; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [u32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u32x16(self, a: &mut u32x16<Self>) -> &mut [u32; 16usize] {
-        unsafe { core::mem::transmute::<&mut [__m256i; 2usize], &mut [u32; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [u32; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
@@ -7816,11 +7816,11 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
-        unsafe { core::mem::transmute::<&[__m256d; 2usize], &[f64; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m256d; 2usize], [f64; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f64x8(self, a: &mut f64x8<Self>) -> &mut [f64; 8usize] {
-        unsafe { core::mem::transmute::<&mut [__m256d; 2usize], &mut [f64; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m256d; 2usize], [f64; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -110,11 +110,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
-        unsafe { core::mem::transmute::<&float32x4_t, &[f32; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<float32x4_t, [f32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f32x4(self, a: &mut f32x4<Self>) -> &mut [f32; 4usize] {
-        unsafe { core::mem::transmute::<&mut float32x4_t, &mut [f32; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<float32x4_t, [f32; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
@@ -371,11 +371,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
-        unsafe { core::mem::transmute::<&int8x16_t, &[i8; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<int8x16_t, [i8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i8x16(self, a: &mut i8x16<Self>) -> &mut [i8; 16usize] {
-        unsafe { core::mem::transmute::<&mut int8x16_t, &mut [i8; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<int8x16_t, [i8; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
@@ -577,11 +577,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
-        unsafe { core::mem::transmute::<&uint8x16_t, &[u8; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<uint8x16_t, [u8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u8x16(self, a: &mut u8x16<Self>) -> &mut [u8; 16usize] {
-        unsafe { core::mem::transmute::<&mut uint8x16_t, &mut [u8; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<uint8x16_t, [u8; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
@@ -879,11 +879,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
-        unsafe { core::mem::transmute::<&int16x8_t, &[i16; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<int16x8_t, [i16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i16x8(self, a: &mut i16x8<Self>) -> &mut [i16; 8usize] {
-        unsafe { core::mem::transmute::<&mut int16x8_t, &mut [i16; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<int16x8_t, [i16; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
@@ -1085,11 +1085,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
-        unsafe { core::mem::transmute::<&uint16x8_t, &[u16; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<uint16x8_t, [u16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u16x8(self, a: &mut u16x8<Self>) -> &mut [u16; 8usize] {
-        unsafe { core::mem::transmute::<&mut uint16x8_t, &mut [u16; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<uint16x8_t, [u16; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
@@ -1374,11 +1374,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
-        unsafe { core::mem::transmute::<&int32x4_t, &[i32; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<int32x4_t, [i32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i32x4(self, a: &mut i32x4<Self>) -> &mut [i32; 4usize] {
-        unsafe { core::mem::transmute::<&mut int32x4_t, &mut [i32; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<int32x4_t, [i32; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
@@ -1584,11 +1584,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
-        unsafe { core::mem::transmute::<&uint32x4_t, &[u32; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<uint32x4_t, [u32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u32x4(self, a: &mut u32x4<Self>) -> &mut [u32; 4usize] {
-        unsafe { core::mem::transmute::<&mut uint32x4_t, &mut [u32; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<uint32x4_t, [u32; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
@@ -1873,11 +1873,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
-        unsafe { core::mem::transmute::<&float64x2_t, &[f64; 2usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<float64x2_t, [f64; 2usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f64x2(self, a: &mut f64x2<Self>) -> &mut [f64; 2usize] {
-        unsafe { core::mem::transmute::<&mut float64x2_t, &mut [f64; 2usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<float64x2_t, [f64; 2usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
@@ -2194,11 +2194,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
-        unsafe { core::mem::transmute::<&float32x4x2_t, &[f32; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<float32x4x2_t, [f32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f32x8(self, a: &mut f32x8<Self>) -> &mut [f32; 8usize] {
-        unsafe { core::mem::transmute::<&mut float32x4x2_t, &mut [f32; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<float32x4x2_t, [f32; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
@@ -2594,11 +2594,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
-        unsafe { core::mem::transmute::<&int8x16x2_t, &[i8; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<int8x16x2_t, [i8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i8x32(self, a: &mut i8x32<Self>) -> &mut [i8; 32usize] {
-        unsafe { core::mem::transmute::<&mut int8x16x2_t, &mut [i8; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<int8x16x2_t, [i8; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
@@ -2901,11 +2901,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
-        unsafe { core::mem::transmute::<&uint8x16x2_t, &[u8; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<uint8x16x2_t, [u8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u8x32(self, a: &mut u8x32<Self>) -> &mut [u8; 32usize] {
-        unsafe { core::mem::transmute::<&mut uint8x16x2_t, &mut [u8; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<uint8x16x2_t, [u8; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
@@ -3318,11 +3318,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
-        unsafe { core::mem::transmute::<&int16x8x2_t, &[i16; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<int16x8x2_t, [i16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i16x16(self, a: &mut i16x16<Self>) -> &mut [i16; 16usize] {
-        unsafe { core::mem::transmute::<&mut int16x8x2_t, &mut [i16; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<int16x8x2_t, [i16; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
@@ -3625,11 +3625,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
-        unsafe { core::mem::transmute::<&uint16x8x2_t, &[u16; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<uint16x8x2_t, [u16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u16x16(self, a: &mut u16x16<Self>) -> &mut [u16; 16usize] {
-        unsafe { core::mem::transmute::<&mut uint16x8x2_t, &mut [u16; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<uint16x8x2_t, [u16; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
@@ -4051,11 +4051,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
-        unsafe { core::mem::transmute::<&int32x4x2_t, &[i32; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<int32x4x2_t, [i32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i32x8(self, a: &mut i32x8<Self>) -> &mut [i32; 8usize] {
-        unsafe { core::mem::transmute::<&mut int32x4x2_t, &mut [i32; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<int32x4x2_t, [i32; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
@@ -4363,11 +4363,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
-        unsafe { core::mem::transmute::<&uint32x4x2_t, &[u32; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<uint32x4x2_t, [u32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u32x8(self, a: &mut u32x8<Self>) -> &mut [u32; 8usize] {
-        unsafe { core::mem::transmute::<&mut uint32x4x2_t, &mut [u32; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<uint32x4x2_t, [u32; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
@@ -4777,11 +4777,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
-        unsafe { core::mem::transmute::<&float64x2x2_t, &[f64; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<float64x2x2_t, [f64; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f64x4(self, a: &mut f64x4<Self>) -> &mut [f64; 4usize] {
-        unsafe { core::mem::transmute::<&mut float64x2x2_t, &mut [f64; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<float64x2x2_t, [f64; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
@@ -5245,11 +5245,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
-        unsafe { core::mem::transmute::<&float32x4x4_t, &[f32; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<float32x4x4_t, [f32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f32x16(self, a: &mut f32x16<Self>) -> &mut [f32; 16usize] {
-        unsafe { core::mem::transmute::<&mut float32x4x4_t, &mut [f32; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<float32x4x4_t, [f32; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
@@ -5662,11 +5662,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
-        unsafe { core::mem::transmute::<&int8x16x4_t, &[i8; 64usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<int8x16x4_t, [i8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i8x64(self, a: &mut i8x64<Self>) -> &mut [i8; 64usize] {
-        unsafe { core::mem::transmute::<&mut int8x16x4_t, &mut [i8; 64usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<int8x16x4_t, [i8; 64usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
@@ -5978,11 +5978,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
-        unsafe { core::mem::transmute::<&uint8x16x4_t, &[u8; 64usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<uint8x16x4_t, [u8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u8x64(self, a: &mut u8x64<Self>) -> &mut [u8; 64usize] {
-        unsafe { core::mem::transmute::<&mut uint8x16x4_t, &mut [u8; 64usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<uint8x16x4_t, [u8; 64usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
@@ -6398,11 +6398,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
-        unsafe { core::mem::transmute::<&int16x8x4_t, &[i16; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<int16x8x4_t, [i16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i16x32(self, a: &mut i16x32<Self>) -> &mut [i16; 32usize] {
-        unsafe { core::mem::transmute::<&mut int16x8x4_t, &mut [i16; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<int16x8x4_t, [i16; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
@@ -6723,11 +6723,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
-        unsafe { core::mem::transmute::<&uint16x8x4_t, &[u16; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<uint16x8x4_t, [u16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u16x32(self, a: &mut u16x32<Self>) -> &mut [u16; 32usize] {
-        unsafe { core::mem::transmute::<&mut uint16x8x4_t, &mut [u16; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<uint16x8x4_t, [u16; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
@@ -7165,11 +7165,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
-        unsafe { core::mem::transmute::<&int32x4x4_t, &[i32; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<int32x4x4_t, [i32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i32x16(self, a: &mut i32x16<Self>) -> &mut [i32; 16usize] {
-        unsafe { core::mem::transmute::<&mut int32x4x4_t, &mut [i32; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<int32x4x4_t, [i32; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
@@ -7486,11 +7486,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
-        unsafe { core::mem::transmute::<&uint32x4x4_t, &[u32; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<uint32x4x4_t, [u32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u32x16(self, a: &mut u32x16<Self>) -> &mut [u32; 16usize] {
-        unsafe { core::mem::transmute::<&mut uint32x4x4_t, &mut [u32; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<uint32x4x4_t, [u32; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
@@ -7908,11 +7908,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
-        unsafe { core::mem::transmute::<&float64x2x4_t, &[f64; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<float64x2x4_t, [f64; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f64x8(self, a: &mut f64x8<Self>) -> &mut [f64; 8usize] {
-        unsafe { core::mem::transmute::<&mut float64x2x4_t, &mut [f64; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<float64x2x4_t, [f64; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -146,11 +146,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
-        unsafe { core::mem::transmute::<&__m128, &[f32; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128, [f32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f32x4(self, a: &mut f32x4<Self>) -> &mut [f32; 4usize] {
-        unsafe { core::mem::transmute::<&mut __m128, &mut [f32; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128, [f32; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
@@ -455,11 +455,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
-        unsafe { core::mem::transmute::<&__m128i, &[i8; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128i, [i8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i8x16(self, a: &mut i8x16<Self>) -> &mut [i8; 16usize] {
-        unsafe { core::mem::transmute::<&mut __m128i, &mut [i8; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128i, [i8; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
@@ -688,11 +688,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
-        unsafe { core::mem::transmute::<&__m128i, &[u8; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128i, [u8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u8x16(self, a: &mut u8x16<Self>) -> &mut [u8; 16usize] {
-        unsafe { core::mem::transmute::<&mut __m128i, &mut [u8; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128i, [u8; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
@@ -1022,11 +1022,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
-        unsafe { core::mem::transmute::<&__m128i, &[i16; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128i, [i16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i16x8(self, a: &mut i16x8<Self>) -> &mut [i16; 8usize] {
-        unsafe { core::mem::transmute::<&mut __m128i, &mut [i16; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128i, [i16; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
@@ -1230,11 +1230,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
-        unsafe { core::mem::transmute::<&__m128i, &[u16; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128i, [u16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u16x8(self, a: &mut u16x8<Self>) -> &mut [u16; 8usize] {
-        unsafe { core::mem::transmute::<&mut __m128i, &mut [u16; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128i, [u16; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
@@ -1534,11 +1534,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
-        unsafe { core::mem::transmute::<&__m128i, &[i32; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128i, [i32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i32x4(self, a: &mut i32x4<Self>) -> &mut [i32; 4usize] {
-        unsafe { core::mem::transmute::<&mut __m128i, &mut [i32; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128i, [i32; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
@@ -1744,11 +1744,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
-        unsafe { core::mem::transmute::<&__m128i, &[u32; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128i, [u32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u32x4(self, a: &mut u32x4<Self>) -> &mut [u32; 4usize] {
-        unsafe { core::mem::transmute::<&mut __m128i, &mut [u32; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128i, [u32; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
@@ -2051,11 +2051,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
-        unsafe { core::mem::transmute::<&__m128d, &[f64; 2usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<__m128d, [f64; 2usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f64x2(self, a: &mut f64x2<Self>) -> &mut [f64; 2usize] {
-        unsafe { core::mem::transmute::<&mut __m128d, &mut [f64; 2usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<__m128d, [f64; 2usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
@@ -2375,11 +2375,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
-        unsafe { core::mem::transmute::<&[__m128; 2usize], &[f32; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128; 2usize], [f32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f32x8(self, a: &mut f32x8<Self>) -> &mut [f32; 8usize] {
-        unsafe { core::mem::transmute::<&mut [__m128; 2usize], &mut [f32; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128; 2usize], [f32; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
@@ -2753,11 +2753,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
-        unsafe { core::mem::transmute::<&[__m128i; 2usize], &[i8; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [i8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i8x32(self, a: &mut i8x32<Self>) -> &mut [i8; 32usize] {
-        unsafe { core::mem::transmute::<&mut [__m128i; 2usize], &mut [i8; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [i8; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
@@ -3038,11 +3038,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
-        unsafe { core::mem::transmute::<&[__m128i; 2usize], &[u8; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [u8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u8x32(self, a: &mut u8x32<Self>) -> &mut [u8; 32usize] {
-        unsafe { core::mem::transmute::<&mut [__m128i; 2usize], &mut [u8; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [u8; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
@@ -3431,11 +3431,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
-        unsafe { core::mem::transmute::<&[__m128i; 2usize], &[i16; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [i16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i16x16(self, a: &mut i16x16<Self>) -> &mut [i16; 16usize] {
-        unsafe { core::mem::transmute::<&mut [__m128i; 2usize], &mut [i16; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [i16; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
@@ -3716,11 +3716,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
-        unsafe { core::mem::transmute::<&[__m128i; 2usize], &[u16; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [u16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u16x16(self, a: &mut u16x16<Self>) -> &mut [u16; 16usize] {
-        unsafe { core::mem::transmute::<&mut [__m128i; 2usize], &mut [u16; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [u16; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
@@ -4122,11 +4122,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
-        unsafe { core::mem::transmute::<&[__m128i; 2usize], &[i32; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [i32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i32x8(self, a: &mut i32x8<Self>) -> &mut [i32; 8usize] {
-        unsafe { core::mem::transmute::<&mut [__m128i; 2usize], &mut [i32; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [i32; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
@@ -4412,11 +4412,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
-        unsafe { core::mem::transmute::<&[__m128i; 2usize], &[u32; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [u32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u32x8(self, a: &mut u32x8<Self>) -> &mut [u32; 8usize] {
-        unsafe { core::mem::transmute::<&mut [__m128i; 2usize], &mut [u32; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [u32; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
@@ -4802,11 +4802,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
-        unsafe { core::mem::transmute::<&[__m128d; 2usize], &[f64; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128d; 2usize], [f64; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f64x4(self, a: &mut f64x4<Self>) -> &mut [f64; 4usize] {
-        unsafe { core::mem::transmute::<&mut [__m128d; 2usize], &mut [f64; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128d; 2usize], [f64; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
@@ -5246,11 +5246,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
-        unsafe { core::mem::transmute::<&[__m128; 4usize], &[f32; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128; 4usize], [f32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f32x16(self, a: &mut f32x16<Self>) -> &mut [f32; 16usize] {
-        unsafe { core::mem::transmute::<&mut [__m128; 4usize], &mut [f32; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128; 4usize], [f32; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
@@ -5669,11 +5669,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
-        unsafe { core::mem::transmute::<&[__m128i; 4usize], &[i8; 64usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [i8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i8x64(self, a: &mut i8x64<Self>) -> &mut [i8; 64usize] {
-        unsafe { core::mem::transmute::<&mut [__m128i; 4usize], &mut [i8; 64usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [i8; 64usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
@@ -5947,11 +5947,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
-        unsafe { core::mem::transmute::<&[__m128i; 4usize], &[u8; 64usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [u8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u8x64(self, a: &mut u8x64<Self>) -> &mut [u8; 64usize] {
-        unsafe { core::mem::transmute::<&mut [__m128i; 4usize], &mut [u8; 64usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [u8; 64usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
@@ -6420,11 +6420,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
-        unsafe { core::mem::transmute::<&[__m128i; 4usize], &[i16; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [i16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i16x32(self, a: &mut i16x32<Self>) -> &mut [i16; 32usize] {
-        unsafe { core::mem::transmute::<&mut [__m128i; 4usize], &mut [i16; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [i16; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
@@ -6707,11 +6707,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
-        unsafe { core::mem::transmute::<&[__m128i; 4usize], &[u16; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [u16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u16x32(self, a: &mut u16x32<Self>) -> &mut [u16; 32usize] {
-        unsafe { core::mem::transmute::<&mut [__m128i; 4usize], &mut [u16; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [u16; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
@@ -7170,11 +7170,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
-        unsafe { core::mem::transmute::<&[__m128i; 4usize], &[i32; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [i32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i32x16(self, a: &mut i32x16<Self>) -> &mut [i32; 16usize] {
-        unsafe { core::mem::transmute::<&mut [__m128i; 4usize], &mut [i32; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [i32; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
@@ -7453,11 +7453,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
-        unsafe { core::mem::transmute::<&[__m128i; 4usize], &[u32; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [u32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u32x16(self, a: &mut u32x16<Self>) -> &mut [u32; 16usize] {
-        unsafe { core::mem::transmute::<&mut [__m128i; 4usize], &mut [u32; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [u32; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
@@ -7881,11 +7881,11 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
-        unsafe { core::mem::transmute::<&[__m128d; 4usize], &[f64; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[__m128d; 4usize], [f64; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f64x8(self, a: &mut f64x8<Self>) -> &mut [f64; 8usize] {
-        unsafe { core::mem::transmute::<&mut [__m128d; 4usize], &mut [f64; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[__m128d; 4usize], [f64; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -109,11 +109,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
-        unsafe { core::mem::transmute::<&v128, &[f32; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<v128, [f32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f32x4(self, a: &mut f32x4<Self>) -> &mut [f32; 4usize] {
-        unsafe { core::mem::transmute::<&mut v128, &mut [f32; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<v128, [f32; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
@@ -411,11 +411,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
-        unsafe { core::mem::transmute::<&v128, &[i8; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<v128, [i8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i8x16(self, a: &mut i8x16<Self>) -> &mut [i8; 16usize] {
-        unsafe { core::mem::transmute::<&mut v128, &mut [i8; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<v128, [i8; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
@@ -632,11 +632,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
-        unsafe { core::mem::transmute::<&v128, &[u8; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<v128, [u8; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u8x16(self, a: &mut u8x16<Self>) -> &mut [u8; 16usize] {
-        unsafe { core::mem::transmute::<&mut v128, &mut [u8; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<v128, [u8; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
@@ -939,11 +939,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
-        unsafe { core::mem::transmute::<&v128, &[i16; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<v128, [i16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i16x8(self, a: &mut i16x8<Self>) -> &mut [i16; 8usize] {
-        unsafe { core::mem::transmute::<&mut v128, &mut [i16; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<v128, [i16; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
@@ -1144,11 +1144,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
-        unsafe { core::mem::transmute::<&v128, &[u16; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<v128, [u16; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u16x8(self, a: &mut u16x8<Self>) -> &mut [u16; 8usize] {
-        unsafe { core::mem::transmute::<&mut v128, &mut [u16; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<v128, [u16; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
@@ -1431,11 +1431,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
-        unsafe { core::mem::transmute::<&v128, &[i32; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<v128, [i32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i32x4(self, a: &mut i32x4<Self>) -> &mut [i32; 4usize] {
-        unsafe { core::mem::transmute::<&mut v128, &mut [i32; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<v128, [i32; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
@@ -1640,11 +1640,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
-        unsafe { core::mem::transmute::<&v128, &[u32; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<v128, [u32; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u32x4(self, a: &mut u32x4<Self>) -> &mut [u32; 4usize] {
-        unsafe { core::mem::transmute::<&mut v128, &mut [u32; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<v128, [u32; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
@@ -1927,11 +1927,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
-        unsafe { core::mem::transmute::<&v128, &[f64; 2usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<v128, [f64; 2usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f64x2(self, a: &mut f64x2<Self>) -> &mut [f64; 2usize] {
-        unsafe { core::mem::transmute::<&mut v128, &mut [f64; 2usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<v128, [f64; 2usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
@@ -2274,11 +2274,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
-        unsafe { core::mem::transmute::<&[v128; 2usize], &[f32; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 2usize], [f32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f32x8(self, a: &mut f32x8<Self>) -> &mut [f32; 8usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 2usize], &mut [f32; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 2usize], [f32; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
@@ -2652,11 +2652,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
-        unsafe { core::mem::transmute::<&[v128; 2usize], &[i8; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 2usize], [i8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i8x32(self, a: &mut i8x32<Self>) -> &mut [i8; 32usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 2usize], &mut [i8; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 2usize], [i8; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
@@ -2937,11 +2937,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
-        unsafe { core::mem::transmute::<&[v128; 2usize], &[u8; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 2usize], [u8; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u8x32(self, a: &mut u8x32<Self>) -> &mut [u8; 32usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 2usize], &mut [u8; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 2usize], [u8; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
@@ -3330,11 +3330,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
-        unsafe { core::mem::transmute::<&[v128; 2usize], &[i16; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 2usize], [i16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i16x16(self, a: &mut i16x16<Self>) -> &mut [i16; 16usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 2usize], &mut [i16; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 2usize], [i16; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
@@ -3615,11 +3615,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
-        unsafe { core::mem::transmute::<&[v128; 2usize], &[u16; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 2usize], [u16; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u16x16(self, a: &mut u16x16<Self>) -> &mut [u16; 16usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 2usize], &mut [u16; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 2usize], [u16; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
@@ -4017,11 +4017,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
-        unsafe { core::mem::transmute::<&[v128; 2usize], &[i32; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 2usize], [i32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i32x8(self, a: &mut i32x8<Self>) -> &mut [i32; 8usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 2usize], &mut [i32; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 2usize], [i32; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
@@ -4307,11 +4307,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
-        unsafe { core::mem::transmute::<&[v128; 2usize], &[u32; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 2usize], [u32; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u32x8(self, a: &mut u32x8<Self>) -> &mut [u32; 8usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 2usize], &mut [u32; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 2usize], [u32; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
@@ -4697,11 +4697,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
-        unsafe { core::mem::transmute::<&[v128; 2usize], &[f64; 4usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 2usize], [f64; 4usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f64x4(self, a: &mut f64x4<Self>) -> &mut [f64; 4usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 2usize], &mut [f64; 4usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 2usize], [f64; 4usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
@@ -5141,11 +5141,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
-        unsafe { core::mem::transmute::<&[v128; 4usize], &[f32; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 4usize], [f32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f32x16(self, a: &mut f32x16<Self>) -> &mut [f32; 16usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 4usize], &mut [f32; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 4usize], [f32; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
@@ -5557,11 +5557,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
-        unsafe { core::mem::transmute::<&[v128; 4usize], &[i8; 64usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 4usize], [i8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i8x64(self, a: &mut i8x64<Self>) -> &mut [i8; 64usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 4usize], &mut [i8; 64usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 4usize], [i8; 64usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
@@ -5835,11 +5835,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
-        unsafe { core::mem::transmute::<&[v128; 4usize], &[u8; 64usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 4usize], [u8; 64usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u8x64(self, a: &mut u8x64<Self>) -> &mut [u8; 64usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 4usize], &mut [u8; 64usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 4usize], [u8; 64usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
@@ -6278,11 +6278,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
-        unsafe { core::mem::transmute::<&[v128; 4usize], &[i16; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 4usize], [i16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i16x32(self, a: &mut i16x32<Self>) -> &mut [i16; 32usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 4usize], &mut [i16; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 4usize], [i16; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
@@ -6565,11 +6565,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
-        unsafe { core::mem::transmute::<&[v128; 4usize], &[u16; 32usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 4usize], [u16; 32usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u16x32(self, a: &mut u16x32<Self>) -> &mut [u16; 32usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 4usize], &mut [u16; 32usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 4usize], [u16; 32usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
@@ -7006,11 +7006,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
-        unsafe { core::mem::transmute::<&[v128; 4usize], &[i32; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 4usize], [i32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_i32x16(self, a: &mut i32x16<Self>) -> &mut [i32; 16usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 4usize], &mut [i32; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 4usize], [i32; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
@@ -7289,11 +7289,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
-        unsafe { core::mem::transmute::<&[v128; 4usize], &[u32; 16usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 4usize], [u32; 16usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_u32x16(self, a: &mut u32x16<Self>) -> &mut [u32; 16usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 4usize], &mut [u32; 16usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 4usize], [u32; 16usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
@@ -7710,11 +7710,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
-        unsafe { core::mem::transmute::<&[v128; 4usize], &[f64; 8usize]>(&a.val.0) }
+        crate::transmute::checked_cast_ref::<[v128; 4usize], [f64; 8usize]>(&a.val.0)
     }
     #[inline(always)]
     fn as_array_mut_f64x8(self, a: &mut f64x8<Self>) -> &mut [f64; 8usize] {
-        unsafe { core::mem::transmute::<&mut [v128; 4usize], &mut [f64; 8usize]>(&mut a.val.0) }
+        crate::transmute::checked_cast_mut::<[v128; 4usize], [f64; 8usize]>(&mut a.val.0)
     }
     #[inline(always)]
     fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {

--- a/fearless_simd/src/transmute.rs
+++ b/fearless_simd/src/transmute.rs
@@ -245,6 +245,7 @@ pub(crate) fn checked_transmute_copy<Src: SimdPod, Dst: SimdPod>(src: &Src) -> D
     clippy::disallowed_methods,
     reason = "This is the central checked wrapper around transmute"
 )]
+#[allow(dead_code, reason = "Not all backends use this function")]
 pub(crate) fn checked_cast_ref<Src: SimdPod, Dst: SimdPod>(src: &Src) -> &Dst {
     const {
         assert!(
@@ -272,6 +273,7 @@ pub(crate) fn checked_cast_ref<Src: SimdPod, Dst: SimdPod>(src: &Src) -> &Dst {
     clippy::disallowed_methods,
     reason = "This is the central checked wrapper around transmute"
 )]
+#[allow(dead_code, reason = "Not all backends use this function")]
 pub(crate) fn checked_cast_mut<Src: SimdPod, Dst: SimdPod>(src: &mut Src) -> &mut Dst {
     const {
         assert!(

--- a/fearless_simd/src/transmute.rs
+++ b/fearless_simd/src/transmute.rs
@@ -6,7 +6,7 @@
 //! This all serves a single `checked_transmute_copy` function,
 //! if we find this growing in complexity we should probably just use the real bytemuck
 
-use core::mem::size_of;
+use core::mem::{align_of, size_of};
 
 use crate::support::{Aligned128, Aligned256, Aligned512};
 
@@ -236,4 +236,58 @@ pub(crate) fn checked_transmute_copy<Src: SimdPod, Dst: SimdPod>(src: &Src) -> D
     // Safety: `SimdPod` guarantees source and destination validity for all bit patterns, and
     // the const assertion above prevents the "destination larger than source" failure mode.
     unsafe { core::mem::transmute_copy(src) }
+}
+
+/// Like `bytemuck::cast_ref`, but rejects incompatible types at compile time
+/// and only accepts this crate's SIMD plain-old-data storage types.
+#[inline(always)]
+#[allow(
+    clippy::disallowed_methods,
+    reason = "This is the central checked wrapper around transmute"
+)]
+pub(crate) fn checked_cast_ref<Src: SimdPod, Dst: SimdPod>(src: &Src) -> &Dst {
+    const {
+        assert!(
+            size_of::<Src>() == size_of::<Dst>(),
+            "checked_cast_ref requires source and destination to have the same size"
+        );
+        assert!(
+            align_of::<Src>() >= align_of::<Dst>(),
+            "checked_cast_ref requires source to have alignment equal or greater to the destination"
+        );
+    }
+    // Safety: `SimdPod` guarantees source and destination validity for all bit patterns, and
+    // the const assertions above enforce compatible size and alignment.
+    //
+    // The pointer cast has less footguns than `transmute`:
+    // `src as *const Src` keeps the same address and provenance from the original reference,
+    // so we will never run into lifetime issues.
+    unsafe { &*(src as *const Src).cast::<Dst>() }
+}
+
+/// Like `bytemuck::cast_mut`, but rejects incompatible types at compile time
+/// and only accepts this crate's SIMD plain-old-data storage types.
+#[inline(always)]
+#[allow(
+    clippy::disallowed_methods,
+    reason = "This is the central checked wrapper around transmute"
+)]
+pub(crate) fn checked_cast_mut<Src: SimdPod, Dst: SimdPod>(src: &mut Src) -> &mut Dst {
+    const {
+        assert!(
+            size_of::<Src>() == size_of::<Dst>(),
+            "checked_cast_mut requires source and destination to have the same size"
+        );
+        assert!(
+            align_of::<Src>() >= align_of::<Dst>(),
+            "checked_cast_mut requires source to have alignment equal or greater to the destination"
+        );
+    }
+    // Safety: `SimdPod` guarantees source and destination validity for all bit patterns, and
+    // the const assertions above enforce compatible size and alignment.
+    //
+    // The pointer cast has less footguns than `transmute`:
+    // `src as *mut Src` keeps the same address and provenance from the original reference,
+    // so we will never run into lifetime issues.
+    unsafe { &mut *(src as *mut Src).cast::<Dst>() }
 }

--- a/fearless_simd/src/transmute.rs
+++ b/fearless_simd/src/transmute.rs
@@ -252,6 +252,9 @@ pub(crate) fn checked_cast_ref<Src: SimdPod, Dst: SimdPod>(src: &Src) -> &Dst {
             size_of::<Src>() == size_of::<Dst>(),
             "checked_cast_ref requires source and destination to have the same size"
         );
+        // alignment is always a power of two as per Rust Reference:
+        // https://doc.rust-lang.org/stable/reference/type-layout.html#size-and-alignment
+        // so >= is sufficient and won't run into issues with coprime alignments
         assert!(
             align_of::<Src>() >= align_of::<Dst>(),
             "checked_cast_ref requires source to have alignment equal or greater to the destination"
@@ -280,6 +283,9 @@ pub(crate) fn checked_cast_mut<Src: SimdPod, Dst: SimdPod>(src: &mut Src) -> &mu
             size_of::<Src>() == size_of::<Dst>(),
             "checked_cast_mut requires source and destination to have the same size"
         );
+        // alignment is always a power of two as per Rust Reference:
+        // https://doc.rust-lang.org/stable/reference/type-layout.html#size-and-alignment
+        // so >= is sufficient and won't run into issues with coprime alignments
         assert!(
             align_of::<Src>() >= align_of::<Dst>(),
             "checked_cast_mut requires source to have alignment equal or greater to the destination"

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -410,23 +410,16 @@ pub(crate) fn generic_as_array<T: ToTokens>(
                 crate::transmute::checked_transmute_copy::<#native_ty, [#rust_scalar; #num_scalars]>(&a.val.0)
             }
         },
-        RefKind::Ref | RefKind::Mut => {
-            let ref_tok = kind.token();
-            quote! {
-                #method_sig {
-                    unsafe {
-                        // Safety: The native vector type backing any implementation will be:
-                        // - A `#[repr(simd)]` type, which has the same layout as an array of scalars
-                        // - An array of `#[repr(simd)]` types
-                        // - For AArch64 specifically, a `#[repr(C)]` tuple of `#[repr(simd)]` types
-                        //
-                        // Not only do these all have the same layout as a flat array of the corresponding scalars, but they
-                        // wrap primitives where all bit patterns are valid (ints and floats).
-                        core::mem::transmute::<#ref_tok #native_ty, #ref_tok [#rust_scalar; #num_scalars]>(#ref_tok a.val.0)
-                    }
-                }
+        RefKind::Ref => quote! {
+            #method_sig {
+                crate::transmute::checked_cast_ref::<#native_ty, [#rust_scalar; #num_scalars]>(&a.val.0)
             }
-        }
+        },
+        RefKind::Mut => quote! {
+            #method_sig {
+                crate::transmute::checked_cast_mut::<#native_ty, [#rust_scalar; #num_scalars]>(&mut a.val.0)
+            }
+        },
     }
 }
 

--- a/fearless_simd_tests/tests/harness/lm_generated/mod_256.rs
+++ b/fearless_simd_tests/tests/harness/lm_generated/mod_256.rs
@@ -298,22 +298,21 @@ fn trunc_f32x8_special_values<S: Simd>(simd: S) {
     );
     let result = a.trunc();
 
-    // Note: f32::NAN != f32::NAN hence we transmute to compare the bit pattern
-    unsafe {
-        assert_eq!(
-            std::mem::transmute::<[f32; 8], [u32; 8]>(*result),
-            std::mem::transmute::<[f32; 8], [u32; 8]>([
-                f32::NAN,
-                f32::NEG_INFINITY,
-                f32::INFINITY,
-                -f32::NAN,
-                f32::NAN,
-                f32::NEG_INFINITY,
-                f32::INFINITY,
-                -f32::NAN
-            ])
-        );
-    }
+    // Note: f32::NAN != f32::NAN hence we compare the bit pattern.
+    assert_eq!(
+        (*result).map(f32::to_bits),
+        [
+            f32::NAN,
+            f32::NEG_INFINITY,
+            f32::INFINITY,
+            -f32::NAN,
+            f32::NAN,
+            f32::NEG_INFINITY,
+            f32::INFINITY,
+            -f32::NAN
+        ]
+        .map(f32::to_bits)
+    );
 }
 
 #[simd_test]

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -247,18 +247,11 @@ fn trunc_f32x4_special_values<S: Simd>(simd: S) {
     );
     let result = a.trunc();
 
-    // Note: f32::NAN != f32::NAN hence we transmute to compare the bit pattern
-    unsafe {
-        assert_eq!(
-            std::mem::transmute::<[f32; 4], [u32; 4]>(*result),
-            std::mem::transmute::<[f32; 4], [u32; 4]>([
-                f32::NAN,
-                f32::NEG_INFINITY,
-                f32::INFINITY,
-                -f32::NAN
-            ])
-        );
-    }
+    // Note: f32::NAN != f32::NAN hence we compare the bit pattern.
+    assert_eq!(
+        (*result).map(f32::to_bits),
+        [f32::NAN, f32::NEG_INFINITY, f32::INFINITY, -f32::NAN].map(f32::to_bits)
+    );
 }
 
 #[simd_test]
@@ -942,13 +935,8 @@ fn store_interleaved_128_f32x16<S: Simd>(simd: S) {
         15.0,
     ];
 
-    // Note: f32::NAN != f32::NAN hence we transmute to compare the bit pattern
-    unsafe {
-        assert_eq!(
-            std::mem::transmute::<[f32; 16], [u32; 16]>(dest),
-            std::mem::transmute::<[f32; 16], [u32; 16]>(expected)
-        );
-    }
+    // Note: f32::NAN != f32::NAN hence we compare the bit pattern.
+    assert_eq!(dest.map(f32::to_bits), expected.map(f32::to_bits));
 }
 
 #[simd_test]


### PR DESCRIPTION
Stacked on top of #234

reimplements bytemuck::cast/cast_mut but more clearly zero-cost and failing at build time rather than at runtime

then uses those functions to expunge the remaining unchecked `transmute` calls

and bans unchecked transmute via clippy