### PR TITLE
Implement swizzle_dyn_within_blocks, add tests

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -175,6 +175,20 @@ impl Simd for Avx2 {
         self.slide_f32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: f32x4<Avx2>, indices: u8x16<Avx2>) -> f32x4<Avx2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_f32x4(a).val.0, indices.into());
+                token.cvt_from_bytes_f32x4(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn abs_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -697,6 +711,20 @@ impl Simd for Avx2 {
         self.slide_i8x16::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i8x16<Avx2>, indices: u8x16<Avx2>) -> i8x16<Avx2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_i8x16(a).val.0, indices.into());
+                token.cvt_from_bytes_i8x16(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1063,6 +1091,20 @@ impl Simd for Avx2 {
         b: u8x16<Self>,
     ) -> u8x16<Self> {
         self.slide_u8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u8x16<Avx2>, indices: u8x16<Avx2>) -> u8x16<Avx2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_u8x16(a).val.0, indices.into());
+                token.cvt_from_bytes_u8x16(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1606,6 +1648,20 @@ impl Simd for Avx2 {
         self.slide_i16x8::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i16x8<Avx2>, indices: u8x16<Avx2>) -> i16x8<Avx2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_i16x8(a).val.0, indices.into());
+                token.cvt_from_bytes_i16x8(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1953,6 +2009,20 @@ impl Simd for Avx2 {
         b: u16x8<Self>,
     ) -> u16x8<Self> {
         self.slide_u16x8::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u16x8<Avx2>, indices: u8x16<Avx2>) -> u16x8<Avx2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_u16x8(a).val.0, indices.into());
+                token.cvt_from_bytes_u16x8(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2475,6 +2545,20 @@ impl Simd for Avx2 {
         self.slide_i32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i32x4<Avx2>, indices: u8x16<Avx2>) -> i32x4<Avx2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_i32x4(a).val.0, indices.into());
+                token.cvt_from_bytes_i32x4(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2842,6 +2926,20 @@ impl Simd for Avx2 {
         b: u32x4<Self>,
     ) -> u32x4<Self> {
         self.slide_u32x4::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u32x4<Avx2>, indices: u8x16<Avx2>) -> u32x4<Avx2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_u32x4(a).val.0, indices.into());
+                token.cvt_from_bytes_u32x4(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -3378,6 +3476,20 @@ impl Simd for Avx2 {
         b: f64x2<Self>,
     ) -> f64x2<Self> {
         self.slide_f64x2::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: f64x2<Avx2>, indices: u8x16<Avx2>) -> f64x2<Avx2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_f64x2(a).val.0, indices.into());
