### PR TITLE
Multiversioning behind feature flags for SIMD levels

### DIFF
--- a/check_targets.sh
+++ b/check_targets.sh
@@ -23,6 +23,7 @@ RUSTFLAGS=-Ctarget-cpu=x86-64-v2 cargo check -p fearless_simd --target x86_64-un
 RUSTFLAGS=-Ctarget-cpu=x86-64-v2 cargo check -p fearless_simd --target x86_64-unknown-linux-gnu  --features force_support_fallback
 cargo check -p fearless_simd --target x86_64-unknown-linux-gnu
 cargo check -p fearless_simd --target x86_64-unknown-linux-gnu  --features force_support_fallback
+cargo check -p fearless_simd --target x86_64-unknown-linux-gnu --no-default-features --features std
 
 # x86 (i.e. 32 bit) at all supported static SIMD levels.
 RUSTFLAGS=-Ctarget-cpu=x86-64-v3 cargo check -p fearless_simd --target i686-pc-windows-msvc
@@ -31,6 +32,7 @@ RUSTFLAGS=-Ctarget-cpu=x86-64-v2 cargo check -p fearless_simd --target i686-pc-w
 RUSTFLAGS=-Ctarget-cpu=x86-64-v2 cargo check -p fearless_simd --target i686-pc-windows-msvc  --features force_support_fallback
 cargo check -p fearless_simd --target i686-pc-windows-msvc
 cargo check -p fearless_simd --target i686-pc-windows-msvc  --features force_support_fallback
+cargo check -p fearless_simd --target i686-pc-windows-msvc --no-default-features --features std
 
 # Wasm, both with and without SIMD.
 cargo check -p fearless_simd --target wasm32-unknown-unknown

