### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 -->
 
-The latest published Fearless SIMD release is [0.6.0](#060-2026-06-30) which was released on 2026-06-30.
-You can find its changes [documented below](#060-2026-06-30).
+The latest published Fearless SIMD release is [0.6.0](#060-2026-07-01) which was released on 2026-07-01.
+You can find its changes [documented below](#060-2026-07-01).
 
 ## [Unreleased]
 
@@ -18,12 +18,18 @@ This release has an [MSRV][] of 1.89.
 ### Added
 
 - Added Ice Lake-class AVX-512 support with a generated `Avx512` level and 512-bit native-width vector types. ([#231][] by [@Shnatsel][])
-- Added `dispatch_sse4_2`, `dispatch_avx2`, and `dispatch_avx512` feature flags to control which x86 SIMD levels are used by automatic multiversioning via `dispatch!` and `Level::dispatch`. ([#258][] by [@Shnatsel][])
+- Added controls for x86 automatic multiversioning using `cfg` flags, letting final binary builds decide which levels `dispatch!` uses. ([#258][], [#264][] by [@Shnatsel][])
+- Added the `swizzle_dyn_within_blocks` method on SIMD vector types for dynamic byte-indexed swizzles within each native-width block. ([#266][] by [@Shnatsel][])
 
 ### Changed
 
 - The MSRV is now Rust 1.89. ([#231][] by [@Shnatsel][])
-- Documentation and examples have been expanded and cleaned up for safer SIMD use cases, inlining, supported instruction sets, x86 multiversioning, and feature flags. ([#252][], [#258][] by [@Shnatsel][])
+- Documentation and examples have been expanded and cleaned up to show autovectorization, use of intrinsics, x86 multiversioning, and AVX-512-width inputs. ([#252][], [#258][], [#261][], [#264][] by [@Shnatsel][])
+- `Level::Fallback` and x86 `Level::Sse4_2` variants now remain available whenever their token types exist. ([#264][] by [@Shnatsel][])
+
+### Fixed
+
+- `dispatch!` and `Level::dispatch` now correctly omit AVX2 code paths when the Ice Lake/AVX-512 feature set is available. ([#263][] by [@Shnatsel][])
 
 ## [0.5.0][] (2026-06-18)
 
@@ -254,6 +260,10 @@ No changelog was kept for this release.
 [#245]: https://github.com/linebender/fearless_simd/pull/245
 [#252]: https://github.com/linebender/fearless_simd/pull/252
 [#258]: https://github.com/linebender/fearless_simd/pull/258
+[#261]: https://github.com/linebender/fearless_simd/pull/261
+[#263]: https://github.com/linebender/fearless_simd/pull/263
+[#264]: https://github.com/linebender/fearless_simd/pull/264
+[#266]: https://github.com/linebender/fearless_simd/pull/266
 
 [Unreleased]: https://github.com/linebender/fearless_simd/compare/v0.6.0...HEAD
 [0.6.0]: https://github.com/linebender/fearless_simd/compare/v0.5.0...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 -->
 
-The latest published Fearless SIMD release is [0.6.0](#060-2026-07-01) which was released on 2026-07-01.
-You can find its changes [documented below](#060-2026-07-01).
+The latest published Fearless SIMD release is [0.6.0](#060-2026-07-10) which was released on 2026-07-10.
+You can find its changes [documented below](#060-2026-07-10).
 
 ## [Unreleased]
 
-## [0.6.0][] (2026-07-01)
+## [0.6.0][] (2026-07-10)
 
 This release has an [MSRV][] of 1.89.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,24 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 -->
 
-The latest published Fearless SIMD release is [0.5.0](#050-2026-06-18) which was released on 2026-06-18.
-You can find its changes [documented below](#050-2026-06-18).
+The latest published Fearless SIMD release is [0.6.0](#060-2026-06-30) which was released on 2026-06-30.
+You can find its changes [documented below](#060-2026-06-30).
 
 ## [Unreleased]
+
+## [0.6.0][] (2026-06-30)
 
 This release has an [MSRV][] of 1.89.
 
 ### Added
 
-- Added Ice Lake-class AVX-512 support with a generated `Avx512` level and 512-bit native-width vector types.
+- Added Ice Lake-class AVX-512 support with a generated `Avx512` level and 512-bit native-width vector types. ([#231][] by [@Shnatsel][])
+- Added `dispatch_sse4_2`, `dispatch_avx2`, and `dispatch_avx512` feature flags to control which x86 SIMD levels are used by automatic multiversioning via `dispatch!` and `Level::dispatch`. ([#258][] by [@Shnatsel][])
 
 ### Changed
 
-- The MSRV is now Rust 1.89.
+- The MSRV is now Rust 1.89. ([#231][] by [@Shnatsel][])
+- Documentation and examples have been expanded and cleaned up for safer SIMD use cases, inlining, supported instruction sets, x86 multiversioning, and feature flags. ([#252][], [#258][] by [@Shnatsel][])
 
 ## [0.5.0][] (2026-06-18)
 
@@ -235,6 +239,7 @@ No changelog was kept for this release.
 [#225]: https://github.com/linebender/fearless_simd/pull/225
 [#226]: https://github.com/linebender/fearless_simd/pull/226
 [#230]: https://github.com/linebender/fearless_simd/pull/230
+[#231]: https://github.com/linebender/fearless_simd/pull/231
 [#232]: https://github.com/linebender/fearless_simd/pull/232
 [#233]: https://github.com/linebender/fearless_simd/pull/233
 [#234]: https://github.com/linebender/fearless_simd/pull/234
@@ -247,8 +252,11 @@ No changelog was kept for this release.
 [#243]: https://github.com/linebender/fearless_simd/pull/243
 [#244]: https://github.com/linebender/fearless_simd/pull/244
 [#245]: https://github.com/linebender/fearless_simd/pull/245
+[#252]: https://github.com/linebender/fearless_simd/pull/252
+[#258]: https://github.com/linebender/fearless_simd/pull/258
 
-[Unreleased]: https://github.com/linebender/fearless_simd/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/linebender/fearless_simd/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/linebender/fearless_simd/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/linebender/fearless_simd/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/linebender/fearless_simd/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/linebender/fearless_simd/compare/v0.4.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find its changes [documented below](#060-2026-06-30).
 
 ## [Unreleased]
 
-## [0.6.0][] (2026-06-30)
+## [0.6.0][] (2026-07-01)
 
 This release has an [MSRV][] of 1.89.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "fearless_simd"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "libm",
 ]

--- a/fearless_simd/Cargo.toml
+++ b/fearless_simd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fearless_simd"
-version = "0.5.0"
+version = "0.6.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
While we didn't make any API-breaking changes, previously the widest native vector width was 256 bits, and downstream code could implicitly depend on it. #261 demonstrates this failure mode. So I think calling it 0.6.0 is prudent.