### PR TITLE
Add top 5 uncredited contributors to AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,8 @@
 # source control.
 Google LLC
 Raph Levien
+Laurenz Stampfl
+valadaptive
+Sergey "Shnatsel" Davidoff
+Benjamin Saunders
+Daniel McNab


### PR DESCRIPTION
The README says

> Please feel free to add your name to the [AUTHORS](https://github.com/linebender/fearless_simd/blob/main/AUTHORS) file in any substantive pull request.

But it seems everyone just ignored it.