--- a/fearless_simd/Cargo.toml
+++ b/fearless_simd/Cargo.toml
@@ -26,16 +26,29 @@ rustdoc-args = [
 
 
 [features]
-default = ["std"]
+default = ["std", "multiversion_sse4_2", "multiversion_avx2", "multiversion_avx512"]
 # Get floating point functions from the standard library (likely using your targets libc).
 # Also allows using `Level::new` on all platforms, to detect which target features are enabled
 std = []
 # Use floating point implementations from libm
 libm = ["dep:libm"]
 
-# Force the "fallback" SIMD level to be supported
+# Force the "fallback" SIMD level to be supported, even if SIMD is always available.
 # This is primarily used for tests
 force_support_fallback = []
+
+# Enable automatic multiversioning for SSE4.2 through `dispatch!` and `Level::dispatch`.
+# Has no effect on architectures other than x86 and x86-64.
+# Disabling this does not remove the `Sse4_2` token or explicit `kernel!` support.
+multiversion_sse4_2 = []
+# Enable automatic multiversioning for AVX2 through `dispatch!` and `Level::dispatch`.
+# Has no effect on architectures other than x86 and x86-64.
+# Disabling this does not remove the `Avx2` token or explicit `kernel!` support.
+multiversion_avx2 = []
+# Enable automatic multiversioning for AVX-512 through `dispatch!` and `Level::dispatch`.
+# Has no effect on architectures other than x86 and x86-64.
+# Disabling this doeces not remove the `Avx512` token or explicit `kernel!` support.
+multiversion_avx512 = []
 
 [lints]
 workspace = true

--- a/fearless_simd/Cargo.toml
+++ b/fearless_simd/Cargo.toml
@@ -26,12 +26,7 @@ rustdoc-args = [
 
 
 [features]
-default = [
-  "std",
-  "dispatch_sse4_2",
-  "dispatch_avx2",
-  "dispatch_avx512",
-]
+default = ["std", "dispatch_sse4_2", "dispatch_avx2", "dispatch_avx512"]
 # Get floating point functions from the standard library (likely using your targets libc).
 # Also allows using `Level::new` on all platforms, to detect which target features are enabled
 std = []

--- a/fearless_simd/Cargo.toml
+++ b/fearless_simd/Cargo.toml
@@ -26,7 +26,12 @@ rustdoc-args = [
 
 
 [features]
-default = ["std", "multiversion_sse4_2", "multiversion_avx2", "multiversion_avx512"]
+default = [
+  "std",
+  "multiversion_sse4_2",
+  "multiversion_avx2",
+  "multiversion_avx512",
+]
 # Get floating point functions from the standard library (likely using your targets libc).
 # Also allows using `Level::new` on all platforms, to detect which target features are enabled
 std = []

--- a/fearless_simd/Cargo.toml
+++ b/fearless_simd/Cargo.toml
@@ -28,9 +28,9 @@ rustdoc-args = [
 [features]
 default = [
   "std",
-  "multiversion_sse4_2",
-  "multiversion_avx2",
-  "multiversion_avx512",
+  "dispatch_sse4_2",
+  "dispatch_avx2",
+  "dispatch_avx512",
 ]
 # Get floating point functions from the standard library (likely using your targets libc).
 # Also allows using `Level::new` on all platforms, to detect which target features are enabled
@@ -45,15 +45,15 @@ force_support_fallback = []
 # Enable automatic multiversioning for SSE4.2 through `dispatch!` and `Level::dispatch`.
 # Has no effect on architectures other than x86 and x86-64.
 # Disabling this does not remove the `Sse4_2` token or explicit `kernel!` support.
-multiversion_sse4_2 = []
+dispatch_sse4_2 = []
 # Enable automatic multiversioning for AVX2 through `dispatch!` and `Level::dispatch`.
 # Has no effect on architectures other than x86 and x86-64.
 # Disabling this does not remove the `Avx2` token or explicit `kernel!` support.
-multiversion_avx2 = []
+dispatch_avx2 = []
 # Enable automatic multiversioning for AVX-512 through `dispatch!` and `Level::dispatch`.
 # Has no effect on architectures other than x86 and x86-64.
 # Disabling this doeces not remove the `Avx512` token or explicit `kernel!` support.
-multiversion_avx512 = []
+dispatch_avx512 = []
 
 [lints]
 workspace = true

--- a/fearless_simd/README.md
+++ b/fearless_simd/README.md
@@ -30,6 +30,7 @@ See https://linebender.org/blog/doc-include/ for related discussion. -->
 [`dispatch`]: https://docs.rs/fearless_simd/latest/fearless_simd/macro.dispatch.html
 [`Level`]: https://docs.rs/fearless_simd/latest/fearless_simd/enum.Level.html
 [`Level::new`]: https://docs.rs/fearless_simd/latest/fearless_simd/enum.Level.html#method.new
+[`Level::dispatch`]: https://docs.rs/fearless_simd/latest/fearless_simd/enum.Level.html#method.dispatch
 [`std::simd`]: https://doc.rust-lang.org/std/simd/index.html
 [kernel]: https://docs.rs/fearless_simd/latest/fearless_simd/macro.kernel.html
 [Simd::vectorize]: https://docs.rs/fearless_simd/latest/fearless_simd/trait.Simd.html#tymethod.vectorize
@@ -195,6 +196,13 @@ The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/fe
   Also allows using [`Level::new`] on all platforms, to detect which target features are enabled.
 - `libm`: Use floating point implementations from [libm].
 - `force_support_fallback`: Force scalar fallback, to be supported, even if your compilation target has a better baseline.
+- `multiversion_sse4_2`, `multiversion_avx2`, `multiversion_avx512` (enabled by default): Enable automatic x86 multiversioning for the
+  corresponding instruction set in [`dispatch`] and [`Level::dispatch`].
+
+The x86 feature flags only control automatic multiversioning. Disabling one does not remove its token type, its
+[`Simd`] implementation, or explicit [kernel] support; for example, an `Avx2` token can still be used to call an AVX2
+kernel when the CPU supports it. Because Cargo features are additive, opt out of x86 multiversioning with
+`default-features = false`, then enable the pieces you want, for example `features = ["std", "multiversion_sse4_2"]`.
 
 At least one of `std` and `libm` is required; `std` overrides `libm`.
 

--- a/fearless_simd/README.md
+++ b/fearless_simd/README.md
@@ -185,7 +185,7 @@ runtime.
 
 ## Multiversioning on x86
 
-x86 CPUs are not guaranteed to have any SIMD particular instruction set, so fearless_simd compiles a version
+x86 CPUs are not guaranteed to have any SIMD particular instruction set, so `fearless_simd` compiles a version
 of each function generic over [`Simd`] for each instruction set, and [`dispatch`] selects the best one at runtime.
 
 This is strictly required to take advantage of SIMD, but results in an increased binary size on x86.

--- a/fearless_simd/README.md
+++ b/fearless_simd/README.md
@@ -183,10 +183,24 @@ At the time of writing, relaxed SIMD is only supported in Chrome. To make use of
 with relaxed SIMD enabled (`RUSTFLAGS="-Ctarget-feature=+simd128,+relaxed-simd"`) and one with it disabled, and then feature-detect at
 runtime.
 
-## Credits
+## Multiversioning on x86
 
-This crate was inspired by [`pulp`], [`std::simd`], among others in the Rust ecosystem, though makes many decisions differently.
-It benefited from conversations with Luca Versari, though he is not responsible for any of the mistakes or bad decisions.
+x86 CPUs are not guaranteed to have any SIMD particular instruction set, so fearless_simd compiles a version
+of each function generic over [`Simd`] for each instruction set, and [`dispatch`] selects the best one at runtime.
+
+This is strictly required to take advantage of SIMD, but results in an increased binary size on x86.
+If binary size is a concern, the increase can be partially mitigated by setting
+[`codegen-units=1`](https://nnethercote.github.io/perf-book/build-configuration.html#codegen-units)
+or [`lto=true`](https://nnethercote.github.io/perf-book/build-configuration.html#link-time-optimization) in your Cargo.toml,
+at the cost of longer build times.
+
+As a last resort, you can turn off multiversioning for specific SIMD instruction sets, see "Feature Flags" below.
+Note that later extensions can be beneficial even if you are only using 128-bit vectors:
+AVX2 and AVX-512 provide more efficient instructions for some operations,
+and AVX-512 also more than doubles the number of vector registers of all sizes.
+
+You can also [disable certain instruction sets for select functions](https://github.com/linebender/fearless_simd/blob/main/fearless_simd/examples/sigmoid.rs)
+without disabling them globally.
 
 ## Feature Flags
 
@@ -194,17 +208,22 @@ The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/fe
 
 - `std` (enabled by default): Get floating point functions from the standard library (likely using your target's libc).
   Also allows using [`Level::new`] on all platforms, to detect which target features are enabled.
-- `libm`: Use floating point implementations from [libm].
+- `libm`: Use floating point implementations from [libm]. Useful for `#[no_std]`.
 - `force_support_fallback`: Force scalar fallback, to be supported, even if your compilation target has a better baseline.
 - `multiversion_sse4_2`, `multiversion_avx2`, `multiversion_avx512` (enabled by default): Enable automatic x86 multiversioning for the
   corresponding instruction set in [`dispatch`] and [`Level::dispatch`].
 
 The x86 feature flags only control automatic multiversioning. Disabling one does not remove its token type, its
-[`Simd`] implementation, or explicit [kernel] support; for example, an `Avx2` token can still be used to call an AVX2
-kernel when the CPU supports it. Because Cargo features are additive, opt out of x86 multiversioning with
+[`Simd`] implementation, or explicit [`kernel`] support; for example, an `Avx2` token can still be used to call an
+AVX2 kernel when the CPU supports it. Because Cargo features are additive, opt out of x86 multiversioning with
 `default-features = false`, then enable the pieces you want, for example `features = ["std", "multiversion_sse4_2"]`.
 
 At least one of `std` and `libm` is required; `std` overrides `libm`.
+
+## Credits
+
+This crate was inspired by [`pulp`], [`std::simd`], among others in the Rust ecosystem, though makes many decisions differently.
+It benefited from conversations with Luca Versari, though he is not responsible for any of the mistakes or bad decisions.
 
 [`pulp`]: https://crates.io/crates/pulp
 

--- a/fearless_simd/README.md
+++ b/fearless_simd/README.md
@@ -210,13 +210,13 @@ The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/fe
   Also allows using [`Level::new`] on all platforms, to detect which target features are enabled.
 - `libm`: Use floating point implementations from [libm]. Useful for `#[no_std]`.
 - `force_support_fallback`: Force scalar fallback, to be supported, even if your compilation target has a better baseline.
-- `multiversion_sse4_2`, `multiversion_avx2`, `multiversion_avx512` (enabled by default): Enable automatic x86 multiversioning for the
+- `dispatch_sse4_2`, `dispatch_avx2`, `dispatch_avx512` (enabled by default): Enable automatic x86 multiversioning for the
   corresponding instruction set in [`dispatch`] and [`Level::dispatch`].
 
 The x86 feature flags only control automatic multiversioning. Disabling one does not remove its token type, its
 [`Simd`] implementation, or explicit [`kernel`] support; for example, an `Avx2` token can still be used to call an
 AVX2 kernel when the CPU supports it. Because Cargo features are additive, opt out of x86 multiversioning with
-`default-features = false`, then enable the pieces you want, for example `features = ["std", "multiversion_sse4_2"]`.
+`default-features = false`, then enable the pieces you want, for example `features = ["std", "dispatch_sse4_2"]`.
 
 At least one of `std` and `libm` is required; `std` overrides `libm`.
 

--- a/fearless_simd/examples/disable_avx2_for_one_function.rs
+++ b/fearless_simd/examples/disable_avx2_for_one_function.rs
@@ -23,6 +23,8 @@ fn disable_avx2<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
 
 #[inline(always)]
 fn sigmoid<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
+    // verify that this function is never called with AVX2
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     debug_assert!(!matches!(simd.level(), Level::Avx2(_)));
 
     // If this function calls anything else with its `simd`,

--- a/fearless_simd/examples/disable_avx2_for_one_function.rs
+++ b/fearless_simd/examples/disable_avx2_for_one_function.rs
@@ -1,0 +1,46 @@
+// Copyright 2024 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This example demonstrates a SIMD function that's never compiled for AVX2.
+//!
+//! This can be useful if benchmarks show a specific insruction set regressing performance.
+
+use fearless_simd::{Level, dispatch, prelude::*};
+
+#[inline(always)]
+fn disable_avx2<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
+    let level = simd.level();
+    match level {
+        Level::Avx2(_) => {
+            // downgrade AVX2 to SSE4.2
+            let simd_sse4_2 = level.as_sse4_2().unwrap();
+            sigmoid(simd_sse4_2, x, out)
+        }
+        _ => sigmoid(simd, x, out),
+    }
+}
+
+#[inline(always)]
+fn sigmoid<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
+    debug_assert!(!matches!(simd.level(), Level::Avx2(_)));
+
+    // If this function calls anything else with its `simd`,
+    // the callee will also never get an AVX2 implementation.
+    // The downgrade only needs to happen once anywhere in the call chain.
+
+    let n = S::f32s::N;
+    for (x, y) in x.chunks_exact(n).zip(out.chunks_exact_mut(n)) {
+        let a = S::f32s::from_slice(simd, x);
+        let b = a / (a * a + 1.0).sqrt();
+        y.copy_from_slice(b.as_slice());
+    }
+}
+
+fn main() {
+    let level = Level::new();
+    let inp = [0.1, -0.2, 0.001, 0.4, 1., 2., 3., 4.];
+    let mut out = [0.; 8];
+    dispatch!(level, simd => disable_avx2(simd, &inp, &mut out));
+
+    println!("{out:?}");
+}

--- a/fearless_simd/examples/disable_avx2_for_one_function.rs
+++ b/fearless_simd/examples/disable_avx2_for_one_function.rs
@@ -23,9 +23,8 @@ fn disable_avx2<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
 
 #[inline(always)]
 fn sigmoid<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
-    // verify that this function is never called with AVX2
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    debug_assert!(!matches!(simd.level(), Level::Avx2(_)));
+    debug_assert!(!matches!(simd.level(), Level::Avx2(_)), "Called with AVX2");
 
     // If this function calls anything else with its `simd`,
     // the callee will also never get an AVX2 implementation.

--- a/fearless_simd/examples/disable_avx2_for_one_function.rs
+++ b/fearless_simd/examples/disable_avx2_for_one_function.rs
@@ -12,11 +12,8 @@ fn disable_avx2<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
     let level = simd.level();
     match level {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        Level::Avx2(_) => {
-            // downgrade AVX2 to SSE4.2
-            let simd_sse4_2 = level.as_sse4_2().unwrap();
-            sigmoid(simd_sse4_2, x, out)
-        }
+        // Downgrade AVX2 to SSE4.2 when calling `sigmoid()`
+        Level::Avx2(_) => sigmoid(level.as_sse4_2().unwrap(), x, out),
         _ => sigmoid(simd, x, out),
     }
 }

--- a/fearless_simd/examples/disable_avx2_for_one_function.rs
+++ b/fearless_simd/examples/disable_avx2_for_one_function.rs
@@ -11,6 +11,7 @@ use fearless_simd::{Level, dispatch, prelude::*};
 fn disable_avx2<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
     let level = simd.level();
     match level {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         Level::Avx2(_) => {
             // downgrade AVX2 to SSE4.2
             let simd_sse4_2 = level.as_sse4_2().unwrap();

--- a/fearless_simd/examples/disable_avx2_for_one_function.rs
+++ b/fearless_simd/examples/disable_avx2_for_one_function.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 the Fearless_SIMD Authors
+// Copyright 2026 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! This example demonstrates a SIMD function that's never compiled for AVX2.

--- a/fearless_simd/examples/disable_avx2_for_one_function.rs
+++ b/fearless_simd/examples/disable_avx2_for_one_function.rs
@@ -3,7 +3,7 @@
 
 //! This example demonstrates a SIMD function that's never compiled for AVX2.
 //!
-//! This can be useful if benchmarks show a specific insruction set regressing performance.
+//! This can be useful if benchmarks show a specific instruction set regressing performance.
 
 use fearless_simd::{Level, dispatch, prelude::*};
 

--- a/fearless_simd/src/kernel_macros.rs
+++ b/fearless_simd/src/kernel_macros.rs
@@ -335,4 +335,14 @@ mod tests {
             "`kernel!` should instantiate a working AVX-512 kernel"
         );
     }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[test]
+    fn x86_kernel_functions_are_not_multiversion_gated() {
+        fn accept_avx2_kernel(_: fn(crate::Avx2, __m256i, __m256i) -> __m256i) {}
+        fn accept_avx512_kernel(_: fn(crate::Avx512, __m512i, __m512i) -> __m512i) {}
+
+        accept_avx2_kernel(add_i32x8_avx2);
+        accept_avx512_kernel(add_i32x16_avx512);
+    }
 }

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -166,6 +166,9 @@
 //! AVX2 and AVX-512 provide more efficient instructions for some operations,
 //! and AVX-512 also more than doubles the number of vector registers of all sizes.
 //!
+//! You can also [disable certain instruction sets for select functions](https://github.com/linebender/fearless_simd/blob/main/fearless_simd/examples/sigmoid.rs)
+//! without disabling them globally.
+//!
 //! # Feature Flags
 //!
 //! The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) are available:

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -163,6 +163,13 @@
 //!   Also allows using [`Level::new`] on all platforms, to detect which target features are enabled.
 //! - `libm`: Use floating point implementations from [libm].
 //! - `force_support_fallback`: Force scalar fallback, to be supported, even if your compilation target has a better baseline.
+//! - `multiversion_sse4_2`, `multiversion_avx2`, `multiversion_avx512` (enabled by default): Enable automatic x86 multiversioning for the
+//!   corresponding instruction set in [`dispatch`] and [`Level::dispatch`].
+//!
+//! The x86 feature flags only control automatic multiversioning. Disabling one does not remove its token type, its
+//! [`Simd`] implementation, or explicit [`kernel`] support; for example, an `Avx2` token can still be used to call an
+//! AVX2 kernel when the CPU supports it. Because Cargo features are additive, opt out of x86 multiversioning with
+//! `default-features = false`, then enable the pieces you want, for example `features = ["std", "multiversion_sse4_2"]`.
 //!
 //! At least one of `std` and `libm` is required; `std` overrides `libm`.
 //!

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -150,10 +150,21 @@
 //! with relaxed SIMD enabled (`RUSTFLAGS="-Ctarget-feature=+simd128,+relaxed-simd"`) and one with it disabled, and then feature-detect at
 //! runtime.
 //!
-//! # Credits
+//! # Multiversioning on x86
 //!
-//! This crate was inspired by [`pulp`], [`std::simd`], among others in the Rust ecosystem, though makes many decisions differently.
-//! It benefited from conversations with Luca Versari, though he is not responsible for any of the mistakes or bad decisions.
+//! x86 CPUs are not guaranteed to have any SIMD particular instruction set, so fearless_simd compiles a version
+//! of each function generic over [`Simd`] for each instruction set, and [`dispatch`] selects the best one at runtime.
+//!
+//! This is strictly required to take advantage of SIMD, but results in an increased binary size on x86.
+//! If binary size is a concern, the increase can be partially mitigated by setting
+//! [`codegen-units=1`](https://nnethercote.github.io/perf-book/build-configuration.html#codegen-units)
+//! or [`lto=true`](https://nnethercote.github.io/perf-book/build-configuration.html#link-time-optimization) in your Cargo.toml,
+//! at the cost of longer build times.
+//!
+//! As a last resort, you can turn off multiversioning for specific SIMD instruction sets, see "Feature Flags" below.
+//! Note that later extensions can be beneficial even if you are only using 128-bit vectors:
+//! AVX2 and AVX-512 provide more efficient instructions for some operations,
+//! and AVX-512 also more than doubles the number of vector registers of all sizes.
 //!
 //! # Feature Flags
 //!
@@ -161,7 +172,7 @@
 //!
 //! - `std` (enabled by default): Get floating point functions from the standard library (likely using your target's libc).
 //!   Also allows using [`Level::new`] on all platforms, to detect which target features are enabled.
-//! - `libm`: Use floating point implementations from [libm].
+//! - `libm`: Use floating point implementations from [libm]. Useful for `#[no_std]`.
 //! - `force_support_fallback`: Force scalar fallback, to be supported, even if your compilation target has a better baseline.
 //! - `multiversion_sse4_2`, `multiversion_avx2`, `multiversion_avx512` (enabled by default): Enable automatic x86 multiversioning for the
 //!   corresponding instruction set in [`dispatch`] and [`Level::dispatch`].
@@ -172,6 +183,11 @@
 //! `default-features = false`, then enable the pieces you want, for example `features = ["std", "multiversion_sse4_2"]`.
 //!
 //! At least one of `std` and `libm` is required; `std` overrides `libm`.
+//!
+//! # Credits
+//!
+//! This crate was inspired by [`pulp`], [`std::simd`], among others in the Rust ecosystem, though makes many decisions differently.
+//! It benefited from conversations with Luca Versari, though he is not responsible for any of the mistakes or bad decisions.
 //!
 //! [`pulp`]: https://crates.io/crates/pulp
 // LINEBENDER LINT SET - lib.rs - v3

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -177,13 +177,13 @@
 //!   Also allows using [`Level::new`] on all platforms, to detect which target features are enabled.
 //! - `libm`: Use floating point implementations from [libm]. Useful for `#[no_std]`.
 //! - `force_support_fallback`: Force scalar fallback, to be supported, even if your compilation target has a better baseline.
-//! - `multiversion_sse4_2`, `multiversion_avx2`, `multiversion_avx512` (enabled by default): Enable automatic x86 multiversioning for the
+//! - `dispatch_sse4_2`, `dispatch_avx2`, `dispatch_avx512` (enabled by default): Enable automatic x86 multiversioning for the
 //!   corresponding instruction set in [`dispatch`] and [`Level::dispatch`].
 //!
 //! The x86 feature flags only control automatic multiversioning. Disabling one does not remove its token type, its
 //! [`Simd`] implementation, or explicit [`kernel`] support; for example, an `Avx2` token can still be used to call an
 //! AVX2 kernel when the CPU supports it. Because Cargo features are additive, opt out of x86 multiversioning with
-//! `default-features = false`, then enable the pieces you want, for example `features = ["std", "multiversion_sse4_2"]`.
+//! `default-features = false`, then enable the pieces you want, for example `features = ["std", "dispatch_sse4_2"]`.
 //!
 //! At least one of `std` and `libm` is required; `std` overrides `libm`.
 //!

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -152,7 +152,7 @@
 //!
 //! # Multiversioning on x86
 //!
-//! x86 CPUs are not guaranteed to have any SIMD particular instruction set, so fearless_simd compiles a version
+//! x86 CPUs are not guaranteed to have any SIMD particular instruction set, so `fearless_simd` compiles a version
 //! of each function generic over [`Simd`] for each instruction set, and [`dispatch`] selects the best one at runtime.
 //!
 //! This is strictly required to take advantage of SIMD, but results in an increased binary size on x86.

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -330,24 +330,6 @@ mod tests {
         }
     }
 
-    #[cfg(all(
-        feature = "std",
-        any(target_arch = "x86", target_arch = "x86_64"),
-        not(feature = "multiversion_avx2")
-    ))]
-    fn x86_detects_avx2_level() -> bool {
-        std::arch::is_x86_feature_detected!("avx2")
-            && std::arch::is_x86_feature_detected!("bmi1")
-            && std::arch::is_x86_feature_detected!("bmi2")
-            && std::arch::is_x86_feature_detected!("cmpxchg16b")
-            && std::arch::is_x86_feature_detected!("f16c")
-            && std::arch::is_x86_feature_detected!("fma")
-            && std::arch::is_x86_feature_detected!("lzcnt")
-            && std::arch::is_x86_feature_detected!("movbe")
-            && std::arch::is_x86_feature_detected!("popcnt")
-            && std::arch::is_x86_feature_detected!("xsave")
-    }
-
     #[allow(dead_code, reason = "Compile test")]
     fn dispatch_generic() {
         fn generic<S: Simd, T>(_: S, x: T) -> T {
@@ -376,21 +358,6 @@ mod tests {
         let actual = dispatch!(level, simd => x86_dispatch_backend(simd));
 
         assert_eq!(actual, expected_x86_dispatch_backend(level));
-    }
-
-    #[cfg(all(
-        feature = "std",
-        any(target_arch = "x86", target_arch = "x86_64"),
-        not(feature = "multiversion_avx2")
-    ))]
-    #[test]
-    fn disabled_avx2_multiversioning_does_not_filter_avx2_token_access() {
-        if x86_detects_avx2_level() {
-            assert!(
-                Level::new().as_avx2().is_some(),
-                "`multiversion_avx2` controls dispatch multiversioning, not AVX2 token access"
-            );
-        }
     }
 
     #[cfg(all(

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -77,15 +77,15 @@ macro_rules! dispatch {
                 ))
             ))]
             $crate::Level::Sse4_2(sse4_2) => {
-                $crate::__fearless_simd_dispatch_multiversion_sse4_2!(sse4_2, $simd => $op)
+                $crate::__fearless_simd_dispatch_dispatch_sse4_2!(sse4_2, $simd => $op)
             }
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             $crate::Level::Avx512(avx512) => {
-                $crate::__fearless_simd_dispatch_multiversion_avx512!(avx512, $simd => $op)
+                $crate::__fearless_simd_dispatch_dispatch_avx512!(avx512, $simd => $op)
             }
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             $crate::Level::Avx2(avx2) => {
-                $crate::__fearless_simd_dispatch_multiversion_avx2!(avx2, $simd => $op)
+                $crate::__fearless_simd_dispatch_dispatch_avx2!(avx2, $simd => $op)
             }
             #[cfg(any(
                 all(target_arch = "aarch64", not(target_feature = "neon")),
