### PR TITLE
Rewrite kernel! macro examples in a way that is amenable to rustfmt

### DIFF
--- a/fearless_simd/examples/srgb.rs
+++ b/fearless_simd/examples/srgb.rs
@@ -25,21 +25,21 @@ use core::arch::x86::{__m128, _mm_blend_ps};
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{__m128, _mm_blend_ps};
 
-fearless_simd::kernel! {
+fearless_simd::kernel!(
     /// Copy the alpha lane on AArch64 using a NEON lane-copy intrinsic.
     #[inline]
     fn copy_alpha_neon(neon: Neon, a: float32x4_t, b: float32x4_t) -> float32x4_t {
         vcopyq_laneq_f32::<3, 3>(a, b)
     }
-}
+);
 
-fearless_simd::kernel! {
+fearless_simd::kernel!(
     /// Copy the alpha lane on x86 using the SSE4.2 token to enable SSE4.1 blend instructions.
     #[inline]
     fn copy_alpha_sse4_2(sse4_2: Sse4_2, a: __m128, b: __m128) -> __m128 {
         _mm_blend_ps::<8>(a, b)
     }
-}
+);
 
 /// Return `a` with its alpha channel replaced by `b`'s alpha channel.
 ///

--- a/fearless_simd/src/kernel_macros.rs
+++ b/fearless_simd/src/kernel_macros.rs
@@ -26,11 +26,11 @@
 /// #[cfg(target_arch = "x86_64")]
 /// use std::arch::x86_64::{__m256i, _mm256_add_epi32};
 ///
-/// fearless_simd::kernel! {
+/// fearless_simd::kernel!(
 ///     fn add_i32x8(avx2: Avx2, a: __m256i, b: __m256i) -> __m256i {
 ///         _mm256_add_epi32(a, b)
 ///     }
-/// }
+/// );
 ///
 /// # fn main() {
 /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -59,9 +59,9 @@
 /// For soundness, this macro only accepts safe functions.
 ///
 /// ```compile_fail
-/// fearless_simd::kernel! {
+/// fearless_simd::kernel!(
 ///     unsafe fn should_not_compile(avx2: Avx2) {}
-/// }
+/// );
 #[macro_export]
 macro_rules! kernel {
     (
@@ -220,23 +220,23 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{__m256i, _mm256_add_epi32};
 
-    crate::kernel! {
+    crate::kernel!(
         fn add_f32x4_neon(neon: Neon, a: float32x4_t, b: float32x4_t) -> float32x4_t {
             vaddq_f32(a, b)
         }
-    }
+    );
 
-    crate::kernel! {
+    crate::kernel!(
         fn add_f32x4_wasm(wasm: WasmSimd128, a: v128, b: v128) -> v128 {
             f32x4_add(a, b)
         }
-    }
+    );
 
-    crate::kernel! {
+    crate::kernel!(
         fn add_i32x8_avx2(avx2: Avx2, a: __m256i, b: __m256i) -> __m256i {
             _mm256_add_epi32(a, b)
         }
-    }
+    );
 
     #[cfg(target_arch = "aarch64")]
     #[test]


### PR DESCRIPTION
rustfmt treats macros called like `kernel!( ... )` as potentially containing Rust code and tries to format them, but `kernel!{ ... }`  is treated as opaque.

Use the auto-formattable form in all examples so that rustfmt doesn't break for crate users.