### PR TITLE
Make SIMD stores safe

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -128,13 +128,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f32,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x4(self, a: u8x16<Self>) -> f32x4<Self> {
@@ -434,13 +428,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i8,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x16(self, a: u8x16<Self>) -> i8x16<Self> {
@@ -664,13 +652,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u8,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
@@ -987,13 +969,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i16,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x8(self, a: u8x16<Self>) -> i16x8<Self> {
@@ -1192,13 +1168,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u16,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x8(self, a: u8x16<Self>) -> u16x8<Self> {
@@ -1490,13 +1460,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i32,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x4(self, a: u8x16<Self>) -> i32x4<Self> {
@@ -1697,13 +1661,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u32,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x4(self, a: u8x16<Self>) -> u32x4<Self> {
@@ -1998,13 +1956,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f64,
-                dest.as_mut_ptr(),
-                2usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x2(self, a: u8x16<Self>) -> f64x2<Self> {
@@ -2315,13 +2267,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f32,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x8(self, a: u8x32<Self>) -> f32x8<Self> {
@@ -2684,13 +2630,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i8,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x32(self, a: u8x32<Self>) -> i8x32<Self> {
@@ -2997,13 +2937,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u8,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
@@ -3425,13 +3359,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i16,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x16(self, a: u8x32<Self>) -> i16x16<Self> {
@@ -3719,13 +3647,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u16,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x16(self, a: u8x32<Self>) -> u16x16<Self> {
@@ -4133,13 +4055,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i32,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x8(self, a: u8x32<Self>) -> i32x8<Self> {
@@ -4401,13 +4317,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u32,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x8(self, a: u8x32<Self>) -> u32x8<Self> {
@@ -4778,13 +4688,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f64,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x4(self, a: u8x32<Self>) -> f64x4<Self> {
@@ -5171,13 +5075,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f32,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x16(self, a: u8x64<Self>) -> f32x16<Self> {
@@ -5594,13 +5492,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i8,
-                dest.as_mut_ptr(),
-                64usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x64(self, a: u8x64<Self>) -> i8x64<Self> {
@@ -5872,13 +5764,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u8,
-                dest.as_mut_ptr(),
-                64usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
@@ -6339,13 +6225,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i16,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x32(self, a: u8x64<Self>) -> i16x32<Self> {
@@ -6626,13 +6506,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u16,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x32(self, a: u8x64<Self>) -> u16x32<Self> {
@@ -7097,13 +6971,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i32,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x16(self, a: u8x64<Self>) -> i32x16<Self> {
@@ -7380,13 +7248,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u32,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x16(self, a: u8x64<Self>) -> u32x16<Self> {
@@ -7824,13 +7686,7 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f64,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x8(self, a: u8x64<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -118,13 +118,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f32,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x4(self, a: u8x16<Self>) -> f32x4<Self> {
@@ -379,13 +373,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i8,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x16(self, a: u8x16<Self>) -> i8x16<Self> {
@@ -585,13 +573,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u8,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
@@ -890,13 +872,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i16,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x8(self, a: u8x16<Self>) -> i16x8<Self> {
@@ -1096,13 +1072,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u16,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x8(self, a: u8x16<Self>) -> u16x8<Self> {
@@ -1389,13 +1359,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i32,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x4(self, a: u8x16<Self>) -> i32x4<Self> {
@@ -1599,13 +1563,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u32,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x4(self, a: u8x16<Self>) -> u32x4<Self> {
@@ -1890,13 +1848,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f64,
-                dest.as_mut_ptr(),
-                2usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x2(self, a: u8x16<Self>) -> f64x2<Self> {
@@ -2211,13 +2163,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f32,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x8(self, a: u8x32<Self>) -> f32x8<Self> {
@@ -2611,13 +2557,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i8,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x32(self, a: u8x32<Self>) -> i8x32<Self> {
@@ -2918,13 +2858,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u8,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
@@ -3335,13 +3269,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i16,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x16(self, a: u8x32<Self>) -> i16x16<Self> {
@@ -3642,13 +3570,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u16,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x16(self, a: u8x32<Self>) -> u16x16<Self> {
@@ -4068,13 +3990,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i32,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x8(self, a: u8x32<Self>) -> i32x8<Self> {
@@ -4380,13 +4296,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u32,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x8(self, a: u8x32<Self>) -> u32x8<Self> {
@@ -4794,13 +4704,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f64,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x4(self, a: u8x32<Self>) -> f64x4<Self> {
@@ -5262,13 +5166,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f32,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x16(self, a: u8x64<Self>) -> f32x16<Self> {
@@ -5679,13 +5577,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i8,
-                dest.as_mut_ptr(),
-                64usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x64(self, a: u8x64<Self>) -> i8x64<Self> {
@@ -5995,13 +5887,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u8,
-                dest.as_mut_ptr(),
-                64usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
@@ -6415,13 +6301,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i16,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x32(self, a: u8x64<Self>) -> i16x32<Self> {
@@ -6740,13 +6620,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u16,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x32(self, a: u8x64<Self>) -> u16x32<Self> {
@@ -7182,13 +7056,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i32,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x16(self, a: u8x64<Self>) -> i32x16<Self> {
@@ -7503,13 +7371,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u32,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x16(self, a: u8x64<Self>) -> u32x16<Self> {
@@ -7925,13 +7787,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f64,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x8(self, a: u8x64<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -154,13 +154,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f32,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x4(self, a: u8x16<Self>) -> f32x4<Self> {
@@ -463,13 +457,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i8,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x16(self, a: u8x16<Self>) -> i8x16<Self> {
@@ -696,13 +684,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u8,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
@@ -1030,13 +1012,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i16,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x8(self, a: u8x16<Self>) -> i16x8<Self> {
@@ -1238,13 +1214,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u16,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x8(self, a: u8x16<Self>) -> u16x8<Self> {
@@ -1542,13 +1512,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i32,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x4(self, a: u8x16<Self>) -> i32x4<Self> {
@@ -1752,13 +1716,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u32,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x4(self, a: u8x16<Self>) -> u32x4<Self> {
@@ -2059,13 +2017,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f64,
-                dest.as_mut_ptr(),
-                2usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x2(self, a: u8x16<Self>) -> f64x2<Self> {
@@ -2383,13 +2335,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f32,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x8(self, a: u8x32<Self>) -> f32x8<Self> {
@@ -2761,13 +2707,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i8,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x32(self, a: u8x32<Self>) -> i8x32<Self> {
@@ -3046,13 +2986,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u8,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
@@ -3439,13 +3373,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i16,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x16(self, a: u8x32<Self>) -> i16x16<Self> {
@@ -3724,13 +3652,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u16,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x16(self, a: u8x32<Self>) -> u16x16<Self> {
@@ -4130,13 +4052,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i32,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x8(self, a: u8x32<Self>) -> i32x8<Self> {
@@ -4420,13 +4336,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u32,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x8(self, a: u8x32<Self>) -> u32x8<Self> {
@@ -4810,13 +4720,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f64,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x4(self, a: u8x32<Self>) -> f64x4<Self> {
@@ -5254,13 +5158,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f32,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x16(self, a: u8x64<Self>) -> f32x16<Self> {
@@ -5677,13 +5575,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i8,
-                dest.as_mut_ptr(),
-                64usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x64(self, a: u8x64<Self>) -> i8x64<Self> {
@@ -5955,13 +5847,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u8,
-                dest.as_mut_ptr(),
-                64usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
@@ -6428,13 +6314,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i16,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x32(self, a: u8x64<Self>) -> i16x32<Self> {
@@ -6715,13 +6595,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u16,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x32(self, a: u8x64<Self>) -> u16x32<Self> {
@@ -7178,13 +7052,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i32,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x16(self, a: u8x64<Self>) -> i32x16<Self> {
@@ -7461,13 +7329,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u32,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x16(self, a: u8x64<Self>) -> u32x16<Self> {
@@ -7889,13 +7751,7 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f64,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x8(self, a: u8x64<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -117,13 +117,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f32,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x4(self, a: u8x16<Self>) -> f32x4<Self> {
@@ -419,13 +413,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i8,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x16(self, a: u8x16<Self>) -> i8x16<Self> {
@@ -640,13 +628,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u8,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
@@ -947,13 +929,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i16,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x8(self, a: u8x16<Self>) -> i16x8<Self> {
@@ -1152,13 +1128,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u16,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x8(self, a: u8x16<Self>) -> u16x8<Self> {
@@ -1439,13 +1409,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i32,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x4(self, a: u8x16<Self>) -> i32x4<Self> {
@@ -1648,13 +1612,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u32,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x4(self, a: u8x16<Self>) -> u32x4<Self> {
@@ -1935,13 +1893,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f64,
-                dest.as_mut_ptr(),
-                2usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x2(self, a: u8x16<Self>) -> f64x2<Self> {
@@ -2282,13 +2234,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f32,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x8(self, a: u8x32<Self>) -> f32x8<Self> {
@@ -2660,13 +2606,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i8,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x32(self, a: u8x32<Self>) -> i8x32<Self> {
@@ -2945,13 +2885,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u8,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
@@ -3338,13 +3272,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i16,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x16(self, a: u8x32<Self>) -> i16x16<Self> {
@@ -3623,13 +3551,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u16,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x16(self, a: u8x32<Self>) -> u16x16<Self> {
@@ -4025,13 +3947,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i32,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x8(self, a: u8x32<Self>) -> i32x8<Self> {
@@ -4315,13 +4231,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u32,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x8(self, a: u8x32<Self>) -> u32x8<Self> {
@@ -4705,13 +4615,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f64,
-                dest.as_mut_ptr(),
-                4usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x4(self, a: u8x32<Self>) -> f64x4<Self> {
@@ -5149,13 +5053,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f32,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f32x16(self, a: u8x64<Self>) -> f32x16<Self> {
@@ -5565,13 +5463,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i8,
-                dest.as_mut_ptr(),
-                64usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i8x64(self, a: u8x64<Self>) -> i8x64<Self> {
@@ -5843,13 +5735,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u8,
-                dest.as_mut_ptr(),
-                64usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
@@ -6286,13 +6172,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i16,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i16x32(self, a: u8x64<Self>) -> i16x32<Self> {
@@ -6573,13 +6453,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u16,
-                dest.as_mut_ptr(),
-                32usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u16x32(self, a: u8x64<Self>) -> u16x32<Self> {
@@ -7014,13 +6888,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const i32,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_i32x16(self, a: u8x64<Self>) -> i32x16<Self> {
@@ -7297,13 +7165,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const u32,
-                dest.as_mut_ptr(),
-                16usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_u32x16(self, a: u8x64<Self>) -> u32x16<Self> {
@@ -7718,13 +7580,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const f64,
-                dest.as_mut_ptr(),
-                8usize,
-            );
-        }
+        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn cvt_from_bytes_f64x8(self, a: u8x64<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/transmute.rs
+++ b/fearless_simd/src/transmute.rs
@@ -3,7 +3,7 @@
 
 //! We have bytemuck at home
 //!
-//! This all serves a single `checked_transmute_copy` function,
+//! This all serves a small set of checked transmute and cast functions;
 //! if we find this growing in complexity we should probably just use the real bytemuck
 
 use core::mem::{align_of, size_of};
@@ -238,6 +238,29 @@ pub(crate) fn checked_transmute_copy<Src: SimdPod, Dst: SimdPod>(src: &Src) -> D
     // Safety: `SimdPod` guarantees source and destination validity for all bit patterns, and
     // the const assertion above prevents the "destination larger than source" failure mode.
     unsafe { core::mem::transmute_copy(src) }
+}
+
+/// Store a plain-old-data value into a differently typed same-sized destination.
+///
+/// This is the store-side counterpart to [`checked_transmute_copy`].
+/// The destination only needs to satisfy its own alignment,
+/// not the source type's alignment.
+#[inline(always)]
+#[allow(dead_code, reason = "Not all backends use this function")]
+pub(crate) fn checked_transmute_store<Src: SimdPod, Dst: SimdPod>(src: Src, dest: &mut Dst) {
+    const {
+        assert!(
+            size_of::<Src>() == size_of::<Dst>(),
+            "checked_transmute_store requires source and destination to have the same size"
+        );
+    }
+    // Safety: `SimdPod` guarantees source and destination validity for all bit patterns, and
+    // the const assertion above ensures that the write fully covers exactly one destination.
+    // `write_unaligned` avoids making a reference to `Src`, so this is valid even when `dest`
+    // has weaker alignment than `Src`.
+    // Performance: this lowers into the same LLVM IR as platform-specific store intrinsics.
+    // The alternative of ptr::copy_nonoverlapping lowers into a memcpy, which is worse.
+    unsafe { core::ptr::write_unaligned((dest as *mut Dst).cast::<Src>(), src) }
 }
 
 /// Like `bytemuck::cast_ref`, but rejects incompatible types at compile time

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -423,26 +423,10 @@ pub(crate) fn generic_as_array<T: ToTokens>(
     }
 }
 
-pub(crate) fn generic_store_array(method_sig: TokenStream, vec_ty: &VecType) -> TokenStream {
-    let scalar_ty = vec_ty.scalar.rust(vec_ty.scalar_bits);
-    let count = vec_ty.len;
-
-    let store_expr = quote! {
-        unsafe {
-            // Copies `count` scalars from the backing type, which has the same layout as the destination array (see
-            // `generic_as_array`). The backing type is aligned to its own size, and the destination array must *by
-            // definition* be aligned to at least the alignment of the scalar.
-            core::ptr::copy_nonoverlapping(
-                (&raw const a.val.0) as *const #scalar_ty,
-                dest.as_mut_ptr(),
-                #count,
-            );
-        }
-    };
-
+pub(crate) fn generic_store_array(method_sig: TokenStream, _vec_ty: &VecType) -> TokenStream {
     quote! {
         #method_sig {
-            #store_expr
+            crate::transmute::checked_transmute_store(a.val.0, dest);
         }
     }
 }


### PR DESCRIPTION
Mirrors #232 but for stores

Performance is unchanged or potentially improved: the old codegen emitted `ptr::copy_nonoverlapping` which lowered into a `memcpy` in the LLVM IR, while this approach lowers into an unaligned store directly, which is the same thing as platform-specific SIMD instructions lower to. (Yes, platform-specific SIMD intrinsics lower into a generic op!)