@@ -146,8 +146,8 @@ macro_rules! __fearless_simd_dispatch_with_token {
 /// Implementation detail of [`crate::dispatch`]; this is not public API.
 #[macro_export]
 #[doc(hidden)]
-#[cfg(feature = "multiversion_avx512")]
-macro_rules! __fearless_simd_dispatch_multiversion_avx512 {
+#[cfg(feature = "dispatch_avx512")]
+macro_rules! __fearless_simd_dispatch_dispatch_avx512 {
     ($avx512:expr, $simd:pat => $op:expr) => {
         $crate::__fearless_simd_dispatch_with_token!($avx512, $simd => $op)
     };
@@ -156,18 +156,18 @@ macro_rules! __fearless_simd_dispatch_multiversion_avx512 {
 /// Implementation detail of [`crate::dispatch`]; this is not public API.
 #[macro_export]
 #[doc(hidden)]
-#[cfg(not(feature = "multiversion_avx512"))]
-macro_rules! __fearless_simd_dispatch_multiversion_avx512 {
+#[cfg(not(feature = "dispatch_avx512"))]
+macro_rules! __fearless_simd_dispatch_dispatch_avx512 {
     ($avx512:expr, $simd:pat => $op:expr) => {{
-        $crate::__fearless_simd_dispatch_multiversion_avx2_from_superset!($avx512, $simd => $op)
+        $crate::__fearless_simd_dispatch_dispatch_avx2_from_superset!($avx512, $simd => $op)
     }};
 }
 
 /// Implementation detail of [`crate::dispatch`]; this is not public API.
 #[macro_export]
 #[doc(hidden)]
-#[cfg(feature = "multiversion_avx2")]
-macro_rules! __fearless_simd_dispatch_multiversion_avx2 {
+#[cfg(feature = "dispatch_avx2")]
+macro_rules! __fearless_simd_dispatch_dispatch_avx2 {
     ($avx2:expr, $simd:pat => $op:expr) => {
         $crate::__fearless_simd_dispatch_with_token!($avx2, $simd => $op)
     };
@@ -176,18 +176,18 @@ macro_rules! __fearless_simd_dispatch_multiversion_avx2 {
 /// Implementation detail of [`crate::dispatch`]; this is not public API.
 #[macro_export]
 #[doc(hidden)]
-#[cfg(not(feature = "multiversion_avx2"))]
-macro_rules! __fearless_simd_dispatch_multiversion_avx2 {
+#[cfg(not(feature = "dispatch_avx2"))]
+macro_rules! __fearless_simd_dispatch_dispatch_avx2 {
     ($avx2:expr, $simd:pat => $op:expr) => {{
-        $crate::__fearless_simd_dispatch_multiversion_sse4_2_from_superset!($avx2, $simd => $op)
+        $crate::__fearless_simd_dispatch_dispatch_sse4_2_from_superset!($avx2, $simd => $op)
     }};
 }
 
 /// Implementation detail of [`crate::dispatch`]; this is not public API.
 #[macro_export]
 #[doc(hidden)]
-#[cfg(feature = "multiversion_avx2")]
-macro_rules! __fearless_simd_dispatch_multiversion_avx2_from_superset {
+#[cfg(feature = "dispatch_avx2")]
+macro_rules! __fearless_simd_dispatch_dispatch_avx2_from_superset {
     ($proof:expr, $simd:pat => $op:expr) => {{
         let __fearless_simd_proof = $proof;
         let __fearless_simd_token = $crate::Simd::level(__fearless_simd_proof)
@@ -200,18 +200,18 @@ macro_rules! __fearless_simd_dispatch_multiversion_avx2_from_superset {
 /// Implementation detail of [`crate::dispatch`]; this is not public API.
 #[macro_export]
 #[doc(hidden)]
-#[cfg(not(feature = "multiversion_avx2"))]
-macro_rules! __fearless_simd_dispatch_multiversion_avx2_from_superset {
+#[cfg(not(feature = "dispatch_avx2"))]
+macro_rules! __fearless_simd_dispatch_dispatch_avx2_from_superset {
     ($proof:expr, $simd:pat => $op:expr) => {{
-        $crate::__fearless_simd_dispatch_multiversion_sse4_2_from_superset!($proof, $simd => $op)
+        $crate::__fearless_simd_dispatch_dispatch_sse4_2_from_superset!($proof, $simd => $op)
     }};
 }
 
 /// Implementation detail of [`crate::dispatch`]; this is not public API.
 #[macro_export]
 #[doc(hidden)]
-#[cfg(feature = "multiversion_sse4_2")]
-macro_rules! __fearless_simd_dispatch_multiversion_sse4_2 {
+#[cfg(feature = "dispatch_sse4_2")]
+macro_rules! __fearless_simd_dispatch_dispatch_sse4_2 {
     ($sse4_2:expr, $simd:pat => $op:expr) => {
         $crate::__fearless_simd_dispatch_with_token!($sse4_2, $simd => $op)
     };
@@ -220,8 +220,8 @@ macro_rules! __fearless_simd_dispatch_multiversion_sse4_2 {
 /// Implementation detail of [`crate::dispatch`]; this is not public API.
 #[macro_export]
 #[doc(hidden)]
-#[cfg(not(feature = "multiversion_sse4_2"))]
-macro_rules! __fearless_simd_dispatch_multiversion_sse4_2 {
+#[cfg(not(feature = "dispatch_sse4_2"))]
+macro_rules! __fearless_simd_dispatch_dispatch_sse4_2 {
     ($sse4_2:expr, $simd:pat => $op:expr) => {{
         let __fearless_simd_proof = $sse4_2;
         let _ = __fearless_simd_proof;
@@ -232,8 +232,8 @@ macro_rules! __fearless_simd_dispatch_multiversion_sse4_2 {
 /// Implementation detail of [`crate::dispatch`]; this is not public API.
 #[macro_export]
 #[doc(hidden)]
-#[cfg(feature = "multiversion_sse4_2")]
-macro_rules! __fearless_simd_dispatch_multiversion_sse4_2_from_superset {
+#[cfg(feature = "dispatch_sse4_2")]
+macro_rules! __fearless_simd_dispatch_dispatch_sse4_2_from_superset {
     ($proof:expr, $simd:pat => $op:expr) => {{
         let __fearless_simd_proof = $proof;
         let __fearless_simd_token = $crate::Simd::level(__fearless_simd_proof)
@@ -246,8 +246,8 @@ macro_rules! __fearless_simd_dispatch_multiversion_sse4_2_from_superset {
 /// Implementation detail of [`crate::dispatch`]; this is not public API.
 #[macro_export]
 #[doc(hidden)]
-#[cfg(not(feature = "multiversion_sse4_2"))]
-macro_rules! __fearless_simd_dispatch_multiversion_sse4_2_from_superset {
+#[cfg(not(feature = "dispatch_sse4_2"))]
+macro_rules! __fearless_simd_dispatch_dispatch_sse4_2_from_superset {
     ($proof:expr, $simd:pat => $op:expr) => {{
         let __fearless_simd_proof = $proof;
         let _ = __fearless_simd_proof;
@@ -319,11 +319,11 @@ mod tests {
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn expected_x86_dispatch_backend(level: Level) -> X86DispatchBackend {
-        if cfg!(feature = "multiversion_avx512") && level.as_avx512().is_some() {
+        if cfg!(feature = "dispatch_avx512") && level.as_avx512().is_some() {
             X86DispatchBackend::Avx512
-        } else if cfg!(feature = "multiversion_avx2") && level.as_avx2().is_some() {
+        } else if cfg!(feature = "dispatch_avx2") && level.as_avx2().is_some() {
             X86DispatchBackend::Avx2
-        } else if cfg!(feature = "multiversion_sse4_2") && level.as_sse4_2().is_some() {
+        } else if cfg!(feature = "dispatch_sse4_2") && level.as_sse4_2().is_some() {
             X86DispatchBackend::Sse4_2
         } else {
             X86DispatchBackend::Fallback
@@ -363,14 +363,14 @@ mod tests {
     #[cfg(all(
         feature = "std",
         any(target_arch = "x86", target_arch = "x86_64"),
-        not(feature = "multiversion_avx512")
+        not(feature = "dispatch_avx512")
     ))]
     #[test]
     fn disabled_avx512_multiversioning_does_not_filter_avx512_token_access() {
         if crate::x86_detects_icelake_avx512() {
             assert!(
                 Level::new().as_avx512().is_some(),
-                "`multiversion_avx512` controls dispatch multiversioning, not AVX-512 token access"
+                "`dispatch_avx512` controls dispatch multiversioning, not AVX-512 token access"
             );
         }
     }

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -51,32 +51,14 @@ macro_rules! dispatch {
     // indicating whether or not the `force_support_fallback` crate feature is enabled.
     ($level:expr, $simd:pat => $op:expr) => {{ $crate::internal_unstable_dispatch_inner!($level, $simd => $op) }};
     (@impl $level:expr, $simd:pat => $op:expr; $forced_fallback_arm: literal) => {{
-        /// Convert the `Simd` value into an `impl Simd`, which enforces that
-        /// it is correctly handled.
-        // TODO: Just make into a `pub` function in fearless_simd itself?
-        #[inline(always)]
-        fn launder<S: $crate::Simd>(x: S) -> impl $crate::Simd {
-            x
-        }
-
         match $level {
             #[cfg(target_arch = "aarch64")]
             $crate::Level::Neon(neon) => {
-                let $simd = launder(neon);
-                $crate::Simd::vectorize(
-                    neon,
-                    #[inline(always)]
-                    || $op,
-                )
+                $crate::__fearless_simd_dispatch_with_token!(neon, $simd => $op)
             }
             #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
             $crate::Level::WasmSimd128(wasm) => {
-                let $simd = launder(wasm);
-                $crate::Simd::vectorize(
-                    wasm,
-                    #[inline(always)]
-                    || $op,
-                )
+                $crate::__fearless_simd_dispatch_with_token!(wasm, $simd => $op)
             }
             // This fallthrough logic is documented at the definition site of `Level`.
             #[cfg(all(
@@ -95,30 +77,15 @@ macro_rules! dispatch {
                 ))
             ))]
             $crate::Level::Sse4_2(sse4_2) => {
-                let $simd = launder(sse4_2);
-                $crate::Simd::vectorize(
-                    sse4_2,
-                    #[inline(always)]
-                    || $op,
-                )
+                $crate::__fearless_simd_dispatch_multiversion_sse4_2!(sse4_2, $simd => $op)
             }
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             $crate::Level::Avx512(avx512) => {
-                let $simd = launder(avx512);
-                $crate::Simd::vectorize(
-                    avx512,
-                    #[inline(always)]
-                    || $op,
-                )
+                $crate::__fearless_simd_dispatch_multiversion_avx512!(avx512, $simd => $op)
             }
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             $crate::Level::Avx2(avx2) => {
-                let $simd = launder(avx2);
-                $crate::Simd::vectorize(
-                    avx2,
-                    #[inline(always)]
-                    || $op,
-                )
+                $crate::__fearless_simd_dispatch_multiversion_avx2!(avx2, $simd => $op)
             }
             #[cfg(any(
                 all(target_arch = "aarch64", not(target_feature = "neon")),
@@ -140,16 +107,146 @@ macro_rules! dispatch {
                 $forced_fallback_arm
             ))]
             $crate::Level::Fallback(fb) => {
-                let $simd = launder(fb);
-                // This vectorize call does nothing, but it is reasonable to be consistent here.
-                $crate::Simd::vectorize(
-                    fb,
-                    #[inline(always)]
-                    || $op,
-                )
+                // This vectorize call does nothing for Fallback, but it is reasonable to be consistent here.
+                $crate::__fearless_simd_dispatch_with_token!(fb, $simd => $op)
             }
             _ => unreachable!(),
         }
+    }};
+}
+
+/// Implementation detail of [`crate::dispatch`]; this is not public API.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __fearless_simd_dispatch_with_token {
+    ($token:expr, $simd:pat => $op:expr) => {{
+        /// Convert the `Simd` value into an `impl Simd`, which enforces that
+        /// it is correctly handled.
+        // TODO: Just make into a `pub` function in fearless_simd itself?
+        #[inline(always)]
+        fn launder<S: $crate::Simd>(x: S) -> impl $crate::Simd {
+            x
+        }
+
+        let __fearless_simd_token = $token;
+        let $simd = launder(__fearless_simd_token);
+        $crate::Simd::vectorize(
+            __fearless_simd_token,
+            #[inline(always)]
+            || $op,
+        )
+    }};
+}
+
+/// Implementation detail of [`crate::dispatch`]; this is not public API.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(feature = "multiversion_avx512")]
+macro_rules! __fearless_simd_dispatch_multiversion_avx512 {
+    ($avx512:expr, $simd:pat => $op:expr) => {
+        $crate::__fearless_simd_dispatch_with_token!($avx512, $simd => $op)
+    };
+}
+
+/// Implementation detail of [`crate::dispatch`]; this is not public API.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(not(feature = "multiversion_avx512"))]
+macro_rules! __fearless_simd_dispatch_multiversion_avx512 {
+    ($avx512:expr, $simd:pat => $op:expr) => {{
+        $crate::__fearless_simd_dispatch_multiversion_avx2_from_superset!($avx512, $simd => $op)
+    }};
+}
+
+/// Implementation detail of [`crate::dispatch`]; this is not public API.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(feature = "multiversion_avx2")]
+macro_rules! __fearless_simd_dispatch_multiversion_avx2 {
+    ($avx2:expr, $simd:pat => $op:expr) => {
+        $crate::__fearless_simd_dispatch_with_token!($avx2, $simd => $op)
+    };
+}
+
+/// Implementation detail of [`crate::dispatch`]; this is not public API.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(not(feature = "multiversion_avx2"))]
+macro_rules! __fearless_simd_dispatch_multiversion_avx2 {
+    ($avx2:expr, $simd:pat => $op:expr) => {{
+        $crate::__fearless_simd_dispatch_multiversion_sse4_2_from_superset!($avx2, $simd => $op)
+    }};
+}
+
+/// Implementation detail of [`crate::dispatch`]; this is not public API.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(feature = "multiversion_avx2")]
+macro_rules! __fearless_simd_dispatch_multiversion_avx2_from_superset {
+    ($proof:expr, $simd:pat => $op:expr) => {{
+        let __fearless_simd_proof = $proof;
+        let _ = __fearless_simd_proof;
+        // SAFETY: this helper is only called with proof of an x86 level that includes AVX2.
+        let __fearless_simd_token = unsafe { $crate::Avx2::new_unchecked() };
+        $crate::__fearless_simd_dispatch_with_token!(__fearless_simd_token, $simd => $op)
+    }};
+}
+
+/// Implementation detail of [`crate::dispatch`]; this is not public API.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(not(feature = "multiversion_avx2"))]
+macro_rules! __fearless_simd_dispatch_multiversion_avx2_from_superset {
+    ($proof:expr, $simd:pat => $op:expr) => {{
+        $crate::__fearless_simd_dispatch_multiversion_sse4_2_from_superset!($proof, $simd => $op)
+    }};
+}
+
+/// Implementation detail of [`crate::dispatch`]; this is not public API.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(feature = "multiversion_sse4_2")]
+macro_rules! __fearless_simd_dispatch_multiversion_sse4_2 {
+    ($sse4_2:expr, $simd:pat => $op:expr) => {
+        $crate::__fearless_simd_dispatch_with_token!($sse4_2, $simd => $op)
+    };
+}
+
+/// Implementation detail of [`crate::dispatch`]; this is not public API.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(not(feature = "multiversion_sse4_2"))]
+macro_rules! __fearless_simd_dispatch_multiversion_sse4_2 {
+    ($sse4_2:expr, $simd:pat => $op:expr) => {{
+        let __fearless_simd_proof = $sse4_2;
+        let _ = __fearless_simd_proof;
+        $crate::__fearless_simd_dispatch_with_token!($crate::Fallback::new(), $simd => $op)
+    }};
+}
+
+/// Implementation detail of [`crate::dispatch`]; this is not public API.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(feature = "multiversion_sse4_2")]
+macro_rules! __fearless_simd_dispatch_multiversion_sse4_2_from_superset {
+    ($proof:expr, $simd:pat => $op:expr) => {{
+        let __fearless_simd_proof = $proof;
+        let _ = __fearless_simd_proof;
+        // SAFETY: this helper is only called with proof of an x86 level that includes SSE4.2.
+        let __fearless_simd_token = unsafe { $crate::Sse4_2::new_unchecked() };
+        $crate::__fearless_simd_dispatch_with_token!(__fearless_simd_token, $simd => $op)
+    }};
+}
+
+/// Implementation detail of [`crate::dispatch`]; this is not public API.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(not(feature = "multiversion_sse4_2"))]
+macro_rules! __fearless_simd_dispatch_multiversion_sse4_2_from_superset {
+    ($proof:expr, $simd:pat => $op:expr) => {{
+        let __fearless_simd_proof = $proof;
+        let _ = __fearless_simd_proof;
+        $crate::__fearless_simd_dispatch_with_token!($crate::Fallback::new(), $simd => $op)
     }};
 }
 
@@ -189,6 +286,63 @@ macro_rules! internal_unstable_dispatch_inner {
 mod tests {
     use crate::{Level, Simd};
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum X86DispatchBackend {
+        Fallback,
+        Sse4_2,
+        Avx2,
+        Avx512,
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    fn x86_dispatch_backend<S: Simd>(_: S) -> X86DispatchBackend {
+        use core::any::TypeId;
+
+        if TypeId::of::<S>() == TypeId::of::<crate::Fallback>() {
+            X86DispatchBackend::Fallback
+        } else if TypeId::of::<S>() == TypeId::of::<crate::Sse4_2>() {
+            X86DispatchBackend::Sse4_2
+        } else if TypeId::of::<S>() == TypeId::of::<crate::Avx2>() {
+            X86DispatchBackend::Avx2
+        } else if TypeId::of::<S>() == TypeId::of::<crate::Avx512>() {
+            X86DispatchBackend::Avx512
+        } else {
+            unreachable!("unexpected x86 dispatch backend")
+        }
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    fn expected_x86_dispatch_backend(level: Level) -> X86DispatchBackend {
+        if cfg!(feature = "multiversion_avx512") && level.as_avx512().is_some() {
+            X86DispatchBackend::Avx512
+        } else if cfg!(feature = "multiversion_avx2") && level.as_avx2().is_some() {
+            X86DispatchBackend::Avx2
+        } else if cfg!(feature = "multiversion_sse4_2") && level.as_sse4_2().is_some() {
+            X86DispatchBackend::Sse4_2
+        } else {
+            X86DispatchBackend::Fallback
+        }
+    }
+
+    #[cfg(all(
+        feature = "std",
+        any(target_arch = "x86", target_arch = "x86_64"),
+        not(feature = "multiversion_avx2")
+    ))]
+    fn x86_detects_avx2_level() -> bool {
+        std::arch::is_x86_feature_detected!("avx2")
+            && std::arch::is_x86_feature_detected!("bmi1")
+            && std::arch::is_x86_feature_detected!("bmi2")
+            && std::arch::is_x86_feature_detected!("cmpxchg16b")
+            && std::arch::is_x86_feature_detected!("f16c")
+            && std::arch::is_x86_feature_detected!("fma")
+            && std::arch::is_x86_feature_detected!("lzcnt")
+            && std::arch::is_x86_feature_detected!("movbe")
+            && std::arch::is_x86_feature_detected!("popcnt")
+            && std::arch::is_x86_feature_detected!("xsave")
+    }
+
     #[allow(dead_code, reason = "Compile test")]
     fn dispatch_generic() {
         fn generic<S: Simd, T>(_: S, x: T) -> T {
@@ -208,6 +362,45 @@ mod tests {
     #[test]
     fn dispatch_output() {
         assert_eq!(42, dispatch!(Level::new(), _simd => 42));
+    }
+
+    #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[test]
+    fn dispatch_respects_x86_multiversion_features() {
+        let level = Level::new();
+        let actual = dispatch!(level, simd => x86_dispatch_backend(simd));
+
+        assert_eq!(actual, expected_x86_dispatch_backend(level));
+    }
+
+    #[cfg(all(
+        feature = "std",
+        any(target_arch = "x86", target_arch = "x86_64"),
+        not(feature = "multiversion_avx2")
+    ))]
+    #[test]
+    fn disabled_avx2_multiversioning_does_not_filter_avx2_token_access() {
+        if x86_detects_avx2_level() {
+            assert!(
+                Level::new().as_avx2().is_some(),
+                "`multiversion_avx2` controls dispatch multiversioning, not AVX2 token access"
+            );
+        }
+    }
+
+    #[cfg(all(
+        feature = "std",
+        any(target_arch = "x86", target_arch = "x86_64"),
+        not(feature = "multiversion_avx512")
+    ))]
+    #[test]
+    fn disabled_avx512_multiversioning_does_not_filter_avx512_token_access() {
+        if crate::x86_detects_icelake_avx512() {
+            assert!(
+                Level::new().as_avx512().is_some(),
+                "`multiversion_avx512` controls dispatch multiversioning, not AVX-512 token access"
+            );
+        }
     }
 
     mod no_import_simd {

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -190,9 +190,9 @@ macro_rules! __fearless_simd_dispatch_multiversion_avx2 {
 macro_rules! __fearless_simd_dispatch_multiversion_avx2_from_superset {
     ($proof:expr, $simd:pat => $op:expr) => {{
         let __fearless_simd_proof = $proof;
-        let _ = __fearless_simd_proof;
-        // SAFETY: this helper is only called with proof of an x86 level that includes AVX2.
-        let __fearless_simd_token = unsafe { $crate::Avx2::new_unchecked() };
+        let __fearless_simd_token = $crate::Simd::level(__fearless_simd_proof)
+            .as_avx2()
+            .expect("a superset x86 SIMD level should provide an AVX2 token");
         $crate::__fearless_simd_dispatch_with_token!(__fearless_simd_token, $simd => $op)
     }};
 }
@@ -236,9 +236,9 @@ macro_rules! __fearless_simd_dispatch_multiversion_sse4_2 {
 macro_rules! __fearless_simd_dispatch_multiversion_sse4_2_from_superset {
     ($proof:expr, $simd:pat => $op:expr) => {{
         let __fearless_simd_proof = $proof;
-        let _ = __fearless_simd_proof;
-        // SAFETY: this helper is only called with proof of an x86 level that includes SSE4.2.
-        let __fearless_simd_token = unsafe { $crate::Sse4_2::new_unchecked() };
+        let __fearless_simd_token = $crate::Simd::level(__fearless_simd_proof)
+            .as_sse4_2()
+            .expect("a superset x86 SIMD level should provide an SSE4.2 token");
         $crate::__fearless_simd_dispatch_with_token!(__fearless_simd_token, $simd => $op)
     }};
 }

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -115,6 +115,11 @@ macro_rules! dispatch {
     }};
 }
 
+// The x86 multiversion helpers are split into cfg-selected macro definitions
+// because exported macro bodies are expanded in the downstream crate,
+// so putting `#[cfg(feature = "...")]` directly inside `dispatch!` would test
+// the downstream crate's features instead of `fearless_simd`'s features.
+
 /// Implementation detail of [`crate::dispatch`]; this is not public API.
 #[macro_export]
 #[doc(hidden)]


### PR DESCRIPTION
A different, better take on #228. It doesn't disable the tokens themselves and still lets you use `kernel!` with whatever features you please. The cargo features only control multiversioning via the `dispatch!` macro for functions generic over `Simd`.

~~TODO: better documentation, incl. on opting out specific functions instead of crate-wide, advice on features for library authors, advice on reducing binary size without degrading performance via codegen-units=1 and lto=true~~ Done