### PR TITLE
Revert "Add top 5 uncredited contributors to AUTHORS (#242)"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,8 +6,3 @@
 # source control.
 Google LLC
 Raph Levien
-Laurenz Stampfl
-valadaptive
-Sergey "Shnatsel" Davidoff
-Benjamin Saunders
-Daniel McNab


### PR DESCRIPTION
This reverts commit 4f885d94ea27085339a94ff3dafe69aaea6d9f4b

as requested in https://github.com/linebender/fearless_simd/pull/242#issuecomment-4725028210