### PR TITLE
Add myself to AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 # source control.
 Google LLC
 Raph Levien
+Sergey "Shnatsel" Davidoff


### PR DESCRIPTION
The README states

> Please feel free to add your name to the [AUTHORS](https://github.com/linebender/fearless_simd/blob/main/AUTHORS) file in any substantive pull request.

Looking at #248 I'd say this bar is met.

I did not sign a CLA with copyright assignment for this repository, so I'm still the copyright holder, satisfying the conditions in https://github.com/linebender/fearless_simd/pull/246#issuecomment-4728907579