### PR TITLE
Drop a needless `unsafe` block from vectorize() impls

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -91,7 +91,7 @@ impl Simd for Avx2 {
     #[inline]
     fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
         #[target_feature(enable = "avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,lzcnt,movbe,popcnt,xsave")]
-        unsafe fn vectorize_avx2<F: FnOnce() -> R, R>(f: F) -> R {
+        fn vectorize_avx2<F: FnOnce() -> R, R>(f: F) -> R {
             f()
         }
         unsafe { vectorize_avx2(f) }

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -81,7 +81,7 @@ impl Simd for Neon {
     #[inline]
     fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
         #[target_feature(enable = "neon")]
-        unsafe fn vectorize_neon<F: FnOnce() -> R, R>(f: F) -> R {
+        fn vectorize_neon<F: FnOnce() -> R, R>(f: F) -> R {
             f()
         }
         unsafe { vectorize_neon(f) }

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -117,7 +117,7 @@ impl Simd for Sse4_2 {
     #[inline]
     fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
         #[target_feature(enable = "sse4.2,cmpxchg16b,popcnt")]
-        unsafe fn vectorize_sse4_2<F: FnOnce() -> R, R>(f: F) -> R {
+        fn vectorize_sse4_2<F: FnOnce() -> R, R>(f: F) -> R {
             f()
         }
         unsafe { vectorize_sse4_2(f) }

--- a/fearless_simd_gen/src/level.rs
+++ b/fearless_simd_gen/src/level.rs
@@ -113,7 +113,7 @@ pub(crate) trait Level {
                 // The closure passed to it is already required to be #[inline(always)],
                 // so this wrapper is the only opportunity for the compiler to make inlining decisions.
                 #[target_feature(enable = #target_features)]
-                unsafe fn #vectorize<F: FnOnce() -> R, R>(f: F) -> R {
+                fn #vectorize<F: FnOnce() -> R, R>(f: F) -> R {
                     f()
                 }
                 unsafe { #vectorize(f) }


### PR DESCRIPTION
No longer needed on Rust 1.87 and later.

The current version is sound because it is a function and not a macro, so this is not a security fix, just eases review.