+                token.cvt_from_bytes_f64x2(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn abs_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
@@ -3973,6 +4085,20 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: f32x8<Avx2>, indices: u8x32<Avx2>) -> f32x8<Avx2> {
+                let result = _mm256_shuffle_epi8(token.cvt_to_bytes_f32x8(a).val.0, indices.into());
+                token.cvt_from_bytes_f32x8(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn abs_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -4558,6 +4684,20 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i8x32<Avx2>, indices: u8x32<Avx2>) -> i8x32<Avx2> {
+                let result = _mm256_shuffle_epi8(token.cvt_to_bytes_i8x32(a).val.0, indices.into());
+                token.cvt_from_bytes_i8x32(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5012,6 +5152,20 @@ impl Simd for Avx2 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u8x32<Avx2>, indices: u8x32<Avx2>) -> u8x32<Avx2> {
+                let result = _mm256_shuffle_epi8(token.cvt_to_bytes_u8x32(a).val.0, indices.into());
+                token.cvt_from_bytes_u8x32(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
@@ -5657,6 +5811,25 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x16(
+        self,
+        a: i16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> i16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i16x16<Avx2>, indices: u8x32<Avx2>) -> i16x16<Avx2> {
+                let result =
+                    _mm256_shuffle_epi8(token.cvt_to_bytes_i16x16(a).val.0, indices.into());
+                token.cvt_from_bytes_i16x16(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -6094,6 +6267,25 @@ impl Simd for Avx2 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x16(
+        self,
+        a: u16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> u16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u16x16<Avx2>, indices: u8x32<Avx2>) -> u16x16<Avx2> {
+                let result =
+                    _mm256_shuffle_epi8(token.cvt_to_bytes_u16x16(a).val.0, indices.into());
+                token.cvt_from_bytes_u16x16(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -6737,6 +6929,20 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i32x8<Avx2>, indices: u8x32<Avx2>) -> i32x8<Avx2> {
+                let result = _mm256_shuffle_epi8(token.cvt_to_bytes_i32x8(a).val.0, indices.into());
+                token.cvt_from_bytes_i32x8(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7170,6 +7376,20 @@ impl Simd for Avx2 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u32x8<Avx2>, indices: u8x32<Avx2>) -> u32x8<Avx2> {
+                let result = _mm256_shuffle_epi8(token.cvt_to_bytes_u32x8(a).val.0, indices.into());
+                token.cvt_from_bytes_u32x8(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
@@ -7784,6 +8004,20 @@ impl Simd for Avx2 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: f64x4<Avx2>, indices: u8x32<Avx2>) -> f64x4<Avx2> {
+                let result = _mm256_shuffle_epi8(token.cvt_to_bytes_f64x4(a).val.0, indices.into());
+                token.cvt_from_bytes_f64x4(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn abs_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
@@ -8420,6 +8654,19 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x16(
+        self,
+        a: f32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_f32x8(
+            self.swizzle_dyn_within_blocks_f32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_f32x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn abs_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.abs_f32x8(a0), self.abs_f32x8(a1))
@@ -8859,6 +9106,15 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
+        let (a0, a1) = self.split_i8x64(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i8x32(
+            self.swizzle_dyn_within_blocks_i8x32(a0, indices0),
+            self.swizzle_dyn_within_blocks_i8x32(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
         let (b0, b1) = self.split_i8x64(b);
@@ -9127,6 +9383,15 @@ impl Simd for Avx2 {
         self.combine_u8x32(
             self.slide_within_blocks_u8x32::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x32::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self> {
+        let (a0, a1) = self.split_u8x64(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u8x32(
+            self.swizzle_dyn_within_blocks_u8x32(a0, indices0),
+            self.swizzle_dyn_within_blocks_u8x32(a1, indices1),
         )
     }
     #[inline(always)]
@@ -9628,6 +9893,19 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x32(
+        self,
+        a: i16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> i16x32<Self> {
+        let (a0, a1) = self.split_i16x32(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i16x16(
+            self.swizzle_dyn_within_blocks_i16x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_i16x16(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
         let (b0, b1) = self.split_i16x32(b);
@@ -9905,6 +10183,19 @@ impl Simd for Avx2 {
         self.combine_u16x16(
             self.slide_within_blocks_u16x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x16::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x32(
+        self,
+        a: u16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> u16x32<Self> {
+        let (a0, a1) = self.split_u16x32(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u16x16(
+            self.swizzle_dyn_within_blocks_u16x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_u16x16(a1, indices1),
         )
     }
     #[inline(always)]
@@ -10414,6 +10705,19 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x16(
+        self,
+        a: i32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> i32x16<Self> {
+        let (a0, a1) = self.split_i32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i32x8(
+            self.swizzle_dyn_within_blocks_i32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_i32x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
         let (b0, b1) = self.split_i32x16(b);
@@ -10687,6 +10991,19 @@ impl Simd for Avx2 {
         self.combine_u32x8(
             self.slide_within_blocks_u32x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x8::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x16(
+        self,
+        a: u32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> u32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u32x8(
+            self.swizzle_dyn_within_blocks_u32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_u32x8(a1, indices1),
         )
     }
     #[inline(always)]
@@ -11163,6 +11480,15 @@ impl Simd for Avx2 {
         self.combine_f64x4(
             self.slide_within_blocks_f64x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x4::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_f64x4(
+            self.swizzle_dyn_within_blocks_f64x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_f64x4(a1, indices1),
         )
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -183,6 +183,21 @@ impl Simd for Avx512 {
         self.slide_f32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: f32x4<Avx512>, indices: u8x16<Avx512>) -> f32x4<Avx512> {
+                let bytes = token.cvt_to_bytes_f32x4(a).val.0;
+                let result = _mm_mask_shuffle_epi8(bytes, u16::MAX, bytes, indices.into());
+                token.cvt_from_bytes_f32x4(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn abs_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -702,6 +717,21 @@ impl Simd for Avx512 {
         self.slide_i8x16::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x16<Avx512>, indices: u8x16<Avx512>) -> i8x16<Avx512> {
+                let bytes = token.cvt_to_bytes_i8x16(a).val.0;
+                let result = _mm_mask_shuffle_epi8(bytes, u16::MAX, bytes, indices.into());
+                token.cvt_from_bytes_i8x16(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1146,6 +1176,21 @@ impl Simd for Avx512 {
         b: u8x16<Self>,
     ) -> u8x16<Self> {
         self.slide_u8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x16<Avx512>, indices: u8x16<Avx512>) -> u8x16<Avx512> {
+                let bytes = token.cvt_to_bytes_u8x16(a).val.0;
+                let result = _mm_mask_shuffle_epi8(bytes, u16::MAX, bytes, indices.into());
+                token.cvt_from_bytes_u8x16(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1719,6 +1764,21 @@ impl Simd for Avx512 {
         self.slide_i16x8::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x8<Avx512>, indices: u8x16<Avx512>) -> i16x8<Avx512> {
+                let bytes = token.cvt_to_bytes_i16x8(a).val.0;
+                let result = _mm_mask_shuffle_epi8(bytes, u16::MAX, bytes, indices.into());
+                token.cvt_from_bytes_i16x8(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2114,6 +2174,21 @@ impl Simd for Avx512 {
         b: u16x8<Self>,
     ) -> u16x8<Self> {
         self.slide_u16x8::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x8<Avx512>, indices: u8x16<Avx512>) -> u16x8<Avx512> {
+                let bytes = token.cvt_to_bytes_u16x8(a).val.0;
+                let result = _mm_mask_shuffle_epi8(bytes, u16::MAX, bytes, indices.into());
+                token.cvt_from_bytes_u16x8(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2638,6 +2713,21 @@ impl Simd for Avx512 {
         self.slide_i32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x4<Avx512>, indices: u8x16<Avx512>) -> i32x4<Avx512> {
+                let bytes = token.cvt_to_bytes_i32x4(a).val.0;
+                let result = _mm_mask_shuffle_epi8(bytes, u16::MAX, bytes, indices.into());
+                token.cvt_from_bytes_i32x4(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3033,6 +3123,21 @@ impl Simd for Avx512 {
         b: u32x4<Self>,
     ) -> u32x4<Self> {
         self.slide_u32x4::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x4<Avx512>, indices: u8x16<Avx512>) -> u32x4<Avx512> {
+                let bytes = token.cvt_to_bytes_u32x4(a).val.0;
+                let result = _mm_mask_shuffle_epi8(bytes, u16::MAX, bytes, indices.into());
+                token.cvt_from_bytes_u32x4(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -3546,6 +3651,21 @@ impl Simd for Avx512 {
         b: f64x2<Self>,
     ) -> f64x2<Self> {
         self.slide_f64x2::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: f64x2<Avx512>, indices: u8x16<Avx512>) -> f64x2<Avx512> {
+                let bytes = token.cvt_to_bytes_f64x2(a).val.0;
+                let result = _mm_mask_shuffle_epi8(bytes, u16::MAX, bytes, indices.into());
+                token.cvt_from_bytes_f64x2(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn abs_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
@@ -4146,6 +4266,21 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: f32x8<Avx512>, indices: u8x32<Avx512>) -> f32x8<Avx512> {
+                let bytes = token.cvt_to_bytes_f32x8(a).val.0;
+                let result = _mm256_mask_shuffle_epi8(bytes, u32::MAX, bytes, indices.into());
+                token.cvt_from_bytes_f32x8(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn abs_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
@@ -4768,6 +4903,21 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x32<Avx512>, indices: u8x32<Avx512>) -> i8x32<Avx512> {
+                let bytes = token.cvt_to_bytes_i8x32(a).val.0;
+                let result = _mm256_mask_shuffle_epi8(bytes, u32::MAX, bytes, indices.into());
+                token.cvt_from_bytes_i8x32(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5323,6 +5473,21 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x32<Avx512>, indices: u8x32<Avx512>) -> u8x32<Avx512> {
+                let bytes = token.cvt_to_bytes_u8x32(a).val.0;
+                let result = _mm256_mask_shuffle_epi8(bytes, u32::MAX, bytes, indices.into());
+                token.cvt_from_bytes_u8x32(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
@@ -6017,6 +6182,25 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x16(
+        self,
+        a: i16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> i16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x16<Avx512>, indices: u8x32<Avx512>) -> i16x16<Avx512> {
+                let bytes = token.cvt_to_bytes_i16x16(a).val.0;
+                let result = _mm256_mask_shuffle_epi8(bytes, u32::MAX, bytes, indices.into());
+                token.cvt_from_bytes_i16x16(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -6503,6 +6687,25 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x16(
+        self,
+        a: u16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> u16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x16<Avx512>, indices: u8x32<Avx512>) -> u16x16<Avx512> {
+                let bytes = token.cvt_to_bytes_u16x16(a).val.0;
+                let result = _mm256_mask_shuffle_epi8(bytes, u32::MAX, bytes, indices.into());
+                token.cvt_from_bytes_u16x16(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -7142,6 +7345,21 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x8<Avx512>, indices: u8x32<Avx512>) -> i32x8<Avx512> {
+                let bytes = token.cvt_to_bytes_i32x8(a).val.0;
+                let result = _mm256_mask_shuffle_epi8(bytes, u32::MAX, bytes, indices.into());
+                token.cvt_from_bytes_i32x8(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7616,6 +7834,21 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x8<Avx512>, indices: u8x32<Avx512>) -> u32x8<Avx512> {
+                let bytes = token.cvt_to_bytes_u32x8(a).val.0;
+                let result = _mm256_mask_shuffle_epi8(bytes, u32::MAX, bytes, indices.into());
+                token.cvt_from_bytes_u32x8(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
@@ -8222,6 +8455,21 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: f64x4<Avx512>, indices: u8x32<Avx512>) -> f64x4<Avx512> {
+                let bytes = token.cvt_to_bytes_f64x4(a).val.0;
+                let result = _mm256_mask_shuffle_epi8(bytes, u32::MAX, bytes, indices.into());
+                token.cvt_from_bytes_f64x4(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn abs_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
@@ -8890,6 +9138,25 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x16(
+        self,
+        a: f32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> f32x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: f32x16<Avx512>, indices: u8x64<Avx512>) -> f32x16<Avx512> {
+                let result =
+                    _mm512_shuffle_epi8(token.cvt_to_bytes_f32x16(a).val.0, indices.into());
+                token.cvt_from_bytes_f32x16(u8x64 {
+                    val: crate::support::Aligned512(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn abs_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -9554,6 +9821,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x64<Avx512>, indices: u8x64<Avx512>) -> i8x64<Avx512> {
+                let result = _mm512_shuffle_epi8(token.cvt_to_bytes_i8x64(a).val.0, indices.into());
+                token.cvt_from_bytes_i8x64(u8x64 {
+                    val: crate::support::Aligned512(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -10125,6 +10406,20 @@ impl Simd for Avx512 {
             val: crate::support::Aligned512(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x64<Avx512>, indices: u8x64<Avx512>) -> u8x64<Avx512> {
+                let result = _mm512_shuffle_epi8(token.cvt_to_bytes_u8x64(a).val.0, indices.into());
+                token.cvt_from_bytes_u8x64(u8x64 {
+                    val: crate::support::Aligned512(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -10849,6 +11144,25 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x32(
+        self,
+        a: i16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> i16x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x32<Avx512>, indices: u8x64<Avx512>) -> i16x32<Avx512> {
+                let result =
+                    _mm512_shuffle_epi8(token.cvt_to_bytes_i16x32(a).val.0, indices.into());
+                token.cvt_from_bytes_i16x32(u8x64 {
+                    val: crate::support::Aligned512(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -11345,6 +11659,25 @@ impl Simd for Avx512 {
             val: crate::support::Aligned512(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x32(
+        self,
+        a: u16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> u16x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x32<Avx512>, indices: u8x64<Avx512>) -> u16x32<Avx512> {
+                let result =
+                    _mm512_shuffle_epi8(token.cvt_to_bytes_u16x32(a).val.0, indices.into());
+                token.cvt_from_bytes_u16x32(u8x64 {
+                    val: crate::support::Aligned512(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -12022,6 +12355,25 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x16(
+        self,
+        a: i32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> i32x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x16<Avx512>, indices: u8x64<Avx512>) -> i32x16<Avx512> {
+                let result =
+                    _mm512_shuffle_epi8(token.cvt_to_bytes_i32x16(a).val.0, indices.into());
+                token.cvt_from_bytes_i32x16(u8x64 {
+                    val: crate::support::Aligned512(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -12510,6 +12862,25 @@ impl Simd for Avx512 {
             val: crate::support::Aligned512(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x16(
+        self,
+        a: u32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> u32x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x16<Avx512>, indices: u8x64<Avx512>) -> u32x16<Avx512> {
+                let result =
+                    _mm512_shuffle_epi8(token.cvt_to_bytes_u32x16(a).val.0, indices.into());
+                token.cvt_from_bytes_u32x16(u8x64 {
+                    val: crate::support::Aligned512(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -13151,6 +13522,20 @@ impl Simd for Avx512 {
             val: crate::support::Aligned512(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: f64x8<Avx512>, indices: u8x64<Avx512>) -> f64x8<Avx512> {
+                let result = _mm512_shuffle_epi8(token.cvt_to_bytes_f64x8(a).val.0, indices.into());
+                token.cvt_from_bytes_f64x8(u8x64 {
+                    val: crate::support::Aligned512(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn abs_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -215,6 +215,78 @@ impl Simd for Fallback {
         self.slide_f32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
+        let bytes = self.cvt_to_bytes_f32x4(a);
+        let result: u8x16<Self> = [
+            {
+                let index = indices[0usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[1usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[2usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[3usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[4usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[5usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[6usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[7usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[8usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[9usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[10usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[11usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[12usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[13usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[14usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[15usize] as usize;
+                bytes[index % 16usize]
+            },
+        ]
+        .simd_into(self);
+        self.cvt_from_bytes_f32x4(result)
+    }
+    #[inline(always)]
     fn abs_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
         [
             f32::abs(a[0usize]),
@@ -609,6 +681,78 @@ impl Simd for Fallback {
         b: i8x16<Self>,
     ) -> i8x16<Self> {
         self.slide_i8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
+        let bytes = self.cvt_to_bytes_i8x16(a);
+        let result: u8x16<Self> = [
+            {
+                let index = indices[0usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[1usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[2usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[3usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[4usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[5usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[6usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[7usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[8usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[9usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[10usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[11usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[12usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[13usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[14usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[15usize] as usize;
+                bytes[index % 16usize]
+            },
+        ]
+        .simd_into(self);
+        self.cvt_from_bytes_i8x16(result)
     }
     #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
@@ -1234,6 +1378,78 @@ impl Simd for Fallback {
         b: u8x16<Self>,
     ) -> u8x16<Self> {
         self.slide_u8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
+        let bytes = self.cvt_to_bytes_u8x16(a);
+        let result: u8x16<Self> = [
+            {
+                let index = indices[0usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[1usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[2usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[3usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[4usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[5usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[6usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[7usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[8usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[9usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[10usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[11usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[12usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[13usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[14usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[15usize] as usize;
+                bytes[index % 16usize]
+            },
+        ]
+        .simd_into(self);
+        self.cvt_from_bytes_u8x16(result)
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -2187,6 +2403,78 @@ impl Simd for Fallback {
         self.slide_i16x8::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
+        let bytes = self.cvt_to_bytes_i16x8(a);
+        let result: u8x16<Self> = [
+            {
+                let index = indices[0usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[1usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[2usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[3usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[4usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[5usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[6usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[7usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[8usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[9usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[10usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[11usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[12usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[13usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[14usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[15usize] as usize;
+                bytes[index % 16usize]
+            },
+        ]
+        .simd_into(self);
+        self.cvt_from_bytes_i16x8(result)
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         [
             i16::wrapping_add(a[0usize], b[0usize]),
@@ -2611,6 +2899,78 @@ impl Simd for Fallback {
         b: u16x8<Self>,
     ) -> u16x8<Self> {
         self.slide_u16x8::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
+        let bytes = self.cvt_to_bytes_u16x8(a);
+        let result: u8x16<Self> = [
+            {
+                let index = indices[0usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[1usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[2usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[3usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[4usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[5usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[6usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[7usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[8usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[9usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[10usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[11usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[12usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[13usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[14usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[15usize] as usize;
+                bytes[index % 16usize]
+            },
+        ]
+        .simd_into(self);
+        self.cvt_from_bytes_u16x8(result)
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -3243,6 +3603,78 @@ impl Simd for Fallback {
         self.slide_i32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
+        let bytes = self.cvt_to_bytes_i32x4(a);
+        let result: u8x16<Self> = [
+            {
+                let index = indices[0usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[1usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[2usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[3usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[4usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[5usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[6usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[7usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[8usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[9usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[10usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[11usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[12usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[13usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[14usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[15usize] as usize;
+                bytes[index % 16usize]
+            },
+        ]
+        .simd_into(self);
+        self.cvt_from_bytes_i32x4(result)
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         [
             i32::wrapping_add(a[0usize], b[0usize]),
@@ -3569,6 +4001,78 @@ impl Simd for Fallback {
         b: u32x4<Self>,
     ) -> u32x4<Self> {
         self.slide_u32x4::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
+        let bytes = self.cvt_to_bytes_u32x4(a);
+        let result: u8x16<Self> = [
+            {
+                let index = indices[0usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[1usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[2usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[3usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[4usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[5usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[6usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[7usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[8usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[9usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[10usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[11usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[12usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[13usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[14usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[15usize] as usize;
+                bytes[index % 16usize]
+            },
+        ]
+        .simd_into(self);
+        self.cvt_from_bytes_u32x4(result)
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4035,6 +4539,78 @@ impl Simd for Fallback {
         self.slide_f64x2::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
+        let bytes = self.cvt_to_bytes_f64x2(a);
+        let result: u8x16<Self> = [
+            {
+                let index = indices[0usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[1usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[2usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[3usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[4usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[5usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[6usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[7usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[8usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[9usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[10usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[11usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[12usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[13usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[14usize] as usize;
+                bytes[index % 16usize]
+            },
+            {
+                let index = indices[15usize] as usize;
+                bytes[index % 16usize]
+            },
+        ]
+        .simd_into(self);
+        self.cvt_from_bytes_f64x2(result)
+    }
+    #[inline(always)]
     fn abs_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
         [f64::abs(a[0usize]), f64::abs(a[1usize])].simd_into(self)
     }
@@ -4441,6 +5017,15 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_f32x4(
+            self.swizzle_dyn_within_blocks_f32x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_f32x4(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn abs_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f32x4(self.abs_f32x4(a0), self.abs_f32x4(a1))
@@ -4798,6 +5383,15 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_i8x16(
+            self.swizzle_dyn_within_blocks_i8x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_i8x16(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
         let (b0, b1) = self.split_i8x32(b);
@@ -5059,6 +5653,15 @@ impl Simd for Fallback {
         self.combine_u8x16(
             self.slide_within_blocks_u8x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x16::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_u8x16(
+            self.swizzle_dyn_within_blocks_u8x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_u8x16(a1, indices1),
         )
     }
     #[inline(always)]
@@ -5440,6 +6043,19 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x16(
+        self,
+        a: i16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_i16x8(
+            self.swizzle_dyn_within_blocks_i16x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_i16x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
         let (b0, b1) = self.split_i16x16(b);
@@ -5701,6 +6317,19 @@ impl Simd for Fallback {
         self.combine_u16x8(
             self.slide_within_blocks_u16x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x8::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x16(
+        self,
+        a: u16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_u16x8(
+            self.swizzle_dyn_within_blocks_u16x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_u16x8(a1, indices1),
         )
     }
     #[inline(always)]
@@ -6104,6 +6733,15 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_i32x4(
+            self.swizzle_dyn_within_blocks_i32x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_i32x4(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
         let (b0, b1) = self.split_i32x8(b);
@@ -6370,6 +7008,15 @@ impl Simd for Fallback {
         self.combine_u32x4(
             self.slide_within_blocks_u32x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x4::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_u32x4(
+            self.swizzle_dyn_within_blocks_u32x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_u32x4(a1, indices1),
         )
     }
     #[inline(always)]
@@ -6745,6 +7392,15 @@ impl Simd for Fallback {
         self.combine_f64x2(
             self.slide_within_blocks_f64x2::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x2::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_f64x2(
+            self.swizzle_dyn_within_blocks_f64x2(a0, indices0),
+            self.swizzle_dyn_within_blocks_f64x2(a1, indices1),
         )
     }
     #[inline(always)]
@@ -7177,6 +7833,19 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x16(
+        self,
+        a: f32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_f32x8(
+            self.swizzle_dyn_within_blocks_f32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_f32x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn abs_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.abs_f32x8(a0), self.abs_f32x8(a1))
@@ -7557,6 +8226,15 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
+        let (a0, a1) = self.split_i8x64(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i8x32(
+            self.swizzle_dyn_within_blocks_i8x32(a0, indices0),
+            self.swizzle_dyn_within_blocks_i8x32(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
         let (b0, b1) = self.split_i8x64(b);
@@ -7811,6 +8489,15 @@ impl Simd for Fallback {
         self.combine_u8x32(
             self.slide_within_blocks_u8x32::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x32::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self> {
+        let (a0, a1) = self.split_u8x64(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u8x32(
+            self.swizzle_dyn_within_blocks_u8x32(a0, indices0),
+            self.swizzle_dyn_within_blocks_u8x32(a1, indices1),
         )
     }
     #[inline(always)]
@@ -8258,6 +8945,19 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x32(
+        self,
+        a: i16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> i16x32<Self> {
+        let (a0, a1) = self.split_i16x32(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i16x16(
+            self.swizzle_dyn_within_blocks_i16x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_i16x16(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
         let (b0, b1) = self.split_i16x32(b);
@@ -8521,6 +9221,19 @@ impl Simd for Fallback {
         self.combine_u16x16(
             self.slide_within_blocks_u16x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x16::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x32(
+        self,
+        a: u16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> u16x32<Self> {
+        let (a0, a1) = self.split_u16x32(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u16x16(
+            self.swizzle_dyn_within_blocks_u16x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_u16x16(a1, indices1),
         )
     }
     #[inline(always)]
@@ -8953,6 +9666,19 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x16(
+        self,
+        a: i32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> i32x16<Self> {
+        let (a0, a1) = self.split_i32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i32x8(
+            self.swizzle_dyn_within_blocks_i32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_i32x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
         let (b0, b1) = self.split_i32x16(b);
@@ -9212,6 +9938,19 @@ impl Simd for Fallback {
         self.combine_u32x8(
             self.slide_within_blocks_u32x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x8::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x16(
+        self,
+        a: u32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> u32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u32x8(
+            self.swizzle_dyn_within_blocks_u32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_u32x8(a1, indices1),
         )
     }
     #[inline(always)]
@@ -9603,6 +10342,15 @@ impl Simd for Fallback {
         self.combine_f64x4(
             self.slide_within_blocks_f64x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x4::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_f64x4(
+            self.swizzle_dyn_within_blocks_f64x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_f64x4(a1, indices1),
         )
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -165,6 +165,20 @@ impl Simd for Neon {
         self.slide_f32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: f32x4<Neon>, indices: u8x16<Neon>) -> f32x4<Neon> {
+                let result = vqtbl1q_u8(token.cvt_to_bytes_f32x4(a).val.0, indices.into());
+                token.cvt_from_bytes_f32x4(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn abs_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -642,6 +656,20 @@ impl Simd for Neon {
         self.slide_i8x16::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i8x16<Neon>, indices: u8x16<Neon>) -> i8x16<Neon> {
+                let result = vqtbl1q_u8(token.cvt_to_bytes_i8x16(a).val.0, indices.into());
+                token.cvt_from_bytes_i8x16(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1006,6 +1034,20 @@ impl Simd for Neon {
         b: u8x16<Self>,
     ) -> u8x16<Self> {
         self.slide_u8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u8x16<Neon>, indices: u8x16<Neon>) -> u8x16<Neon> {
+                let result = vqtbl1q_u8(token.cvt_to_bytes_u8x16(a).val.0, indices.into());
+                token.cvt_from_bytes_u8x16(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1553,6 +1595,20 @@ impl Simd for Neon {
         self.slide_i16x8::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i16x8<Neon>, indices: u8x16<Neon>) -> i16x8<Neon> {
+                let result = vqtbl1q_u8(token.cvt_to_bytes_i16x8(a).val.0, indices.into());
+                token.cvt_from_bytes_i16x8(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1917,6 +1973,20 @@ impl Simd for Neon {
         b: u16x8<Self>,
     ) -> u16x8<Self> {
         self.slide_u16x8::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u16x8<Neon>, indices: u8x16<Neon>) -> u16x8<Neon> {
+                let result = vqtbl1q_u8(token.cvt_to_bytes_u16x8(a).val.0, indices.into());
+                token.cvt_from_bytes_u16x8(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2454,6 +2524,20 @@ impl Simd for Neon {
         self.slide_i32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i32x4<Neon>, indices: u8x16<Neon>) -> i32x4<Neon> {
+                let result = vqtbl1q_u8(token.cvt_to_bytes_i32x4(a).val.0, indices.into());
+                token.cvt_from_bytes_i32x4(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2828,6 +2912,20 @@ impl Simd for Neon {
         b: u32x4<Self>,
     ) -> u32x4<Self> {
         self.slide_u32x4::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u32x4<Neon>, indices: u8x16<Neon>) -> u32x4<Neon> {
+                let result = vqtbl1q_u8(token.cvt_to_bytes_u32x4(a).val.0, indices.into());
+                token.cvt_from_bytes_u32x4(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -3362,6 +3460,20 @@ impl Simd for Neon {
         b: f64x2<Self>,
     ) -> f64x2<Self> {
         self.slide_f64x2::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: f64x2<Neon>, indices: u8x16<Neon>) -> f64x2<Neon> {
+                let result = vqtbl1q_u8(token.cvt_to_bytes_f64x2(a).val.0, indices.into());
+                token.cvt_from_bytes_f64x2(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn abs_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
@@ -3981,6 +4093,15 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_f32x4(
+            self.swizzle_dyn_within_blocks_f32x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_f32x4(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn abs_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f32x4(self.abs_f32x4(a0), self.abs_f32x4(a1))
@@ -4375,6 +4496,15 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_i8x16(
+            self.swizzle_dyn_within_blocks_i8x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_i8x16(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
         let (b0, b1) = self.split_i8x32(b);
@@ -4673,6 +4803,15 @@ impl Simd for Neon {
         self.combine_u8x16(
             self.slide_within_blocks_u8x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x16::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_u8x16(
+            self.swizzle_dyn_within_blocks_u8x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_u8x16(a1, indices1),
         )
     }
     #[inline(always)]
@@ -5098,6 +5237,19 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x16(
+        self,
+        a: i16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_i16x8(
+            self.swizzle_dyn_within_blocks_i16x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_i16x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
         let (b0, b1) = self.split_i16x16(b);
@@ -5396,6 +5548,19 @@ impl Simd for Neon {
         self.combine_u16x8(
             self.slide_within_blocks_u16x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x8::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x16(
+        self,
+        a: u16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_u16x8(
+            self.swizzle_dyn_within_blocks_u16x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_u16x8(a1, indices1),
         )
     }
     #[inline(always)]
@@ -5834,6 +5999,15 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_i32x4(
+            self.swizzle_dyn_within_blocks_i32x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_i32x4(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
         let (b0, b1) = self.split_i32x8(b);
@@ -6137,6 +6311,15 @@ impl Simd for Neon {
         self.combine_u32x4(
             self.slide_within_blocks_u32x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x4::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_u32x4(
+            self.swizzle_dyn_within_blocks_u32x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_u32x4(a1, indices1),
         )
     }
     #[inline(always)]
@@ -6556,6 +6739,15 @@ impl Simd for Neon {
         self.combine_f64x2(
             self.slide_within_blocks_f64x2::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x2::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_f64x2(
+            self.swizzle_dyn_within_blocks_f64x2(a0, indices0),
+            self.swizzle_dyn_within_blocks_f64x2(a1, indices1),
         )
     }
     #[inline(always)]
@@ -7050,6 +7242,19 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x16(
+        self,
+        a: f32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_f32x8(
+            self.swizzle_dyn_within_blocks_f32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_f32x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn abs_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.abs_f32x8(a0), self.abs_f32x8(a1))
@@ -7461,6 +7666,15 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
+        let (a0, a1) = self.split_i8x64(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i8x32(
+            self.swizzle_dyn_within_blocks_i8x32(a0, indices0),
+            self.swizzle_dyn_within_blocks_i8x32(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
         let (b0, b1) = self.split_i8x64(b);
@@ -7768,6 +7982,15 @@ impl Simd for Neon {
         self.combine_u8x32(
             self.slide_within_blocks_u8x32::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x32::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self> {
+        let (a0, a1) = self.split_u8x64(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u8x32(
+            self.swizzle_dyn_within_blocks_u8x32(a0, indices0),
+            self.swizzle_dyn_within_blocks_u8x32(a1, indices1),
         )
     }
     #[inline(always)]
@@ -8196,6 +8419,19 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x32(
+        self,
+        a: i16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> i16x32<Self> {
+        let (a0, a1) = self.split_i16x32(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i16x16(
+            self.swizzle_dyn_within_blocks_i16x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_i16x16(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
         let (b0, b1) = self.split_i16x32(b);
@@ -8512,6 +8748,19 @@ impl Simd for Neon {
         self.combine_u16x16(
             self.slide_within_blocks_u16x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x16::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x32(
+        self,
+        a: u16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> u16x32<Self> {
+        let (a0, a1) = self.split_u16x32(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u16x16(
+            self.swizzle_dyn_within_blocks_u16x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_u16x16(a1, indices1),
         )
     }
     #[inline(always)]
@@ -8962,6 +9211,19 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x16(
+        self,
+        a: i32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> i32x16<Self> {
+        let (a0, a1) = self.split_i32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i32x8(
+            self.swizzle_dyn_within_blocks_i32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_i32x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
         let (b0, b1) = self.split_i32x16(b);
@@ -9274,6 +9536,19 @@ impl Simd for Neon {
         self.combine_u32x8(
             self.slide_within_blocks_u32x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x8::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x16(
+        self,
+        a: u32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> u32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u32x8(
+            self.swizzle_dyn_within_blocks_u32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_u32x8(a1, indices1),
         )
     }
     #[inline(always)]
@@ -9701,6 +9976,15 @@ impl Simd for Neon {
         self.combine_f64x4(
             self.slide_within_blocks_f64x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x4::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_f64x4(
+            self.swizzle_dyn_within_blocks_f64x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_f64x4(a1, indices1),
         )
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -144,7 +144,7 @@ pub trait Simd:
         a: f32x4<Self>,
         b: f32x4<Self>,
     ) -> f32x4<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self>;
     #[doc = "Compute the absolute value of each element."]
     fn abs_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
@@ -254,7 +254,7 @@ pub trait Simd:
         a: i8x16<Self>,
         b: i8x16<Self>,
     ) -> i8x16<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
@@ -340,7 +340,7 @@ pub trait Simd:
         a: u8x16<Self>,
         b: u8x16<Self>,
     ) -> u8x16<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
@@ -463,7 +463,7 @@ pub trait Simd:
         a: i16x8<Self>,
         b: i16x8<Self>,
     ) -> i16x8<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
@@ -549,7 +549,7 @@ pub trait Simd:
         a: u16x8<Self>,
         b: u16x8<Self>,
     ) -> u16x8<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
@@ -672,7 +672,7 @@ pub trait Simd:
         a: i32x4<Self>,
         b: i32x4<Self>,
     ) -> i32x4<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
@@ -760,7 +760,7 @@ pub trait Simd:
         a: u32x4<Self>,
         b: u32x4<Self>,
     ) -> u32x4<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
@@ -883,7 +883,7 @@ pub trait Simd:
         a: f64x2<Self>,
         b: f64x2<Self>,
     ) -> f64x2<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self>;
     #[doc = "Compute the absolute value of each element."]
     fn abs_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
@@ -1018,7 +1018,7 @@ pub trait Simd:
         a: f32x8<Self>,
         b: f32x8<Self>,
     ) -> f32x8<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self>;
     #[doc = "Compute the absolute value of each element."]
     fn abs_f32x8(self, a: f32x8<Self>) -> f32x8<Self>;
@@ -1130,7 +1130,7 @@ pub trait Simd:
         a: i8x32<Self>,
         b: i8x32<Self>,
     ) -> i8x32<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self>;
@@ -1218,7 +1218,7 @@ pub trait Simd:
         a: u8x32<Self>,
         b: u8x32<Self>,
     ) -> u8x32<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self>;
@@ -1345,7 +1345,7 @@ pub trait Simd:
         a: i16x16<Self>,
         b: i16x16<Self>,
     ) -> i16x16<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i16x16(
         self,
         a: i16x16<Self>,
@@ -1437,7 +1437,7 @@ pub trait Simd:
         a: u16x16<Self>,
         b: u16x16<Self>,
     ) -> u16x16<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u16x16(
         self,
         a: u16x16<Self>,
@@ -1570,7 +1570,7 @@ pub trait Simd:
         a: i32x8<Self>,
         b: i32x8<Self>,
     ) -> i32x8<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self>;
@@ -1660,7 +1660,7 @@ pub trait Simd:
         a: u32x8<Self>,
         b: u32x8<Self>,
     ) -> u32x8<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self>;
@@ -1787,7 +1787,7 @@ pub trait Simd:
         a: f64x4<Self>,
         b: f64x4<Self>,
     ) -> f64x4<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self>;
     #[doc = "Compute the absolute value of each element."]
     fn abs_f64x4(self, a: f64x4<Self>) -> f64x4<Self>;
@@ -1926,7 +1926,7 @@ pub trait Simd:
         a: f32x16<Self>,
         b: f32x16<Self>,
     ) -> f32x16<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_f32x16(
         self,
         a: f32x16<Self>,
@@ -2044,7 +2044,7 @@ pub trait Simd:
         a: i8x64<Self>,
         b: i8x64<Self>,
     ) -> i8x64<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self>;
@@ -2130,7 +2130,7 @@ pub trait Simd:
         a: u8x64<Self>,
         b: u8x64<Self>,
     ) -> u8x64<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self>;
@@ -2255,7 +2255,7 @@ pub trait Simd:
         a: i16x32<Self>,
         b: i16x32<Self>,
     ) -> i16x32<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i16x32(
         self,
         a: i16x32<Self>,
@@ -2345,7 +2345,7 @@ pub trait Simd:
         a: u16x32<Self>,
         b: u16x32<Self>,
     ) -> u16x32<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u16x32(
         self,
         a: u16x32<Self>,
@@ -2478,7 +2478,7 @@ pub trait Simd:
         a: i32x16<Self>,
         b: i32x16<Self>,
     ) -> i32x16<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i32x16(
         self,
         a: i32x16<Self>,
@@ -2570,7 +2570,7 @@ pub trait Simd:
         a: u32x16<Self>,
         b: u32x16<Self>,
     ) -> u32x16<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u32x16(
         self,
         a: u32x16<Self>,
@@ -2701,7 +2701,7 @@ pub trait Simd:
         a: f64x8<Self>,
         b: f64x8<Self>,
     ) -> f64x8<Self>;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self>;
     #[doc = "Compute the absolute value of each element."]
     fn abs_f64x8(self, a: f64x8<Self>) -> f64x8<Self>;
@@ -2915,7 +2915,7 @@ pub trait SimdBase<S: Simd>:
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self;
 }
 #[doc = r" Functionality implemented by floating-point SIMD vectors."]

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -2884,8 +2884,6 @@ pub trait SimdBase<S: Simd>:
     type Mask: SimdMask<S, Element = <Self::Element as SimdElement>::Mask>;
     #[doc = r" A 128-bit SIMD vector of the same scalar type."]
     type Block: SimdBase<S, Element = Self::Element>;
-    #[doc = r" A same-width byte vector used to dynamically index bytes in this vector."]
-    type Indices: SimdBase<S, Element = u8>;
     #[doc = r" The array type that this vector type corresponds to, which will"]
     #[doc = r" always be `[Self::Element; Self::N]`. It has the same layout as"]
     #[doc = r" this vector type, but likely has a lower alignment."]
@@ -2916,7 +2914,7 @@ pub trait SimdBase<S: Simd>:
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self;
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self;
 }
 #[doc = r" Functionality implemented by floating-point SIMD vectors."]
 pub trait SimdFloat<S: Simd>:

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -144,6 +144,8 @@ pub trait Simd:
         a: f32x4<Self>,
         b: f32x4<Self>,
     ) -> f32x4<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self>;
     #[doc = "Compute the absolute value of each element."]
     fn abs_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Negate each element of the vector."]
@@ -252,6 +254,8 @@ pub trait Simd:
         a: i8x16<Self>,
         b: i8x16<Self>,
     ) -> i8x16<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -336,6 +340,8 @@ pub trait Simd:
         a: u8x16<Self>,
         b: u8x16<Self>,
     ) -> u8x16<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -457,6 +463,8 @@ pub trait Simd:
         a: i16x8<Self>,
         b: i16x8<Self>,
     ) -> i16x8<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -541,6 +549,8 @@ pub trait Simd:
         a: u16x8<Self>,
         b: u16x8<Self>,
     ) -> u16x8<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -662,6 +672,8 @@ pub trait Simd:
         a: i32x4<Self>,
         b: i32x4<Self>,
     ) -> i32x4<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -748,6 +760,8 @@ pub trait Simd:
         a: u32x4<Self>,
         b: u32x4<Self>,
     ) -> u32x4<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -869,6 +883,8 @@ pub trait Simd:
         a: f64x2<Self>,
         b: f64x2<Self>,
     ) -> f64x2<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self>;
     #[doc = "Compute the absolute value of each element."]
     fn abs_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Negate each element of the vector."]
@@ -1002,6 +1018,8 @@ pub trait Simd:
         a: f32x8<Self>,
         b: f32x8<Self>,
     ) -> f32x8<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self>;
     #[doc = "Compute the absolute value of each element."]
     fn abs_f32x8(self, a: f32x8<Self>) -> f32x8<Self>;
     #[doc = "Negate each element of the vector."]
@@ -1112,6 +1130,8 @@ pub trait Simd:
         a: i8x32<Self>,
         b: i8x32<Self>,
     ) -> i8x32<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -1198,6 +1218,8 @@ pub trait Simd:
         a: u8x32<Self>,
         b: u8x32<Self>,
     ) -> u8x32<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -1323,6 +1345,12 @@ pub trait Simd:
         a: i16x16<Self>,
         b: i16x16<Self>,
     ) -> i16x16<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_i16x16(
+        self,
+        a: i16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> i16x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -1408,6 +1436,12 @@ pub trait Simd:
         self,
         a: u16x16<Self>,
         b: u16x16<Self>,
+    ) -> u16x16<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_u16x16(
+        self,
+        a: u16x16<Self>,
+        indices: u8x32<Self>,
     ) -> u16x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self>;
@@ -1536,6 +1570,8 @@ pub trait Simd:
         a: i32x8<Self>,
         b: i32x8<Self>,
     ) -> i32x8<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -1624,6 +1660,8 @@ pub trait Simd:
         a: u32x8<Self>,
         b: u32x8<Self>,
     ) -> u32x8<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -1749,6 +1787,8 @@ pub trait Simd:
         a: f64x4<Self>,
         b: f64x4<Self>,
     ) -> f64x4<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self>;
     #[doc = "Compute the absolute value of each element."]
     fn abs_f64x4(self, a: f64x4<Self>) -> f64x4<Self>;
     #[doc = "Negate each element of the vector."]
@@ -1886,6 +1926,12 @@ pub trait Simd:
         a: f32x16<Self>,
         b: f32x16<Self>,
     ) -> f32x16<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_f32x16(
+        self,
+        a: f32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> f32x16<Self>;
     #[doc = "Compute the absolute value of each element."]
     fn abs_f32x16(self, a: f32x16<Self>) -> f32x16<Self>;
     #[doc = "Negate each element of the vector."]
@@ -1998,6 +2044,8 @@ pub trait Simd:
         a: i8x64<Self>,
         b: i8x64<Self>,
     ) -> i8x64<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -2082,6 +2130,8 @@ pub trait Simd:
         a: u8x64<Self>,
         b: u8x64<Self>,
     ) -> u8x64<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -2205,6 +2255,12 @@ pub trait Simd:
         a: i16x32<Self>,
         b: i16x32<Self>,
     ) -> i16x32<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_i16x32(
+        self,
+        a: i16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> i16x32<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -2288,6 +2344,12 @@ pub trait Simd:
         self,
         a: u16x32<Self>,
         b: u16x32<Self>,
+    ) -> u16x32<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_u16x32(
+        self,
+        a: u16x32<Self>,
+        indices: u8x64<Self>,
     ) -> u16x32<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self>;
@@ -2416,6 +2478,12 @@ pub trait Simd:
         a: i32x16<Self>,
         b: i32x16<Self>,
     ) -> i32x16<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_i32x16(
+        self,
+        a: i32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> i32x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -2501,6 +2569,12 @@ pub trait Simd:
         self,
         a: u32x16<Self>,
         b: u32x16<Self>,
+    ) -> u32x16<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_u32x16(
+        self,
+        a: u32x16<Self>,
+        indices: u8x64<Self>,
     ) -> u32x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self>;
@@ -2627,6 +2701,8 @@ pub trait Simd:
         a: f64x8<Self>,
         b: f64x8<Self>,
     ) -> f64x8<Self>;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self>;
     #[doc = "Compute the absolute value of each element."]
     fn abs_f64x8(self, a: f64x8<Self>) -> f64x8<Self>;
     #[doc = "Negate each element of the vector."]
@@ -2808,6 +2884,8 @@ pub trait SimdBase<S: Simd>:
     type Mask: SimdMask<S, Element = <Self::Element as SimdElement>::Mask>;
     #[doc = r" A 128-bit SIMD vector of the same scalar type."]
     type Block: SimdBase<S, Element = Self::Element>;
+    #[doc = r" A same-width byte vector used to dynamically index bytes in this vector."]
+    type Indices: SimdBase<S, Element = u8>;
     #[doc = r" The array type that this vector type corresponds to, which will"]
     #[doc = r" always be `[Self::Element; Self::N]`. It has the same layout as"]
     #[doc = r" this vector type, but likely has a lower alignment."]
@@ -2837,6 +2915,8 @@ pub trait SimdBase<S: Simd>:
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self;
+    #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero."]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self;
 }
 #[doc = r" Functionality implemented by floating-point SIMD vectors."]
 pub trait SimdFloat<S: Simd>:

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -86,7 +86,6 @@ impl<S: Simd> SimdBase<S> for f32x4<S> {
     const N: usize = 4;
     type Mask = mask32x4<S>;
     type Block = f32x4<S>;
-    type Indices = u8x16<S>;
     type Array = [f32; 4];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -132,7 +131,7 @@ impl<S: Simd> SimdBase<S> for f32x4<S> {
             .slide_within_blocks_f32x4::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_f32x4(self, indices.simd_into(self.simd))
     }
@@ -345,7 +344,6 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
     const N: usize = 16;
     type Mask = mask8x16<S>;
     type Block = i8x16<S>;
-    type Indices = u8x16<S>;
     type Array = [i8; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -391,7 +389,7 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
             .slide_within_blocks_i8x16::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i8x16(self, indices.simd_into(self.simd))
     }
@@ -536,7 +534,6 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
     const N: usize = 16;
     type Mask = mask8x16<S>;
     type Block = u8x16<S>;
-    type Indices = u8x16<S>;
     type Array = [u8; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -582,7 +579,7 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
             .slide_within_blocks_u8x16::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_u8x16(self, indices.simd_into(self.simd))
     }
@@ -818,7 +815,6 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
     const N: usize = 8;
     type Mask = mask16x8<S>;
     type Block = i16x8<S>;
-    type Indices = u8x16<S>;
     type Array = [i16; 8];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -864,7 +860,7 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
             .slide_within_blocks_i16x8::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i16x8(self, indices.simd_into(self.simd))
     }
@@ -1009,7 +1005,6 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
     const N: usize = 8;
     type Mask = mask16x8<S>;
     type Block = u16x8<S>;
-    type Indices = u8x16<S>;
     type Array = [u16; 8];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -1055,7 +1050,7 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
             .slide_within_blocks_u16x8::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_u16x8(self, indices.simd_into(self.simd))
     }
@@ -1291,7 +1286,6 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
     const N: usize = 4;
     type Mask = mask32x4<S>;
     type Block = i32x4<S>;
-    type Indices = u8x16<S>;
     type Array = [i32; 4];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -1337,7 +1331,7 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
             .slide_within_blocks_i32x4::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i32x4(self, indices.simd_into(self.simd))
     }
@@ -1494,7 +1488,6 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
     const N: usize = 4;
     type Mask = mask32x4<S>;
     type Block = u32x4<S>;
-    type Indices = u8x16<S>;
     type Array = [u32; 4];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -1540,7 +1533,7 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
             .slide_within_blocks_u32x4::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_u32x4(self, indices.simd_into(self.simd))
     }
@@ -1788,7 +1781,6 @@ impl<S: Simd> SimdBase<S> for f64x2<S> {
     const N: usize = 2;
     type Mask = mask64x2<S>;
     type Block = f64x2<S>;
-    type Indices = u8x16<S>;
     type Array = [f64; 2];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -1834,7 +1826,7 @@ impl<S: Simd> SimdBase<S> for f64x2<S> {
             .slide_within_blocks_f64x2::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_f64x2(self, indices.simd_into(self.simd))
     }
@@ -2124,7 +2116,6 @@ impl<S: Simd> SimdBase<S> for f32x8<S> {
     const N: usize = 8;
     type Mask = mask32x8<S>;
     type Block = f32x4<S>;
-    type Indices = u8x32<S>;
     type Array = [f32; 8];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -2170,7 +2161,7 @@ impl<S: Simd> SimdBase<S> for f32x8<S> {
             .slide_within_blocks_f32x8::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_f32x8(self, indices.simd_into(self.simd))
     }
@@ -2390,7 +2381,6 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
     const N: usize = 32;
     type Mask = mask8x32<S>;
     type Block = i8x16<S>;
-    type Indices = u8x32<S>;
     type Array = [i8; 32];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -2436,7 +2426,7 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
             .slide_within_blocks_i8x32::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i8x32(self, indices.simd_into(self.simd))
     }
@@ -2588,7 +2578,6 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
     const N: usize = 32;
     type Mask = mask8x32<S>;
     type Block = u8x16<S>;
-    type Indices = u8x32<S>;
     type Array = [u8; 32];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -2634,7 +2623,7 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
             .slide_within_blocks_u8x32::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_u8x32(self, indices.simd_into(self.simd))
     }
@@ -2882,7 +2871,6 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
     const N: usize = 16;
     type Mask = mask16x16<S>;
     type Block = i16x8<S>;
-    type Indices = u8x32<S>;
     type Array = [i16; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -2928,7 +2916,7 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
             .slide_within_blocks_i16x16::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i16x16(self, indices.simd_into(self.simd))
     }
@@ -3086,7 +3074,6 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
     const N: usize = 16;
     type Mask = mask16x16<S>;
     type Block = u16x8<S>;
-    type Indices = u8x32<S>;
     type Array = [u16; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -3132,7 +3119,7 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
             .slide_within_blocks_u16x16::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_u16x16(self, indices.simd_into(self.simd))
     }
@@ -3376,7 +3363,6 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
     const N: usize = 8;
     type Mask = mask32x8<S>;
     type Block = i32x4<S>;
-    type Indices = u8x32<S>;
     type Array = [i32; 8];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -3422,7 +3408,7 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
             .slide_within_blocks_i32x8::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i32x8(self, indices.simd_into(self.simd))
     }
@@ -3586,7 +3572,6 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
     const N: usize = 8;
     type Mask = mask32x8<S>;
     type Block = u32x4<S>;
-    type Indices = u8x32<S>;
     type Array = [u32; 8];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -3632,7 +3617,7 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
             .slide_within_blocks_u32x8::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_u32x8(self, indices.simd_into(self.simd))
     }
@@ -3887,7 +3872,6 @@ impl<S: Simd> SimdBase<S> for f64x4<S> {
     const N: usize = 4;
     type Mask = mask64x4<S>;
     type Block = f64x2<S>;
-    type Indices = u8x32<S>;
     type Array = [f64; 4];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -3933,7 +3917,7 @@ impl<S: Simd> SimdBase<S> for f64x4<S> {
             .slide_within_blocks_f64x4::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_f64x4(self, indices.simd_into(self.simd))
     }
@@ -4235,7 +4219,6 @@ impl<S: Simd> SimdBase<S> for f32x16<S> {
     const N: usize = 16;
     type Mask = mask32x16<S>;
     type Block = f32x4<S>;
-    type Indices = u8x64<S>;
     type Array = [f32; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -4282,7 +4265,7 @@ impl<S: Simd> SimdBase<S> for f32x16<S> {
             .slide_within_blocks_f32x16::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_f32x16(self, indices.simd_into(self.simd))
     }
@@ -4496,7 +4479,6 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
     const N: usize = 64;
     type Mask = mask8x64<S>;
     type Block = i8x16<S>;
-    type Indices = u8x64<S>;
     type Array = [i8; 64];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -4543,7 +4525,7 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
             .slide_within_blocks_i8x64::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i8x64(self, indices.simd_into(self.simd))
     }
@@ -4688,7 +4670,6 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
     const N: usize = 64;
     type Mask = mask8x64<S>;
     type Block = u8x16<S>;
-    type Indices = u8x64<S>;
     type Array = [u8; 64];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -4735,7 +4716,7 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
             .slide_within_blocks_u8x64::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_u8x64(self, indices.simd_into(self.simd))
     }
@@ -4976,7 +4957,6 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
     const N: usize = 32;
     type Mask = mask16x32<S>;
     type Block = i16x8<S>;
-    type Indices = u8x64<S>;
     type Array = [i16; 32];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -5023,7 +5003,7 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
             .slide_within_blocks_i16x32::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i16x32(self, indices.simd_into(self.simd))
     }
@@ -5174,7 +5154,6 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
     const N: usize = 32;
     type Mask = mask16x32<S>;
     type Block = u16x8<S>;
-    type Indices = u8x64<S>;
     type Array = [u16; 32];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -5221,7 +5200,7 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
             .slide_within_blocks_u16x32::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_u16x32(self, indices.simd_into(self.simd))
     }
@@ -5463,7 +5442,6 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
     const N: usize = 16;
     type Mask = mask32x16<S>;
     type Block = i32x4<S>;
-    type Indices = u8x64<S>;
     type Array = [i32; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -5510,7 +5488,7 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
             .slide_within_blocks_i32x16::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i32x16(self, indices.simd_into(self.simd))
     }
@@ -5673,7 +5651,6 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
     const N: usize = 16;
     type Mask = mask32x16<S>;
     type Block = u32x4<S>;
-    type Indices = u8x64<S>;
     type Array = [u32; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -5720,7 +5697,7 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
             .slide_within_blocks_u32x16::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_u32x16(self, indices.simd_into(self.simd))
     }
@@ -5969,7 +5946,6 @@ impl<S: Simd> SimdBase<S> for f64x8<S> {
     const N: usize = 8;
     type Mask = mask64x8<S>;
     type Block = f64x2<S>;
-    type Indices = u8x64<S>;
     type Array = [f64; 8];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -6016,7 +5992,7 @@ impl<S: Simd> SimdBase<S> for f64x8<S> {
             .slide_within_blocks_f64x8::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
-    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_f64x8(self, indices.simd_into(self.simd))
     }

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -86,6 +86,7 @@ impl<S: Simd> SimdBase<S> for f32x4<S> {
     const N: usize = 4;
     type Mask = mask32x4<S>;
     type Block = f32x4<S>;
+    type Indices = u8x16<S>;
     type Array = [f32; 4];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -129,6 +130,11 @@ impl<S: Simd> SimdBase<S> for f32x4<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_f32x4::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_f32x4(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdFloat<S> for f32x4<S> {
@@ -339,6 +345,7 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
     const N: usize = 16;
     type Mask = mask8x16<S>;
     type Block = i8x16<S>;
+    type Indices = u8x16<S>;
     type Array = [i8; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -382,6 +389,11 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_i8x16::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_i8x16(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for i8x16<S> {
@@ -524,6 +536,7 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
     const N: usize = 16;
     type Mask = mask8x16<S>;
     type Block = u8x16<S>;
+    type Indices = u8x16<S>;
     type Array = [u8; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -567,6 +580,11 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u8x16::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_u8x16(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for u8x16<S> {
@@ -800,6 +818,7 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
     const N: usize = 8;
     type Mask = mask16x8<S>;
     type Block = i16x8<S>;
+    type Indices = u8x16<S>;
     type Array = [i16; 8];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -843,6 +862,11 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_i16x8::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_i16x8(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for i16x8<S> {
@@ -985,6 +1009,7 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
     const N: usize = 8;
     type Mask = mask16x8<S>;
     type Block = u16x8<S>;
+    type Indices = u8x16<S>;
     type Array = [u16; 8];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -1028,6 +1053,11 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u16x8::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_u16x8(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for u16x8<S> {
@@ -1261,6 +1291,7 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
     const N: usize = 4;
     type Mask = mask32x4<S>;
     type Block = i32x4<S>;
+    type Indices = u8x16<S>;
     type Array = [i32; 4];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -1304,6 +1335,11 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_i32x4::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_i32x4(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for i32x4<S> {
@@ -1458,6 +1494,7 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
     const N: usize = 4;
     type Mask = mask32x4<S>;
     type Block = u32x4<S>;
+    type Indices = u8x16<S>;
     type Array = [u32; 4];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -1501,6 +1538,11 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u32x4::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_u32x4(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for u32x4<S> {
@@ -1746,6 +1788,7 @@ impl<S: Simd> SimdBase<S> for f64x2<S> {
     const N: usize = 2;
     type Mask = mask64x2<S>;
     type Block = f64x2<S>;
+    type Indices = u8x16<S>;
     type Array = [f64; 2];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -1789,6 +1832,11 @@ impl<S: Simd> SimdBase<S> for f64x2<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_f64x2::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_f64x2(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdFloat<S> for f64x2<S> {
@@ -2076,6 +2124,7 @@ impl<S: Simd> SimdBase<S> for f32x8<S> {
     const N: usize = 8;
     type Mask = mask32x8<S>;
     type Block = f32x4<S>;
+    type Indices = u8x32<S>;
     type Array = [f32; 8];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -2119,6 +2168,11 @@ impl<S: Simd> SimdBase<S> for f32x8<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_f32x8::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_f32x8(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdFloat<S> for f32x8<S> {
@@ -2336,6 +2390,7 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
     const N: usize = 32;
     type Mask = mask8x32<S>;
     type Block = i8x16<S>;
+    type Indices = u8x32<S>;
     type Array = [i8; 32];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -2379,6 +2434,11 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_i8x32::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_i8x32(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for i8x32<S> {
@@ -2528,6 +2588,7 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
     const N: usize = 32;
     type Mask = mask8x32<S>;
     type Block = u8x16<S>;
+    type Indices = u8x32<S>;
     type Array = [u8; 32];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -2571,6 +2632,11 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u8x32::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_u8x32(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for u8x32<S> {
@@ -2816,6 +2882,7 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
     const N: usize = 16;
     type Mask = mask16x16<S>;
     type Block = i16x8<S>;
+    type Indices = u8x32<S>;
     type Array = [i16; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -2859,6 +2926,11 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_i16x16::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_i16x16(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for i16x16<S> {
@@ -3014,6 +3086,7 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
     const N: usize = 16;
     type Mask = mask16x16<S>;
     type Block = u16x8<S>;
+    type Indices = u8x32<S>;
     type Array = [u16; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -3057,6 +3130,11 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u16x16::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_u16x16(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for u16x16<S> {
@@ -3298,6 +3376,7 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
     const N: usize = 8;
     type Mask = mask32x8<S>;
     type Block = i32x4<S>;
+    type Indices = u8x32<S>;
     type Array = [i32; 8];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -3341,6 +3420,11 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_i32x8::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_i32x8(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for i32x8<S> {
@@ -3502,6 +3586,7 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
     const N: usize = 8;
     type Mask = mask32x8<S>;
     type Block = u32x4<S>;
+    type Indices = u8x32<S>;
     type Array = [u32; 8];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -3545,6 +3630,11 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u32x8::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_u32x8(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for u32x8<S> {
@@ -3797,6 +3887,7 @@ impl<S: Simd> SimdBase<S> for f64x4<S> {
     const N: usize = 4;
     type Mask = mask64x4<S>;
     type Block = f64x2<S>;
+    type Indices = u8x32<S>;
     type Array = [f64; 4];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -3840,6 +3931,11 @@ impl<S: Simd> SimdBase<S> for f64x4<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_f64x4::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_f64x4(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdFloat<S> for f64x4<S> {
@@ -4139,6 +4235,7 @@ impl<S: Simd> SimdBase<S> for f32x16<S> {
     const N: usize = 16;
     type Mask = mask32x16<S>;
     type Block = f32x4<S>;
+    type Indices = u8x64<S>;
     type Array = [f32; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -4183,6 +4280,11 @@ impl<S: Simd> SimdBase<S> for f32x16<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_f32x16::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_f32x16(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdFloat<S> for f32x16<S> {
@@ -4394,6 +4496,7 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
     const N: usize = 64;
     type Mask = mask8x64<S>;
     type Block = i8x16<S>;
+    type Indices = u8x64<S>;
     type Array = [i8; 64];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -4438,6 +4541,11 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_i8x64::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_i8x64(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for i8x64<S> {
@@ -4580,6 +4688,7 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
     const N: usize = 64;
     type Mask = mask8x64<S>;
     type Block = u8x16<S>;
+    type Indices = u8x64<S>;
     type Array = [u8; 64];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -4624,6 +4733,11 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u8x64::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_u8x64(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for u8x64<S> {
@@ -4862,6 +4976,7 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
     const N: usize = 32;
     type Mask = mask16x32<S>;
     type Block = i16x8<S>;
+    type Indices = u8x64<S>;
     type Array = [i16; 32];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -4906,6 +5021,11 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_i16x32::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_i16x32(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for i16x32<S> {
@@ -5054,6 +5174,7 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
     const N: usize = 32;
     type Mask = mask16x32<S>;
     type Block = u16x8<S>;
+    type Indices = u8x64<S>;
     type Array = [u16; 32];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -5098,6 +5219,11 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u16x32::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_u16x32(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for u16x32<S> {
@@ -5337,6 +5463,7 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
     const N: usize = 16;
     type Mask = mask32x16<S>;
     type Block = i32x4<S>;
+    type Indices = u8x64<S>;
     type Array = [i32; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -5381,6 +5508,11 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_i32x16::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_i32x16(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for i32x16<S> {
@@ -5541,6 +5673,7 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
     const N: usize = 16;
     type Mask = mask32x16<S>;
     type Block = u32x4<S>;
+    type Indices = u8x64<S>;
     type Array = [u32; 16];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -5585,6 +5718,11 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u32x16::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_u32x16(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdInt<S> for u32x16<S> {
@@ -5831,6 +5969,7 @@ impl<S: Simd> SimdBase<S> for f64x8<S> {
     const N: usize = 8;
     type Mask = mask64x8<S>;
     type Block = f64x2<S>;
+    type Indices = u8x64<S>;
     type Array = [f64; 8];
     #[inline(always)]
     fn witness(&self) -> S {
@@ -5875,6 +6014,11 @@ impl<S: Simd> SimdBase<S> for f64x8<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_f64x8::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+        self.simd
+            .swizzle_dyn_within_blocks_f64x8(self, indices.simd_into(self.simd))
     }
 }
 impl<S: Simd> crate::SimdFloat<S> for f64x8<S> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -201,6 +201,20 @@ impl Simd for Sse4_2 {
         self.slide_f32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: f32x4<Sse4_2>, indices: u8x16<Sse4_2>) -> f32x4<Sse4_2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_f32x4(a).val.0, indices.into());
+                token.cvt_from_bytes_f32x4(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn abs_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -708,6 +722,20 @@ impl Simd for Sse4_2 {
         self.slide_i8x16::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i8x16<Sse4_2>, indices: u8x16<Sse4_2>) -> i8x16<Sse4_2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_i8x16(a).val.0, indices.into());
+                token.cvt_from_bytes_i8x16(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1071,6 +1099,20 @@ impl Simd for Sse4_2 {
         b: u8x16<Self>,
     ) -> u8x16<Self> {
         self.slide_u8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u8x16<Sse4_2>, indices: u8x16<Sse4_2>) -> u8x16<Sse4_2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_u8x16(a).val.0, indices.into());
+                token.cvt_from_bytes_u8x16(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1611,6 +1653,20 @@ impl Simd for Sse4_2 {
         self.slide_i16x8::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i16x8<Sse4_2>, indices: u8x16<Sse4_2>) -> i16x8<Sse4_2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_i16x8(a).val.0, indices.into());
+                token.cvt_from_bytes_i16x8(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1955,6 +2011,20 @@ impl Simd for Sse4_2 {
         b: u16x8<Self>,
     ) -> u16x8<Self> {
         self.slide_u16x8::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u16x8<Sse4_2>, indices: u8x16<Sse4_2>) -> u16x8<Sse4_2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_u16x8(a).val.0, indices.into());
+                token.cvt_from_bytes_u16x8(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2471,6 +2541,20 @@ impl Simd for Sse4_2 {
         self.slide_i32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i32x4<Sse4_2>, indices: u8x16<Sse4_2>) -> i32x4<Sse4_2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_i32x4(a).val.0, indices.into());
+                token.cvt_from_bytes_i32x4(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2823,6 +2907,20 @@ impl Simd for Sse4_2 {
         b: u32x4<Self>,
     ) -> u32x4<Self> {
         self.slide_u32x4::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u32x4<Sse4_2>, indices: u8x16<Sse4_2>) -> u32x4<Sse4_2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_u32x4(a).val.0, indices.into());
+                token.cvt_from_bytes_u32x4(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -3341,6 +3439,20 @@ impl Simd for Sse4_2 {
         b: f64x2<Self>,
     ) -> f64x2<Self> {
         self.slide_f64x2::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: f64x2<Sse4_2>, indices: u8x16<Sse4_2>) -> f64x2<Sse4_2> {
+                let result = _mm_shuffle_epi8(token.cvt_to_bytes_f64x2(a).val.0, indices.into());
+                token.cvt_from_bytes_f64x2(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, indices)
     }
     #[inline(always)]
     fn abs_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
@@ -3906,6 +4018,15 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_f32x4(
+            self.swizzle_dyn_within_blocks_f32x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_f32x4(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn abs_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f32x4(self.abs_f32x4(a0), self.abs_f32x4(a1))
@@ -4277,6 +4398,15 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_i8x16(
+            self.swizzle_dyn_within_blocks_i8x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_i8x16(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
         let (b0, b1) = self.split_i8x32(b);
@@ -4552,6 +4682,15 @@ impl Simd for Sse4_2 {
         self.combine_u8x16(
             self.slide_within_blocks_u8x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x16::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_u8x16(
+            self.swizzle_dyn_within_blocks_u8x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_u8x16(a1, indices1),
         )
     }
     #[inline(always)]
@@ -4952,6 +5091,19 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x16(
+        self,
+        a: i16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_i16x8(
+            self.swizzle_dyn_within_blocks_i16x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_i16x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
         let (b0, b1) = self.split_i16x16(b);
@@ -5227,6 +5379,19 @@ impl Simd for Sse4_2 {
         self.combine_u16x8(
             self.slide_within_blocks_u16x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x8::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x16(
+        self,
+        a: u16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_u16x8(
+            self.swizzle_dyn_within_blocks_u16x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_u16x8(a1, indices1),
         )
     }
     #[inline(always)]
@@ -5648,6 +5813,15 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_i32x4(
+            self.swizzle_dyn_within_blocks_i32x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_i32x4(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
         let (b0, b1) = self.split_i32x8(b);
@@ -5928,6 +6102,15 @@ impl Simd for Sse4_2 {
         self.combine_u32x4(
             self.slide_within_blocks_u32x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x4::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_u32x4(
+            self.swizzle_dyn_within_blocks_u32x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_u32x4(a1, indices1),
         )
     }
     #[inline(always)]
@@ -6322,6 +6505,15 @@ impl Simd for Sse4_2 {
         self.combine_f64x2(
             self.slide_within_blocks_f64x2::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x2::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_f64x2(
+            self.swizzle_dyn_within_blocks_f64x2(a0, indices0),
+            self.swizzle_dyn_within_blocks_f64x2(a1, indices1),
         )
     }
     #[inline(always)]
@@ -6773,6 +6965,19 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x16(
+        self,
+        a: f32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_f32x8(
+            self.swizzle_dyn_within_blocks_f32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_f32x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn abs_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.abs_f32x8(a0), self.abs_f32x8(a1))
@@ -7212,6 +7417,15 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
+        let (a0, a1) = self.split_i8x64(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i8x32(
+            self.swizzle_dyn_within_blocks_i8x32(a0, indices0),
+            self.swizzle_dyn_within_blocks_i8x32(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
         let (b0, b1) = self.split_i8x64(b);
@@ -7480,6 +7694,15 @@ impl Simd for Sse4_2 {
         self.combine_u8x32(
             self.slide_within_blocks_u8x32::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x32::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self> {
+        let (a0, a1) = self.split_u8x64(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u8x32(
+            self.swizzle_dyn_within_blocks_u8x32(a0, indices0),
+            self.swizzle_dyn_within_blocks_u8x32(a1, indices1),
         )
     }
     #[inline(always)]
@@ -7987,6 +8210,19 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x32(
+        self,
+        a: i16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> i16x32<Self> {
+        let (a0, a1) = self.split_i16x32(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i16x16(
+            self.swizzle_dyn_within_blocks_i16x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_i16x16(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
         let (b0, b1) = self.split_i16x32(b);
@@ -8264,6 +8500,19 @@ impl Simd for Sse4_2 {
         self.combine_u16x16(
             self.slide_within_blocks_u16x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x16::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x32(
+        self,
+        a: u16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> u16x32<Self> {
+        let (a0, a1) = self.split_u16x32(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u16x16(
+            self.swizzle_dyn_within_blocks_u16x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_u16x16(a1, indices1),
         )
     }
     #[inline(always)]
@@ -8761,6 +9010,19 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x16(
+        self,
+        a: i32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> i32x16<Self> {
+        let (a0, a1) = self.split_i32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i32x8(
+            self.swizzle_dyn_within_blocks_i32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_i32x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
         let (b0, b1) = self.split_i32x16(b);
@@ -9034,6 +9296,19 @@ impl Simd for Sse4_2 {
         self.combine_u32x8(
             self.slide_within_blocks_u32x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x8::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x16(
+        self,
+        a: u32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> u32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u32x8(
+            self.swizzle_dyn_within_blocks_u32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_u32x8(a1, indices1),
         )
     }
     #[inline(always)]
@@ -9489,6 +9764,15 @@ impl Simd for Sse4_2 {
         self.combine_f64x4(
             self.slide_within_blocks_f64x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x4::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_f64x4(
+            self.swizzle_dyn_within_blocks_f64x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_f64x4(a1, indices1),
         )
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -157,6 +157,14 @@ impl Simd for WasmSimd128 {
         self.slide_f32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
+        let result = u8x16_swizzle(self.cvt_to_bytes_f32x4(a).val.0, indices.into());
+        self.cvt_from_bytes_f32x4(u8x16 {
+            val: crate::support::Aligned128(result),
+            simd: self,
+        })
+    }
+    #[inline(always)]
     fn abs_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
         f32x4_abs(a.into()).simd_into(self)
     }
@@ -451,6 +459,14 @@ impl Simd for WasmSimd128 {
         self.slide_i8x16::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
+        let result = u8x16_swizzle(self.cvt_to_bytes_i8x16(a).val.0, indices.into());
+        self.cvt_from_bytes_i8x16(u8x16 {
+            val: crate::support::Aligned128(result),
+            simd: self,
+        })
+    }
+    #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         i8x16_add(a.into(), b.into()).simd_into(self)
     }
@@ -662,6 +678,14 @@ impl Simd for WasmSimd128 {
         b: u8x16<Self>,
     ) -> u8x16<Self> {
         self.slide_u8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
+        let result = u8x16_swizzle(self.cvt_to_bytes_u8x16(a).val.0, indices.into());
+        self.cvt_from_bytes_u8x16(u8x16 {
+            val: crate::support::Aligned128(result),
+            simd: self,
+        })
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -974,6 +998,14 @@ impl Simd for WasmSimd128 {
         self.slide_i16x8::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
+        let result = u8x16_swizzle(self.cvt_to_bytes_i16x8(a).val.0, indices.into());
+        self.cvt_from_bytes_i16x8(u8x16 {
+            val: crate::support::Aligned128(result),
+            simd: self,
+        })
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         i16x8_add(a.into(), b.into()).simd_into(self)
     }
@@ -1169,6 +1201,14 @@ impl Simd for WasmSimd128 {
         b: u16x8<Self>,
     ) -> u16x8<Self> {
         self.slide_u16x8::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
+        let result = u8x16_swizzle(self.cvt_to_bytes_u16x8(a).val.0, indices.into());
+        self.cvt_from_bytes_u16x8(u8x16 {
+            val: crate::support::Aligned128(result),
+            simd: self,
+        })
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -1461,6 +1501,14 @@ impl Simd for WasmSimd128 {
         self.slide_i32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
+        let result = u8x16_swizzle(self.cvt_to_bytes_i32x4(a).val.0, indices.into());
+        self.cvt_from_bytes_i32x4(u8x16 {
+            val: crate::support::Aligned128(result),
+            simd: self,
+        })
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         i32x4_add(a.into(), b.into()).simd_into(self)
     }
@@ -1660,6 +1708,14 @@ impl Simd for WasmSimd128 {
         b: u32x4<Self>,
     ) -> u32x4<Self> {
         self.slide_u32x4::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
+        let result = u8x16_swizzle(self.cvt_to_bytes_u32x4(a).val.0, indices.into());
+        self.cvt_from_bytes_u32x4(u8x16 {
+            val: crate::support::Aligned128(result),
+            simd: self,
+        })
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -1950,6 +2006,14 @@ impl Simd for WasmSimd128 {
         b: f64x2<Self>,
     ) -> f64x2<Self> {
         self.slide_f64x2::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
+        let result = u8x16_swizzle(self.cvt_to_bytes_f64x2(a).val.0, indices.into());
+        self.cvt_from_bytes_f64x2(u8x16 {
+            val: crate::support::Aligned128(result),
+            simd: self,
+        })
     }
     #[inline(always)]
     fn abs_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
@@ -2304,6 +2368,15 @@ impl Simd for WasmSimd128 {
         self.combine_f32x4(
             self.slide_within_blocks_f32x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_f32x4::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_f32x4(
+            self.swizzle_dyn_within_blocks_f32x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_f32x4(a1, indices1),
         )
     }
     #[inline(always)]
@@ -2677,6 +2750,15 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_i8x16(
+            self.swizzle_dyn_within_blocks_i8x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_i8x16(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
         let (b0, b1) = self.split_i8x32(b);
@@ -2951,6 +3033,15 @@ impl Simd for WasmSimd128 {
         self.combine_u8x16(
             self.slide_within_blocks_u8x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x16::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_u8x16(
+            self.swizzle_dyn_within_blocks_u8x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_u8x16(a1, indices1),
         )
     }
     #[inline(always)]
@@ -3350,6 +3441,19 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x16(
+        self,
+        a: i16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_i16x8(
+            self.swizzle_dyn_within_blocks_i16x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_i16x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
         let (b0, b1) = self.split_i16x16(b);
@@ -3624,6 +3728,19 @@ impl Simd for WasmSimd128 {
         self.combine_u16x8(
             self.slide_within_blocks_u16x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x8::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x16(
+        self,
+        a: u16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_u16x8(
+            self.swizzle_dyn_within_blocks_u16x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_u16x8(a1, indices1),
         )
     }
     #[inline(always)]
@@ -4032,6 +4149,15 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_i32x4(
+            self.swizzle_dyn_within_blocks_i32x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_i32x4(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
         let (b0, b1) = self.split_i32x8(b);
@@ -4311,6 +4437,15 @@ impl Simd for WasmSimd128 {
         self.combine_u32x4(
             self.slide_within_blocks_u32x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x4::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_u32x4(
+            self.swizzle_dyn_within_blocks_u32x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_u32x4(a1, indices1),
         )
     }
     #[inline(always)]
@@ -4704,6 +4839,15 @@ impl Simd for WasmSimd128 {
         self.combine_f64x2(
             self.slide_within_blocks_f64x2::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x2::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        let (indices0, indices1) = self.split_u8x32(indices);
+        self.combine_f64x2(
+            self.swizzle_dyn_within_blocks_f64x2(a0, indices0),
+            self.swizzle_dyn_within_blocks_f64x2(a1, indices1),
         )
     }
     #[inline(always)]
@@ -5154,6 +5298,19 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_f32x16(
+        self,
+        a: f32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_f32x8(
+            self.swizzle_dyn_within_blocks_f32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_f32x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn abs_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.abs_f32x8(a0), self.abs_f32x8(a1))
@@ -5563,6 +5720,15 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
+        let (a0, a1) = self.split_i8x64(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i8x32(
+            self.swizzle_dyn_within_blocks_i8x32(a0, indices0),
+            self.swizzle_dyn_within_blocks_i8x32(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
         let (b0, b1) = self.split_i8x64(b);
@@ -5830,6 +5996,15 @@ impl Simd for WasmSimd128 {
         self.combine_u8x32(
             self.slide_within_blocks_u8x32::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x32::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self> {
+        let (a0, a1) = self.split_u8x64(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u8x32(
+            self.swizzle_dyn_within_blocks_u8x32(a0, indices0),
+            self.swizzle_dyn_within_blocks_u8x32(a1, indices1),
         )
     }
     #[inline(always)]
@@ -6280,6 +6455,19 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i16x32(
+        self,
+        a: i16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> i16x32<Self> {
+        let (a0, a1) = self.split_i16x32(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i16x16(
+            self.swizzle_dyn_within_blocks_i16x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_i16x16(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
         let (b0, b1) = self.split_i16x32(b);
@@ -6556,6 +6744,19 @@ impl Simd for WasmSimd128 {
         self.combine_u16x16(
             self.slide_within_blocks_u16x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x16::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u16x32(
+        self,
+        a: u16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> u16x32<Self> {
+        let (a0, a1) = self.split_u16x32(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u16x16(
+            self.swizzle_dyn_within_blocks_u16x16(a0, indices0),
+            self.swizzle_dyn_within_blocks_u16x16(a1, indices1),
         )
     }
     #[inline(always)]
@@ -7004,6 +7205,19 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn swizzle_dyn_within_blocks_i32x16(
+        self,
+        a: i32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> i32x16<Self> {
+        let (a0, a1) = self.split_i32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_i32x8(
+            self.swizzle_dyn_within_blocks_i32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_i32x8(a1, indices1),
+        )
+    }
+    #[inline(always)]
     fn add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
         let (b0, b1) = self.split_i32x16(b);
@@ -7276,6 +7490,19 @@ impl Simd for WasmSimd128 {
         self.combine_u32x8(
             self.slide_within_blocks_u32x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x8::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_u32x16(
+        self,
+        a: u32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> u32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_u32x8(
+            self.swizzle_dyn_within_blocks_u32x8(a0, indices0),
+            self.swizzle_dyn_within_blocks_u32x8(a1, indices1),
         )
     }
     #[inline(always)]
@@ -7701,6 +7928,15 @@ impl Simd for WasmSimd128 {
         self.combine_f64x4(
             self.slide_within_blocks_f64x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x4::<SHIFT>(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        let (indices0, indices1) = self.split_u8x64(indices);
+        self.combine_f64x4(
+            self.swizzle_dyn_within_blocks_f64x4(a0, indices0),
+            self.swizzle_dyn_within_blocks_f64x4(a1, indices1),
         )
     }
     #[inline(always)]

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -69,6 +69,20 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
                 }
             }
         }
+        OpSig::SwizzleDynWithinBlocks => {
+            let indices_ty = ty.indices_ty();
+            let split_indices = generic_op_name("split", &indices_ty);
+            quote! {
+                #method_sig {
+                    let (a0, a1) = self.#split(a);
+                    let (indices0, indices1) = self.#split_indices(indices);
+                    self.#combine(
+                        self.#do_half(a0, indices0),
+                        self.#do_half(a1, indices1),
+                    )
+                }
+            }
+        }
         OpSig::Ternary => {
             quote! {
                 #method_sig {

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -70,8 +70,8 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
             }
         }
         OpSig::SwizzleDynWithinBlocks => {
-            let indices_ty = ty.indices_ty();
-            let split_indices = generic_op_name("split", &indices_ty);
+            let bytes_ty = ty.bytes_ty();
+            let split_indices = generic_op_name("split", &bytes_ty);
             quote! {
                 #method_sig {
                     let (a0, a1) = self.#split(a);

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -398,7 +398,7 @@ impl Level for Fallback {
                     self.native_width(),
                     "wide swizzles should use the generic split implementation"
                 );
-                let bytes_ty = vec_ty.indices_ty();
+                let bytes_ty = vec_ty.bytes_ty();
                 let bytes_rust = bytes_ty.rust();
                 let to_bytes = generic_op_name("cvt_to_bytes", vec_ty);
                 let from_bytes = generic_op_name("cvt_from_bytes", vec_ty);

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -392,6 +392,38 @@ impl Level for Fallback {
                     }
                 }
             }
+            OpSig::SwizzleDynWithinBlocks => {
+                assert_eq!(
+                    vec_ty.n_bits(),
+                    self.native_width(),
+                    "wide swizzles should use the generic split implementation"
+                );
+                let bytes_ty = vec_ty.indices_ty();
+                let bytes_rust = bytes_ty.rust();
+                let to_bytes = generic_op_name("cvt_to_bytes", vec_ty);
+                let from_bytes = generic_op_name("cvt_from_bytes", vec_ty);
+                let byte_count = bytes_ty.len;
+                let items = make_list(
+                    (0..byte_count)
+                        .map(|idx| {
+                            quote! {
+                                {
+                                    let index = indices[#idx] as usize;
+                                    bytes[index % #byte_count]
+                                }
+                            }
+                        })
+                        .collect::<Vec<_>>(),
+                );
+
+                quote! {
+                    #method_sig {
+                        let bytes = self.#to_bytes(a);
+                        let result: #bytes_rust<Self> = #items.simd_into(self);
+                        self.#from_bytes(result)
+                    }
+                }
+            }
             OpSig::Cvt {
                 target_ty,
                 scalar_bits,

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -424,6 +424,26 @@ impl Level for Neon {
                     }
                 }
             }
+            OpSig::SwizzleDynWithinBlocks => {
+                assert_eq!(
+                    vec_ty.n_bits(),
+                    self.native_width(),
+                    "wide swizzles should use the generic split implementation"
+                );
+
+                let bytes_ty = vec_ty.indices_ty();
+                let bytes = bytes_ty.rust();
+                let wrapper = bytes_ty.aligned_wrapper();
+                let to_bytes = generic_op_name("cvt_to_bytes", vec_ty);
+                let from_bytes = generic_op_name("cvt_from_bytes", vec_ty);
+
+                self.kernel_method(op, vec_ty, |token| {
+                    quote! {
+                        let result = vqtbl1q_u8(#token.#to_bytes(a).val.0, indices.into());
+                        #token.#from_bytes(#bytes { val: #wrapper(result), simd: #token })
+                    }
+                })
+            }
             OpSig::Cvt {
                 target_ty,
                 scalar_bits,

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -431,7 +431,7 @@ impl Level for Neon {
                     "wide swizzles should use the generic split implementation"
                 );
 
-                let bytes_ty = vec_ty.indices_ty();
+                let bytes_ty = vec_ty.bytes_ty();
                 let bytes = bytes_ty.rust();
                 let wrapper = bytes_ty.aligned_wrapper();
                 let to_bytes = generic_op_name("cvt_to_bytes", vec_ty);

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -168,6 +168,8 @@ fn mk_simd_base() -> TokenStream {
             type Mask: SimdMask<S, Element = <Self::Element as SimdElement>::Mask>;
             /// A 128-bit SIMD vector of the same scalar type.
             type Block: SimdBase<S, Element = Self::Element>;
+            /// A same-width byte vector used to dynamically index bytes in this vector.
+            type Indices: SimdBase<S, Element = u8>;
             /// The array type that this vector type corresponds to, which will
             /// always be `[Self::Element; Self::N]`. It has the same layout as
             /// this vector type, but likely has a lower alignment.

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -168,8 +168,6 @@ fn mk_simd_base() -> TokenStream {
             type Mask: SimdMask<S, Element = <Self::Element as SimdElement>::Mask>;
             /// A 128-bit SIMD vector of the same scalar type.
             type Block: SimdBase<S, Element = Self::Element>;
-            /// A same-width byte vector used to dynamically index bytes in this vector.
-            type Indices: SimdBase<S, Element = u8>;
             /// The array type that this vector type corresponds to, which will
             /// always be `[Self::Element; Self::N]`. It has the same layout as
             /// this vector type, but likely has a lower alignment.

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -399,6 +399,7 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
     }
     let mask_ty = ty.mask_ty().rust();
     let block_ty = ty.block_ty().rust();
+    let indices_ty = ty.indices_ty().rust();
     let block_splat_body = match ty.n_bits() {
         128 => quote! {
             block
@@ -429,12 +430,14 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
     let as_array_mut_op = generic_op_name("as_array_mut", ty);
     let slide_op = generic_op_name("slide", ty);
     let slide_blockwise_op = generic_op_name("slide_within_blocks", ty);
+    let swizzle_dyn_within_blocks_op = generic_op_name("swizzle_dyn_within_blocks", ty);
     quote! {
         impl<S: Simd> SimdBase<S> for #name<S> {
             type Element = #scalar;
             const N: usize = #len;
             type Mask = #mask_ty<S>;
             type Block = #block_ty<S>;
+            type Indices = #indices_ty<S>;
             type Array = [#scalar; #len];
 
             #[inline(always)]
@@ -485,6 +488,11 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
             #[inline(always)]
             fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
                 self.simd.#slide_blockwise_op::<SHIFT>(self, rhs.simd_into(self.simd))
+            }
+
+            #[inline(always)]
+            fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+                self.simd.#swizzle_dyn_within_blocks_op(self, indices.simd_into(self.simd))
             }
         }
         impl<S: Simd> crate::#vec_trait_id<S> for #name<S> {

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -32,7 +32,7 @@ pub(crate) fn mk_simd_types() -> TokenStream {
         let as_array_mut_op = generic_op_name("as_array_mut", ty);
         let from_bytes_op = generic_op_name("cvt_from_bytes", ty);
         let to_bytes_op = generic_op_name("cvt_to_bytes", ty);
-        let bytes = VecType::new(ScalarType::Unsigned, 8, align).rust();
+        let bytes = ty.bytes_ty().rust();
         let mask = ty.mask_ty().rust();
 
         if ty.scalar == ScalarType::Mask {
@@ -399,7 +399,6 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
     }
     let mask_ty = ty.mask_ty().rust();
     let block_ty = ty.block_ty().rust();
-    let indices_ty = ty.indices_ty().rust();
     let block_splat_body = match ty.n_bits() {
         128 => quote! {
             block
@@ -437,7 +436,6 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
             const N: usize = #len;
             type Mask = #mask_ty<S>;
             type Block = #block_ty<S>;
-            type Indices = #indices_ty<S>;
             type Array = [#scalar; #len];
 
             #[inline(always)]
@@ -491,7 +489,7 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
             }
 
             #[inline(always)]
-            fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Indices, S>) -> Self {
+            fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
                 self.simd.#swizzle_dyn_within_blocks_op(self, indices.simd_into(self.simd))
             }
         }

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -490,7 +490,7 @@ impl Level for WasmSimd128 {
                     "wide swizzles should use the generic split implementation"
                 );
 
-                let bytes_ty = vec_ty.indices_ty();
+                let bytes_ty = vec_ty.bytes_ty();
                 let bytes = bytes_ty.rust();
                 let wrapper = bytes_ty.aligned_wrapper();
                 let to_bytes = generic_op_name("cvt_to_bytes", vec_ty);

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -483,6 +483,26 @@ impl Level for WasmSimd128 {
                     }
                 }
             }
+            OpSig::SwizzleDynWithinBlocks => {
+                assert_eq!(
+                    vec_ty.n_bits(),
+                    self.native_width(),
+                    "wide swizzles should use the generic split implementation"
+                );
+
+                let bytes_ty = vec_ty.indices_ty();
+                let bytes = bytes_ty.rust();
+                let wrapper = bytes_ty.aligned_wrapper();
+                let to_bytes = generic_op_name("cvt_to_bytes", vec_ty);
+                let from_bytes = generic_op_name("cvt_from_bytes", vec_ty);
+
+                quote! {
+                    #method_sig {
+                        let result = u8x16_swizzle(self.#to_bytes(a).val.0, indices.into());
+                        self.#from_bytes(#bytes { val: #wrapper(result), simd: self })
+                    }
+                }
+            }
             OpSig::Cvt {
                 target_ty,
                 scalar_bits,

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -306,6 +306,7 @@ impl Level for X86 {
             OpSig::Zip { select_low } => self.handle_zip(op, vec_ty, select_low),
             OpSig::Unzip { select_even } => self.handle_unzip(op, vec_ty, select_even),
             OpSig::Slide { granularity } => self.handle_slide(method_sig, vec_ty, granularity),
+            OpSig::SwizzleDynWithinBlocks => self.handle_swizzle_dyn_within_blocks(op, vec_ty),
             OpSig::Cvt {
                 target_ty,
                 scalar_bits,
@@ -2461,6 +2462,43 @@ impl X86 {
                 self.#from_bytes(#combined_bytes { val: #block_wrapper(result), simd: self })
             }
         }
+    }
+
+    pub(crate) fn handle_swizzle_dyn_within_blocks(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+        let bytes_ty = vec_ty.indices_ty();
+        let bytes = bytes_ty.rust();
+        let wrapper = bytes_ty.aligned_wrapper();
+        let to_bytes = generic_op_name("cvt_to_bytes", vec_ty);
+        let from_bytes = generic_op_name("cvt_from_bytes", vec_ty);
+
+        self.kernel_method(op, vec_ty, |token| {
+            let body = if *self == Self::Avx512 {
+                match vec_ty.n_bits() {
+                    128 => quote! {
+                        let bytes = #token.#to_bytes(a).val.0;
+                        let result = _mm_mask_shuffle_epi8(bytes, u16::MAX, bytes, indices.into());
+                    },
+                    256 => quote! {
+                        let bytes = #token.#to_bytes(a).val.0;
+                        let result = _mm256_mask_shuffle_epi8(bytes, u32::MAX, bytes, indices.into());
+                    },
+                    512 => quote! {
+                        let result = _mm512_shuffle_epi8(#token.#to_bytes(a).val.0, indices.into());
+                    },
+                    _ => unreachable!(),
+                }
+            } else {
+                let shuffle = simple_sign_unaware_intrinsic("shuffle", &bytes_ty);
+                quote! {
+                    let result = #shuffle(#token.#to_bytes(a).val.0, indices.into());
+                }
+            };
+
+            quote! {
+                #body
+                #token.#from_bytes(#bytes { val: #wrapper(result), simd: #token })
+            }
+        })
     }
 
     pub(crate) fn handle_cvt(

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2465,7 +2465,7 @@ impl X86 {
     }
 
     pub(crate) fn handle_swizzle_dyn_within_blocks(&self, op: Op, vec_ty: &VecType) -> TokenStream {
-        let bytes_ty = vec_ty.indices_ty();
+        let bytes_ty = vec_ty.bytes_ty();
         let bytes = bytes_ty.rust();
         let wrapper = bytes_ty.aligned_wrapper();
         let to_bytes = generic_op_name("cvt_to_bytes", vec_ty);

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -605,7 +605,7 @@ const BASE_OPS: &[Op] = &[
         OpSig::SwizzleDynWithinBlocks,
         "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\n\
         The `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\n\
-        Out-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero.",
+        Out-of-range index behavior varies by platform.",
     ),
 ];
 

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -82,6 +82,9 @@ pub(crate) enum OpSig {
     Deinterleave,
     /// Takes two arguments of a vector type, plus a const generic shift amount, and returns that same vector type.
     Slide { granularity: SlideGranularity },
+    /// Takes a vector and a same-width byte-index vector, and returns the original vector type with its bytes
+    /// dynamically swizzled within each 128-bit block.
+    SwizzleDynWithinBlocks,
     /// Takes a single argument of the source vector type, and returns a vector type of the target scalar type and the
     /// same length.
     Cvt {
@@ -304,6 +307,10 @@ impl Op {
                 (vec![vec.clone(), vec.clone()], quote! { (#vec, #vec) })
             }
             OpSig::Slide { .. } => (vec![vec.clone(), vec.clone()], vec),
+            OpSig::SwizzleDynWithinBlocks => {
+                let indices_ty = vec_ty.indices_ty().rust();
+                (vec![vec.clone(), quote! { #indices_ty<#simd_ty> }], vec)
+            }
             OpSig::Cvt {
                 target_ty,
                 scalar_bits,
@@ -420,6 +427,11 @@ impl Op {
                 let arg0 = &arg_names[0];
                 let arg1 = &arg_names[1];
                 quote! { <const SHIFT: usize>(#arg0, #arg1: impl SimdInto<Self, S>) -> Self }
+            }
+            OpSig::SwizzleDynWithinBlocks => {
+                let arg0 = &arg_names[0];
+                let arg1 = &arg_names[1];
+                quote! { (#arg0, #arg1: impl SimdInto<Self::Indices, S>) -> Self }
             }
             OpSig::Compare => {
                 let arg0 = &arg_names[0];
@@ -586,6 +598,14 @@ const BASE_OPS: &[Op] = &[
             granularity: SlideGranularity::WithinBlocks,
         },
         "Like `slide`, but operates independently on each 128-bit block.",
+    ),
+    Op::new(
+        "swizzle_dyn_within_blocks",
+        OpKind::BaseTraitMethod,
+        OpSig::SwizzleDynWithinBlocks,
+        "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\n\
+        The `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\n\
+        Out-of-range index behavior is target-native: on x86 this follows `pshufb`, while NEON and WASM table swizzles produce zero.",
     ),
 ];
 
@@ -1611,6 +1631,7 @@ impl OpSig {
             | Self::AsArray { .. }
             | Self::FromBytes
             | Self::ToBytes => &["a"],
+            Self::SwizzleDynWithinBlocks => &["a", "indices"],
             Self::Binary
             | Self::Compare
             | Self::Combine { .. }
@@ -1643,6 +1664,7 @@ impl OpSig {
             | Self::MaskReduce { .. }
             | Self::AsArray { .. }
             | Self::ToBytes => &["self"],
+            Self::SwizzleDynWithinBlocks => &["self", "indices"],
             Self::Binary
             | Self::Compare
             | Self::Zip { .. }
@@ -1704,6 +1726,7 @@ impl OpSig {
             | Self::StoreArray
             | Self::FromBytes
             | Self::ToBytes
+            | Self::SwizzleDynWithinBlocks
             | Self::Slide { .. } => return None,
         };
         Some(args)

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -308,8 +308,8 @@ impl Op {
             }
             OpSig::Slide { .. } => (vec![vec.clone(), vec.clone()], vec),
             OpSig::SwizzleDynWithinBlocks => {
-                let indices_ty = vec_ty.indices_ty().rust();
-                (vec![vec.clone(), quote! { #indices_ty<#simd_ty> }], vec)
+                let bytes_ty = vec_ty.bytes_ty().rust();
+                (vec![vec.clone(), quote! { #bytes_ty<#simd_ty> }], vec)
             }
             OpSig::Cvt {
                 target_ty,
@@ -431,7 +431,7 @@ impl Op {
             OpSig::SwizzleDynWithinBlocks => {
                 let arg0 = &arg_names[0];
                 let arg1 = &arg_names[1];
-                quote! { (#arg0, #arg1: impl SimdInto<Self::Indices, S>) -> Self }
+                quote! { (#arg0, #arg1: impl SimdInto<Self::Bytes, S>) -> Self }
             }
             OpSig::Compare => {
                 let arg0 = &arg_names[0];

--- a/fearless_simd_gen/src/types.rs
+++ b/fearless_simd_gen/src/types.rs
@@ -157,7 +157,7 @@ impl VecType {
         Self::new(self.scalar, self.scalar_bits, 128 / self.scalar_bits)
     }
 
-    pub(crate) fn indices_ty(&self) -> Self {
+    pub(crate) fn bytes_ty(&self) -> Self {
         Self::new(ScalarType::Unsigned, 8, self.n_bits() / 8)
     }
 

--- a/fearless_simd_gen/src/types.rs
+++ b/fearless_simd_gen/src/types.rs
@@ -157,6 +157,10 @@ impl VecType {
         Self::new(self.scalar, self.scalar_bits, 128 / self.scalar_bits)
     }
 
+    pub(crate) fn indices_ty(&self) -> Self {
+        Self::new(ScalarType::Unsigned, 8, self.n_bits() / 8)
+    }
+
     pub(crate) fn split_operand(&self) -> Option<Self> {
         if self.n_bits() <= 128 {
             return None;

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -3802,7 +3802,7 @@ fn expected_swizzle_within_blocks<const N: usize>(bytes: [u8; N], indices: [u8; 
     })
 }
 
-#[allow(clippy::cast_possible_truncation)] // truncation is deliberate
+#[expect(clippy::cast_possible_truncation, reason = "truncation is deliberate")]
 fn swizzle_test_byte(i: usize) -> u8 {
     (i * 37 + 11) as u8
 }

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -3802,10 +3802,19 @@ fn expected_swizzle_within_blocks<const N: usize>(bytes: [u8; N], indices: [u8; 
     })
 }
 
+#[allow(clippy::cast_possible_truncation)] // truncation is deliberate
+fn swizzle_test_byte(i: usize) -> u8 {
+    (i * 37 + 11) as u8
+}
+
+fn swizzle_test_index(i: usize) -> u8 {
+    u8::try_from(15 - (i % 16)).unwrap()
+}
+
 #[simd_test]
 fn swizzle_dyn_within_blocks_f32x4<S: Simd>(simd: S) {
-    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 16] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 16] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x16::simd_from(simd, bytes);
@@ -3818,8 +3827,8 @@ fn swizzle_dyn_within_blocks_f32x4<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_i8x16<S: Simd>(simd: S) {
-    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 16] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 16] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x16::simd_from(simd, bytes);
@@ -3832,8 +3841,8 @@ fn swizzle_dyn_within_blocks_i8x16<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_u8x16<S: Simd>(simd: S) {
-    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 16] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 16] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x16::simd_from(simd, bytes);
@@ -3846,8 +3855,8 @@ fn swizzle_dyn_within_blocks_u8x16<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_i16x8<S: Simd>(simd: S) {
-    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 16] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 16] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x16::simd_from(simd, bytes);
@@ -3860,8 +3869,8 @@ fn swizzle_dyn_within_blocks_i16x8<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_u16x8<S: Simd>(simd: S) {
-    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 16] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 16] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x16::simd_from(simd, bytes);
@@ -3874,8 +3883,8 @@ fn swizzle_dyn_within_blocks_u16x8<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_i32x4<S: Simd>(simd: S) {
-    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 16] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 16] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x16::simd_from(simd, bytes);
@@ -3888,8 +3897,8 @@ fn swizzle_dyn_within_blocks_i32x4<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_u32x4<S: Simd>(simd: S) {
-    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 16] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 16] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x16::simd_from(simd, bytes);
@@ -3902,8 +3911,8 @@ fn swizzle_dyn_within_blocks_u32x4<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_f64x2<S: Simd>(simd: S) {
-    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 16] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 16] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x16::simd_from(simd, bytes);
@@ -3916,8 +3925,8 @@ fn swizzle_dyn_within_blocks_f64x2<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_f32x8<S: Simd>(simd: S) {
-    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 32] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 32] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x32::simd_from(simd, bytes);
@@ -3930,8 +3939,8 @@ fn swizzle_dyn_within_blocks_f32x8<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_i8x32<S: Simd>(simd: S) {
-    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 32] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 32] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x32::simd_from(simd, bytes);
@@ -3944,8 +3953,8 @@ fn swizzle_dyn_within_blocks_i8x32<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_u8x32<S: Simd>(simd: S) {
-    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 32] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 32] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x32::simd_from(simd, bytes);
@@ -3958,8 +3967,8 @@ fn swizzle_dyn_within_blocks_u8x32<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_i16x16<S: Simd>(simd: S) {
-    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 32] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 32] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x32::simd_from(simd, bytes);
@@ -3972,8 +3981,8 @@ fn swizzle_dyn_within_blocks_i16x16<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_u16x16<S: Simd>(simd: S) {
-    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 32] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 32] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x32::simd_from(simd, bytes);
@@ -3986,8 +3995,8 @@ fn swizzle_dyn_within_blocks_u16x16<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_i32x8<S: Simd>(simd: S) {
-    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 32] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 32] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x32::simd_from(simd, bytes);
@@ -4000,8 +4009,8 @@ fn swizzle_dyn_within_blocks_i32x8<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_u32x8<S: Simd>(simd: S) {
-    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 32] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 32] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x32::simd_from(simd, bytes);
@@ -4014,8 +4023,8 @@ fn swizzle_dyn_within_blocks_u32x8<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_f64x4<S: Simd>(simd: S) {
-    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 32] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 32] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x32::simd_from(simd, bytes);
@@ -4028,8 +4037,8 @@ fn swizzle_dyn_within_blocks_f64x4<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_f32x16<S: Simd>(simd: S) {
-    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 64] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 64] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x64::simd_from(simd, bytes);
@@ -4042,8 +4051,8 @@ fn swizzle_dyn_within_blocks_f32x16<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_i8x64<S: Simd>(simd: S) {
-    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 64] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 64] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x64::simd_from(simd, bytes);
@@ -4056,8 +4065,8 @@ fn swizzle_dyn_within_blocks_i8x64<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_u8x64<S: Simd>(simd: S) {
-    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 64] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 64] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x64::simd_from(simd, bytes);
@@ -4070,8 +4079,8 @@ fn swizzle_dyn_within_blocks_u8x64<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_i16x32<S: Simd>(simd: S) {
-    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 64] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 64] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x64::simd_from(simd, bytes);
@@ -4084,8 +4093,8 @@ fn swizzle_dyn_within_blocks_i16x32<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_u16x32<S: Simd>(simd: S) {
-    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 64] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 64] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x64::simd_from(simd, bytes);
@@ -4098,8 +4107,8 @@ fn swizzle_dyn_within_blocks_u16x32<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_i32x16<S: Simd>(simd: S) {
-    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 64] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 64] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x64::simd_from(simd, bytes);
@@ -4112,8 +4121,8 @@ fn swizzle_dyn_within_blocks_i32x16<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_u32x16<S: Simd>(simd: S) {
-    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 64] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 64] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x64::simd_from(simd, bytes);
@@ -4126,8 +4135,8 @@ fn swizzle_dyn_within_blocks_u32x16<S: Simd>(simd: S) {
 
 #[simd_test]
 fn swizzle_dyn_within_blocks_f64x8<S: Simd>(simd: S) {
-    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
-    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let bytes: [u8; 64] = core::array::from_fn(swizzle_test_byte);
+    let indices: [u8; 64] = core::array::from_fn(swizzle_test_index);
     let expected = expected_swizzle_within_blocks(bytes, indices);
 
     let byte_vec = u8x64::simd_from(simd, bytes);
@@ -4145,8 +4154,8 @@ fn swizzle_dyn_within_blocks_generic_indices<S: Simd>(simd: S) {
         value.swizzle_dyn_within_blocks(indices)
     }
 
-    let value = u8x16::from_fn(simd, |i| i as u8);
-    let indices = u8x16::from_fn(simd, |i| (15 - i) as u8);
+    let value = u8x16::from_fn(simd, |i| u8::try_from(i).unwrap());
+    let indices = u8x16::from_fn(simd, |i| u8::try_from(15 - i).unwrap());
     let result = do_swizzle::<S, u8x16<S>>(value, indices);
 
     assert_eq!(
@@ -4166,7 +4175,7 @@ fn swizzle_dyn_within_blocks_x86_pshufb_oob<S: Simd>(simd: S) {
             return;
         }
 
-        let value = u8x16::from_fn(simd, |i| i as u8);
+        let value = u8x16::from_fn(simd, |i| u8::try_from(i).unwrap());
         let indices = u8x16::simd_from(
             simd,
             [

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -4165,33 +4165,15 @@ fn swizzle_dyn_within_blocks_generic_indices<S: Simd>(simd: S) {
 }
 
 #[simd_test]
-fn swizzle_dyn_within_blocks_x86_pshufb_oob<S: Simd>(simd: S) {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    {
-        if !matches!(
-            simd.level(),
-            Level::Sse4_2(_) | Level::Avx2(_) | Level::Avx512(_)
-        ) {
-            return;
-        }
-
-        let value = u8x16::from_fn(simd, |i| u8::try_from(i).unwrap());
-        let indices = u8x16::simd_from(
-            simd,
-            [
-                16, 17, 31, 0x80, 0x8f, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5,
-            ],
-        );
-        let result = value.swizzle_dyn_within_blocks(indices);
-
-        assert_eq!(
-            *result,
-            [0, 1, 15, 0, 0, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5]
-        );
-    }
-
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-    let _ = simd;
+fn swizzle_dyn_within_blocks_oob_does_not_panic<S: Simd>(simd: S) {
+    let value = u8x16::from_fn(simd, |i| u8::try_from(i).unwrap());
+    let indices = u8x16::simd_from(
+        simd,
+        [
+            16, 17, 31, 0x80, 0x8f, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5,
+        ],
+    );
+    let _ = value.swizzle_dyn_within_blocks(indices);
 }
 
 #[simd_test]

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -3794,6 +3794,397 @@ fn bitcast_native<S: Simd>(simd: S) {
     );
 }
 
+fn expected_swizzle_within_blocks<const N: usize>(bytes: [u8; N], indices: [u8; N]) -> [u8; N] {
+    assert_eq!(N % 16, 0);
+    core::array::from_fn(|i| {
+        let block_start = (i / 16) * 16;
+        bytes[block_start + usize::from(indices[i])]
+    })
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_f32x4<S: Simd>(simd: S) {
+    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x16::simd_from(simd, bytes);
+    let index_vec = u8x16::simd_from(simd, indices);
+    let value: f32x4<S> = byte_vec.bitcast();
+    let result_bytes: u8x16<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_i8x16<S: Simd>(simd: S) {
+    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x16::simd_from(simd, bytes);
+    let index_vec = u8x16::simd_from(simd, indices);
+    let value: i8x16<S> = byte_vec.bitcast();
+    let result_bytes: u8x16<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_u8x16<S: Simd>(simd: S) {
+    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x16::simd_from(simd, bytes);
+    let index_vec = u8x16::simd_from(simd, indices);
+    let value: u8x16<S> = byte_vec.bitcast();
+    let result_bytes: u8x16<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_i16x8<S: Simd>(simd: S) {
+    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x16::simd_from(simd, bytes);
+    let index_vec = u8x16::simd_from(simd, indices);
+    let value: i16x8<S> = byte_vec.bitcast();
+    let result_bytes: u8x16<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_u16x8<S: Simd>(simd: S) {
+    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x16::simd_from(simd, bytes);
+    let index_vec = u8x16::simd_from(simd, indices);
+    let value: u16x8<S> = byte_vec.bitcast();
+    let result_bytes: u8x16<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_i32x4<S: Simd>(simd: S) {
+    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x16::simd_from(simd, bytes);
+    let index_vec = u8x16::simd_from(simd, indices);
+    let value: i32x4<S> = byte_vec.bitcast();
+    let result_bytes: u8x16<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_u32x4<S: Simd>(simd: S) {
+    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x16::simd_from(simd, bytes);
+    let index_vec = u8x16::simd_from(simd, indices);
+    let value: u32x4<S> = byte_vec.bitcast();
+    let result_bytes: u8x16<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_f64x2<S: Simd>(simd: S) {
+    let bytes: [u8; 16] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 16] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x16::simd_from(simd, bytes);
+    let index_vec = u8x16::simd_from(simd, indices);
+    let value: f64x2<S> = byte_vec.bitcast();
+    let result_bytes: u8x16<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_f32x8<S: Simd>(simd: S) {
+    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x32::simd_from(simd, bytes);
+    let index_vec = u8x32::simd_from(simd, indices);
+    let value: f32x8<S> = byte_vec.bitcast();
+    let result_bytes: u8x32<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_i8x32<S: Simd>(simd: S) {
+    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x32::simd_from(simd, bytes);
+    let index_vec = u8x32::simd_from(simd, indices);
+    let value: i8x32<S> = byte_vec.bitcast();
+    let result_bytes: u8x32<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_u8x32<S: Simd>(simd: S) {
+    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x32::simd_from(simd, bytes);
+    let index_vec = u8x32::simd_from(simd, indices);
+    let value: u8x32<S> = byte_vec.bitcast();
+    let result_bytes: u8x32<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_i16x16<S: Simd>(simd: S) {
+    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x32::simd_from(simd, bytes);
+    let index_vec = u8x32::simd_from(simd, indices);
+    let value: i16x16<S> = byte_vec.bitcast();
+    let result_bytes: u8x32<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_u16x16<S: Simd>(simd: S) {
+    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x32::simd_from(simd, bytes);
+    let index_vec = u8x32::simd_from(simd, indices);
+    let value: u16x16<S> = byte_vec.bitcast();
+    let result_bytes: u8x32<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_i32x8<S: Simd>(simd: S) {
+    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x32::simd_from(simd, bytes);
+    let index_vec = u8x32::simd_from(simd, indices);
+    let value: i32x8<S> = byte_vec.bitcast();
+    let result_bytes: u8x32<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_u32x8<S: Simd>(simd: S) {
+    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x32::simd_from(simd, bytes);
+    let index_vec = u8x32::simd_from(simd, indices);
+    let value: u32x8<S> = byte_vec.bitcast();
+    let result_bytes: u8x32<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_f64x4<S: Simd>(simd: S) {
+    let bytes: [u8; 32] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 32] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x32::simd_from(simd, bytes);
+    let index_vec = u8x32::simd_from(simd, indices);
+    let value: f64x4<S> = byte_vec.bitcast();
+    let result_bytes: u8x32<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_f32x16<S: Simd>(simd: S) {
+    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x64::simd_from(simd, bytes);
+    let index_vec = u8x64::simd_from(simd, indices);
+    let value: f32x16<S> = byte_vec.bitcast();
+    let result_bytes: u8x64<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_i8x64<S: Simd>(simd: S) {
+    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x64::simd_from(simd, bytes);
+    let index_vec = u8x64::simd_from(simd, indices);
+    let value: i8x64<S> = byte_vec.bitcast();
+    let result_bytes: u8x64<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_u8x64<S: Simd>(simd: S) {
+    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x64::simd_from(simd, bytes);
+    let index_vec = u8x64::simd_from(simd, indices);
+    let value: u8x64<S> = byte_vec.bitcast();
+    let result_bytes: u8x64<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_i16x32<S: Simd>(simd: S) {
+    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x64::simd_from(simd, bytes);
+    let index_vec = u8x64::simd_from(simd, indices);
+    let value: i16x32<S> = byte_vec.bitcast();
+    let result_bytes: u8x64<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_u16x32<S: Simd>(simd: S) {
+    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x64::simd_from(simd, bytes);
+    let index_vec = u8x64::simd_from(simd, indices);
+    let value: u16x32<S> = byte_vec.bitcast();
+    let result_bytes: u8x64<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_i32x16<S: Simd>(simd: S) {
+    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x64::simd_from(simd, bytes);
+    let index_vec = u8x64::simd_from(simd, indices);
+    let value: i32x16<S> = byte_vec.bitcast();
+    let result_bytes: u8x64<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_u32x16<S: Simd>(simd: S) {
+    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x64::simd_from(simd, bytes);
+    let index_vec = u8x64::simd_from(simd, indices);
+    let value: u32x16<S> = byte_vec.bitcast();
+    let result_bytes: u8x64<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_f64x8<S: Simd>(simd: S) {
+    let bytes: [u8; 64] = core::array::from_fn(|i| ((i * 37 + 11) & 0xff) as u8);
+    let indices: [u8; 64] = core::array::from_fn(|i| (15 - (i % 16)) as u8);
+    let expected = expected_swizzle_within_blocks(bytes, indices);
+
+    let byte_vec = u8x64::simd_from(simd, bytes);
+    let index_vec = u8x64::simd_from(simd, indices);
+    let value: f64x8<S> = byte_vec.bitcast();
+    let result_bytes: u8x64<S> = value.swizzle_dyn_within_blocks(index_vec).bitcast();
+
+    assert_eq!(*result_bytes, expected);
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_generic_indices<S: Simd>(simd: S) {
+    #[inline(always)]
+    fn do_swizzle<S: Simd, V: SimdBase<S>>(value: V, indices: V::Indices) -> V {
+        value.swizzle_dyn_within_blocks(indices)
+    }
+
+    let value = u8x16::from_fn(simd, |i| i as u8);
+    let indices = u8x16::from_fn(simd, |i| (15 - i) as u8);
+    let result = do_swizzle::<S, u8x16<S>>(value, indices);
+
+    assert_eq!(
+        *result,
+        [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    );
+}
+
+#[simd_test]
+fn swizzle_dyn_within_blocks_x86_pshufb_oob<S: Simd>(simd: S) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if !matches!(
+            simd.level(),
+            Level::Sse4_2(_) | Level::Avx2(_) | Level::Avx512(_)
+        ) {
+            return;
+        }
+
+        let value = u8x16::from_fn(simd, |i| i as u8);
+        let indices = u8x16::simd_from(
+            simd,
+            [
+                16, 17, 31, 0x80, 0x8f, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5,
+            ],
+        );
+        let result = value.swizzle_dyn_within_blocks(indices);
+
+        assert_eq!(
+            *result,
+            [0, 1, 15, 0, 0, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5]
+        );
+    }
+
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    let _ = simd;
+}
+
 #[simd_test]
 fn wrapping_add_u32<S: Simd>(simd: S) {
     assert_eq!(

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -4150,7 +4150,7 @@ fn swizzle_dyn_within_blocks_f64x8<S: Simd>(simd: S) {
 #[simd_test]
 fn swizzle_dyn_within_blocks_generic_indices<S: Simd>(simd: S) {
     #[inline(always)]
-    fn do_swizzle<S: Simd, V: SimdBase<S>>(value: V, indices: V::Indices) -> V {
+    fn do_swizzle<S: Simd, V: SimdBase<S>>(value: V, indices: V::Bytes) -> V {
         value.swizzle_dyn_within_blocks(indices)
     }
 


### PR DESCRIPTION
This addresses my criticism of #265

This maps to cheap hardware instructions on x86 and also maps really well to split+combine on blocks on NEON and WASM, so unlike #265 this can be implemented for all widths.

The API follows the `std::simd` [`swizzle_dyn`](https://doc.rust-lang.org/stable/std/simd/struct.Simd.html#method.swizzle_dyn), which uses byte-level index vectors. This also makes the implementation really straightforward, since everything is treated as byte vectors internally, so it's implemented for all types too.

The scalar fallback is branch-free thanks to `% len` which should be faster than the branchy fallback in #265 and also more amenable to autovectorization on obscure platforms we don't have intrinsics for.