### PR TITLE
Add shift_elements_* and rotate_elements_* functions to match std::simd API

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -175,6 +175,70 @@ impl Simd for Avx2 {
         self.slide_f32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_f32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_f32x4::<4>(a, a),
+            1 => self.slide_f32x4::<3>(a, a),
+            2 => self.slide_f32x4::<2>(a, a),
+            3 => self.slide_f32x4::<1>(a, a),
+            4 => self.slide_f32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f32x4(padding);
+        self.slide_f32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f32x4(padding);
+        match OFFSET {
+            0 => self.slide_f32x4::<4>(padding, a),
+            1 => self.slide_f32x4::<3>(padding, a),
+            2 => self.slide_f32x4::<2>(padding, a),
+            3 => self.slide_f32x4::<1>(padding, a),
+            4 => self.slide_f32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -711,6 +775,94 @@ impl Simd for Avx2 {
         self.slide_i8x16::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i8x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i8x16::<16>(a, a),
+            1 => self.slide_i8x16::<15>(a, a),
+            2 => self.slide_i8x16::<14>(a, a),
+            3 => self.slide_i8x16::<13>(a, a),
+            4 => self.slide_i8x16::<12>(a, a),
+            5 => self.slide_i8x16::<11>(a, a),
+            6 => self.slide_i8x16::<10>(a, a),
+            7 => self.slide_i8x16::<9>(a, a),
+            8 => self.slide_i8x16::<8>(a, a),
+            9 => self.slide_i8x16::<7>(a, a),
+            10 => self.slide_i8x16::<6>(a, a),
+            11 => self.slide_i8x16::<5>(a, a),
+            12 => self.slide_i8x16::<4>(a, a),
+            13 => self.slide_i8x16::<3>(a, a),
+            14 => self.slide_i8x16::<2>(a, a),
+            15 => self.slide_i8x16::<1>(a, a),
+            16 => self.slide_i8x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i8x16(padding);
+        self.slide_i8x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i8x16(padding);
+        match OFFSET {
+            0 => self.slide_i8x16::<16>(padding, a),
+            1 => self.slide_i8x16::<15>(padding, a),
+            2 => self.slide_i8x16::<14>(padding, a),
+            3 => self.slide_i8x16::<13>(padding, a),
+            4 => self.slide_i8x16::<12>(padding, a),
+            5 => self.slide_i8x16::<11>(padding, a),
+            6 => self.slide_i8x16::<10>(padding, a),
+            7 => self.slide_i8x16::<9>(padding, a),
+            8 => self.slide_i8x16::<8>(padding, a),
+            9 => self.slide_i8x16::<7>(padding, a),
+            10 => self.slide_i8x16::<6>(padding, a),
+            11 => self.slide_i8x16::<5>(padding, a),
+            12 => self.slide_i8x16::<4>(padding, a),
+            13 => self.slide_i8x16::<3>(padding, a),
+            14 => self.slide_i8x16::<2>(padding, a),
+            15 => self.slide_i8x16::<1>(padding, a),
+            16 => self.slide_i8x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1091,6 +1243,94 @@ impl Simd for Avx2 {
         b: u8x16<Self>,
     ) -> u8x16<Self> {
         self.slide_u8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u8x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u8x16::<16>(a, a),
+            1 => self.slide_u8x16::<15>(a, a),
+            2 => self.slide_u8x16::<14>(a, a),
+            3 => self.slide_u8x16::<13>(a, a),
+            4 => self.slide_u8x16::<12>(a, a),
+            5 => self.slide_u8x16::<11>(a, a),
+            6 => self.slide_u8x16::<10>(a, a),
+            7 => self.slide_u8x16::<9>(a, a),
+            8 => self.slide_u8x16::<8>(a, a),
+            9 => self.slide_u8x16::<7>(a, a),
+            10 => self.slide_u8x16::<6>(a, a),
+            11 => self.slide_u8x16::<5>(a, a),
+            12 => self.slide_u8x16::<4>(a, a),
+            13 => self.slide_u8x16::<3>(a, a),
+            14 => self.slide_u8x16::<2>(a, a),
+            15 => self.slide_u8x16::<1>(a, a),
+            16 => self.slide_u8x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u8x16(padding);
+        self.slide_u8x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u8x16(padding);
+        match OFFSET {
+            0 => self.slide_u8x16::<16>(padding, a),
+            1 => self.slide_u8x16::<15>(padding, a),
+            2 => self.slide_u8x16::<14>(padding, a),
+            3 => self.slide_u8x16::<13>(padding, a),
+            4 => self.slide_u8x16::<12>(padding, a),
+            5 => self.slide_u8x16::<11>(padding, a),
+            6 => self.slide_u8x16::<10>(padding, a),
+            7 => self.slide_u8x16::<9>(padding, a),
+            8 => self.slide_u8x16::<8>(padding, a),
+            9 => self.slide_u8x16::<7>(padding, a),
+            10 => self.slide_u8x16::<6>(padding, a),
+            11 => self.slide_u8x16::<5>(padding, a),
+            12 => self.slide_u8x16::<4>(padding, a),
+            13 => self.slide_u8x16::<3>(padding, a),
+            14 => self.slide_u8x16::<2>(padding, a),
+            15 => self.slide_u8x16::<1>(padding, a),
+            16 => self.slide_u8x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
@@ -1648,6 +1888,78 @@ impl Simd for Avx2 {
         self.slide_i16x8::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_i16x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_i16x8::<8>(a, a),
+            1 => self.slide_i16x8::<7>(a, a),
+            2 => self.slide_i16x8::<6>(a, a),
+            3 => self.slide_i16x8::<5>(a, a),
+            4 => self.slide_i16x8::<4>(a, a),
+            5 => self.slide_i16x8::<3>(a, a),
+            6 => self.slide_i16x8::<2>(a, a),
+            7 => self.slide_i16x8::<1>(a, a),
+            8 => self.slide_i16x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i16x8(padding);
+        self.slide_i16x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i16x8(padding);
+        match OFFSET {
+            0 => self.slide_i16x8::<8>(padding, a),
+            1 => self.slide_i16x8::<7>(padding, a),
+            2 => self.slide_i16x8::<6>(padding, a),
+            3 => self.slide_i16x8::<5>(padding, a),
+            4 => self.slide_i16x8::<4>(padding, a),
+            5 => self.slide_i16x8::<3>(padding, a),
+            6 => self.slide_i16x8::<2>(padding, a),
+            7 => self.slide_i16x8::<1>(padding, a),
+            8 => self.slide_i16x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2009,6 +2321,78 @@ impl Simd for Avx2 {
         b: u16x8<Self>,
     ) -> u16x8<Self> {
         self.slide_u16x8::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_u16x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_u16x8::<8>(a, a),
+            1 => self.slide_u16x8::<7>(a, a),
+            2 => self.slide_u16x8::<6>(a, a),
+            3 => self.slide_u16x8::<5>(a, a),
+            4 => self.slide_u16x8::<4>(a, a),
+            5 => self.slide_u16x8::<3>(a, a),
+            6 => self.slide_u16x8::<2>(a, a),
+            7 => self.slide_u16x8::<1>(a, a),
+            8 => self.slide_u16x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u16x8(padding);
+        self.slide_u16x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u16x8(padding);
+        match OFFSET {
+            0 => self.slide_u16x8::<8>(padding, a),
+            1 => self.slide_u16x8::<7>(padding, a),
+            2 => self.slide_u16x8::<6>(padding, a),
+            3 => self.slide_u16x8::<5>(padding, a),
+            4 => self.slide_u16x8::<4>(padding, a),
+            5 => self.slide_u16x8::<3>(padding, a),
+            6 => self.slide_u16x8::<2>(padding, a),
+            7 => self.slide_u16x8::<1>(padding, a),
+            8 => self.slide_u16x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
@@ -2545,6 +2929,70 @@ impl Simd for Avx2 {
         self.slide_i32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_i32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_i32x4::<4>(a, a),
+            1 => self.slide_i32x4::<3>(a, a),
+            2 => self.slide_i32x4::<2>(a, a),
+            3 => self.slide_i32x4::<1>(a, a),
+            4 => self.slide_i32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_i32x4(padding);
+        self.slide_i32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_i32x4(padding);
+        match OFFSET {
+            0 => self.slide_i32x4::<4>(padding, a),
+            1 => self.slide_i32x4::<3>(padding, a),
+            2 => self.slide_i32x4::<2>(padding, a),
+            3 => self.slide_i32x4::<1>(padding, a),
+            4 => self.slide_i32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2926,6 +3374,70 @@ impl Simd for Avx2 {
         b: u32x4<Self>,
     ) -> u32x4<Self> {
         self.slide_u32x4::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_u32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_u32x4::<4>(a, a),
+            1 => self.slide_u32x4::<3>(a, a),
+            2 => self.slide_u32x4::<2>(a, a),
+            3 => self.slide_u32x4::<1>(a, a),
+            4 => self.slide_u32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_u32x4(padding);
+        self.slide_u32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_u32x4(padding);
+        match OFFSET {
+            0 => self.slide_u32x4::<4>(padding, a),
+            1 => self.slide_u32x4::<3>(padding, a),
+            2 => self.slide_u32x4::<2>(padding, a),
+            3 => self.slide_u32x4::<1>(padding, a),
+            4 => self.slide_u32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
@@ -3476,6 +3988,66 @@ impl Simd for Avx2 {
         b: f64x2<Self>,
     ) -> f64x2<Self> {
         self.slide_f64x2::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        self.slide_f64x2::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        match OFFSET {
+            0 => self.slide_f64x2::<2>(a, a),
+            1 => self.slide_f64x2::<1>(a, a),
+            2 => self.slide_f64x2::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        let padding = self.splat_f64x2(padding);
+        self.slide_f64x2::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        let padding = self.splat_f64x2(padding);
+        match OFFSET {
+            0 => self.slide_f64x2::<2>(padding, a),
+            1 => self.slide_f64x2::<1>(padding, a),
+            2 => self.slide_f64x2::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
@@ -4085,6 +4657,78 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_f32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_f32x8::<8>(a, a),
+            1 => self.slide_f32x8::<7>(a, a),
+            2 => self.slide_f32x8::<6>(a, a),
+            3 => self.slide_f32x8::<5>(a, a),
+            4 => self.slide_f32x8::<4>(a, a),
+            5 => self.slide_f32x8::<3>(a, a),
+            6 => self.slide_f32x8::<2>(a, a),
+            7 => self.slide_f32x8::<1>(a, a),
+            8 => self.slide_f32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f32x8(padding);
+        self.slide_f32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f32x8(padding);
+        match OFFSET {
+            0 => self.slide_f32x8::<8>(padding, a),
+            1 => self.slide_f32x8::<7>(padding, a),
+            2 => self.slide_f32x8::<6>(padding, a),
+            3 => self.slide_f32x8::<5>(padding, a),
+            4 => self.slide_f32x8::<4>(padding, a),
+            5 => self.slide_f32x8::<3>(padding, a),
+            6 => self.slide_f32x8::<2>(padding, a),
+            7 => self.slide_f32x8::<1>(padding, a),
+            8 => self.slide_f32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -4684,6 +5328,126 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_i8x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_i8x32::<32>(a, a),
+            1 => self.slide_i8x32::<31>(a, a),
+            2 => self.slide_i8x32::<30>(a, a),
+            3 => self.slide_i8x32::<29>(a, a),
+            4 => self.slide_i8x32::<28>(a, a),
+            5 => self.slide_i8x32::<27>(a, a),
+            6 => self.slide_i8x32::<26>(a, a),
+            7 => self.slide_i8x32::<25>(a, a),
+            8 => self.slide_i8x32::<24>(a, a),
+            9 => self.slide_i8x32::<23>(a, a),
+            10 => self.slide_i8x32::<22>(a, a),
+            11 => self.slide_i8x32::<21>(a, a),
+            12 => self.slide_i8x32::<20>(a, a),
+            13 => self.slide_i8x32::<19>(a, a),
+            14 => self.slide_i8x32::<18>(a, a),
+            15 => self.slide_i8x32::<17>(a, a),
+            16 => self.slide_i8x32::<16>(a, a),
+            17 => self.slide_i8x32::<15>(a, a),
+            18 => self.slide_i8x32::<14>(a, a),
+            19 => self.slide_i8x32::<13>(a, a),
+            20 => self.slide_i8x32::<12>(a, a),
+            21 => self.slide_i8x32::<11>(a, a),
+            22 => self.slide_i8x32::<10>(a, a),
+            23 => self.slide_i8x32::<9>(a, a),
+            24 => self.slide_i8x32::<8>(a, a),
+            25 => self.slide_i8x32::<7>(a, a),
+            26 => self.slide_i8x32::<6>(a, a),
+            27 => self.slide_i8x32::<5>(a, a),
+            28 => self.slide_i8x32::<4>(a, a),
+            29 => self.slide_i8x32::<3>(a, a),
+            30 => self.slide_i8x32::<2>(a, a),
+            31 => self.slide_i8x32::<1>(a, a),
+            32 => self.slide_i8x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i8x32(padding);
+        self.slide_i8x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i8x32(padding);
+        match OFFSET {
+            0 => self.slide_i8x32::<32>(padding, a),
+            1 => self.slide_i8x32::<31>(padding, a),
+            2 => self.slide_i8x32::<30>(padding, a),
+            3 => self.slide_i8x32::<29>(padding, a),
+            4 => self.slide_i8x32::<28>(padding, a),
+            5 => self.slide_i8x32::<27>(padding, a),
+            6 => self.slide_i8x32::<26>(padding, a),
+            7 => self.slide_i8x32::<25>(padding, a),
+            8 => self.slide_i8x32::<24>(padding, a),
+            9 => self.slide_i8x32::<23>(padding, a),
+            10 => self.slide_i8x32::<22>(padding, a),
+            11 => self.slide_i8x32::<21>(padding, a),
+            12 => self.slide_i8x32::<20>(padding, a),
+            13 => self.slide_i8x32::<19>(padding, a),
+            14 => self.slide_i8x32::<18>(padding, a),
+            15 => self.slide_i8x32::<17>(padding, a),
+            16 => self.slide_i8x32::<16>(padding, a),
+            17 => self.slide_i8x32::<15>(padding, a),
+            18 => self.slide_i8x32::<14>(padding, a),
+            19 => self.slide_i8x32::<13>(padding, a),
+            20 => self.slide_i8x32::<12>(padding, a),
+            21 => self.slide_i8x32::<11>(padding, a),
+            22 => self.slide_i8x32::<10>(padding, a),
+            23 => self.slide_i8x32::<9>(padding, a),
+            24 => self.slide_i8x32::<8>(padding, a),
+            25 => self.slide_i8x32::<7>(padding, a),
+            26 => self.slide_i8x32::<6>(padding, a),
+            27 => self.slide_i8x32::<5>(padding, a),
+            28 => self.slide_i8x32::<4>(padding, a),
+            29 => self.slide_i8x32::<3>(padding, a),
+            30 => self.slide_i8x32::<2>(padding, a),
+            31 => self.slide_i8x32::<1>(padding, a),
+            32 => self.slide_i8x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5152,6 +5916,126 @@ impl Simd for Avx2 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_u8x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_u8x32::<32>(a, a),
+            1 => self.slide_u8x32::<31>(a, a),
+            2 => self.slide_u8x32::<30>(a, a),
+            3 => self.slide_u8x32::<29>(a, a),
+            4 => self.slide_u8x32::<28>(a, a),
+            5 => self.slide_u8x32::<27>(a, a),
+            6 => self.slide_u8x32::<26>(a, a),
+            7 => self.slide_u8x32::<25>(a, a),
+            8 => self.slide_u8x32::<24>(a, a),
+            9 => self.slide_u8x32::<23>(a, a),
+            10 => self.slide_u8x32::<22>(a, a),
+            11 => self.slide_u8x32::<21>(a, a),
+            12 => self.slide_u8x32::<20>(a, a),
+            13 => self.slide_u8x32::<19>(a, a),
+            14 => self.slide_u8x32::<18>(a, a),
+            15 => self.slide_u8x32::<17>(a, a),
+            16 => self.slide_u8x32::<16>(a, a),
+            17 => self.slide_u8x32::<15>(a, a),
+            18 => self.slide_u8x32::<14>(a, a),
+            19 => self.slide_u8x32::<13>(a, a),
+            20 => self.slide_u8x32::<12>(a, a),
+            21 => self.slide_u8x32::<11>(a, a),
+            22 => self.slide_u8x32::<10>(a, a),
+            23 => self.slide_u8x32::<9>(a, a),
+            24 => self.slide_u8x32::<8>(a, a),
+            25 => self.slide_u8x32::<7>(a, a),
+            26 => self.slide_u8x32::<6>(a, a),
+            27 => self.slide_u8x32::<5>(a, a),
+            28 => self.slide_u8x32::<4>(a, a),
+            29 => self.slide_u8x32::<3>(a, a),
+            30 => self.slide_u8x32::<2>(a, a),
+            31 => self.slide_u8x32::<1>(a, a),
+            32 => self.slide_u8x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u8x32(padding);
+        self.slide_u8x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u8x32(padding);
+        match OFFSET {
+            0 => self.slide_u8x32::<32>(padding, a),
+            1 => self.slide_u8x32::<31>(padding, a),
+            2 => self.slide_u8x32::<30>(padding, a),
+            3 => self.slide_u8x32::<29>(padding, a),
+            4 => self.slide_u8x32::<28>(padding, a),
+            5 => self.slide_u8x32::<27>(padding, a),
+            6 => self.slide_u8x32::<26>(padding, a),
+            7 => self.slide_u8x32::<25>(padding, a),
+            8 => self.slide_u8x32::<24>(padding, a),
+            9 => self.slide_u8x32::<23>(padding, a),
+            10 => self.slide_u8x32::<22>(padding, a),
+            11 => self.slide_u8x32::<21>(padding, a),
+            12 => self.slide_u8x32::<20>(padding, a),
+            13 => self.slide_u8x32::<19>(padding, a),
+            14 => self.slide_u8x32::<18>(padding, a),
+            15 => self.slide_u8x32::<17>(padding, a),
+            16 => self.slide_u8x32::<16>(padding, a),
+            17 => self.slide_u8x32::<15>(padding, a),
+            18 => self.slide_u8x32::<14>(padding, a),
+            19 => self.slide_u8x32::<13>(padding, a),
+            20 => self.slide_u8x32::<12>(padding, a),
+            21 => self.slide_u8x32::<11>(padding, a),
+            22 => self.slide_u8x32::<10>(padding, a),
+            23 => self.slide_u8x32::<9>(padding, a),
+            24 => self.slide_u8x32::<8>(padding, a),
+            25 => self.slide_u8x32::<7>(padding, a),
+            26 => self.slide_u8x32::<6>(padding, a),
+            27 => self.slide_u8x32::<5>(padding, a),
+            28 => self.slide_u8x32::<4>(padding, a),
+            29 => self.slide_u8x32::<3>(padding, a),
+            30 => self.slide_u8x32::<2>(padding, a),
+            31 => self.slide_u8x32::<1>(padding, a),
+            32 => self.slide_u8x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self> {
@@ -5811,6 +6695,94 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i16x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i16x16::<16>(a, a),
+            1 => self.slide_i16x16::<15>(a, a),
+            2 => self.slide_i16x16::<14>(a, a),
+            3 => self.slide_i16x16::<13>(a, a),
+            4 => self.slide_i16x16::<12>(a, a),
+            5 => self.slide_i16x16::<11>(a, a),
+            6 => self.slide_i16x16::<10>(a, a),
+            7 => self.slide_i16x16::<9>(a, a),
+            8 => self.slide_i16x16::<8>(a, a),
+            9 => self.slide_i16x16::<7>(a, a),
+            10 => self.slide_i16x16::<6>(a, a),
+            11 => self.slide_i16x16::<5>(a, a),
+            12 => self.slide_i16x16::<4>(a, a),
+            13 => self.slide_i16x16::<3>(a, a),
+            14 => self.slide_i16x16::<2>(a, a),
+            15 => self.slide_i16x16::<1>(a, a),
+            16 => self.slide_i16x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i16x16(padding);
+        self.slide_i16x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i16x16(padding);
+        match OFFSET {
+            0 => self.slide_i16x16::<16>(padding, a),
+            1 => self.slide_i16x16::<15>(padding, a),
+            2 => self.slide_i16x16::<14>(padding, a),
+            3 => self.slide_i16x16::<13>(padding, a),
+            4 => self.slide_i16x16::<12>(padding, a),
+            5 => self.slide_i16x16::<11>(padding, a),
+            6 => self.slide_i16x16::<10>(padding, a),
+            7 => self.slide_i16x16::<9>(padding, a),
+            8 => self.slide_i16x16::<8>(padding, a),
+            9 => self.slide_i16x16::<7>(padding, a),
+            10 => self.slide_i16x16::<6>(padding, a),
+            11 => self.slide_i16x16::<5>(padding, a),
+            12 => self.slide_i16x16::<4>(padding, a),
+            13 => self.slide_i16x16::<3>(padding, a),
+            14 => self.slide_i16x16::<2>(padding, a),
+            15 => self.slide_i16x16::<1>(padding, a),
+            16 => self.slide_i16x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x16(
         self,
         a: i16x16<Self>,
@@ -6267,6 +7239,94 @@ impl Simd for Avx2 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u16x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u16x16::<16>(a, a),
+            1 => self.slide_u16x16::<15>(a, a),
+            2 => self.slide_u16x16::<14>(a, a),
+            3 => self.slide_u16x16::<13>(a, a),
+            4 => self.slide_u16x16::<12>(a, a),
+            5 => self.slide_u16x16::<11>(a, a),
+            6 => self.slide_u16x16::<10>(a, a),
+            7 => self.slide_u16x16::<9>(a, a),
+            8 => self.slide_u16x16::<8>(a, a),
+            9 => self.slide_u16x16::<7>(a, a),
+            10 => self.slide_u16x16::<6>(a, a),
+            11 => self.slide_u16x16::<5>(a, a),
+            12 => self.slide_u16x16::<4>(a, a),
+            13 => self.slide_u16x16::<3>(a, a),
+            14 => self.slide_u16x16::<2>(a, a),
+            15 => self.slide_u16x16::<1>(a, a),
+            16 => self.slide_u16x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u16x16(padding);
+        self.slide_u16x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u16x16(padding);
+        match OFFSET {
+            0 => self.slide_u16x16::<16>(padding, a),
+            1 => self.slide_u16x16::<15>(padding, a),
+            2 => self.slide_u16x16::<14>(padding, a),
+            3 => self.slide_u16x16::<13>(padding, a),
+            4 => self.slide_u16x16::<12>(padding, a),
+            5 => self.slide_u16x16::<11>(padding, a),
+            6 => self.slide_u16x16::<10>(padding, a),
+            7 => self.slide_u16x16::<9>(padding, a),
+            8 => self.slide_u16x16::<8>(padding, a),
+            9 => self.slide_u16x16::<7>(padding, a),
+            10 => self.slide_u16x16::<6>(padding, a),
+            11 => self.slide_u16x16::<5>(padding, a),
+            12 => self.slide_u16x16::<4>(padding, a),
+            13 => self.slide_u16x16::<3>(padding, a),
+            14 => self.slide_u16x16::<2>(padding, a),
+            15 => self.slide_u16x16::<1>(padding, a),
+            16 => self.slide_u16x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x16(
@@ -6929,6 +7989,78 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_i32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_i32x8::<8>(a, a),
+            1 => self.slide_i32x8::<7>(a, a),
+            2 => self.slide_i32x8::<6>(a, a),
+            3 => self.slide_i32x8::<5>(a, a),
+            4 => self.slide_i32x8::<4>(a, a),
+            5 => self.slide_i32x8::<3>(a, a),
+            6 => self.slide_i32x8::<2>(a, a),
+            7 => self.slide_i32x8::<1>(a, a),
+            8 => self.slide_i32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i32x8(padding);
+        self.slide_i32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i32x8(padding);
+        match OFFSET {
+            0 => self.slide_i32x8::<8>(padding, a),
+            1 => self.slide_i32x8::<7>(padding, a),
+            2 => self.slide_i32x8::<6>(padding, a),
+            3 => self.slide_i32x8::<5>(padding, a),
+            4 => self.slide_i32x8::<4>(padding, a),
+            5 => self.slide_i32x8::<3>(padding, a),
+            6 => self.slide_i32x8::<2>(padding, a),
+            7 => self.slide_i32x8::<1>(padding, a),
+            8 => self.slide_i32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7376,6 +8508,78 @@ impl Simd for Avx2 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_u32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_u32x8::<8>(a, a),
+            1 => self.slide_u32x8::<7>(a, a),
+            2 => self.slide_u32x8::<6>(a, a),
+            3 => self.slide_u32x8::<5>(a, a),
+            4 => self.slide_u32x8::<4>(a, a),
+            5 => self.slide_u32x8::<3>(a, a),
+            6 => self.slide_u32x8::<2>(a, a),
+            7 => self.slide_u32x8::<1>(a, a),
+            8 => self.slide_u32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u32x8(padding);
+        self.slide_u32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u32x8(padding);
+        match OFFSET {
+            0 => self.slide_u32x8::<8>(padding, a),
+            1 => self.slide_u32x8::<7>(padding, a),
+            2 => self.slide_u32x8::<6>(padding, a),
+            3 => self.slide_u32x8::<5>(padding, a),
+            4 => self.slide_u32x8::<4>(padding, a),
+            5 => self.slide_u32x8::<3>(padding, a),
+            6 => self.slide_u32x8::<2>(padding, a),
+            7 => self.slide_u32x8::<1>(padding, a),
+            8 => self.slide_u32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
@@ -8004,6 +9208,70 @@ impl Simd for Avx2 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_f64x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_f64x4::<4>(a, a),
+            1 => self.slide_f64x4::<3>(a, a),
+            2 => self.slide_f64x4::<2>(a, a),
+            3 => self.slide_f64x4::<1>(a, a),
+            4 => self.slide_f64x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f64x4(padding);
+        self.slide_f64x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f64x4(padding);
+        match OFFSET {
+            0 => self.slide_f64x4::<4>(padding, a),
+            1 => self.slide_f64x4::<3>(padding, a),
+            2 => self.slide_f64x4::<2>(padding, a),
+            3 => self.slide_f64x4::<1>(padding, a),
+            4 => self.slide_f64x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
@@ -8654,6 +9922,94 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_f32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_f32x16::<16>(a, a),
+            1 => self.slide_f32x16::<15>(a, a),
+            2 => self.slide_f32x16::<14>(a, a),
+            3 => self.slide_f32x16::<13>(a, a),
+            4 => self.slide_f32x16::<12>(a, a),
+            5 => self.slide_f32x16::<11>(a, a),
+            6 => self.slide_f32x16::<10>(a, a),
+            7 => self.slide_f32x16::<9>(a, a),
+            8 => self.slide_f32x16::<8>(a, a),
+            9 => self.slide_f32x16::<7>(a, a),
+            10 => self.slide_f32x16::<6>(a, a),
+            11 => self.slide_f32x16::<5>(a, a),
+            12 => self.slide_f32x16::<4>(a, a),
+            13 => self.slide_f32x16::<3>(a, a),
+            14 => self.slide_f32x16::<2>(a, a),
+            15 => self.slide_f32x16::<1>(a, a),
+            16 => self.slide_f32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_f32x16(padding);
+        self.slide_f32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_f32x16(padding);
+        match OFFSET {
+            0 => self.slide_f32x16::<16>(padding, a),
+            1 => self.slide_f32x16::<15>(padding, a),
+            2 => self.slide_f32x16::<14>(padding, a),
+            3 => self.slide_f32x16::<13>(padding, a),
+            4 => self.slide_f32x16::<12>(padding, a),
+            5 => self.slide_f32x16::<11>(padding, a),
+            6 => self.slide_f32x16::<10>(padding, a),
+            7 => self.slide_f32x16::<9>(padding, a),
+            8 => self.slide_f32x16::<8>(padding, a),
+            9 => self.slide_f32x16::<7>(padding, a),
+            10 => self.slide_f32x16::<6>(padding, a),
+            11 => self.slide_f32x16::<5>(padding, a),
+            12 => self.slide_f32x16::<4>(padding, a),
+            13 => self.slide_f32x16::<3>(padding, a),
+            14 => self.slide_f32x16::<2>(padding, a),
+            15 => self.slide_f32x16::<1>(padding, a),
+            16 => self.slide_f32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x16(
         self,
         a: f32x16<Self>,
@@ -9106,6 +10462,190 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        self.slide_i8x64::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        match OFFSET {
+            0 => self.slide_i8x64::<64>(a, a),
+            1 => self.slide_i8x64::<63>(a, a),
+            2 => self.slide_i8x64::<62>(a, a),
+            3 => self.slide_i8x64::<61>(a, a),
+            4 => self.slide_i8x64::<60>(a, a),
+            5 => self.slide_i8x64::<59>(a, a),
+            6 => self.slide_i8x64::<58>(a, a),
+            7 => self.slide_i8x64::<57>(a, a),
+            8 => self.slide_i8x64::<56>(a, a),
+            9 => self.slide_i8x64::<55>(a, a),
+            10 => self.slide_i8x64::<54>(a, a),
+            11 => self.slide_i8x64::<53>(a, a),
+            12 => self.slide_i8x64::<52>(a, a),
+            13 => self.slide_i8x64::<51>(a, a),
+            14 => self.slide_i8x64::<50>(a, a),
+            15 => self.slide_i8x64::<49>(a, a),
+            16 => self.slide_i8x64::<48>(a, a),
+            17 => self.slide_i8x64::<47>(a, a),
+            18 => self.slide_i8x64::<46>(a, a),
+            19 => self.slide_i8x64::<45>(a, a),
+            20 => self.slide_i8x64::<44>(a, a),
+            21 => self.slide_i8x64::<43>(a, a),
+            22 => self.slide_i8x64::<42>(a, a),
+            23 => self.slide_i8x64::<41>(a, a),
+            24 => self.slide_i8x64::<40>(a, a),
+            25 => self.slide_i8x64::<39>(a, a),
+            26 => self.slide_i8x64::<38>(a, a),
+            27 => self.slide_i8x64::<37>(a, a),
+            28 => self.slide_i8x64::<36>(a, a),
+            29 => self.slide_i8x64::<35>(a, a),
+            30 => self.slide_i8x64::<34>(a, a),
+            31 => self.slide_i8x64::<33>(a, a),
+            32 => self.slide_i8x64::<32>(a, a),
+            33 => self.slide_i8x64::<31>(a, a),
+            34 => self.slide_i8x64::<30>(a, a),
+            35 => self.slide_i8x64::<29>(a, a),
+            36 => self.slide_i8x64::<28>(a, a),
+            37 => self.slide_i8x64::<27>(a, a),
+            38 => self.slide_i8x64::<26>(a, a),
+            39 => self.slide_i8x64::<25>(a, a),
+            40 => self.slide_i8x64::<24>(a, a),
+            41 => self.slide_i8x64::<23>(a, a),
+            42 => self.slide_i8x64::<22>(a, a),
+            43 => self.slide_i8x64::<21>(a, a),
+            44 => self.slide_i8x64::<20>(a, a),
+            45 => self.slide_i8x64::<19>(a, a),
+            46 => self.slide_i8x64::<18>(a, a),
+            47 => self.slide_i8x64::<17>(a, a),
+            48 => self.slide_i8x64::<16>(a, a),
+            49 => self.slide_i8x64::<15>(a, a),
+            50 => self.slide_i8x64::<14>(a, a),
+            51 => self.slide_i8x64::<13>(a, a),
+            52 => self.slide_i8x64::<12>(a, a),
+            53 => self.slide_i8x64::<11>(a, a),
+            54 => self.slide_i8x64::<10>(a, a),
+            55 => self.slide_i8x64::<9>(a, a),
+            56 => self.slide_i8x64::<8>(a, a),
+            57 => self.slide_i8x64::<7>(a, a),
+            58 => self.slide_i8x64::<6>(a, a),
+            59 => self.slide_i8x64::<5>(a, a),
+            60 => self.slide_i8x64::<4>(a, a),
+            61 => self.slide_i8x64::<3>(a, a),
+            62 => self.slide_i8x64::<2>(a, a),
+            63 => self.slide_i8x64::<1>(a, a),
+            64 => self.slide_i8x64::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_i8x64(padding);
+        self.slide_i8x64::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_i8x64(padding);
+        match OFFSET {
+            0 => self.slide_i8x64::<64>(padding, a),
+            1 => self.slide_i8x64::<63>(padding, a),
+            2 => self.slide_i8x64::<62>(padding, a),
+            3 => self.slide_i8x64::<61>(padding, a),
+            4 => self.slide_i8x64::<60>(padding, a),
+            5 => self.slide_i8x64::<59>(padding, a),
+            6 => self.slide_i8x64::<58>(padding, a),
+            7 => self.slide_i8x64::<57>(padding, a),
+            8 => self.slide_i8x64::<56>(padding, a),
+            9 => self.slide_i8x64::<55>(padding, a),
+            10 => self.slide_i8x64::<54>(padding, a),
+            11 => self.slide_i8x64::<53>(padding, a),
+            12 => self.slide_i8x64::<52>(padding, a),
+            13 => self.slide_i8x64::<51>(padding, a),
+            14 => self.slide_i8x64::<50>(padding, a),
+            15 => self.slide_i8x64::<49>(padding, a),
+            16 => self.slide_i8x64::<48>(padding, a),
+            17 => self.slide_i8x64::<47>(padding, a),
+            18 => self.slide_i8x64::<46>(padding, a),
+            19 => self.slide_i8x64::<45>(padding, a),
+            20 => self.slide_i8x64::<44>(padding, a),
+            21 => self.slide_i8x64::<43>(padding, a),
+            22 => self.slide_i8x64::<42>(padding, a),
+            23 => self.slide_i8x64::<41>(padding, a),
+            24 => self.slide_i8x64::<40>(padding, a),
+            25 => self.slide_i8x64::<39>(padding, a),
+            26 => self.slide_i8x64::<38>(padding, a),
+            27 => self.slide_i8x64::<37>(padding, a),
+            28 => self.slide_i8x64::<36>(padding, a),
+            29 => self.slide_i8x64::<35>(padding, a),
+            30 => self.slide_i8x64::<34>(padding, a),
+            31 => self.slide_i8x64::<33>(padding, a),
+            32 => self.slide_i8x64::<32>(padding, a),
+            33 => self.slide_i8x64::<31>(padding, a),
+            34 => self.slide_i8x64::<30>(padding, a),
+            35 => self.slide_i8x64::<29>(padding, a),
+            36 => self.slide_i8x64::<28>(padding, a),
+            37 => self.slide_i8x64::<27>(padding, a),
+            38 => self.slide_i8x64::<26>(padding, a),
+            39 => self.slide_i8x64::<25>(padding, a),
+            40 => self.slide_i8x64::<24>(padding, a),
+            41 => self.slide_i8x64::<23>(padding, a),
+            42 => self.slide_i8x64::<22>(padding, a),
+            43 => self.slide_i8x64::<21>(padding, a),
+            44 => self.slide_i8x64::<20>(padding, a),
+            45 => self.slide_i8x64::<19>(padding, a),
+            46 => self.slide_i8x64::<18>(padding, a),
+            47 => self.slide_i8x64::<17>(padding, a),
+            48 => self.slide_i8x64::<16>(padding, a),
+            49 => self.slide_i8x64::<15>(padding, a),
+            50 => self.slide_i8x64::<14>(padding, a),
+            51 => self.slide_i8x64::<13>(padding, a),
+            52 => self.slide_i8x64::<12>(padding, a),
+            53 => self.slide_i8x64::<11>(padding, a),
+            54 => self.slide_i8x64::<10>(padding, a),
+            55 => self.slide_i8x64::<9>(padding, a),
+            56 => self.slide_i8x64::<8>(padding, a),
+            57 => self.slide_i8x64::<7>(padding, a),
+            58 => self.slide_i8x64::<6>(padding, a),
+            59 => self.slide_i8x64::<5>(padding, a),
+            60 => self.slide_i8x64::<4>(padding, a),
+            61 => self.slide_i8x64::<3>(padding, a),
+            62 => self.slide_i8x64::<2>(padding, a),
+            63 => self.slide_i8x64::<1>(padding, a),
+            64 => self.slide_i8x64::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
         let (indices0, indices1) = self.split_u8x64(indices);
@@ -9384,6 +10924,190 @@ impl Simd for Avx2 {
             self.slide_within_blocks_u8x32::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x32::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        self.slide_u8x64::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        match OFFSET {
+            0 => self.slide_u8x64::<64>(a, a),
+            1 => self.slide_u8x64::<63>(a, a),
+            2 => self.slide_u8x64::<62>(a, a),
+            3 => self.slide_u8x64::<61>(a, a),
+            4 => self.slide_u8x64::<60>(a, a),
+            5 => self.slide_u8x64::<59>(a, a),
+            6 => self.slide_u8x64::<58>(a, a),
+            7 => self.slide_u8x64::<57>(a, a),
+            8 => self.slide_u8x64::<56>(a, a),
+            9 => self.slide_u8x64::<55>(a, a),
+            10 => self.slide_u8x64::<54>(a, a),
+            11 => self.slide_u8x64::<53>(a, a),
+            12 => self.slide_u8x64::<52>(a, a),
+            13 => self.slide_u8x64::<51>(a, a),
+            14 => self.slide_u8x64::<50>(a, a),
+            15 => self.slide_u8x64::<49>(a, a),
+            16 => self.slide_u8x64::<48>(a, a),
+            17 => self.slide_u8x64::<47>(a, a),
+            18 => self.slide_u8x64::<46>(a, a),
+            19 => self.slide_u8x64::<45>(a, a),
+            20 => self.slide_u8x64::<44>(a, a),
+            21 => self.slide_u8x64::<43>(a, a),
+            22 => self.slide_u8x64::<42>(a, a),
+            23 => self.slide_u8x64::<41>(a, a),
+            24 => self.slide_u8x64::<40>(a, a),
+            25 => self.slide_u8x64::<39>(a, a),
+            26 => self.slide_u8x64::<38>(a, a),
+            27 => self.slide_u8x64::<37>(a, a),
+            28 => self.slide_u8x64::<36>(a, a),
+            29 => self.slide_u8x64::<35>(a, a),
+            30 => self.slide_u8x64::<34>(a, a),
+            31 => self.slide_u8x64::<33>(a, a),
+            32 => self.slide_u8x64::<32>(a, a),
+            33 => self.slide_u8x64::<31>(a, a),
+            34 => self.slide_u8x64::<30>(a, a),
+            35 => self.slide_u8x64::<29>(a, a),
+            36 => self.slide_u8x64::<28>(a, a),
+            37 => self.slide_u8x64::<27>(a, a),
+            38 => self.slide_u8x64::<26>(a, a),
+            39 => self.slide_u8x64::<25>(a, a),
+            40 => self.slide_u8x64::<24>(a, a),
+            41 => self.slide_u8x64::<23>(a, a),
+            42 => self.slide_u8x64::<22>(a, a),
+            43 => self.slide_u8x64::<21>(a, a),
+            44 => self.slide_u8x64::<20>(a, a),
+            45 => self.slide_u8x64::<19>(a, a),
+            46 => self.slide_u8x64::<18>(a, a),
+            47 => self.slide_u8x64::<17>(a, a),
+            48 => self.slide_u8x64::<16>(a, a),
+            49 => self.slide_u8x64::<15>(a, a),
+            50 => self.slide_u8x64::<14>(a, a),
+            51 => self.slide_u8x64::<13>(a, a),
+            52 => self.slide_u8x64::<12>(a, a),
+            53 => self.slide_u8x64::<11>(a, a),
+            54 => self.slide_u8x64::<10>(a, a),
+            55 => self.slide_u8x64::<9>(a, a),
+            56 => self.slide_u8x64::<8>(a, a),
+            57 => self.slide_u8x64::<7>(a, a),
+            58 => self.slide_u8x64::<6>(a, a),
+            59 => self.slide_u8x64::<5>(a, a),
+            60 => self.slide_u8x64::<4>(a, a),
+            61 => self.slide_u8x64::<3>(a, a),
+            62 => self.slide_u8x64::<2>(a, a),
+            63 => self.slide_u8x64::<1>(a, a),
+            64 => self.slide_u8x64::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_u8x64(padding);
+        self.slide_u8x64::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_u8x64(padding);
+        match OFFSET {
+            0 => self.slide_u8x64::<64>(padding, a),
+            1 => self.slide_u8x64::<63>(padding, a),
+            2 => self.slide_u8x64::<62>(padding, a),
+            3 => self.slide_u8x64::<61>(padding, a),
+            4 => self.slide_u8x64::<60>(padding, a),
+            5 => self.slide_u8x64::<59>(padding, a),
+            6 => self.slide_u8x64::<58>(padding, a),
+            7 => self.slide_u8x64::<57>(padding, a),
+            8 => self.slide_u8x64::<56>(padding, a),
+            9 => self.slide_u8x64::<55>(padding, a),
+            10 => self.slide_u8x64::<54>(padding, a),
+            11 => self.slide_u8x64::<53>(padding, a),
+            12 => self.slide_u8x64::<52>(padding, a),
+            13 => self.slide_u8x64::<51>(padding, a),
+            14 => self.slide_u8x64::<50>(padding, a),
+            15 => self.slide_u8x64::<49>(padding, a),
+            16 => self.slide_u8x64::<48>(padding, a),
+            17 => self.slide_u8x64::<47>(padding, a),
+            18 => self.slide_u8x64::<46>(padding, a),
+            19 => self.slide_u8x64::<45>(padding, a),
+            20 => self.slide_u8x64::<44>(padding, a),
+            21 => self.slide_u8x64::<43>(padding, a),
+            22 => self.slide_u8x64::<42>(padding, a),
+            23 => self.slide_u8x64::<41>(padding, a),
+            24 => self.slide_u8x64::<40>(padding, a),
+            25 => self.slide_u8x64::<39>(padding, a),
+            26 => self.slide_u8x64::<38>(padding, a),
+            27 => self.slide_u8x64::<37>(padding, a),
+            28 => self.slide_u8x64::<36>(padding, a),
+            29 => self.slide_u8x64::<35>(padding, a),
+            30 => self.slide_u8x64::<34>(padding, a),
+            31 => self.slide_u8x64::<33>(padding, a),
+            32 => self.slide_u8x64::<32>(padding, a),
+            33 => self.slide_u8x64::<31>(padding, a),
+            34 => self.slide_u8x64::<30>(padding, a),
+            35 => self.slide_u8x64::<29>(padding, a),
+            36 => self.slide_u8x64::<28>(padding, a),
+            37 => self.slide_u8x64::<27>(padding, a),
+            38 => self.slide_u8x64::<26>(padding, a),
+            39 => self.slide_u8x64::<25>(padding, a),
+            40 => self.slide_u8x64::<24>(padding, a),
+            41 => self.slide_u8x64::<23>(padding, a),
+            42 => self.slide_u8x64::<22>(padding, a),
+            43 => self.slide_u8x64::<21>(padding, a),
+            44 => self.slide_u8x64::<20>(padding, a),
+            45 => self.slide_u8x64::<19>(padding, a),
+            46 => self.slide_u8x64::<18>(padding, a),
+            47 => self.slide_u8x64::<17>(padding, a),
+            48 => self.slide_u8x64::<16>(padding, a),
+            49 => self.slide_u8x64::<15>(padding, a),
+            50 => self.slide_u8x64::<14>(padding, a),
+            51 => self.slide_u8x64::<13>(padding, a),
+            52 => self.slide_u8x64::<12>(padding, a),
+            53 => self.slide_u8x64::<11>(padding, a),
+            54 => self.slide_u8x64::<10>(padding, a),
+            55 => self.slide_u8x64::<9>(padding, a),
+            56 => self.slide_u8x64::<8>(padding, a),
+            57 => self.slide_u8x64::<7>(padding, a),
+            58 => self.slide_u8x64::<6>(padding, a),
+            59 => self.slide_u8x64::<5>(padding, a),
+            60 => self.slide_u8x64::<4>(padding, a),
+            61 => self.slide_u8x64::<3>(padding, a),
+            62 => self.slide_u8x64::<2>(padding, a),
+            63 => self.slide_u8x64::<1>(padding, a),
+            64 => self.slide_u8x64::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self> {
@@ -9893,6 +11617,126 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_i16x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_i16x32::<32>(a, a),
+            1 => self.slide_i16x32::<31>(a, a),
+            2 => self.slide_i16x32::<30>(a, a),
+            3 => self.slide_i16x32::<29>(a, a),
+            4 => self.slide_i16x32::<28>(a, a),
+            5 => self.slide_i16x32::<27>(a, a),
+            6 => self.slide_i16x32::<26>(a, a),
+            7 => self.slide_i16x32::<25>(a, a),
+            8 => self.slide_i16x32::<24>(a, a),
+            9 => self.slide_i16x32::<23>(a, a),
+            10 => self.slide_i16x32::<22>(a, a),
+            11 => self.slide_i16x32::<21>(a, a),
+            12 => self.slide_i16x32::<20>(a, a),
+            13 => self.slide_i16x32::<19>(a, a),
+            14 => self.slide_i16x32::<18>(a, a),
+            15 => self.slide_i16x32::<17>(a, a),
+            16 => self.slide_i16x32::<16>(a, a),
+            17 => self.slide_i16x32::<15>(a, a),
+            18 => self.slide_i16x32::<14>(a, a),
+            19 => self.slide_i16x32::<13>(a, a),
+            20 => self.slide_i16x32::<12>(a, a),
+            21 => self.slide_i16x32::<11>(a, a),
+            22 => self.slide_i16x32::<10>(a, a),
+            23 => self.slide_i16x32::<9>(a, a),
+            24 => self.slide_i16x32::<8>(a, a),
+            25 => self.slide_i16x32::<7>(a, a),
+            26 => self.slide_i16x32::<6>(a, a),
+            27 => self.slide_i16x32::<5>(a, a),
+            28 => self.slide_i16x32::<4>(a, a),
+            29 => self.slide_i16x32::<3>(a, a),
+            30 => self.slide_i16x32::<2>(a, a),
+            31 => self.slide_i16x32::<1>(a, a),
+            32 => self.slide_i16x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i16x32(padding);
+        self.slide_i16x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i16x32(padding);
+        match OFFSET {
+            0 => self.slide_i16x32::<32>(padding, a),
+            1 => self.slide_i16x32::<31>(padding, a),
+            2 => self.slide_i16x32::<30>(padding, a),
+            3 => self.slide_i16x32::<29>(padding, a),
+            4 => self.slide_i16x32::<28>(padding, a),
+            5 => self.slide_i16x32::<27>(padding, a),
+            6 => self.slide_i16x32::<26>(padding, a),
+            7 => self.slide_i16x32::<25>(padding, a),
+            8 => self.slide_i16x32::<24>(padding, a),
+            9 => self.slide_i16x32::<23>(padding, a),
+            10 => self.slide_i16x32::<22>(padding, a),
+            11 => self.slide_i16x32::<21>(padding, a),
+            12 => self.slide_i16x32::<20>(padding, a),
+            13 => self.slide_i16x32::<19>(padding, a),
+            14 => self.slide_i16x32::<18>(padding, a),
+            15 => self.slide_i16x32::<17>(padding, a),
+            16 => self.slide_i16x32::<16>(padding, a),
+            17 => self.slide_i16x32::<15>(padding, a),
+            18 => self.slide_i16x32::<14>(padding, a),
+            19 => self.slide_i16x32::<13>(padding, a),
+            20 => self.slide_i16x32::<12>(padding, a),
+            21 => self.slide_i16x32::<11>(padding, a),
+            22 => self.slide_i16x32::<10>(padding, a),
+            23 => self.slide_i16x32::<9>(padding, a),
+            24 => self.slide_i16x32::<8>(padding, a),
+            25 => self.slide_i16x32::<7>(padding, a),
+            26 => self.slide_i16x32::<6>(padding, a),
+            27 => self.slide_i16x32::<5>(padding, a),
+            28 => self.slide_i16x32::<4>(padding, a),
+            29 => self.slide_i16x32::<3>(padding, a),
+            30 => self.slide_i16x32::<2>(padding, a),
+            31 => self.slide_i16x32::<1>(padding, a),
+            32 => self.slide_i16x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x32(
         self,
         a: i16x32<Self>,
@@ -10184,6 +12028,126 @@ impl Simd for Avx2 {
             self.slide_within_blocks_u16x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x16::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_u16x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_u16x32::<32>(a, a),
+            1 => self.slide_u16x32::<31>(a, a),
+            2 => self.slide_u16x32::<30>(a, a),
+            3 => self.slide_u16x32::<29>(a, a),
+            4 => self.slide_u16x32::<28>(a, a),
+            5 => self.slide_u16x32::<27>(a, a),
+            6 => self.slide_u16x32::<26>(a, a),
+            7 => self.slide_u16x32::<25>(a, a),
+            8 => self.slide_u16x32::<24>(a, a),
+            9 => self.slide_u16x32::<23>(a, a),
+            10 => self.slide_u16x32::<22>(a, a),
+            11 => self.slide_u16x32::<21>(a, a),
+            12 => self.slide_u16x32::<20>(a, a),
+            13 => self.slide_u16x32::<19>(a, a),
+            14 => self.slide_u16x32::<18>(a, a),
+            15 => self.slide_u16x32::<17>(a, a),
+            16 => self.slide_u16x32::<16>(a, a),
+            17 => self.slide_u16x32::<15>(a, a),
+            18 => self.slide_u16x32::<14>(a, a),
+            19 => self.slide_u16x32::<13>(a, a),
+            20 => self.slide_u16x32::<12>(a, a),
+            21 => self.slide_u16x32::<11>(a, a),
+            22 => self.slide_u16x32::<10>(a, a),
+            23 => self.slide_u16x32::<9>(a, a),
+            24 => self.slide_u16x32::<8>(a, a),
+            25 => self.slide_u16x32::<7>(a, a),
+            26 => self.slide_u16x32::<6>(a, a),
+            27 => self.slide_u16x32::<5>(a, a),
+            28 => self.slide_u16x32::<4>(a, a),
+            29 => self.slide_u16x32::<3>(a, a),
+            30 => self.slide_u16x32::<2>(a, a),
+            31 => self.slide_u16x32::<1>(a, a),
+            32 => self.slide_u16x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u16x32(padding);
+        self.slide_u16x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u16x32(padding);
+        match OFFSET {
+            0 => self.slide_u16x32::<32>(padding, a),
+            1 => self.slide_u16x32::<31>(padding, a),
+            2 => self.slide_u16x32::<30>(padding, a),
+            3 => self.slide_u16x32::<29>(padding, a),
+            4 => self.slide_u16x32::<28>(padding, a),
+            5 => self.slide_u16x32::<27>(padding, a),
+            6 => self.slide_u16x32::<26>(padding, a),
+            7 => self.slide_u16x32::<25>(padding, a),
+            8 => self.slide_u16x32::<24>(padding, a),
+            9 => self.slide_u16x32::<23>(padding, a),
+            10 => self.slide_u16x32::<22>(padding, a),
+            11 => self.slide_u16x32::<21>(padding, a),
+            12 => self.slide_u16x32::<20>(padding, a),
+            13 => self.slide_u16x32::<19>(padding, a),
+            14 => self.slide_u16x32::<18>(padding, a),
+            15 => self.slide_u16x32::<17>(padding, a),
+            16 => self.slide_u16x32::<16>(padding, a),
+            17 => self.slide_u16x32::<15>(padding, a),
+            18 => self.slide_u16x32::<14>(padding, a),
+            19 => self.slide_u16x32::<13>(padding, a),
+            20 => self.slide_u16x32::<12>(padding, a),
+            21 => self.slide_u16x32::<11>(padding, a),
+            22 => self.slide_u16x32::<10>(padding, a),
+            23 => self.slide_u16x32::<9>(padding, a),
+            24 => self.slide_u16x32::<8>(padding, a),
+            25 => self.slide_u16x32::<7>(padding, a),
+            26 => self.slide_u16x32::<6>(padding, a),
+            27 => self.slide_u16x32::<5>(padding, a),
+            28 => self.slide_u16x32::<4>(padding, a),
+            29 => self.slide_u16x32::<3>(padding, a),
+            30 => self.slide_u16x32::<2>(padding, a),
+            31 => self.slide_u16x32::<1>(padding, a),
+            32 => self.slide_u16x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x32(
@@ -10705,6 +12669,94 @@ impl Simd for Avx2 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i32x16::<16>(a, a),
+            1 => self.slide_i32x16::<15>(a, a),
+            2 => self.slide_i32x16::<14>(a, a),
+            3 => self.slide_i32x16::<13>(a, a),
+            4 => self.slide_i32x16::<12>(a, a),
+            5 => self.slide_i32x16::<11>(a, a),
+            6 => self.slide_i32x16::<10>(a, a),
+            7 => self.slide_i32x16::<9>(a, a),
+            8 => self.slide_i32x16::<8>(a, a),
+            9 => self.slide_i32x16::<7>(a, a),
+            10 => self.slide_i32x16::<6>(a, a),
+            11 => self.slide_i32x16::<5>(a, a),
+            12 => self.slide_i32x16::<4>(a, a),
+            13 => self.slide_i32x16::<3>(a, a),
+            14 => self.slide_i32x16::<2>(a, a),
+            15 => self.slide_i32x16::<1>(a, a),
+            16 => self.slide_i32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i32x16(padding);
+        self.slide_i32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i32x16(padding);
+        match OFFSET {
+            0 => self.slide_i32x16::<16>(padding, a),
+            1 => self.slide_i32x16::<15>(padding, a),
+            2 => self.slide_i32x16::<14>(padding, a),
+            3 => self.slide_i32x16::<13>(padding, a),
+            4 => self.slide_i32x16::<12>(padding, a),
+            5 => self.slide_i32x16::<11>(padding, a),
+            6 => self.slide_i32x16::<10>(padding, a),
+            7 => self.slide_i32x16::<9>(padding, a),
+            8 => self.slide_i32x16::<8>(padding, a),
+            9 => self.slide_i32x16::<7>(padding, a),
+            10 => self.slide_i32x16::<6>(padding, a),
+            11 => self.slide_i32x16::<5>(padding, a),
+            12 => self.slide_i32x16::<4>(padding, a),
+            13 => self.slide_i32x16::<3>(padding, a),
+            14 => self.slide_i32x16::<2>(padding, a),
+            15 => self.slide_i32x16::<1>(padding, a),
+            16 => self.slide_i32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x16(
         self,
         a: i32x16<Self>,
@@ -10992,6 +13044,94 @@ impl Simd for Avx2 {
             self.slide_within_blocks_u32x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x8::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u32x16::<16>(a, a),
+            1 => self.slide_u32x16::<15>(a, a),
+            2 => self.slide_u32x16::<14>(a, a),
+            3 => self.slide_u32x16::<13>(a, a),
+            4 => self.slide_u32x16::<12>(a, a),
+            5 => self.slide_u32x16::<11>(a, a),
+            6 => self.slide_u32x16::<10>(a, a),
+            7 => self.slide_u32x16::<9>(a, a),
+            8 => self.slide_u32x16::<8>(a, a),
+            9 => self.slide_u32x16::<7>(a, a),
+            10 => self.slide_u32x16::<6>(a, a),
+            11 => self.slide_u32x16::<5>(a, a),
+            12 => self.slide_u32x16::<4>(a, a),
+            13 => self.slide_u32x16::<3>(a, a),
+            14 => self.slide_u32x16::<2>(a, a),
+            15 => self.slide_u32x16::<1>(a, a),
+            16 => self.slide_u32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u32x16(padding);
+        self.slide_u32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u32x16(padding);
+        match OFFSET {
+            0 => self.slide_u32x16::<16>(padding, a),
+            1 => self.slide_u32x16::<15>(padding, a),
+            2 => self.slide_u32x16::<14>(padding, a),
+            3 => self.slide_u32x16::<13>(padding, a),
+            4 => self.slide_u32x16::<12>(padding, a),
+            5 => self.slide_u32x16::<11>(padding, a),
+            6 => self.slide_u32x16::<10>(padding, a),
+            7 => self.slide_u32x16::<9>(padding, a),
+            8 => self.slide_u32x16::<8>(padding, a),
+            9 => self.slide_u32x16::<7>(padding, a),
+            10 => self.slide_u32x16::<6>(padding, a),
+            11 => self.slide_u32x16::<5>(padding, a),
+            12 => self.slide_u32x16::<4>(padding, a),
+            13 => self.slide_u32x16::<3>(padding, a),
+            14 => self.slide_u32x16::<2>(padding, a),
+            15 => self.slide_u32x16::<1>(padding, a),
+            16 => self.slide_u32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x16(
@@ -11481,6 +13621,78 @@ impl Simd for Avx2 {
             self.slide_within_blocks_f64x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x4::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_f64x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_f64x8::<8>(a, a),
+            1 => self.slide_f64x8::<7>(a, a),
+            2 => self.slide_f64x8::<6>(a, a),
+            3 => self.slide_f64x8::<5>(a, a),
+            4 => self.slide_f64x8::<4>(a, a),
+            5 => self.slide_f64x8::<3>(a, a),
+            6 => self.slide_f64x8::<2>(a, a),
+            7 => self.slide_f64x8::<1>(a, a),
+            8 => self.slide_f64x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f64x8(padding);
+        self.slide_f64x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f64x8(padding);
+        match OFFSET {
+            0 => self.slide_f64x8::<8>(padding, a),
+            1 => self.slide_f64x8::<7>(padding, a),
+            2 => self.slide_f64x8::<6>(padding, a),
+            3 => self.slide_f64x8::<5>(padding, a),
+            4 => self.slide_f64x8::<4>(padding, a),
+            5 => self.slide_f64x8::<3>(padding, a),
+            6 => self.slide_f64x8::<2>(padding, a),
+            7 => self.slide_f64x8::<1>(padding, a),
+            8 => self.slide_f64x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -176,28 +176,21 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_f32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_f32x4::<0>(a, a),
+            1 => self.slide_f32x4::<1>(a, a),
+            2 => self.slide_f32x4::<2>(a, a),
+            3 => self.slide_f32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_f32x4::<4>(a, a),
             1 => self.slide_f32x4::<3>(a, a),
             2 => self.slide_f32x4::<2>(a, a),
             3 => self.slide_f32x4::<1>(a, a),
-            4 => self.slide_f32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -207,14 +200,15 @@ impl Simd for Avx2 {
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f32x4(padding);
-        self.slide_f32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x4::<0>(a, padding),
+            1 => self.slide_f32x4::<1>(a, padding),
+            2 => self.slide_f32x4::<2>(a, padding),
+            3 => self.slide_f32x4::<3>(a, padding),
+            4 => self.slide_f32x4::<4>(a, padding),
+            _ => self.slide_f32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x4<const OFFSET: usize>(
@@ -222,12 +216,6 @@ impl Simd for Avx2 {
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f32x4(padding);
         match OFFSET {
             0 => self.slide_f32x4::<4>(padding, a),
@@ -235,7 +223,7 @@ impl Simd for Avx2 {
             2 => self.slide_f32x4::<2>(padding, a),
             3 => self.slide_f32x4::<1>(padding, a),
             4 => self.slide_f32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -776,23 +764,29 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i8x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i8x16::<0>(a, a),
+            1 => self.slide_i8x16::<1>(a, a),
+            2 => self.slide_i8x16::<2>(a, a),
+            3 => self.slide_i8x16::<3>(a, a),
+            4 => self.slide_i8x16::<4>(a, a),
+            5 => self.slide_i8x16::<5>(a, a),
+            6 => self.slide_i8x16::<6>(a, a),
+            7 => self.slide_i8x16::<7>(a, a),
+            8 => self.slide_i8x16::<8>(a, a),
+            9 => self.slide_i8x16::<9>(a, a),
+            10 => self.slide_i8x16::<10>(a, a),
+            11 => self.slide_i8x16::<11>(a, a),
+            12 => self.slide_i8x16::<12>(a, a),
+            13 => self.slide_i8x16::<13>(a, a),
+            14 => self.slide_i8x16::<14>(a, a),
+            15 => self.slide_i8x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i8x16::<16>(a, a),
             1 => self.slide_i8x16::<15>(a, a),
             2 => self.slide_i8x16::<14>(a, a),
@@ -809,7 +803,6 @@ impl Simd for Avx2 {
             13 => self.slide_i8x16::<3>(a, a),
             14 => self.slide_i8x16::<2>(a, a),
             15 => self.slide_i8x16::<1>(a, a),
-            16 => self.slide_i8x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -819,14 +812,27 @@ impl Simd for Avx2 {
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i8x16(padding);
-        self.slide_i8x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x16::<0>(a, padding),
+            1 => self.slide_i8x16::<1>(a, padding),
+            2 => self.slide_i8x16::<2>(a, padding),
+            3 => self.slide_i8x16::<3>(a, padding),
+            4 => self.slide_i8x16::<4>(a, padding),
+            5 => self.slide_i8x16::<5>(a, padding),
+            6 => self.slide_i8x16::<6>(a, padding),
+            7 => self.slide_i8x16::<7>(a, padding),
+            8 => self.slide_i8x16::<8>(a, padding),
+            9 => self.slide_i8x16::<9>(a, padding),
+            10 => self.slide_i8x16::<10>(a, padding),
+            11 => self.slide_i8x16::<11>(a, padding),
+            12 => self.slide_i8x16::<12>(a, padding),
+            13 => self.slide_i8x16::<13>(a, padding),
+            14 => self.slide_i8x16::<14>(a, padding),
+            15 => self.slide_i8x16::<15>(a, padding),
+            16 => self.slide_i8x16::<16>(a, padding),
+            _ => self.slide_i8x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x16<const OFFSET: usize>(
@@ -834,12 +840,6 @@ impl Simd for Avx2 {
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i8x16(padding);
         match OFFSET {
             0 => self.slide_i8x16::<16>(padding, a),
@@ -859,7 +859,7 @@ impl Simd for Avx2 {
             14 => self.slide_i8x16::<2>(padding, a),
             15 => self.slide_i8x16::<1>(padding, a),
             16 => self.slide_i8x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -1246,23 +1246,29 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u8x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u8x16::<0>(a, a),
+            1 => self.slide_u8x16::<1>(a, a),
+            2 => self.slide_u8x16::<2>(a, a),
+            3 => self.slide_u8x16::<3>(a, a),
+            4 => self.slide_u8x16::<4>(a, a),
+            5 => self.slide_u8x16::<5>(a, a),
+            6 => self.slide_u8x16::<6>(a, a),
+            7 => self.slide_u8x16::<7>(a, a),
+            8 => self.slide_u8x16::<8>(a, a),
+            9 => self.slide_u8x16::<9>(a, a),
+            10 => self.slide_u8x16::<10>(a, a),
+            11 => self.slide_u8x16::<11>(a, a),
+            12 => self.slide_u8x16::<12>(a, a),
+            13 => self.slide_u8x16::<13>(a, a),
+            14 => self.slide_u8x16::<14>(a, a),
+            15 => self.slide_u8x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u8x16::<16>(a, a),
             1 => self.slide_u8x16::<15>(a, a),
             2 => self.slide_u8x16::<14>(a, a),
@@ -1279,7 +1285,6 @@ impl Simd for Avx2 {
             13 => self.slide_u8x16::<3>(a, a),
             14 => self.slide_u8x16::<2>(a, a),
             15 => self.slide_u8x16::<1>(a, a),
-            16 => self.slide_u8x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -1289,14 +1294,27 @@ impl Simd for Avx2 {
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u8x16(padding);
-        self.slide_u8x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x16::<0>(a, padding),
+            1 => self.slide_u8x16::<1>(a, padding),
+            2 => self.slide_u8x16::<2>(a, padding),
+            3 => self.slide_u8x16::<3>(a, padding),
+            4 => self.slide_u8x16::<4>(a, padding),
+            5 => self.slide_u8x16::<5>(a, padding),
+            6 => self.slide_u8x16::<6>(a, padding),
+            7 => self.slide_u8x16::<7>(a, padding),
+            8 => self.slide_u8x16::<8>(a, padding),
+            9 => self.slide_u8x16::<9>(a, padding),
+            10 => self.slide_u8x16::<10>(a, padding),
+            11 => self.slide_u8x16::<11>(a, padding),
+            12 => self.slide_u8x16::<12>(a, padding),
+            13 => self.slide_u8x16::<13>(a, padding),
+            14 => self.slide_u8x16::<14>(a, padding),
+            15 => self.slide_u8x16::<15>(a, padding),
+            16 => self.slide_u8x16::<16>(a, padding),
+            _ => self.slide_u8x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x16<const OFFSET: usize>(
@@ -1304,12 +1322,6 @@ impl Simd for Avx2 {
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u8x16(padding);
         match OFFSET {
             0 => self.slide_u8x16::<16>(padding, a),
@@ -1329,7 +1341,7 @@ impl Simd for Avx2 {
             14 => self.slide_u8x16::<2>(padding, a),
             15 => self.slide_u8x16::<1>(padding, a),
             16 => self.slide_u8x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -1889,23 +1901,21 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_i16x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_i16x8::<0>(a, a),
+            1 => self.slide_i16x8::<1>(a, a),
+            2 => self.slide_i16x8::<2>(a, a),
+            3 => self.slide_i16x8::<3>(a, a),
+            4 => self.slide_i16x8::<4>(a, a),
+            5 => self.slide_i16x8::<5>(a, a),
+            6 => self.slide_i16x8::<6>(a, a),
+            7 => self.slide_i16x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_i16x8::<8>(a, a),
             1 => self.slide_i16x8::<7>(a, a),
             2 => self.slide_i16x8::<6>(a, a),
@@ -1914,7 +1924,6 @@ impl Simd for Avx2 {
             5 => self.slide_i16x8::<3>(a, a),
             6 => self.slide_i16x8::<2>(a, a),
             7 => self.slide_i16x8::<1>(a, a),
-            8 => self.slide_i16x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -1924,14 +1933,19 @@ impl Simd for Avx2 {
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i16x8(padding);
-        self.slide_i16x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x8::<0>(a, padding),
+            1 => self.slide_i16x8::<1>(a, padding),
+            2 => self.slide_i16x8::<2>(a, padding),
+            3 => self.slide_i16x8::<3>(a, padding),
+            4 => self.slide_i16x8::<4>(a, padding),
+            5 => self.slide_i16x8::<5>(a, padding),
+            6 => self.slide_i16x8::<6>(a, padding),
+            7 => self.slide_i16x8::<7>(a, padding),
+            8 => self.slide_i16x8::<8>(a, padding),
+            _ => self.slide_i16x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x8<const OFFSET: usize>(
@@ -1939,12 +1953,6 @@ impl Simd for Avx2 {
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i16x8(padding);
         match OFFSET {
             0 => self.slide_i16x8::<8>(padding, a),
@@ -1956,7 +1964,7 @@ impl Simd for Avx2 {
             6 => self.slide_i16x8::<2>(padding, a),
             7 => self.slide_i16x8::<1>(padding, a),
             8 => self.slide_i16x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -2324,23 +2332,21 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_u16x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_u16x8::<0>(a, a),
+            1 => self.slide_u16x8::<1>(a, a),
+            2 => self.slide_u16x8::<2>(a, a),
+            3 => self.slide_u16x8::<3>(a, a),
+            4 => self.slide_u16x8::<4>(a, a),
+            5 => self.slide_u16x8::<5>(a, a),
+            6 => self.slide_u16x8::<6>(a, a),
+            7 => self.slide_u16x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_u16x8::<8>(a, a),
             1 => self.slide_u16x8::<7>(a, a),
             2 => self.slide_u16x8::<6>(a, a),
@@ -2349,7 +2355,6 @@ impl Simd for Avx2 {
             5 => self.slide_u16x8::<3>(a, a),
             6 => self.slide_u16x8::<2>(a, a),
             7 => self.slide_u16x8::<1>(a, a),
-            8 => self.slide_u16x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -2359,14 +2364,19 @@ impl Simd for Avx2 {
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u16x8(padding);
-        self.slide_u16x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x8::<0>(a, padding),
+            1 => self.slide_u16x8::<1>(a, padding),
+            2 => self.slide_u16x8::<2>(a, padding),
+            3 => self.slide_u16x8::<3>(a, padding),
+            4 => self.slide_u16x8::<4>(a, padding),
+            5 => self.slide_u16x8::<5>(a, padding),
+            6 => self.slide_u16x8::<6>(a, padding),
+            7 => self.slide_u16x8::<7>(a, padding),
+            8 => self.slide_u16x8::<8>(a, padding),
+            _ => self.slide_u16x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x8<const OFFSET: usize>(
@@ -2374,12 +2384,6 @@ impl Simd for Avx2 {
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u16x8(padding);
         match OFFSET {
             0 => self.slide_u16x8::<8>(padding, a),
@@ -2391,7 +2395,7 @@ impl Simd for Avx2 {
             6 => self.slide_u16x8::<2>(padding, a),
             7 => self.slide_u16x8::<1>(padding, a),
             8 => self.slide_u16x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -2930,28 +2934,21 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_i32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_i32x4::<0>(a, a),
+            1 => self.slide_i32x4::<1>(a, a),
+            2 => self.slide_i32x4::<2>(a, a),
+            3 => self.slide_i32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_i32x4::<4>(a, a),
             1 => self.slide_i32x4::<3>(a, a),
             2 => self.slide_i32x4::<2>(a, a),
             3 => self.slide_i32x4::<1>(a, a),
-            4 => self.slide_i32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -2961,14 +2958,15 @@ impl Simd for Avx2 {
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_i32x4(padding);
-        self.slide_i32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x4::<0>(a, padding),
+            1 => self.slide_i32x4::<1>(a, padding),
+            2 => self.slide_i32x4::<2>(a, padding),
+            3 => self.slide_i32x4::<3>(a, padding),
+            4 => self.slide_i32x4::<4>(a, padding),
+            _ => self.slide_i32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x4<const OFFSET: usize>(
@@ -2976,12 +2974,6 @@ impl Simd for Avx2 {
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_i32x4(padding);
         match OFFSET {
             0 => self.slide_i32x4::<4>(padding, a),
@@ -2989,7 +2981,7 @@ impl Simd for Avx2 {
             2 => self.slide_i32x4::<2>(padding, a),
             3 => self.slide_i32x4::<1>(padding, a),
             4 => self.slide_i32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -3377,28 +3369,21 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_u32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_u32x4::<0>(a, a),
+            1 => self.slide_u32x4::<1>(a, a),
+            2 => self.slide_u32x4::<2>(a, a),
+            3 => self.slide_u32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_u32x4::<4>(a, a),
             1 => self.slide_u32x4::<3>(a, a),
             2 => self.slide_u32x4::<2>(a, a),
             3 => self.slide_u32x4::<1>(a, a),
-            4 => self.slide_u32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -3408,14 +3393,15 @@ impl Simd for Avx2 {
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_u32x4(padding);
-        self.slide_u32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x4::<0>(a, padding),
+            1 => self.slide_u32x4::<1>(a, padding),
+            2 => self.slide_u32x4::<2>(a, padding),
+            3 => self.slide_u32x4::<3>(a, padding),
+            4 => self.slide_u32x4::<4>(a, padding),
+            _ => self.slide_u32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x4<const OFFSET: usize>(
@@ -3423,12 +3409,6 @@ impl Simd for Avx2 {
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_u32x4(padding);
         match OFFSET {
             0 => self.slide_u32x4::<4>(padding, a),
@@ -3436,7 +3416,7 @@ impl Simd for Avx2 {
             2 => self.slide_u32x4::<2>(padding, a),
             3 => self.slide_u32x4::<1>(padding, a),
             4 => self.slide_u32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -3991,26 +3971,17 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
-        self.slide_f64x2::<OFFSET>(a, a)
+        match OFFSET % 2 {
+            0 => self.slide_f64x2::<0>(a, a),
+            1 => self.slide_f64x2::<1>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
-        match OFFSET {
+        match OFFSET % 2 {
             0 => self.slide_f64x2::<2>(a, a),
             1 => self.slide_f64x2::<1>(a, a),
-            2 => self.slide_f64x2::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -4020,14 +3991,13 @@ impl Simd for Avx2 {
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
         let padding = self.splat_f64x2(padding);
-        self.slide_f64x2::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x2::<0>(a, padding),
+            1 => self.slide_f64x2::<1>(a, padding),
+            2 => self.slide_f64x2::<2>(a, padding),
+            _ => self.slide_f64x2::<2>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x2<const OFFSET: usize>(
@@ -4035,18 +4005,12 @@ impl Simd for Avx2 {
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
         let padding = self.splat_f64x2(padding);
         match OFFSET {
             0 => self.slide_f64x2::<2>(padding, a),
             1 => self.slide_f64x2::<1>(padding, a),
             2 => self.slide_f64x2::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x2::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -4658,23 +4622,21 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_f32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_f32x8::<0>(a, a),
+            1 => self.slide_f32x8::<1>(a, a),
+            2 => self.slide_f32x8::<2>(a, a),
+            3 => self.slide_f32x8::<3>(a, a),
+            4 => self.slide_f32x8::<4>(a, a),
+            5 => self.slide_f32x8::<5>(a, a),
+            6 => self.slide_f32x8::<6>(a, a),
+            7 => self.slide_f32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_f32x8::<8>(a, a),
             1 => self.slide_f32x8::<7>(a, a),
             2 => self.slide_f32x8::<6>(a, a),
@@ -4683,7 +4645,6 @@ impl Simd for Avx2 {
             5 => self.slide_f32x8::<3>(a, a),
             6 => self.slide_f32x8::<2>(a, a),
             7 => self.slide_f32x8::<1>(a, a),
-            8 => self.slide_f32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -4693,14 +4654,19 @@ impl Simd for Avx2 {
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f32x8(padding);
-        self.slide_f32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x8::<0>(a, padding),
+            1 => self.slide_f32x8::<1>(a, padding),
+            2 => self.slide_f32x8::<2>(a, padding),
+            3 => self.slide_f32x8::<3>(a, padding),
+            4 => self.slide_f32x8::<4>(a, padding),
+            5 => self.slide_f32x8::<5>(a, padding),
+            6 => self.slide_f32x8::<6>(a, padding),
+            7 => self.slide_f32x8::<7>(a, padding),
+            8 => self.slide_f32x8::<8>(a, padding),
+            _ => self.slide_f32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x8<const OFFSET: usize>(
@@ -4708,12 +4674,6 @@ impl Simd for Avx2 {
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f32x8(padding);
         match OFFSET {
             0 => self.slide_f32x8::<8>(padding, a),
@@ -4725,7 +4685,7 @@ impl Simd for Avx2 {
             6 => self.slide_f32x8::<2>(padding, a),
             7 => self.slide_f32x8::<1>(padding, a),
             8 => self.slide_f32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -5329,23 +5289,45 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_i8x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_i8x32::<0>(a, a),
+            1 => self.slide_i8x32::<1>(a, a),
+            2 => self.slide_i8x32::<2>(a, a),
+            3 => self.slide_i8x32::<3>(a, a),
+            4 => self.slide_i8x32::<4>(a, a),
+            5 => self.slide_i8x32::<5>(a, a),
+            6 => self.slide_i8x32::<6>(a, a),
+            7 => self.slide_i8x32::<7>(a, a),
+            8 => self.slide_i8x32::<8>(a, a),
+            9 => self.slide_i8x32::<9>(a, a),
+            10 => self.slide_i8x32::<10>(a, a),
+            11 => self.slide_i8x32::<11>(a, a),
+            12 => self.slide_i8x32::<12>(a, a),
+            13 => self.slide_i8x32::<13>(a, a),
+            14 => self.slide_i8x32::<14>(a, a),
+            15 => self.slide_i8x32::<15>(a, a),
+            16 => self.slide_i8x32::<16>(a, a),
+            17 => self.slide_i8x32::<17>(a, a),
+            18 => self.slide_i8x32::<18>(a, a),
+            19 => self.slide_i8x32::<19>(a, a),
+            20 => self.slide_i8x32::<20>(a, a),
+            21 => self.slide_i8x32::<21>(a, a),
+            22 => self.slide_i8x32::<22>(a, a),
+            23 => self.slide_i8x32::<23>(a, a),
+            24 => self.slide_i8x32::<24>(a, a),
+            25 => self.slide_i8x32::<25>(a, a),
+            26 => self.slide_i8x32::<26>(a, a),
+            27 => self.slide_i8x32::<27>(a, a),
+            28 => self.slide_i8x32::<28>(a, a),
+            29 => self.slide_i8x32::<29>(a, a),
+            30 => self.slide_i8x32::<30>(a, a),
+            31 => self.slide_i8x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_i8x32::<32>(a, a),
             1 => self.slide_i8x32::<31>(a, a),
             2 => self.slide_i8x32::<30>(a, a),
@@ -5378,7 +5360,6 @@ impl Simd for Avx2 {
             29 => self.slide_i8x32::<3>(a, a),
             30 => self.slide_i8x32::<2>(a, a),
             31 => self.slide_i8x32::<1>(a, a),
-            32 => self.slide_i8x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -5388,14 +5369,43 @@ impl Simd for Avx2 {
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i8x32(padding);
-        self.slide_i8x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x32::<0>(a, padding),
+            1 => self.slide_i8x32::<1>(a, padding),
+            2 => self.slide_i8x32::<2>(a, padding),
+            3 => self.slide_i8x32::<3>(a, padding),
+            4 => self.slide_i8x32::<4>(a, padding),
+            5 => self.slide_i8x32::<5>(a, padding),
+            6 => self.slide_i8x32::<6>(a, padding),
+            7 => self.slide_i8x32::<7>(a, padding),
+            8 => self.slide_i8x32::<8>(a, padding),
+            9 => self.slide_i8x32::<9>(a, padding),
+            10 => self.slide_i8x32::<10>(a, padding),
+            11 => self.slide_i8x32::<11>(a, padding),
+            12 => self.slide_i8x32::<12>(a, padding),
+            13 => self.slide_i8x32::<13>(a, padding),
+            14 => self.slide_i8x32::<14>(a, padding),
+            15 => self.slide_i8x32::<15>(a, padding),
+            16 => self.slide_i8x32::<16>(a, padding),
+            17 => self.slide_i8x32::<17>(a, padding),
+            18 => self.slide_i8x32::<18>(a, padding),
+            19 => self.slide_i8x32::<19>(a, padding),
+            20 => self.slide_i8x32::<20>(a, padding),
+            21 => self.slide_i8x32::<21>(a, padding),
+            22 => self.slide_i8x32::<22>(a, padding),
+            23 => self.slide_i8x32::<23>(a, padding),
+            24 => self.slide_i8x32::<24>(a, padding),
+            25 => self.slide_i8x32::<25>(a, padding),
+            26 => self.slide_i8x32::<26>(a, padding),
+            27 => self.slide_i8x32::<27>(a, padding),
+            28 => self.slide_i8x32::<28>(a, padding),
+            29 => self.slide_i8x32::<29>(a, padding),
+            30 => self.slide_i8x32::<30>(a, padding),
+            31 => self.slide_i8x32::<31>(a, padding),
+            32 => self.slide_i8x32::<32>(a, padding),
+            _ => self.slide_i8x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x32<const OFFSET: usize>(
@@ -5403,12 +5413,6 @@ impl Simd for Avx2 {
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i8x32(padding);
         match OFFSET {
             0 => self.slide_i8x32::<32>(padding, a),
@@ -5444,7 +5448,7 @@ impl Simd for Avx2 {
             30 => self.slide_i8x32::<2>(padding, a),
             31 => self.slide_i8x32::<1>(padding, a),
             32 => self.slide_i8x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -5919,23 +5923,45 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_u8x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_u8x32::<0>(a, a),
+            1 => self.slide_u8x32::<1>(a, a),
+            2 => self.slide_u8x32::<2>(a, a),
+            3 => self.slide_u8x32::<3>(a, a),
+            4 => self.slide_u8x32::<4>(a, a),
+            5 => self.slide_u8x32::<5>(a, a),
+            6 => self.slide_u8x32::<6>(a, a),
+            7 => self.slide_u8x32::<7>(a, a),
+            8 => self.slide_u8x32::<8>(a, a),
+            9 => self.slide_u8x32::<9>(a, a),
+            10 => self.slide_u8x32::<10>(a, a),
+            11 => self.slide_u8x32::<11>(a, a),
+            12 => self.slide_u8x32::<12>(a, a),
+            13 => self.slide_u8x32::<13>(a, a),
+            14 => self.slide_u8x32::<14>(a, a),
+            15 => self.slide_u8x32::<15>(a, a),
+            16 => self.slide_u8x32::<16>(a, a),
+            17 => self.slide_u8x32::<17>(a, a),
+            18 => self.slide_u8x32::<18>(a, a),
+            19 => self.slide_u8x32::<19>(a, a),
+            20 => self.slide_u8x32::<20>(a, a),
+            21 => self.slide_u8x32::<21>(a, a),
+            22 => self.slide_u8x32::<22>(a, a),
+            23 => self.slide_u8x32::<23>(a, a),
+            24 => self.slide_u8x32::<24>(a, a),
+            25 => self.slide_u8x32::<25>(a, a),
+            26 => self.slide_u8x32::<26>(a, a),
+            27 => self.slide_u8x32::<27>(a, a),
+            28 => self.slide_u8x32::<28>(a, a),
+            29 => self.slide_u8x32::<29>(a, a),
+            30 => self.slide_u8x32::<30>(a, a),
+            31 => self.slide_u8x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_u8x32::<32>(a, a),
             1 => self.slide_u8x32::<31>(a, a),
             2 => self.slide_u8x32::<30>(a, a),
@@ -5968,7 +5994,6 @@ impl Simd for Avx2 {
             29 => self.slide_u8x32::<3>(a, a),
             30 => self.slide_u8x32::<2>(a, a),
             31 => self.slide_u8x32::<1>(a, a),
-            32 => self.slide_u8x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -5978,14 +6003,43 @@ impl Simd for Avx2 {
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u8x32(padding);
-        self.slide_u8x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x32::<0>(a, padding),
+            1 => self.slide_u8x32::<1>(a, padding),
+            2 => self.slide_u8x32::<2>(a, padding),
+            3 => self.slide_u8x32::<3>(a, padding),
+            4 => self.slide_u8x32::<4>(a, padding),
+            5 => self.slide_u8x32::<5>(a, padding),
+            6 => self.slide_u8x32::<6>(a, padding),
+            7 => self.slide_u8x32::<7>(a, padding),
+            8 => self.slide_u8x32::<8>(a, padding),
+            9 => self.slide_u8x32::<9>(a, padding),
+            10 => self.slide_u8x32::<10>(a, padding),
+            11 => self.slide_u8x32::<11>(a, padding),
+            12 => self.slide_u8x32::<12>(a, padding),
+            13 => self.slide_u8x32::<13>(a, padding),
+            14 => self.slide_u8x32::<14>(a, padding),
+            15 => self.slide_u8x32::<15>(a, padding),
+            16 => self.slide_u8x32::<16>(a, padding),
+            17 => self.slide_u8x32::<17>(a, padding),
+            18 => self.slide_u8x32::<18>(a, padding),
+            19 => self.slide_u8x32::<19>(a, padding),
+            20 => self.slide_u8x32::<20>(a, padding),
+            21 => self.slide_u8x32::<21>(a, padding),
+            22 => self.slide_u8x32::<22>(a, padding),
+            23 => self.slide_u8x32::<23>(a, padding),
+            24 => self.slide_u8x32::<24>(a, padding),
+            25 => self.slide_u8x32::<25>(a, padding),
+            26 => self.slide_u8x32::<26>(a, padding),
+            27 => self.slide_u8x32::<27>(a, padding),
+            28 => self.slide_u8x32::<28>(a, padding),
+            29 => self.slide_u8x32::<29>(a, padding),
+            30 => self.slide_u8x32::<30>(a, padding),
+            31 => self.slide_u8x32::<31>(a, padding),
+            32 => self.slide_u8x32::<32>(a, padding),
+            _ => self.slide_u8x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x32<const OFFSET: usize>(
@@ -5993,12 +6047,6 @@ impl Simd for Avx2 {
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u8x32(padding);
         match OFFSET {
             0 => self.slide_u8x32::<32>(padding, a),
@@ -6034,7 +6082,7 @@ impl Simd for Avx2 {
             30 => self.slide_u8x32::<2>(padding, a),
             31 => self.slide_u8x32::<1>(padding, a),
             32 => self.slide_u8x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -6696,23 +6744,29 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i16x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i16x16::<0>(a, a),
+            1 => self.slide_i16x16::<1>(a, a),
+            2 => self.slide_i16x16::<2>(a, a),
+            3 => self.slide_i16x16::<3>(a, a),
+            4 => self.slide_i16x16::<4>(a, a),
+            5 => self.slide_i16x16::<5>(a, a),
+            6 => self.slide_i16x16::<6>(a, a),
+            7 => self.slide_i16x16::<7>(a, a),
+            8 => self.slide_i16x16::<8>(a, a),
+            9 => self.slide_i16x16::<9>(a, a),
+            10 => self.slide_i16x16::<10>(a, a),
+            11 => self.slide_i16x16::<11>(a, a),
+            12 => self.slide_i16x16::<12>(a, a),
+            13 => self.slide_i16x16::<13>(a, a),
+            14 => self.slide_i16x16::<14>(a, a),
+            15 => self.slide_i16x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i16x16::<16>(a, a),
             1 => self.slide_i16x16::<15>(a, a),
             2 => self.slide_i16x16::<14>(a, a),
@@ -6729,7 +6783,6 @@ impl Simd for Avx2 {
             13 => self.slide_i16x16::<3>(a, a),
             14 => self.slide_i16x16::<2>(a, a),
             15 => self.slide_i16x16::<1>(a, a),
-            16 => self.slide_i16x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -6739,14 +6792,27 @@ impl Simd for Avx2 {
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i16x16(padding);
-        self.slide_i16x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x16::<0>(a, padding),
+            1 => self.slide_i16x16::<1>(a, padding),
+            2 => self.slide_i16x16::<2>(a, padding),
+            3 => self.slide_i16x16::<3>(a, padding),
+            4 => self.slide_i16x16::<4>(a, padding),
+            5 => self.slide_i16x16::<5>(a, padding),
+            6 => self.slide_i16x16::<6>(a, padding),
+            7 => self.slide_i16x16::<7>(a, padding),
+            8 => self.slide_i16x16::<8>(a, padding),
+            9 => self.slide_i16x16::<9>(a, padding),
+            10 => self.slide_i16x16::<10>(a, padding),
+            11 => self.slide_i16x16::<11>(a, padding),
+            12 => self.slide_i16x16::<12>(a, padding),
+            13 => self.slide_i16x16::<13>(a, padding),
+            14 => self.slide_i16x16::<14>(a, padding),
+            15 => self.slide_i16x16::<15>(a, padding),
+            16 => self.slide_i16x16::<16>(a, padding),
+            _ => self.slide_i16x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x16<const OFFSET: usize>(
@@ -6754,12 +6820,6 @@ impl Simd for Avx2 {
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i16x16(padding);
         match OFFSET {
             0 => self.slide_i16x16::<16>(padding, a),
@@ -6779,7 +6839,7 @@ impl Simd for Avx2 {
             14 => self.slide_i16x16::<2>(padding, a),
             15 => self.slide_i16x16::<1>(padding, a),
             16 => self.slide_i16x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7242,23 +7302,29 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u16x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u16x16::<0>(a, a),
+            1 => self.slide_u16x16::<1>(a, a),
+            2 => self.slide_u16x16::<2>(a, a),
+            3 => self.slide_u16x16::<3>(a, a),
+            4 => self.slide_u16x16::<4>(a, a),
+            5 => self.slide_u16x16::<5>(a, a),
+            6 => self.slide_u16x16::<6>(a, a),
+            7 => self.slide_u16x16::<7>(a, a),
+            8 => self.slide_u16x16::<8>(a, a),
+            9 => self.slide_u16x16::<9>(a, a),
+            10 => self.slide_u16x16::<10>(a, a),
+            11 => self.slide_u16x16::<11>(a, a),
+            12 => self.slide_u16x16::<12>(a, a),
+            13 => self.slide_u16x16::<13>(a, a),
+            14 => self.slide_u16x16::<14>(a, a),
+            15 => self.slide_u16x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u16x16::<16>(a, a),
             1 => self.slide_u16x16::<15>(a, a),
             2 => self.slide_u16x16::<14>(a, a),
@@ -7275,7 +7341,6 @@ impl Simd for Avx2 {
             13 => self.slide_u16x16::<3>(a, a),
             14 => self.slide_u16x16::<2>(a, a),
             15 => self.slide_u16x16::<1>(a, a),
-            16 => self.slide_u16x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -7285,14 +7350,27 @@ impl Simd for Avx2 {
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u16x16(padding);
-        self.slide_u16x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x16::<0>(a, padding),
+            1 => self.slide_u16x16::<1>(a, padding),
+            2 => self.slide_u16x16::<2>(a, padding),
+            3 => self.slide_u16x16::<3>(a, padding),
+            4 => self.slide_u16x16::<4>(a, padding),
+            5 => self.slide_u16x16::<5>(a, padding),
+            6 => self.slide_u16x16::<6>(a, padding),
+            7 => self.slide_u16x16::<7>(a, padding),
+            8 => self.slide_u16x16::<8>(a, padding),
+            9 => self.slide_u16x16::<9>(a, padding),
+            10 => self.slide_u16x16::<10>(a, padding),
+            11 => self.slide_u16x16::<11>(a, padding),
+            12 => self.slide_u16x16::<12>(a, padding),
+            13 => self.slide_u16x16::<13>(a, padding),
+            14 => self.slide_u16x16::<14>(a, padding),
+            15 => self.slide_u16x16::<15>(a, padding),
+            16 => self.slide_u16x16::<16>(a, padding),
+            _ => self.slide_u16x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x16<const OFFSET: usize>(
@@ -7300,12 +7378,6 @@ impl Simd for Avx2 {
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u16x16(padding);
         match OFFSET {
             0 => self.slide_u16x16::<16>(padding, a),
@@ -7325,7 +7397,7 @@ impl Simd for Avx2 {
             14 => self.slide_u16x16::<2>(padding, a),
             15 => self.slide_u16x16::<1>(padding, a),
             16 => self.slide_u16x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7990,23 +8062,21 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_i32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_i32x8::<0>(a, a),
+            1 => self.slide_i32x8::<1>(a, a),
+            2 => self.slide_i32x8::<2>(a, a),
+            3 => self.slide_i32x8::<3>(a, a),
+            4 => self.slide_i32x8::<4>(a, a),
+            5 => self.slide_i32x8::<5>(a, a),
+            6 => self.slide_i32x8::<6>(a, a),
+            7 => self.slide_i32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_i32x8::<8>(a, a),
             1 => self.slide_i32x8::<7>(a, a),
             2 => self.slide_i32x8::<6>(a, a),
@@ -8015,7 +8085,6 @@ impl Simd for Avx2 {
             5 => self.slide_i32x8::<3>(a, a),
             6 => self.slide_i32x8::<2>(a, a),
             7 => self.slide_i32x8::<1>(a, a),
-            8 => self.slide_i32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -8025,14 +8094,19 @@ impl Simd for Avx2 {
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i32x8(padding);
-        self.slide_i32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x8::<0>(a, padding),
+            1 => self.slide_i32x8::<1>(a, padding),
+            2 => self.slide_i32x8::<2>(a, padding),
+            3 => self.slide_i32x8::<3>(a, padding),
+            4 => self.slide_i32x8::<4>(a, padding),
+            5 => self.slide_i32x8::<5>(a, padding),
+            6 => self.slide_i32x8::<6>(a, padding),
+            7 => self.slide_i32x8::<7>(a, padding),
+            8 => self.slide_i32x8::<8>(a, padding),
+            _ => self.slide_i32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x8<const OFFSET: usize>(
@@ -8040,12 +8114,6 @@ impl Simd for Avx2 {
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i32x8(padding);
         match OFFSET {
             0 => self.slide_i32x8::<8>(padding, a),
@@ -8057,7 +8125,7 @@ impl Simd for Avx2 {
             6 => self.slide_i32x8::<2>(padding, a),
             7 => self.slide_i32x8::<1>(padding, a),
             8 => self.slide_i32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -8511,23 +8579,21 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_u32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_u32x8::<0>(a, a),
+            1 => self.slide_u32x8::<1>(a, a),
+            2 => self.slide_u32x8::<2>(a, a),
+            3 => self.slide_u32x8::<3>(a, a),
+            4 => self.slide_u32x8::<4>(a, a),
+            5 => self.slide_u32x8::<5>(a, a),
+            6 => self.slide_u32x8::<6>(a, a),
+            7 => self.slide_u32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_u32x8::<8>(a, a),
             1 => self.slide_u32x8::<7>(a, a),
             2 => self.slide_u32x8::<6>(a, a),
@@ -8536,7 +8602,6 @@ impl Simd for Avx2 {
             5 => self.slide_u32x8::<3>(a, a),
             6 => self.slide_u32x8::<2>(a, a),
             7 => self.slide_u32x8::<1>(a, a),
-            8 => self.slide_u32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -8546,14 +8611,19 @@ impl Simd for Avx2 {
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u32x8(padding);
-        self.slide_u32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x8::<0>(a, padding),
+            1 => self.slide_u32x8::<1>(a, padding),
+            2 => self.slide_u32x8::<2>(a, padding),
+            3 => self.slide_u32x8::<3>(a, padding),
+            4 => self.slide_u32x8::<4>(a, padding),
+            5 => self.slide_u32x8::<5>(a, padding),
+            6 => self.slide_u32x8::<6>(a, padding),
+            7 => self.slide_u32x8::<7>(a, padding),
+            8 => self.slide_u32x8::<8>(a, padding),
+            _ => self.slide_u32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x8<const OFFSET: usize>(
@@ -8561,12 +8631,6 @@ impl Simd for Avx2 {
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u32x8(padding);
         match OFFSET {
             0 => self.slide_u32x8::<8>(padding, a),
@@ -8578,7 +8642,7 @@ impl Simd for Avx2 {
             6 => self.slide_u32x8::<2>(padding, a),
             7 => self.slide_u32x8::<1>(padding, a),
             8 => self.slide_u32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -9211,28 +9275,21 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_f64x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_f64x4::<0>(a, a),
+            1 => self.slide_f64x4::<1>(a, a),
+            2 => self.slide_f64x4::<2>(a, a),
+            3 => self.slide_f64x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_f64x4::<4>(a, a),
             1 => self.slide_f64x4::<3>(a, a),
             2 => self.slide_f64x4::<2>(a, a),
             3 => self.slide_f64x4::<1>(a, a),
-            4 => self.slide_f64x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -9242,14 +9299,15 @@ impl Simd for Avx2 {
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f64x4(padding);
-        self.slide_f64x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x4::<0>(a, padding),
+            1 => self.slide_f64x4::<1>(a, padding),
+            2 => self.slide_f64x4::<2>(a, padding),
+            3 => self.slide_f64x4::<3>(a, padding),
+            4 => self.slide_f64x4::<4>(a, padding),
+            _ => self.slide_f64x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x4<const OFFSET: usize>(
@@ -9257,12 +9315,6 @@ impl Simd for Avx2 {
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f64x4(padding);
         match OFFSET {
             0 => self.slide_f64x4::<4>(padding, a),
@@ -9270,7 +9322,7 @@ impl Simd for Avx2 {
             2 => self.slide_f64x4::<2>(padding, a),
             3 => self.slide_f64x4::<1>(padding, a),
             4 => self.slide_f64x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -9923,23 +9975,29 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_f32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_f32x16::<0>(a, a),
+            1 => self.slide_f32x16::<1>(a, a),
+            2 => self.slide_f32x16::<2>(a, a),
+            3 => self.slide_f32x16::<3>(a, a),
+            4 => self.slide_f32x16::<4>(a, a),
+            5 => self.slide_f32x16::<5>(a, a),
+            6 => self.slide_f32x16::<6>(a, a),
+            7 => self.slide_f32x16::<7>(a, a),
+            8 => self.slide_f32x16::<8>(a, a),
+            9 => self.slide_f32x16::<9>(a, a),
+            10 => self.slide_f32x16::<10>(a, a),
+            11 => self.slide_f32x16::<11>(a, a),
+            12 => self.slide_f32x16::<12>(a, a),
+            13 => self.slide_f32x16::<13>(a, a),
+            14 => self.slide_f32x16::<14>(a, a),
+            15 => self.slide_f32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_f32x16::<16>(a, a),
             1 => self.slide_f32x16::<15>(a, a),
             2 => self.slide_f32x16::<14>(a, a),
@@ -9956,7 +10014,6 @@ impl Simd for Avx2 {
             13 => self.slide_f32x16::<3>(a, a),
             14 => self.slide_f32x16::<2>(a, a),
             15 => self.slide_f32x16::<1>(a, a),
-            16 => self.slide_f32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -9966,14 +10023,27 @@ impl Simd for Avx2 {
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_f32x16(padding);
-        self.slide_f32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x16::<0>(a, padding),
+            1 => self.slide_f32x16::<1>(a, padding),
+            2 => self.slide_f32x16::<2>(a, padding),
+            3 => self.slide_f32x16::<3>(a, padding),
+            4 => self.slide_f32x16::<4>(a, padding),
+            5 => self.slide_f32x16::<5>(a, padding),
+            6 => self.slide_f32x16::<6>(a, padding),
+            7 => self.slide_f32x16::<7>(a, padding),
+            8 => self.slide_f32x16::<8>(a, padding),
+            9 => self.slide_f32x16::<9>(a, padding),
+            10 => self.slide_f32x16::<10>(a, padding),
+            11 => self.slide_f32x16::<11>(a, padding),
+            12 => self.slide_f32x16::<12>(a, padding),
+            13 => self.slide_f32x16::<13>(a, padding),
+            14 => self.slide_f32x16::<14>(a, padding),
+            15 => self.slide_f32x16::<15>(a, padding),
+            16 => self.slide_f32x16::<16>(a, padding),
+            _ => self.slide_f32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x16<const OFFSET: usize>(
@@ -9981,12 +10051,6 @@ impl Simd for Avx2 {
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_f32x16(padding);
         match OFFSET {
             0 => self.slide_f32x16::<16>(padding, a),
@@ -10006,7 +10070,7 @@ impl Simd for Avx2 {
             14 => self.slide_f32x16::<2>(padding, a),
             15 => self.slide_f32x16::<1>(padding, a),
             16 => self.slide_f32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -10463,23 +10527,77 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        self.slide_i8x64::<OFFSET>(a, a)
+        match OFFSET % 64 {
+            0 => self.slide_i8x64::<0>(a, a),
+            1 => self.slide_i8x64::<1>(a, a),
+            2 => self.slide_i8x64::<2>(a, a),
+            3 => self.slide_i8x64::<3>(a, a),
+            4 => self.slide_i8x64::<4>(a, a),
+            5 => self.slide_i8x64::<5>(a, a),
+            6 => self.slide_i8x64::<6>(a, a),
+            7 => self.slide_i8x64::<7>(a, a),
+            8 => self.slide_i8x64::<8>(a, a),
+            9 => self.slide_i8x64::<9>(a, a),
+            10 => self.slide_i8x64::<10>(a, a),
+            11 => self.slide_i8x64::<11>(a, a),
+            12 => self.slide_i8x64::<12>(a, a),
+            13 => self.slide_i8x64::<13>(a, a),
+            14 => self.slide_i8x64::<14>(a, a),
+            15 => self.slide_i8x64::<15>(a, a),
+            16 => self.slide_i8x64::<16>(a, a),
+            17 => self.slide_i8x64::<17>(a, a),
+            18 => self.slide_i8x64::<18>(a, a),
+            19 => self.slide_i8x64::<19>(a, a),
+            20 => self.slide_i8x64::<20>(a, a),
+            21 => self.slide_i8x64::<21>(a, a),
+            22 => self.slide_i8x64::<22>(a, a),
+            23 => self.slide_i8x64::<23>(a, a),
+            24 => self.slide_i8x64::<24>(a, a),
+            25 => self.slide_i8x64::<25>(a, a),
+            26 => self.slide_i8x64::<26>(a, a),
+            27 => self.slide_i8x64::<27>(a, a),
+            28 => self.slide_i8x64::<28>(a, a),
+            29 => self.slide_i8x64::<29>(a, a),
+            30 => self.slide_i8x64::<30>(a, a),
+            31 => self.slide_i8x64::<31>(a, a),
+            32 => self.slide_i8x64::<32>(a, a),
+            33 => self.slide_i8x64::<33>(a, a),
+            34 => self.slide_i8x64::<34>(a, a),
+            35 => self.slide_i8x64::<35>(a, a),
+            36 => self.slide_i8x64::<36>(a, a),
+            37 => self.slide_i8x64::<37>(a, a),
+            38 => self.slide_i8x64::<38>(a, a),
+            39 => self.slide_i8x64::<39>(a, a),
+            40 => self.slide_i8x64::<40>(a, a),
+            41 => self.slide_i8x64::<41>(a, a),
+            42 => self.slide_i8x64::<42>(a, a),
+            43 => self.slide_i8x64::<43>(a, a),
+            44 => self.slide_i8x64::<44>(a, a),
+            45 => self.slide_i8x64::<45>(a, a),
+            46 => self.slide_i8x64::<46>(a, a),
+            47 => self.slide_i8x64::<47>(a, a),
+            48 => self.slide_i8x64::<48>(a, a),
+            49 => self.slide_i8x64::<49>(a, a),
+            50 => self.slide_i8x64::<50>(a, a),
+            51 => self.slide_i8x64::<51>(a, a),
+            52 => self.slide_i8x64::<52>(a, a),
+            53 => self.slide_i8x64::<53>(a, a),
+            54 => self.slide_i8x64::<54>(a, a),
+            55 => self.slide_i8x64::<55>(a, a),
+            56 => self.slide_i8x64::<56>(a, a),
+            57 => self.slide_i8x64::<57>(a, a),
+            58 => self.slide_i8x64::<58>(a, a),
+            59 => self.slide_i8x64::<59>(a, a),
+            60 => self.slide_i8x64::<60>(a, a),
+            61 => self.slide_i8x64::<61>(a, a),
+            62 => self.slide_i8x64::<62>(a, a),
+            63 => self.slide_i8x64::<63>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        match OFFSET {
+        match OFFSET % 64 {
             0 => self.slide_i8x64::<64>(a, a),
             1 => self.slide_i8x64::<63>(a, a),
             2 => self.slide_i8x64::<62>(a, a),
@@ -10544,7 +10662,6 @@ impl Simd for Avx2 {
             61 => self.slide_i8x64::<3>(a, a),
             62 => self.slide_i8x64::<2>(a, a),
             63 => self.slide_i8x64::<1>(a, a),
-            64 => self.slide_i8x64::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -10554,14 +10671,75 @@ impl Simd for Avx2 {
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_i8x64(padding);
-        self.slide_i8x64::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x64::<0>(a, padding),
+            1 => self.slide_i8x64::<1>(a, padding),
+            2 => self.slide_i8x64::<2>(a, padding),
+            3 => self.slide_i8x64::<3>(a, padding),
+            4 => self.slide_i8x64::<4>(a, padding),
+            5 => self.slide_i8x64::<5>(a, padding),
+            6 => self.slide_i8x64::<6>(a, padding),
+            7 => self.slide_i8x64::<7>(a, padding),
+            8 => self.slide_i8x64::<8>(a, padding),
+            9 => self.slide_i8x64::<9>(a, padding),
+            10 => self.slide_i8x64::<10>(a, padding),
+            11 => self.slide_i8x64::<11>(a, padding),
+            12 => self.slide_i8x64::<12>(a, padding),
+            13 => self.slide_i8x64::<13>(a, padding),
+            14 => self.slide_i8x64::<14>(a, padding),
+            15 => self.slide_i8x64::<15>(a, padding),
+            16 => self.slide_i8x64::<16>(a, padding),
+            17 => self.slide_i8x64::<17>(a, padding),
+            18 => self.slide_i8x64::<18>(a, padding),
+            19 => self.slide_i8x64::<19>(a, padding),
+            20 => self.slide_i8x64::<20>(a, padding),
+            21 => self.slide_i8x64::<21>(a, padding),
+            22 => self.slide_i8x64::<22>(a, padding),
+            23 => self.slide_i8x64::<23>(a, padding),
+            24 => self.slide_i8x64::<24>(a, padding),
+            25 => self.slide_i8x64::<25>(a, padding),
+            26 => self.slide_i8x64::<26>(a, padding),
+            27 => self.slide_i8x64::<27>(a, padding),
+            28 => self.slide_i8x64::<28>(a, padding),
+            29 => self.slide_i8x64::<29>(a, padding),
+            30 => self.slide_i8x64::<30>(a, padding),
+            31 => self.slide_i8x64::<31>(a, padding),
+            32 => self.slide_i8x64::<32>(a, padding),
+            33 => self.slide_i8x64::<33>(a, padding),
+            34 => self.slide_i8x64::<34>(a, padding),
+            35 => self.slide_i8x64::<35>(a, padding),
+            36 => self.slide_i8x64::<36>(a, padding),
+            37 => self.slide_i8x64::<37>(a, padding),
+            38 => self.slide_i8x64::<38>(a, padding),
+            39 => self.slide_i8x64::<39>(a, padding),
+            40 => self.slide_i8x64::<40>(a, padding),
+            41 => self.slide_i8x64::<41>(a, padding),
+            42 => self.slide_i8x64::<42>(a, padding),
+            43 => self.slide_i8x64::<43>(a, padding),
+            44 => self.slide_i8x64::<44>(a, padding),
+            45 => self.slide_i8x64::<45>(a, padding),
+            46 => self.slide_i8x64::<46>(a, padding),
+            47 => self.slide_i8x64::<47>(a, padding),
+            48 => self.slide_i8x64::<48>(a, padding),
+            49 => self.slide_i8x64::<49>(a, padding),
+            50 => self.slide_i8x64::<50>(a, padding),
+            51 => self.slide_i8x64::<51>(a, padding),
+            52 => self.slide_i8x64::<52>(a, padding),
+            53 => self.slide_i8x64::<53>(a, padding),
+            54 => self.slide_i8x64::<54>(a, padding),
+            55 => self.slide_i8x64::<55>(a, padding),
+            56 => self.slide_i8x64::<56>(a, padding),
+            57 => self.slide_i8x64::<57>(a, padding),
+            58 => self.slide_i8x64::<58>(a, padding),
+            59 => self.slide_i8x64::<59>(a, padding),
+            60 => self.slide_i8x64::<60>(a, padding),
+            61 => self.slide_i8x64::<61>(a, padding),
+            62 => self.slide_i8x64::<62>(a, padding),
+            63 => self.slide_i8x64::<63>(a, padding),
+            64 => self.slide_i8x64::<64>(a, padding),
+            _ => self.slide_i8x64::<64>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x64<const OFFSET: usize>(
@@ -10569,12 +10747,6 @@ impl Simd for Avx2 {
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_i8x64(padding);
         match OFFSET {
             0 => self.slide_i8x64::<64>(padding, a),
@@ -10642,7 +10814,7 @@ impl Simd for Avx2 {
             62 => self.slide_i8x64::<2>(padding, a),
             63 => self.slide_i8x64::<1>(padding, a),
             64 => self.slide_i8x64::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x64::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -10927,23 +11099,77 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        self.slide_u8x64::<OFFSET>(a, a)
+        match OFFSET % 64 {
+            0 => self.slide_u8x64::<0>(a, a),
+            1 => self.slide_u8x64::<1>(a, a),
+            2 => self.slide_u8x64::<2>(a, a),
+            3 => self.slide_u8x64::<3>(a, a),
+            4 => self.slide_u8x64::<4>(a, a),
+            5 => self.slide_u8x64::<5>(a, a),
+            6 => self.slide_u8x64::<6>(a, a),
+            7 => self.slide_u8x64::<7>(a, a),
+            8 => self.slide_u8x64::<8>(a, a),
+            9 => self.slide_u8x64::<9>(a, a),
+            10 => self.slide_u8x64::<10>(a, a),
+            11 => self.slide_u8x64::<11>(a, a),
+            12 => self.slide_u8x64::<12>(a, a),
+            13 => self.slide_u8x64::<13>(a, a),
+            14 => self.slide_u8x64::<14>(a, a),
+            15 => self.slide_u8x64::<15>(a, a),
+            16 => self.slide_u8x64::<16>(a, a),
+            17 => self.slide_u8x64::<17>(a, a),
+            18 => self.slide_u8x64::<18>(a, a),
+            19 => self.slide_u8x64::<19>(a, a),
+            20 => self.slide_u8x64::<20>(a, a),
+            21 => self.slide_u8x64::<21>(a, a),
+            22 => self.slide_u8x64::<22>(a, a),
+            23 => self.slide_u8x64::<23>(a, a),
+            24 => self.slide_u8x64::<24>(a, a),
+            25 => self.slide_u8x64::<25>(a, a),
+            26 => self.slide_u8x64::<26>(a, a),
+            27 => self.slide_u8x64::<27>(a, a),
+            28 => self.slide_u8x64::<28>(a, a),
+            29 => self.slide_u8x64::<29>(a, a),
+            30 => self.slide_u8x64::<30>(a, a),
+            31 => self.slide_u8x64::<31>(a, a),
+            32 => self.slide_u8x64::<32>(a, a),
+            33 => self.slide_u8x64::<33>(a, a),
+            34 => self.slide_u8x64::<34>(a, a),
+            35 => self.slide_u8x64::<35>(a, a),
+            36 => self.slide_u8x64::<36>(a, a),
+            37 => self.slide_u8x64::<37>(a, a),
+            38 => self.slide_u8x64::<38>(a, a),
+            39 => self.slide_u8x64::<39>(a, a),
+            40 => self.slide_u8x64::<40>(a, a),
+            41 => self.slide_u8x64::<41>(a, a),
+            42 => self.slide_u8x64::<42>(a, a),
+            43 => self.slide_u8x64::<43>(a, a),
+            44 => self.slide_u8x64::<44>(a, a),
+            45 => self.slide_u8x64::<45>(a, a),
+            46 => self.slide_u8x64::<46>(a, a),
+            47 => self.slide_u8x64::<47>(a, a),
+            48 => self.slide_u8x64::<48>(a, a),
+            49 => self.slide_u8x64::<49>(a, a),
+            50 => self.slide_u8x64::<50>(a, a),
+            51 => self.slide_u8x64::<51>(a, a),
+            52 => self.slide_u8x64::<52>(a, a),
+            53 => self.slide_u8x64::<53>(a, a),
+            54 => self.slide_u8x64::<54>(a, a),
+            55 => self.slide_u8x64::<55>(a, a),
+            56 => self.slide_u8x64::<56>(a, a),
+            57 => self.slide_u8x64::<57>(a, a),
+            58 => self.slide_u8x64::<58>(a, a),
+            59 => self.slide_u8x64::<59>(a, a),
+            60 => self.slide_u8x64::<60>(a, a),
+            61 => self.slide_u8x64::<61>(a, a),
+            62 => self.slide_u8x64::<62>(a, a),
+            63 => self.slide_u8x64::<63>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        match OFFSET {
+        match OFFSET % 64 {
             0 => self.slide_u8x64::<64>(a, a),
             1 => self.slide_u8x64::<63>(a, a),
             2 => self.slide_u8x64::<62>(a, a),
@@ -11008,7 +11234,6 @@ impl Simd for Avx2 {
             61 => self.slide_u8x64::<3>(a, a),
             62 => self.slide_u8x64::<2>(a, a),
             63 => self.slide_u8x64::<1>(a, a),
-            64 => self.slide_u8x64::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -11018,14 +11243,75 @@ impl Simd for Avx2 {
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_u8x64(padding);
-        self.slide_u8x64::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x64::<0>(a, padding),
+            1 => self.slide_u8x64::<1>(a, padding),
+            2 => self.slide_u8x64::<2>(a, padding),
+            3 => self.slide_u8x64::<3>(a, padding),
+            4 => self.slide_u8x64::<4>(a, padding),
+            5 => self.slide_u8x64::<5>(a, padding),
+            6 => self.slide_u8x64::<6>(a, padding),
+            7 => self.slide_u8x64::<7>(a, padding),
+            8 => self.slide_u8x64::<8>(a, padding),
+            9 => self.slide_u8x64::<9>(a, padding),
+            10 => self.slide_u8x64::<10>(a, padding),
+            11 => self.slide_u8x64::<11>(a, padding),
+            12 => self.slide_u8x64::<12>(a, padding),
+            13 => self.slide_u8x64::<13>(a, padding),
+            14 => self.slide_u8x64::<14>(a, padding),
+            15 => self.slide_u8x64::<15>(a, padding),
+            16 => self.slide_u8x64::<16>(a, padding),
+            17 => self.slide_u8x64::<17>(a, padding),
+            18 => self.slide_u8x64::<18>(a, padding),
+            19 => self.slide_u8x64::<19>(a, padding),
+            20 => self.slide_u8x64::<20>(a, padding),
+            21 => self.slide_u8x64::<21>(a, padding),
+            22 => self.slide_u8x64::<22>(a, padding),
+            23 => self.slide_u8x64::<23>(a, padding),
+            24 => self.slide_u8x64::<24>(a, padding),
+            25 => self.slide_u8x64::<25>(a, padding),
+            26 => self.slide_u8x64::<26>(a, padding),
+            27 => self.slide_u8x64::<27>(a, padding),
+            28 => self.slide_u8x64::<28>(a, padding),
+            29 => self.slide_u8x64::<29>(a, padding),
+            30 => self.slide_u8x64::<30>(a, padding),
+            31 => self.slide_u8x64::<31>(a, padding),
+            32 => self.slide_u8x64::<32>(a, padding),
+            33 => self.slide_u8x64::<33>(a, padding),
+            34 => self.slide_u8x64::<34>(a, padding),
+            35 => self.slide_u8x64::<35>(a, padding),
+            36 => self.slide_u8x64::<36>(a, padding),
+            37 => self.slide_u8x64::<37>(a, padding),
+            38 => self.slide_u8x64::<38>(a, padding),
+            39 => self.slide_u8x64::<39>(a, padding),
+            40 => self.slide_u8x64::<40>(a, padding),
+            41 => self.slide_u8x64::<41>(a, padding),
+            42 => self.slide_u8x64::<42>(a, padding),
+            43 => self.slide_u8x64::<43>(a, padding),
+            44 => self.slide_u8x64::<44>(a, padding),
+            45 => self.slide_u8x64::<45>(a, padding),
+            46 => self.slide_u8x64::<46>(a, padding),
+            47 => self.slide_u8x64::<47>(a, padding),
+            48 => self.slide_u8x64::<48>(a, padding),
+            49 => self.slide_u8x64::<49>(a, padding),
+            50 => self.slide_u8x64::<50>(a, padding),
+            51 => self.slide_u8x64::<51>(a, padding),
+            52 => self.slide_u8x64::<52>(a, padding),
+            53 => self.slide_u8x64::<53>(a, padding),
+            54 => self.slide_u8x64::<54>(a, padding),
+            55 => self.slide_u8x64::<55>(a, padding),
+            56 => self.slide_u8x64::<56>(a, padding),
+            57 => self.slide_u8x64::<57>(a, padding),
+            58 => self.slide_u8x64::<58>(a, padding),
+            59 => self.slide_u8x64::<59>(a, padding),
+            60 => self.slide_u8x64::<60>(a, padding),
+            61 => self.slide_u8x64::<61>(a, padding),
+            62 => self.slide_u8x64::<62>(a, padding),
+            63 => self.slide_u8x64::<63>(a, padding),
+            64 => self.slide_u8x64::<64>(a, padding),
+            _ => self.slide_u8x64::<64>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x64<const OFFSET: usize>(
@@ -11033,12 +11319,6 @@ impl Simd for Avx2 {
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_u8x64(padding);
         match OFFSET {
             0 => self.slide_u8x64::<64>(padding, a),
@@ -11106,7 +11386,7 @@ impl Simd for Avx2 {
             62 => self.slide_u8x64::<2>(padding, a),
             63 => self.slide_u8x64::<1>(padding, a),
             64 => self.slide_u8x64::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x64::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -11618,23 +11898,45 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_i16x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_i16x32::<0>(a, a),
+            1 => self.slide_i16x32::<1>(a, a),
+            2 => self.slide_i16x32::<2>(a, a),
+            3 => self.slide_i16x32::<3>(a, a),
+            4 => self.slide_i16x32::<4>(a, a),
+            5 => self.slide_i16x32::<5>(a, a),
+            6 => self.slide_i16x32::<6>(a, a),
+            7 => self.slide_i16x32::<7>(a, a),
+            8 => self.slide_i16x32::<8>(a, a),
+            9 => self.slide_i16x32::<9>(a, a),
+            10 => self.slide_i16x32::<10>(a, a),
+            11 => self.slide_i16x32::<11>(a, a),
+            12 => self.slide_i16x32::<12>(a, a),
+            13 => self.slide_i16x32::<13>(a, a),
+            14 => self.slide_i16x32::<14>(a, a),
+            15 => self.slide_i16x32::<15>(a, a),
+            16 => self.slide_i16x32::<16>(a, a),
+            17 => self.slide_i16x32::<17>(a, a),
+            18 => self.slide_i16x32::<18>(a, a),
+            19 => self.slide_i16x32::<19>(a, a),
+            20 => self.slide_i16x32::<20>(a, a),
+            21 => self.slide_i16x32::<21>(a, a),
+            22 => self.slide_i16x32::<22>(a, a),
+            23 => self.slide_i16x32::<23>(a, a),
+            24 => self.slide_i16x32::<24>(a, a),
+            25 => self.slide_i16x32::<25>(a, a),
+            26 => self.slide_i16x32::<26>(a, a),
+            27 => self.slide_i16x32::<27>(a, a),
+            28 => self.slide_i16x32::<28>(a, a),
+            29 => self.slide_i16x32::<29>(a, a),
+            30 => self.slide_i16x32::<30>(a, a),
+            31 => self.slide_i16x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_i16x32::<32>(a, a),
             1 => self.slide_i16x32::<31>(a, a),
             2 => self.slide_i16x32::<30>(a, a),
@@ -11667,7 +11969,6 @@ impl Simd for Avx2 {
             29 => self.slide_i16x32::<3>(a, a),
             30 => self.slide_i16x32::<2>(a, a),
             31 => self.slide_i16x32::<1>(a, a),
-            32 => self.slide_i16x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -11677,14 +11978,43 @@ impl Simd for Avx2 {
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i16x32(padding);
-        self.slide_i16x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x32::<0>(a, padding),
+            1 => self.slide_i16x32::<1>(a, padding),
+            2 => self.slide_i16x32::<2>(a, padding),
+            3 => self.slide_i16x32::<3>(a, padding),
+            4 => self.slide_i16x32::<4>(a, padding),
+            5 => self.slide_i16x32::<5>(a, padding),
+            6 => self.slide_i16x32::<6>(a, padding),
+            7 => self.slide_i16x32::<7>(a, padding),
+            8 => self.slide_i16x32::<8>(a, padding),
+            9 => self.slide_i16x32::<9>(a, padding),
+            10 => self.slide_i16x32::<10>(a, padding),
+            11 => self.slide_i16x32::<11>(a, padding),
+            12 => self.slide_i16x32::<12>(a, padding),
+            13 => self.slide_i16x32::<13>(a, padding),
+            14 => self.slide_i16x32::<14>(a, padding),
+            15 => self.slide_i16x32::<15>(a, padding),
+            16 => self.slide_i16x32::<16>(a, padding),
+            17 => self.slide_i16x32::<17>(a, padding),
+            18 => self.slide_i16x32::<18>(a, padding),
+            19 => self.slide_i16x32::<19>(a, padding),
+            20 => self.slide_i16x32::<20>(a, padding),
+            21 => self.slide_i16x32::<21>(a, padding),
+            22 => self.slide_i16x32::<22>(a, padding),
+            23 => self.slide_i16x32::<23>(a, padding),
+            24 => self.slide_i16x32::<24>(a, padding),
+            25 => self.slide_i16x32::<25>(a, padding),
+            26 => self.slide_i16x32::<26>(a, padding),
+            27 => self.slide_i16x32::<27>(a, padding),
+            28 => self.slide_i16x32::<28>(a, padding),
+            29 => self.slide_i16x32::<29>(a, padding),
+            30 => self.slide_i16x32::<30>(a, padding),
+            31 => self.slide_i16x32::<31>(a, padding),
+            32 => self.slide_i16x32::<32>(a, padding),
+            _ => self.slide_i16x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x32<const OFFSET: usize>(
@@ -11692,12 +12022,6 @@ impl Simd for Avx2 {
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i16x32(padding);
         match OFFSET {
             0 => self.slide_i16x32::<32>(padding, a),
@@ -11733,7 +12057,7 @@ impl Simd for Avx2 {
             30 => self.slide_i16x32::<2>(padding, a),
             31 => self.slide_i16x32::<1>(padding, a),
             32 => self.slide_i16x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -12031,23 +12355,45 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_u16x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_u16x32::<0>(a, a),
+            1 => self.slide_u16x32::<1>(a, a),
+            2 => self.slide_u16x32::<2>(a, a),
+            3 => self.slide_u16x32::<3>(a, a),
+            4 => self.slide_u16x32::<4>(a, a),
+            5 => self.slide_u16x32::<5>(a, a),
+            6 => self.slide_u16x32::<6>(a, a),
+            7 => self.slide_u16x32::<7>(a, a),
+            8 => self.slide_u16x32::<8>(a, a),
+            9 => self.slide_u16x32::<9>(a, a),
+            10 => self.slide_u16x32::<10>(a, a),
+            11 => self.slide_u16x32::<11>(a, a),
+            12 => self.slide_u16x32::<12>(a, a),
+            13 => self.slide_u16x32::<13>(a, a),
+            14 => self.slide_u16x32::<14>(a, a),
+            15 => self.slide_u16x32::<15>(a, a),
+            16 => self.slide_u16x32::<16>(a, a),
+            17 => self.slide_u16x32::<17>(a, a),
+            18 => self.slide_u16x32::<18>(a, a),
+            19 => self.slide_u16x32::<19>(a, a),
+            20 => self.slide_u16x32::<20>(a, a),
+            21 => self.slide_u16x32::<21>(a, a),
+            22 => self.slide_u16x32::<22>(a, a),
+            23 => self.slide_u16x32::<23>(a, a),
+            24 => self.slide_u16x32::<24>(a, a),
+            25 => self.slide_u16x32::<25>(a, a),
+            26 => self.slide_u16x32::<26>(a, a),
+            27 => self.slide_u16x32::<27>(a, a),
+            28 => self.slide_u16x32::<28>(a, a),
+            29 => self.slide_u16x32::<29>(a, a),
+            30 => self.slide_u16x32::<30>(a, a),
+            31 => self.slide_u16x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_u16x32::<32>(a, a),
             1 => self.slide_u16x32::<31>(a, a),
             2 => self.slide_u16x32::<30>(a, a),
@@ -12080,7 +12426,6 @@ impl Simd for Avx2 {
             29 => self.slide_u16x32::<3>(a, a),
             30 => self.slide_u16x32::<2>(a, a),
             31 => self.slide_u16x32::<1>(a, a),
-            32 => self.slide_u16x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -12090,14 +12435,43 @@ impl Simd for Avx2 {
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u16x32(padding);
-        self.slide_u16x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x32::<0>(a, padding),
+            1 => self.slide_u16x32::<1>(a, padding),
+            2 => self.slide_u16x32::<2>(a, padding),
+            3 => self.slide_u16x32::<3>(a, padding),
+            4 => self.slide_u16x32::<4>(a, padding),
+            5 => self.slide_u16x32::<5>(a, padding),
+            6 => self.slide_u16x32::<6>(a, padding),
+            7 => self.slide_u16x32::<7>(a, padding),
+            8 => self.slide_u16x32::<8>(a, padding),
+            9 => self.slide_u16x32::<9>(a, padding),
+            10 => self.slide_u16x32::<10>(a, padding),
+            11 => self.slide_u16x32::<11>(a, padding),
+            12 => self.slide_u16x32::<12>(a, padding),
+            13 => self.slide_u16x32::<13>(a, padding),
+            14 => self.slide_u16x32::<14>(a, padding),
+            15 => self.slide_u16x32::<15>(a, padding),
+            16 => self.slide_u16x32::<16>(a, padding),
+            17 => self.slide_u16x32::<17>(a, padding),
+            18 => self.slide_u16x32::<18>(a, padding),
+            19 => self.slide_u16x32::<19>(a, padding),
+            20 => self.slide_u16x32::<20>(a, padding),
+            21 => self.slide_u16x32::<21>(a, padding),
+            22 => self.slide_u16x32::<22>(a, padding),
+            23 => self.slide_u16x32::<23>(a, padding),
+            24 => self.slide_u16x32::<24>(a, padding),
+            25 => self.slide_u16x32::<25>(a, padding),
+            26 => self.slide_u16x32::<26>(a, padding),
+            27 => self.slide_u16x32::<27>(a, padding),
+            28 => self.slide_u16x32::<28>(a, padding),
+            29 => self.slide_u16x32::<29>(a, padding),
+            30 => self.slide_u16x32::<30>(a, padding),
+            31 => self.slide_u16x32::<31>(a, padding),
+            32 => self.slide_u16x32::<32>(a, padding),
+            _ => self.slide_u16x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x32<const OFFSET: usize>(
@@ -12105,12 +12479,6 @@ impl Simd for Avx2 {
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u16x32(padding);
         match OFFSET {
             0 => self.slide_u16x32::<32>(padding, a),
@@ -12146,7 +12514,7 @@ impl Simd for Avx2 {
             30 => self.slide_u16x32::<2>(padding, a),
             31 => self.slide_u16x32::<1>(padding, a),
             32 => self.slide_u16x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -12670,23 +13038,29 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i32x16::<0>(a, a),
+            1 => self.slide_i32x16::<1>(a, a),
+            2 => self.slide_i32x16::<2>(a, a),
+            3 => self.slide_i32x16::<3>(a, a),
+            4 => self.slide_i32x16::<4>(a, a),
+            5 => self.slide_i32x16::<5>(a, a),
+            6 => self.slide_i32x16::<6>(a, a),
+            7 => self.slide_i32x16::<7>(a, a),
+            8 => self.slide_i32x16::<8>(a, a),
+            9 => self.slide_i32x16::<9>(a, a),
+            10 => self.slide_i32x16::<10>(a, a),
+            11 => self.slide_i32x16::<11>(a, a),
+            12 => self.slide_i32x16::<12>(a, a),
+            13 => self.slide_i32x16::<13>(a, a),
+            14 => self.slide_i32x16::<14>(a, a),
+            15 => self.slide_i32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i32x16::<16>(a, a),
             1 => self.slide_i32x16::<15>(a, a),
             2 => self.slide_i32x16::<14>(a, a),
@@ -12703,7 +13077,6 @@ impl Simd for Avx2 {
             13 => self.slide_i32x16::<3>(a, a),
             14 => self.slide_i32x16::<2>(a, a),
             15 => self.slide_i32x16::<1>(a, a),
-            16 => self.slide_i32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -12713,14 +13086,27 @@ impl Simd for Avx2 {
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i32x16(padding);
-        self.slide_i32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x16::<0>(a, padding),
+            1 => self.slide_i32x16::<1>(a, padding),
+            2 => self.slide_i32x16::<2>(a, padding),
+            3 => self.slide_i32x16::<3>(a, padding),
+            4 => self.slide_i32x16::<4>(a, padding),
+            5 => self.slide_i32x16::<5>(a, padding),
+            6 => self.slide_i32x16::<6>(a, padding),
+            7 => self.slide_i32x16::<7>(a, padding),
+            8 => self.slide_i32x16::<8>(a, padding),
+            9 => self.slide_i32x16::<9>(a, padding),
+            10 => self.slide_i32x16::<10>(a, padding),
+            11 => self.slide_i32x16::<11>(a, padding),
+            12 => self.slide_i32x16::<12>(a, padding),
+            13 => self.slide_i32x16::<13>(a, padding),
+            14 => self.slide_i32x16::<14>(a, padding),
+            15 => self.slide_i32x16::<15>(a, padding),
+            16 => self.slide_i32x16::<16>(a, padding),
+            _ => self.slide_i32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x16<const OFFSET: usize>(
@@ -12728,12 +13114,6 @@ impl Simd for Avx2 {
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i32x16(padding);
         match OFFSET {
             0 => self.slide_i32x16::<16>(padding, a),
@@ -12753,7 +13133,7 @@ impl Simd for Avx2 {
             14 => self.slide_i32x16::<2>(padding, a),
             15 => self.slide_i32x16::<1>(padding, a),
             16 => self.slide_i32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -13047,23 +13427,29 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u32x16::<0>(a, a),
+            1 => self.slide_u32x16::<1>(a, a),
+            2 => self.slide_u32x16::<2>(a, a),
+            3 => self.slide_u32x16::<3>(a, a),
+            4 => self.slide_u32x16::<4>(a, a),
+            5 => self.slide_u32x16::<5>(a, a),
+            6 => self.slide_u32x16::<6>(a, a),
+            7 => self.slide_u32x16::<7>(a, a),
+            8 => self.slide_u32x16::<8>(a, a),
+            9 => self.slide_u32x16::<9>(a, a),
+            10 => self.slide_u32x16::<10>(a, a),
+            11 => self.slide_u32x16::<11>(a, a),
+            12 => self.slide_u32x16::<12>(a, a),
+            13 => self.slide_u32x16::<13>(a, a),
+            14 => self.slide_u32x16::<14>(a, a),
+            15 => self.slide_u32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u32x16::<16>(a, a),
             1 => self.slide_u32x16::<15>(a, a),
             2 => self.slide_u32x16::<14>(a, a),
@@ -13080,7 +13466,6 @@ impl Simd for Avx2 {
             13 => self.slide_u32x16::<3>(a, a),
             14 => self.slide_u32x16::<2>(a, a),
             15 => self.slide_u32x16::<1>(a, a),
-            16 => self.slide_u32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -13090,14 +13475,27 @@ impl Simd for Avx2 {
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u32x16(padding);
-        self.slide_u32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x16::<0>(a, padding),
+            1 => self.slide_u32x16::<1>(a, padding),
+            2 => self.slide_u32x16::<2>(a, padding),
+            3 => self.slide_u32x16::<3>(a, padding),
+            4 => self.slide_u32x16::<4>(a, padding),
+            5 => self.slide_u32x16::<5>(a, padding),
+            6 => self.slide_u32x16::<6>(a, padding),
+            7 => self.slide_u32x16::<7>(a, padding),
+            8 => self.slide_u32x16::<8>(a, padding),
+            9 => self.slide_u32x16::<9>(a, padding),
+            10 => self.slide_u32x16::<10>(a, padding),
+            11 => self.slide_u32x16::<11>(a, padding),
+            12 => self.slide_u32x16::<12>(a, padding),
+            13 => self.slide_u32x16::<13>(a, padding),
+            14 => self.slide_u32x16::<14>(a, padding),
+            15 => self.slide_u32x16::<15>(a, padding),
+            16 => self.slide_u32x16::<16>(a, padding),
+            _ => self.slide_u32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x16<const OFFSET: usize>(
@@ -13105,12 +13503,6 @@ impl Simd for Avx2 {
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u32x16(padding);
         match OFFSET {
             0 => self.slide_u32x16::<16>(padding, a),
@@ -13130,7 +13522,7 @@ impl Simd for Avx2 {
             14 => self.slide_u32x16::<2>(padding, a),
             15 => self.slide_u32x16::<1>(padding, a),
             16 => self.slide_u32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -13624,23 +14016,21 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_f64x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_f64x8::<0>(a, a),
+            1 => self.slide_f64x8::<1>(a, a),
+            2 => self.slide_f64x8::<2>(a, a),
+            3 => self.slide_f64x8::<3>(a, a),
+            4 => self.slide_f64x8::<4>(a, a),
+            5 => self.slide_f64x8::<5>(a, a),
+            6 => self.slide_f64x8::<6>(a, a),
+            7 => self.slide_f64x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_f64x8::<8>(a, a),
             1 => self.slide_f64x8::<7>(a, a),
             2 => self.slide_f64x8::<6>(a, a),
@@ -13649,7 +14039,6 @@ impl Simd for Avx2 {
             5 => self.slide_f64x8::<3>(a, a),
             6 => self.slide_f64x8::<2>(a, a),
             7 => self.slide_f64x8::<1>(a, a),
-            8 => self.slide_f64x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -13659,14 +14048,19 @@ impl Simd for Avx2 {
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f64x8(padding);
-        self.slide_f64x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x8::<0>(a, padding),
+            1 => self.slide_f64x8::<1>(a, padding),
+            2 => self.slide_f64x8::<2>(a, padding),
+            3 => self.slide_f64x8::<3>(a, padding),
+            4 => self.slide_f64x8::<4>(a, padding),
+            5 => self.slide_f64x8::<5>(a, padding),
+            6 => self.slide_f64x8::<6>(a, padding),
+            7 => self.slide_f64x8::<7>(a, padding),
+            8 => self.slide_f64x8::<8>(a, padding),
+            _ => self.slide_f64x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x8<const OFFSET: usize>(
@@ -13674,12 +14068,6 @@ impl Simd for Avx2 {
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f64x8(padding);
         match OFFSET {
             0 => self.slide_f64x8::<8>(padding, a),
@@ -13691,7 +14079,7 @@ impl Simd for Avx2 {
             6 => self.slide_f64x8::<2>(padding, a),
             7 => self.slide_f64x8::<1>(padding, a),
             8 => self.slide_f64x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x8::<0>(padding, a),
         }
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -184,28 +184,21 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_f32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_f32x4::<0>(a, a),
+            1 => self.slide_f32x4::<1>(a, a),
+            2 => self.slide_f32x4::<2>(a, a),
+            3 => self.slide_f32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_f32x4::<4>(a, a),
             1 => self.slide_f32x4::<3>(a, a),
             2 => self.slide_f32x4::<2>(a, a),
             3 => self.slide_f32x4::<1>(a, a),
-            4 => self.slide_f32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -215,14 +208,15 @@ impl Simd for Avx512 {
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f32x4(padding);
-        self.slide_f32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x4::<0>(a, padding),
+            1 => self.slide_f32x4::<1>(a, padding),
+            2 => self.slide_f32x4::<2>(a, padding),
+            3 => self.slide_f32x4::<3>(a, padding),
+            4 => self.slide_f32x4::<4>(a, padding),
+            _ => self.slide_f32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x4<const OFFSET: usize>(
@@ -230,12 +224,6 @@ impl Simd for Avx512 {
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f32x4(padding);
         match OFFSET {
             0 => self.slide_f32x4::<4>(padding, a),
@@ -243,7 +231,7 @@ impl Simd for Avx512 {
             2 => self.slide_f32x4::<2>(padding, a),
             3 => self.slide_f32x4::<1>(padding, a),
             4 => self.slide_f32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -782,23 +770,29 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i8x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i8x16::<0>(a, a),
+            1 => self.slide_i8x16::<1>(a, a),
+            2 => self.slide_i8x16::<2>(a, a),
+            3 => self.slide_i8x16::<3>(a, a),
+            4 => self.slide_i8x16::<4>(a, a),
+            5 => self.slide_i8x16::<5>(a, a),
+            6 => self.slide_i8x16::<6>(a, a),
+            7 => self.slide_i8x16::<7>(a, a),
+            8 => self.slide_i8x16::<8>(a, a),
+            9 => self.slide_i8x16::<9>(a, a),
+            10 => self.slide_i8x16::<10>(a, a),
+            11 => self.slide_i8x16::<11>(a, a),
+            12 => self.slide_i8x16::<12>(a, a),
+            13 => self.slide_i8x16::<13>(a, a),
+            14 => self.slide_i8x16::<14>(a, a),
+            15 => self.slide_i8x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i8x16::<16>(a, a),
             1 => self.slide_i8x16::<15>(a, a),
             2 => self.slide_i8x16::<14>(a, a),
@@ -815,7 +809,6 @@ impl Simd for Avx512 {
             13 => self.slide_i8x16::<3>(a, a),
             14 => self.slide_i8x16::<2>(a, a),
             15 => self.slide_i8x16::<1>(a, a),
-            16 => self.slide_i8x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -825,14 +818,27 @@ impl Simd for Avx512 {
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i8x16(padding);
-        self.slide_i8x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x16::<0>(a, padding),
+            1 => self.slide_i8x16::<1>(a, padding),
+            2 => self.slide_i8x16::<2>(a, padding),
+            3 => self.slide_i8x16::<3>(a, padding),
+            4 => self.slide_i8x16::<4>(a, padding),
+            5 => self.slide_i8x16::<5>(a, padding),
+            6 => self.slide_i8x16::<6>(a, padding),
+            7 => self.slide_i8x16::<7>(a, padding),
+            8 => self.slide_i8x16::<8>(a, padding),
+            9 => self.slide_i8x16::<9>(a, padding),
+            10 => self.slide_i8x16::<10>(a, padding),
+            11 => self.slide_i8x16::<11>(a, padding),
+            12 => self.slide_i8x16::<12>(a, padding),
+            13 => self.slide_i8x16::<13>(a, padding),
+            14 => self.slide_i8x16::<14>(a, padding),
+            15 => self.slide_i8x16::<15>(a, padding),
+            16 => self.slide_i8x16::<16>(a, padding),
+            _ => self.slide_i8x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x16<const OFFSET: usize>(
@@ -840,12 +846,6 @@ impl Simd for Avx512 {
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i8x16(padding);
         match OFFSET {
             0 => self.slide_i8x16::<16>(padding, a),
@@ -865,7 +865,7 @@ impl Simd for Avx512 {
             14 => self.slide_i8x16::<2>(padding, a),
             15 => self.slide_i8x16::<1>(padding, a),
             16 => self.slide_i8x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -1331,23 +1331,29 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u8x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u8x16::<0>(a, a),
+            1 => self.slide_u8x16::<1>(a, a),
+            2 => self.slide_u8x16::<2>(a, a),
+            3 => self.slide_u8x16::<3>(a, a),
+            4 => self.slide_u8x16::<4>(a, a),
+            5 => self.slide_u8x16::<5>(a, a),
+            6 => self.slide_u8x16::<6>(a, a),
+            7 => self.slide_u8x16::<7>(a, a),
+            8 => self.slide_u8x16::<8>(a, a),
+            9 => self.slide_u8x16::<9>(a, a),
+            10 => self.slide_u8x16::<10>(a, a),
+            11 => self.slide_u8x16::<11>(a, a),
+            12 => self.slide_u8x16::<12>(a, a),
+            13 => self.slide_u8x16::<13>(a, a),
+            14 => self.slide_u8x16::<14>(a, a),
+            15 => self.slide_u8x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u8x16::<16>(a, a),
             1 => self.slide_u8x16::<15>(a, a),
             2 => self.slide_u8x16::<14>(a, a),
@@ -1364,7 +1370,6 @@ impl Simd for Avx512 {
             13 => self.slide_u8x16::<3>(a, a),
             14 => self.slide_u8x16::<2>(a, a),
             15 => self.slide_u8x16::<1>(a, a),
-            16 => self.slide_u8x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -1374,14 +1379,27 @@ impl Simd for Avx512 {
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u8x16(padding);
-        self.slide_u8x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x16::<0>(a, padding),
+            1 => self.slide_u8x16::<1>(a, padding),
+            2 => self.slide_u8x16::<2>(a, padding),
+            3 => self.slide_u8x16::<3>(a, padding),
+            4 => self.slide_u8x16::<4>(a, padding),
+            5 => self.slide_u8x16::<5>(a, padding),
+            6 => self.slide_u8x16::<6>(a, padding),
+            7 => self.slide_u8x16::<7>(a, padding),
+            8 => self.slide_u8x16::<8>(a, padding),
+            9 => self.slide_u8x16::<9>(a, padding),
+            10 => self.slide_u8x16::<10>(a, padding),
+            11 => self.slide_u8x16::<11>(a, padding),
+            12 => self.slide_u8x16::<12>(a, padding),
+            13 => self.slide_u8x16::<13>(a, padding),
+            14 => self.slide_u8x16::<14>(a, padding),
+            15 => self.slide_u8x16::<15>(a, padding),
+            16 => self.slide_u8x16::<16>(a, padding),
+            _ => self.slide_u8x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x16<const OFFSET: usize>(
@@ -1389,12 +1407,6 @@ impl Simd for Avx512 {
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u8x16(padding);
         match OFFSET {
             0 => self.slide_u8x16::<16>(padding, a),
@@ -1414,7 +1426,7 @@ impl Simd for Avx512 {
             14 => self.slide_u8x16::<2>(padding, a),
             15 => self.slide_u8x16::<1>(padding, a),
             16 => self.slide_u8x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -2005,23 +2017,21 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_i16x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_i16x8::<0>(a, a),
+            1 => self.slide_i16x8::<1>(a, a),
+            2 => self.slide_i16x8::<2>(a, a),
+            3 => self.slide_i16x8::<3>(a, a),
+            4 => self.slide_i16x8::<4>(a, a),
+            5 => self.slide_i16x8::<5>(a, a),
+            6 => self.slide_i16x8::<6>(a, a),
+            7 => self.slide_i16x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_i16x8::<8>(a, a),
             1 => self.slide_i16x8::<7>(a, a),
             2 => self.slide_i16x8::<6>(a, a),
@@ -2030,7 +2040,6 @@ impl Simd for Avx512 {
             5 => self.slide_i16x8::<3>(a, a),
             6 => self.slide_i16x8::<2>(a, a),
             7 => self.slide_i16x8::<1>(a, a),
-            8 => self.slide_i16x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -2040,14 +2049,19 @@ impl Simd for Avx512 {
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i16x8(padding);
-        self.slide_i16x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x8::<0>(a, padding),
+            1 => self.slide_i16x8::<1>(a, padding),
+            2 => self.slide_i16x8::<2>(a, padding),
+            3 => self.slide_i16x8::<3>(a, padding),
+            4 => self.slide_i16x8::<4>(a, padding),
+            5 => self.slide_i16x8::<5>(a, padding),
+            6 => self.slide_i16x8::<6>(a, padding),
+            7 => self.slide_i16x8::<7>(a, padding),
+            8 => self.slide_i16x8::<8>(a, padding),
+            _ => self.slide_i16x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x8<const OFFSET: usize>(
@@ -2055,12 +2069,6 @@ impl Simd for Avx512 {
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i16x8(padding);
         match OFFSET {
             0 => self.slide_i16x8::<8>(padding, a),
@@ -2072,7 +2080,7 @@ impl Simd for Avx512 {
             6 => self.slide_i16x8::<2>(padding, a),
             7 => self.slide_i16x8::<1>(padding, a),
             8 => self.slide_i16x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -2489,23 +2497,21 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_u16x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_u16x8::<0>(a, a),
+            1 => self.slide_u16x8::<1>(a, a),
+            2 => self.slide_u16x8::<2>(a, a),
+            3 => self.slide_u16x8::<3>(a, a),
+            4 => self.slide_u16x8::<4>(a, a),
+            5 => self.slide_u16x8::<5>(a, a),
+            6 => self.slide_u16x8::<6>(a, a),
+            7 => self.slide_u16x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_u16x8::<8>(a, a),
             1 => self.slide_u16x8::<7>(a, a),
             2 => self.slide_u16x8::<6>(a, a),
@@ -2514,7 +2520,6 @@ impl Simd for Avx512 {
             5 => self.slide_u16x8::<3>(a, a),
             6 => self.slide_u16x8::<2>(a, a),
             7 => self.slide_u16x8::<1>(a, a),
-            8 => self.slide_u16x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -2524,14 +2529,19 @@ impl Simd for Avx512 {
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u16x8(padding);
-        self.slide_u16x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x8::<0>(a, padding),
+            1 => self.slide_u16x8::<1>(a, padding),
+            2 => self.slide_u16x8::<2>(a, padding),
+            3 => self.slide_u16x8::<3>(a, padding),
+            4 => self.slide_u16x8::<4>(a, padding),
+            5 => self.slide_u16x8::<5>(a, padding),
+            6 => self.slide_u16x8::<6>(a, padding),
+            7 => self.slide_u16x8::<7>(a, padding),
+            8 => self.slide_u16x8::<8>(a, padding),
+            _ => self.slide_u16x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x8<const OFFSET: usize>(
@@ -2539,12 +2549,6 @@ impl Simd for Avx512 {
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u16x8(padding);
         match OFFSET {
             0 => self.slide_u16x8::<8>(padding, a),
@@ -2556,7 +2560,7 @@ impl Simd for Avx512 {
             6 => self.slide_u16x8::<2>(padding, a),
             7 => self.slide_u16x8::<1>(padding, a),
             8 => self.slide_u16x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -3098,28 +3102,21 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_i32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_i32x4::<0>(a, a),
+            1 => self.slide_i32x4::<1>(a, a),
+            2 => self.slide_i32x4::<2>(a, a),
+            3 => self.slide_i32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_i32x4::<4>(a, a),
             1 => self.slide_i32x4::<3>(a, a),
             2 => self.slide_i32x4::<2>(a, a),
             3 => self.slide_i32x4::<1>(a, a),
-            4 => self.slide_i32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -3129,14 +3126,15 @@ impl Simd for Avx512 {
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_i32x4(padding);
-        self.slide_i32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x4::<0>(a, padding),
+            1 => self.slide_i32x4::<1>(a, padding),
+            2 => self.slide_i32x4::<2>(a, padding),
+            3 => self.slide_i32x4::<3>(a, padding),
+            4 => self.slide_i32x4::<4>(a, padding),
+            _ => self.slide_i32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x4<const OFFSET: usize>(
@@ -3144,12 +3142,6 @@ impl Simd for Avx512 {
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_i32x4(padding);
         match OFFSET {
             0 => self.slide_i32x4::<4>(padding, a),
@@ -3157,7 +3149,7 @@ impl Simd for Avx512 {
             2 => self.slide_i32x4::<2>(padding, a),
             3 => self.slide_i32x4::<1>(padding, a),
             4 => self.slide_i32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -3574,28 +3566,21 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_u32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_u32x4::<0>(a, a),
+            1 => self.slide_u32x4::<1>(a, a),
+            2 => self.slide_u32x4::<2>(a, a),
+            3 => self.slide_u32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_u32x4::<4>(a, a),
             1 => self.slide_u32x4::<3>(a, a),
             2 => self.slide_u32x4::<2>(a, a),
             3 => self.slide_u32x4::<1>(a, a),
-            4 => self.slide_u32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -3605,14 +3590,15 @@ impl Simd for Avx512 {
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_u32x4(padding);
-        self.slide_u32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x4::<0>(a, padding),
+            1 => self.slide_u32x4::<1>(a, padding),
+            2 => self.slide_u32x4::<2>(a, padding),
+            3 => self.slide_u32x4::<3>(a, padding),
+            4 => self.slide_u32x4::<4>(a, padding),
+            _ => self.slide_u32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x4<const OFFSET: usize>(
@@ -3620,12 +3606,6 @@ impl Simd for Avx512 {
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_u32x4(padding);
         match OFFSET {
             0 => self.slide_u32x4::<4>(padding, a),
@@ -3633,7 +3613,7 @@ impl Simd for Avx512 {
             2 => self.slide_u32x4::<2>(padding, a),
             3 => self.slide_u32x4::<1>(padding, a),
             4 => self.slide_u32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -4166,26 +4146,17 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
-        self.slide_f64x2::<OFFSET>(a, a)
+        match OFFSET % 2 {
+            0 => self.slide_f64x2::<0>(a, a),
+            1 => self.slide_f64x2::<1>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
-        match OFFSET {
+        match OFFSET % 2 {
             0 => self.slide_f64x2::<2>(a, a),
             1 => self.slide_f64x2::<1>(a, a),
-            2 => self.slide_f64x2::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -4195,14 +4166,13 @@ impl Simd for Avx512 {
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
         let padding = self.splat_f64x2(padding);
-        self.slide_f64x2::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x2::<0>(a, padding),
+            1 => self.slide_f64x2::<1>(a, padding),
+            2 => self.slide_f64x2::<2>(a, padding),
+            _ => self.slide_f64x2::<2>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x2<const OFFSET: usize>(
@@ -4210,18 +4180,12 @@ impl Simd for Avx512 {
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
         let padding = self.splat_f64x2(padding);
         match OFFSET {
             0 => self.slide_f64x2::<2>(padding, a),
             1 => self.slide_f64x2::<1>(padding, a),
             2 => self.slide_f64x2::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x2::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -4841,23 +4805,21 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_f32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_f32x8::<0>(a, a),
+            1 => self.slide_f32x8::<1>(a, a),
+            2 => self.slide_f32x8::<2>(a, a),
+            3 => self.slide_f32x8::<3>(a, a),
+            4 => self.slide_f32x8::<4>(a, a),
+            5 => self.slide_f32x8::<5>(a, a),
+            6 => self.slide_f32x8::<6>(a, a),
+            7 => self.slide_f32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_f32x8::<8>(a, a),
             1 => self.slide_f32x8::<7>(a, a),
             2 => self.slide_f32x8::<6>(a, a),
@@ -4866,7 +4828,6 @@ impl Simd for Avx512 {
             5 => self.slide_f32x8::<3>(a, a),
             6 => self.slide_f32x8::<2>(a, a),
             7 => self.slide_f32x8::<1>(a, a),
-            8 => self.slide_f32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -4876,14 +4837,19 @@ impl Simd for Avx512 {
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f32x8(padding);
-        self.slide_f32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x8::<0>(a, padding),
+            1 => self.slide_f32x8::<1>(a, padding),
+            2 => self.slide_f32x8::<2>(a, padding),
+            3 => self.slide_f32x8::<3>(a, padding),
+            4 => self.slide_f32x8::<4>(a, padding),
+            5 => self.slide_f32x8::<5>(a, padding),
+            6 => self.slide_f32x8::<6>(a, padding),
+            7 => self.slide_f32x8::<7>(a, padding),
+            8 => self.slide_f32x8::<8>(a, padding),
+            _ => self.slide_f32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x8<const OFFSET: usize>(
@@ -4891,12 +4857,6 @@ impl Simd for Avx512 {
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f32x8(padding);
         match OFFSET {
             0 => self.slide_f32x8::<8>(padding, a),
@@ -4908,7 +4868,7 @@ impl Simd for Avx512 {
             6 => self.slide_f32x8::<2>(padding, a),
             7 => self.slide_f32x8::<1>(padding, a),
             8 => self.slide_f32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -5548,23 +5508,45 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_i8x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_i8x32::<0>(a, a),
+            1 => self.slide_i8x32::<1>(a, a),
+            2 => self.slide_i8x32::<2>(a, a),
+            3 => self.slide_i8x32::<3>(a, a),
+            4 => self.slide_i8x32::<4>(a, a),
+            5 => self.slide_i8x32::<5>(a, a),
+            6 => self.slide_i8x32::<6>(a, a),
+            7 => self.slide_i8x32::<7>(a, a),
+            8 => self.slide_i8x32::<8>(a, a),
+            9 => self.slide_i8x32::<9>(a, a),
+            10 => self.slide_i8x32::<10>(a, a),
+            11 => self.slide_i8x32::<11>(a, a),
+            12 => self.slide_i8x32::<12>(a, a),
+            13 => self.slide_i8x32::<13>(a, a),
+            14 => self.slide_i8x32::<14>(a, a),
+            15 => self.slide_i8x32::<15>(a, a),
+            16 => self.slide_i8x32::<16>(a, a),
+            17 => self.slide_i8x32::<17>(a, a),
+            18 => self.slide_i8x32::<18>(a, a),
+            19 => self.slide_i8x32::<19>(a, a),
+            20 => self.slide_i8x32::<20>(a, a),
+            21 => self.slide_i8x32::<21>(a, a),
+            22 => self.slide_i8x32::<22>(a, a),
+            23 => self.slide_i8x32::<23>(a, a),
+            24 => self.slide_i8x32::<24>(a, a),
+            25 => self.slide_i8x32::<25>(a, a),
+            26 => self.slide_i8x32::<26>(a, a),
+            27 => self.slide_i8x32::<27>(a, a),
+            28 => self.slide_i8x32::<28>(a, a),
+            29 => self.slide_i8x32::<29>(a, a),
+            30 => self.slide_i8x32::<30>(a, a),
+            31 => self.slide_i8x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_i8x32::<32>(a, a),
             1 => self.slide_i8x32::<31>(a, a),
             2 => self.slide_i8x32::<30>(a, a),
@@ -5597,7 +5579,6 @@ impl Simd for Avx512 {
             29 => self.slide_i8x32::<3>(a, a),
             30 => self.slide_i8x32::<2>(a, a),
             31 => self.slide_i8x32::<1>(a, a),
-            32 => self.slide_i8x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -5607,14 +5588,43 @@ impl Simd for Avx512 {
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i8x32(padding);
-        self.slide_i8x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x32::<0>(a, padding),
+            1 => self.slide_i8x32::<1>(a, padding),
+            2 => self.slide_i8x32::<2>(a, padding),
+            3 => self.slide_i8x32::<3>(a, padding),
+            4 => self.slide_i8x32::<4>(a, padding),
+            5 => self.slide_i8x32::<5>(a, padding),
+            6 => self.slide_i8x32::<6>(a, padding),
+            7 => self.slide_i8x32::<7>(a, padding),
+            8 => self.slide_i8x32::<8>(a, padding),
+            9 => self.slide_i8x32::<9>(a, padding),
+            10 => self.slide_i8x32::<10>(a, padding),
+            11 => self.slide_i8x32::<11>(a, padding),
+            12 => self.slide_i8x32::<12>(a, padding),
+            13 => self.slide_i8x32::<13>(a, padding),
+            14 => self.slide_i8x32::<14>(a, padding),
+            15 => self.slide_i8x32::<15>(a, padding),
+            16 => self.slide_i8x32::<16>(a, padding),
+            17 => self.slide_i8x32::<17>(a, padding),
+            18 => self.slide_i8x32::<18>(a, padding),
+            19 => self.slide_i8x32::<19>(a, padding),
+            20 => self.slide_i8x32::<20>(a, padding),
+            21 => self.slide_i8x32::<21>(a, padding),
+            22 => self.slide_i8x32::<22>(a, padding),
+            23 => self.slide_i8x32::<23>(a, padding),
+            24 => self.slide_i8x32::<24>(a, padding),
+            25 => self.slide_i8x32::<25>(a, padding),
+            26 => self.slide_i8x32::<26>(a, padding),
+            27 => self.slide_i8x32::<27>(a, padding),
+            28 => self.slide_i8x32::<28>(a, padding),
+            29 => self.slide_i8x32::<29>(a, padding),
+            30 => self.slide_i8x32::<30>(a, padding),
+            31 => self.slide_i8x32::<31>(a, padding),
+            32 => self.slide_i8x32::<32>(a, padding),
+            _ => self.slide_i8x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x32<const OFFSET: usize>(
@@ -5622,12 +5632,6 @@ impl Simd for Avx512 {
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i8x32(padding);
         match OFFSET {
             0 => self.slide_i8x32::<32>(padding, a),
@@ -5663,7 +5667,7 @@ impl Simd for Avx512 {
             30 => self.slide_i8x32::<2>(padding, a),
             31 => self.slide_i8x32::<1>(padding, a),
             32 => self.slide_i8x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -6240,23 +6244,45 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_u8x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_u8x32::<0>(a, a),
+            1 => self.slide_u8x32::<1>(a, a),
+            2 => self.slide_u8x32::<2>(a, a),
+            3 => self.slide_u8x32::<3>(a, a),
+            4 => self.slide_u8x32::<4>(a, a),
+            5 => self.slide_u8x32::<5>(a, a),
+            6 => self.slide_u8x32::<6>(a, a),
+            7 => self.slide_u8x32::<7>(a, a),
+            8 => self.slide_u8x32::<8>(a, a),
+            9 => self.slide_u8x32::<9>(a, a),
+            10 => self.slide_u8x32::<10>(a, a),
+            11 => self.slide_u8x32::<11>(a, a),
+            12 => self.slide_u8x32::<12>(a, a),
+            13 => self.slide_u8x32::<13>(a, a),
+            14 => self.slide_u8x32::<14>(a, a),
+            15 => self.slide_u8x32::<15>(a, a),
+            16 => self.slide_u8x32::<16>(a, a),
+            17 => self.slide_u8x32::<17>(a, a),
+            18 => self.slide_u8x32::<18>(a, a),
+            19 => self.slide_u8x32::<19>(a, a),
+            20 => self.slide_u8x32::<20>(a, a),
+            21 => self.slide_u8x32::<21>(a, a),
+            22 => self.slide_u8x32::<22>(a, a),
+            23 => self.slide_u8x32::<23>(a, a),
+            24 => self.slide_u8x32::<24>(a, a),
+            25 => self.slide_u8x32::<25>(a, a),
+            26 => self.slide_u8x32::<26>(a, a),
+            27 => self.slide_u8x32::<27>(a, a),
+            28 => self.slide_u8x32::<28>(a, a),
+            29 => self.slide_u8x32::<29>(a, a),
+            30 => self.slide_u8x32::<30>(a, a),
+            31 => self.slide_u8x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_u8x32::<32>(a, a),
             1 => self.slide_u8x32::<31>(a, a),
             2 => self.slide_u8x32::<30>(a, a),
@@ -6289,7 +6315,6 @@ impl Simd for Avx512 {
             29 => self.slide_u8x32::<3>(a, a),
             30 => self.slide_u8x32::<2>(a, a),
             31 => self.slide_u8x32::<1>(a, a),
-            32 => self.slide_u8x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -6299,14 +6324,43 @@ impl Simd for Avx512 {
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u8x32(padding);
-        self.slide_u8x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x32::<0>(a, padding),
+            1 => self.slide_u8x32::<1>(a, padding),
+            2 => self.slide_u8x32::<2>(a, padding),
+            3 => self.slide_u8x32::<3>(a, padding),
+            4 => self.slide_u8x32::<4>(a, padding),
+            5 => self.slide_u8x32::<5>(a, padding),
+            6 => self.slide_u8x32::<6>(a, padding),
+            7 => self.slide_u8x32::<7>(a, padding),
+            8 => self.slide_u8x32::<8>(a, padding),
+            9 => self.slide_u8x32::<9>(a, padding),
+            10 => self.slide_u8x32::<10>(a, padding),
+            11 => self.slide_u8x32::<11>(a, padding),
+            12 => self.slide_u8x32::<12>(a, padding),
+            13 => self.slide_u8x32::<13>(a, padding),
+            14 => self.slide_u8x32::<14>(a, padding),
+            15 => self.slide_u8x32::<15>(a, padding),
+            16 => self.slide_u8x32::<16>(a, padding),
+            17 => self.slide_u8x32::<17>(a, padding),
+            18 => self.slide_u8x32::<18>(a, padding),
+            19 => self.slide_u8x32::<19>(a, padding),
+            20 => self.slide_u8x32::<20>(a, padding),
+            21 => self.slide_u8x32::<21>(a, padding),
+            22 => self.slide_u8x32::<22>(a, padding),
+            23 => self.slide_u8x32::<23>(a, padding),
+            24 => self.slide_u8x32::<24>(a, padding),
+            25 => self.slide_u8x32::<25>(a, padding),
+            26 => self.slide_u8x32::<26>(a, padding),
+            27 => self.slide_u8x32::<27>(a, padding),
+            28 => self.slide_u8x32::<28>(a, padding),
+            29 => self.slide_u8x32::<29>(a, padding),
+            30 => self.slide_u8x32::<30>(a, padding),
+            31 => self.slide_u8x32::<31>(a, padding),
+            32 => self.slide_u8x32::<32>(a, padding),
+            _ => self.slide_u8x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x32<const OFFSET: usize>(
@@ -6314,12 +6368,6 @@ impl Simd for Avx512 {
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u8x32(padding);
         match OFFSET {
             0 => self.slide_u8x32::<32>(padding, a),
@@ -6355,7 +6403,7 @@ impl Simd for Avx512 {
             30 => self.slide_u8x32::<2>(padding, a),
             31 => self.slide_u8x32::<1>(padding, a),
             32 => self.slide_u8x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7067,23 +7115,29 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i16x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i16x16::<0>(a, a),
+            1 => self.slide_i16x16::<1>(a, a),
+            2 => self.slide_i16x16::<2>(a, a),
+            3 => self.slide_i16x16::<3>(a, a),
+            4 => self.slide_i16x16::<4>(a, a),
+            5 => self.slide_i16x16::<5>(a, a),
+            6 => self.slide_i16x16::<6>(a, a),
+            7 => self.slide_i16x16::<7>(a, a),
+            8 => self.slide_i16x16::<8>(a, a),
+            9 => self.slide_i16x16::<9>(a, a),
+            10 => self.slide_i16x16::<10>(a, a),
+            11 => self.slide_i16x16::<11>(a, a),
+            12 => self.slide_i16x16::<12>(a, a),
+            13 => self.slide_i16x16::<13>(a, a),
+            14 => self.slide_i16x16::<14>(a, a),
+            15 => self.slide_i16x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i16x16::<16>(a, a),
             1 => self.slide_i16x16::<15>(a, a),
             2 => self.slide_i16x16::<14>(a, a),
@@ -7100,7 +7154,6 @@ impl Simd for Avx512 {
             13 => self.slide_i16x16::<3>(a, a),
             14 => self.slide_i16x16::<2>(a, a),
             15 => self.slide_i16x16::<1>(a, a),
-            16 => self.slide_i16x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -7110,14 +7163,27 @@ impl Simd for Avx512 {
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i16x16(padding);
-        self.slide_i16x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x16::<0>(a, padding),
+            1 => self.slide_i16x16::<1>(a, padding),
+            2 => self.slide_i16x16::<2>(a, padding),
+            3 => self.slide_i16x16::<3>(a, padding),
+            4 => self.slide_i16x16::<4>(a, padding),
+            5 => self.slide_i16x16::<5>(a, padding),
+            6 => self.slide_i16x16::<6>(a, padding),
+            7 => self.slide_i16x16::<7>(a, padding),
+            8 => self.slide_i16x16::<8>(a, padding),
+            9 => self.slide_i16x16::<9>(a, padding),
+            10 => self.slide_i16x16::<10>(a, padding),
+            11 => self.slide_i16x16::<11>(a, padding),
+            12 => self.slide_i16x16::<12>(a, padding),
+            13 => self.slide_i16x16::<13>(a, padding),
+            14 => self.slide_i16x16::<14>(a, padding),
+            15 => self.slide_i16x16::<15>(a, padding),
+            16 => self.slide_i16x16::<16>(a, padding),
+            _ => self.slide_i16x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x16<const OFFSET: usize>(
@@ -7125,12 +7191,6 @@ impl Simd for Avx512 {
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i16x16(padding);
         match OFFSET {
             0 => self.slide_i16x16::<16>(padding, a),
@@ -7150,7 +7210,7 @@ impl Simd for Avx512 {
             14 => self.slide_i16x16::<2>(padding, a),
             15 => self.slide_i16x16::<1>(padding, a),
             16 => self.slide_i16x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7662,23 +7722,29 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u16x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u16x16::<0>(a, a),
+            1 => self.slide_u16x16::<1>(a, a),
+            2 => self.slide_u16x16::<2>(a, a),
+            3 => self.slide_u16x16::<3>(a, a),
+            4 => self.slide_u16x16::<4>(a, a),
+            5 => self.slide_u16x16::<5>(a, a),
+            6 => self.slide_u16x16::<6>(a, a),
+            7 => self.slide_u16x16::<7>(a, a),
+            8 => self.slide_u16x16::<8>(a, a),
+            9 => self.slide_u16x16::<9>(a, a),
+            10 => self.slide_u16x16::<10>(a, a),
+            11 => self.slide_u16x16::<11>(a, a),
+            12 => self.slide_u16x16::<12>(a, a),
+            13 => self.slide_u16x16::<13>(a, a),
+            14 => self.slide_u16x16::<14>(a, a),
+            15 => self.slide_u16x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u16x16::<16>(a, a),
             1 => self.slide_u16x16::<15>(a, a),
             2 => self.slide_u16x16::<14>(a, a),
@@ -7695,7 +7761,6 @@ impl Simd for Avx512 {
             13 => self.slide_u16x16::<3>(a, a),
             14 => self.slide_u16x16::<2>(a, a),
             15 => self.slide_u16x16::<1>(a, a),
-            16 => self.slide_u16x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -7705,14 +7770,27 @@ impl Simd for Avx512 {
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u16x16(padding);
-        self.slide_u16x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x16::<0>(a, padding),
+            1 => self.slide_u16x16::<1>(a, padding),
+            2 => self.slide_u16x16::<2>(a, padding),
+            3 => self.slide_u16x16::<3>(a, padding),
+            4 => self.slide_u16x16::<4>(a, padding),
+            5 => self.slide_u16x16::<5>(a, padding),
+            6 => self.slide_u16x16::<6>(a, padding),
+            7 => self.slide_u16x16::<7>(a, padding),
+            8 => self.slide_u16x16::<8>(a, padding),
+            9 => self.slide_u16x16::<9>(a, padding),
+            10 => self.slide_u16x16::<10>(a, padding),
+            11 => self.slide_u16x16::<11>(a, padding),
+            12 => self.slide_u16x16::<12>(a, padding),
+            13 => self.slide_u16x16::<13>(a, padding),
+            14 => self.slide_u16x16::<14>(a, padding),
+            15 => self.slide_u16x16::<15>(a, padding),
+            16 => self.slide_u16x16::<16>(a, padding),
+            _ => self.slide_u16x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x16<const OFFSET: usize>(
@@ -7720,12 +7798,6 @@ impl Simd for Avx512 {
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u16x16(padding);
         match OFFSET {
             0 => self.slide_u16x16::<16>(padding, a),
@@ -7745,7 +7817,7 @@ impl Simd for Avx512 {
             14 => self.slide_u16x16::<2>(padding, a),
             15 => self.slide_u16x16::<1>(padding, a),
             16 => self.slide_u16x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -8406,23 +8478,21 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_i32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_i32x8::<0>(a, a),
+            1 => self.slide_i32x8::<1>(a, a),
+            2 => self.slide_i32x8::<2>(a, a),
+            3 => self.slide_i32x8::<3>(a, a),
+            4 => self.slide_i32x8::<4>(a, a),
+            5 => self.slide_i32x8::<5>(a, a),
+            6 => self.slide_i32x8::<6>(a, a),
+            7 => self.slide_i32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_i32x8::<8>(a, a),
             1 => self.slide_i32x8::<7>(a, a),
             2 => self.slide_i32x8::<6>(a, a),
@@ -8431,7 +8501,6 @@ impl Simd for Avx512 {
             5 => self.slide_i32x8::<3>(a, a),
             6 => self.slide_i32x8::<2>(a, a),
             7 => self.slide_i32x8::<1>(a, a),
-            8 => self.slide_i32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -8441,14 +8510,19 @@ impl Simd for Avx512 {
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i32x8(padding);
-        self.slide_i32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x8::<0>(a, padding),
+            1 => self.slide_i32x8::<1>(a, padding),
+            2 => self.slide_i32x8::<2>(a, padding),
+            3 => self.slide_i32x8::<3>(a, padding),
+            4 => self.slide_i32x8::<4>(a, padding),
+            5 => self.slide_i32x8::<5>(a, padding),
+            6 => self.slide_i32x8::<6>(a, padding),
+            7 => self.slide_i32x8::<7>(a, padding),
+            8 => self.slide_i32x8::<8>(a, padding),
+            _ => self.slide_i32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x8<const OFFSET: usize>(
@@ -8456,12 +8530,6 @@ impl Simd for Avx512 {
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i32x8(padding);
         match OFFSET {
             0 => self.slide_i32x8::<8>(padding, a),
@@ -8473,7 +8541,7 @@ impl Simd for Avx512 {
             6 => self.slide_i32x8::<2>(padding, a),
             7 => self.slide_i32x8::<1>(padding, a),
             8 => self.slide_i32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -8969,23 +9037,21 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_u32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_u32x8::<0>(a, a),
+            1 => self.slide_u32x8::<1>(a, a),
+            2 => self.slide_u32x8::<2>(a, a),
+            3 => self.slide_u32x8::<3>(a, a),
+            4 => self.slide_u32x8::<4>(a, a),
+            5 => self.slide_u32x8::<5>(a, a),
+            6 => self.slide_u32x8::<6>(a, a),
+            7 => self.slide_u32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_u32x8::<8>(a, a),
             1 => self.slide_u32x8::<7>(a, a),
             2 => self.slide_u32x8::<6>(a, a),
@@ -8994,7 +9060,6 @@ impl Simd for Avx512 {
             5 => self.slide_u32x8::<3>(a, a),
             6 => self.slide_u32x8::<2>(a, a),
             7 => self.slide_u32x8::<1>(a, a),
-            8 => self.slide_u32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -9004,14 +9069,19 @@ impl Simd for Avx512 {
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u32x8(padding);
-        self.slide_u32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x8::<0>(a, padding),
+            1 => self.slide_u32x8::<1>(a, padding),
+            2 => self.slide_u32x8::<2>(a, padding),
+            3 => self.slide_u32x8::<3>(a, padding),
+            4 => self.slide_u32x8::<4>(a, padding),
+            5 => self.slide_u32x8::<5>(a, padding),
+            6 => self.slide_u32x8::<6>(a, padding),
+            7 => self.slide_u32x8::<7>(a, padding),
+            8 => self.slide_u32x8::<8>(a, padding),
+            _ => self.slide_u32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x8<const OFFSET: usize>(
@@ -9019,12 +9089,6 @@ impl Simd for Avx512 {
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u32x8(padding);
         match OFFSET {
             0 => self.slide_u32x8::<8>(padding, a),
@@ -9036,7 +9100,7 @@ impl Simd for Avx512 {
             6 => self.slide_u32x8::<2>(padding, a),
             7 => self.slide_u32x8::<1>(padding, a),
             8 => self.slide_u32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -9662,28 +9726,21 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_f64x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_f64x4::<0>(a, a),
+            1 => self.slide_f64x4::<1>(a, a),
+            2 => self.slide_f64x4::<2>(a, a),
+            3 => self.slide_f64x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_f64x4::<4>(a, a),
             1 => self.slide_f64x4::<3>(a, a),
             2 => self.slide_f64x4::<2>(a, a),
             3 => self.slide_f64x4::<1>(a, a),
-            4 => self.slide_f64x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -9693,14 +9750,15 @@ impl Simd for Avx512 {
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f64x4(padding);
-        self.slide_f64x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x4::<0>(a, padding),
+            1 => self.slide_f64x4::<1>(a, padding),
+            2 => self.slide_f64x4::<2>(a, padding),
+            3 => self.slide_f64x4::<3>(a, padding),
+            4 => self.slide_f64x4::<4>(a, padding),
+            _ => self.slide_f64x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x4<const OFFSET: usize>(
@@ -9708,12 +9766,6 @@ impl Simd for Avx512 {
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f64x4(padding);
         match OFFSET {
             0 => self.slide_f64x4::<4>(padding, a),
@@ -9721,7 +9773,7 @@ impl Simd for Avx512 {
             2 => self.slide_f64x4::<2>(padding, a),
             3 => self.slide_f64x4::<1>(padding, a),
             4 => self.slide_f64x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -10407,23 +10459,29 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_f32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_f32x16::<0>(a, a),
+            1 => self.slide_f32x16::<1>(a, a),
+            2 => self.slide_f32x16::<2>(a, a),
+            3 => self.slide_f32x16::<3>(a, a),
+            4 => self.slide_f32x16::<4>(a, a),
+            5 => self.slide_f32x16::<5>(a, a),
+            6 => self.slide_f32x16::<6>(a, a),
+            7 => self.slide_f32x16::<7>(a, a),
+            8 => self.slide_f32x16::<8>(a, a),
+            9 => self.slide_f32x16::<9>(a, a),
+            10 => self.slide_f32x16::<10>(a, a),
+            11 => self.slide_f32x16::<11>(a, a),
+            12 => self.slide_f32x16::<12>(a, a),
+            13 => self.slide_f32x16::<13>(a, a),
+            14 => self.slide_f32x16::<14>(a, a),
+            15 => self.slide_f32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_f32x16::<16>(a, a),
             1 => self.slide_f32x16::<15>(a, a),
             2 => self.slide_f32x16::<14>(a, a),
@@ -10440,7 +10498,6 @@ impl Simd for Avx512 {
             13 => self.slide_f32x16::<3>(a, a),
             14 => self.slide_f32x16::<2>(a, a),
             15 => self.slide_f32x16::<1>(a, a),
-            16 => self.slide_f32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -10450,14 +10507,27 @@ impl Simd for Avx512 {
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_f32x16(padding);
-        self.slide_f32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x16::<0>(a, padding),
+            1 => self.slide_f32x16::<1>(a, padding),
+            2 => self.slide_f32x16::<2>(a, padding),
+            3 => self.slide_f32x16::<3>(a, padding),
+            4 => self.slide_f32x16::<4>(a, padding),
+            5 => self.slide_f32x16::<5>(a, padding),
+            6 => self.slide_f32x16::<6>(a, padding),
+            7 => self.slide_f32x16::<7>(a, padding),
+            8 => self.slide_f32x16::<8>(a, padding),
+            9 => self.slide_f32x16::<9>(a, padding),
+            10 => self.slide_f32x16::<10>(a, padding),
+            11 => self.slide_f32x16::<11>(a, padding),
+            12 => self.slide_f32x16::<12>(a, padding),
+            13 => self.slide_f32x16::<13>(a, padding),
+            14 => self.slide_f32x16::<14>(a, padding),
+            15 => self.slide_f32x16::<15>(a, padding),
+            16 => self.slide_f32x16::<16>(a, padding),
+            _ => self.slide_f32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x16<const OFFSET: usize>(
@@ -10465,12 +10535,6 @@ impl Simd for Avx512 {
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_f32x16(padding);
         match OFFSET {
             0 => self.slide_f32x16::<16>(padding, a),
@@ -10490,7 +10554,7 @@ impl Simd for Avx512 {
             14 => self.slide_f32x16::<2>(padding, a),
             15 => self.slide_f32x16::<1>(padding, a),
             16 => self.slide_f32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -11178,23 +11242,77 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        self.slide_i8x64::<OFFSET>(a, a)
+        match OFFSET % 64 {
+            0 => self.slide_i8x64::<0>(a, a),
+            1 => self.slide_i8x64::<1>(a, a),
+            2 => self.slide_i8x64::<2>(a, a),
+            3 => self.slide_i8x64::<3>(a, a),
+            4 => self.slide_i8x64::<4>(a, a),
+            5 => self.slide_i8x64::<5>(a, a),
+            6 => self.slide_i8x64::<6>(a, a),
+            7 => self.slide_i8x64::<7>(a, a),
+            8 => self.slide_i8x64::<8>(a, a),
+            9 => self.slide_i8x64::<9>(a, a),
+            10 => self.slide_i8x64::<10>(a, a),
+            11 => self.slide_i8x64::<11>(a, a),
+            12 => self.slide_i8x64::<12>(a, a),
+            13 => self.slide_i8x64::<13>(a, a),
+            14 => self.slide_i8x64::<14>(a, a),
+            15 => self.slide_i8x64::<15>(a, a),
+            16 => self.slide_i8x64::<16>(a, a),
+            17 => self.slide_i8x64::<17>(a, a),
+            18 => self.slide_i8x64::<18>(a, a),
+            19 => self.slide_i8x64::<19>(a, a),
+            20 => self.slide_i8x64::<20>(a, a),
+            21 => self.slide_i8x64::<21>(a, a),
+            22 => self.slide_i8x64::<22>(a, a),
+            23 => self.slide_i8x64::<23>(a, a),
+            24 => self.slide_i8x64::<24>(a, a),
+            25 => self.slide_i8x64::<25>(a, a),
+            26 => self.slide_i8x64::<26>(a, a),
+            27 => self.slide_i8x64::<27>(a, a),
+            28 => self.slide_i8x64::<28>(a, a),
+            29 => self.slide_i8x64::<29>(a, a),
+            30 => self.slide_i8x64::<30>(a, a),
+            31 => self.slide_i8x64::<31>(a, a),
+            32 => self.slide_i8x64::<32>(a, a),
+            33 => self.slide_i8x64::<33>(a, a),
+            34 => self.slide_i8x64::<34>(a, a),
+            35 => self.slide_i8x64::<35>(a, a),
+            36 => self.slide_i8x64::<36>(a, a),
+            37 => self.slide_i8x64::<37>(a, a),
+            38 => self.slide_i8x64::<38>(a, a),
+            39 => self.slide_i8x64::<39>(a, a),
+            40 => self.slide_i8x64::<40>(a, a),
+            41 => self.slide_i8x64::<41>(a, a),
+            42 => self.slide_i8x64::<42>(a, a),
+            43 => self.slide_i8x64::<43>(a, a),
+            44 => self.slide_i8x64::<44>(a, a),
+            45 => self.slide_i8x64::<45>(a, a),
+            46 => self.slide_i8x64::<46>(a, a),
+            47 => self.slide_i8x64::<47>(a, a),
+            48 => self.slide_i8x64::<48>(a, a),
+            49 => self.slide_i8x64::<49>(a, a),
+            50 => self.slide_i8x64::<50>(a, a),
+            51 => self.slide_i8x64::<51>(a, a),
+            52 => self.slide_i8x64::<52>(a, a),
+            53 => self.slide_i8x64::<53>(a, a),
+            54 => self.slide_i8x64::<54>(a, a),
+            55 => self.slide_i8x64::<55>(a, a),
+            56 => self.slide_i8x64::<56>(a, a),
+            57 => self.slide_i8x64::<57>(a, a),
+            58 => self.slide_i8x64::<58>(a, a),
+            59 => self.slide_i8x64::<59>(a, a),
+            60 => self.slide_i8x64::<60>(a, a),
+            61 => self.slide_i8x64::<61>(a, a),
+            62 => self.slide_i8x64::<62>(a, a),
+            63 => self.slide_i8x64::<63>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        match OFFSET {
+        match OFFSET % 64 {
             0 => self.slide_i8x64::<64>(a, a),
             1 => self.slide_i8x64::<63>(a, a),
             2 => self.slide_i8x64::<62>(a, a),
@@ -11259,7 +11377,6 @@ impl Simd for Avx512 {
             61 => self.slide_i8x64::<3>(a, a),
             62 => self.slide_i8x64::<2>(a, a),
             63 => self.slide_i8x64::<1>(a, a),
-            64 => self.slide_i8x64::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -11269,14 +11386,75 @@ impl Simd for Avx512 {
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_i8x64(padding);
-        self.slide_i8x64::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x64::<0>(a, padding),
+            1 => self.slide_i8x64::<1>(a, padding),
+            2 => self.slide_i8x64::<2>(a, padding),
+            3 => self.slide_i8x64::<3>(a, padding),
+            4 => self.slide_i8x64::<4>(a, padding),
+            5 => self.slide_i8x64::<5>(a, padding),
+            6 => self.slide_i8x64::<6>(a, padding),
+            7 => self.slide_i8x64::<7>(a, padding),
+            8 => self.slide_i8x64::<8>(a, padding),
+            9 => self.slide_i8x64::<9>(a, padding),
+            10 => self.slide_i8x64::<10>(a, padding),
+            11 => self.slide_i8x64::<11>(a, padding),
+            12 => self.slide_i8x64::<12>(a, padding),
+            13 => self.slide_i8x64::<13>(a, padding),
+            14 => self.slide_i8x64::<14>(a, padding),
+            15 => self.slide_i8x64::<15>(a, padding),
+            16 => self.slide_i8x64::<16>(a, padding),
+            17 => self.slide_i8x64::<17>(a, padding),
+            18 => self.slide_i8x64::<18>(a, padding),
+            19 => self.slide_i8x64::<19>(a, padding),
+            20 => self.slide_i8x64::<20>(a, padding),
+            21 => self.slide_i8x64::<21>(a, padding),
+            22 => self.slide_i8x64::<22>(a, padding),
+            23 => self.slide_i8x64::<23>(a, padding),
+            24 => self.slide_i8x64::<24>(a, padding),
+            25 => self.slide_i8x64::<25>(a, padding),
+            26 => self.slide_i8x64::<26>(a, padding),
+            27 => self.slide_i8x64::<27>(a, padding),
+            28 => self.slide_i8x64::<28>(a, padding),
+            29 => self.slide_i8x64::<29>(a, padding),
+            30 => self.slide_i8x64::<30>(a, padding),
+            31 => self.slide_i8x64::<31>(a, padding),
+            32 => self.slide_i8x64::<32>(a, padding),
+            33 => self.slide_i8x64::<33>(a, padding),
+            34 => self.slide_i8x64::<34>(a, padding),
+            35 => self.slide_i8x64::<35>(a, padding),
+            36 => self.slide_i8x64::<36>(a, padding),
+            37 => self.slide_i8x64::<37>(a, padding),
+            38 => self.slide_i8x64::<38>(a, padding),
+            39 => self.slide_i8x64::<39>(a, padding),
+            40 => self.slide_i8x64::<40>(a, padding),
+            41 => self.slide_i8x64::<41>(a, padding),
+            42 => self.slide_i8x64::<42>(a, padding),
+            43 => self.slide_i8x64::<43>(a, padding),
+            44 => self.slide_i8x64::<44>(a, padding),
+            45 => self.slide_i8x64::<45>(a, padding),
+            46 => self.slide_i8x64::<46>(a, padding),
+            47 => self.slide_i8x64::<47>(a, padding),
+            48 => self.slide_i8x64::<48>(a, padding),
+            49 => self.slide_i8x64::<49>(a, padding),
+            50 => self.slide_i8x64::<50>(a, padding),
+            51 => self.slide_i8x64::<51>(a, padding),
+            52 => self.slide_i8x64::<52>(a, padding),
+            53 => self.slide_i8x64::<53>(a, padding),
+            54 => self.slide_i8x64::<54>(a, padding),
+            55 => self.slide_i8x64::<55>(a, padding),
+            56 => self.slide_i8x64::<56>(a, padding),
+            57 => self.slide_i8x64::<57>(a, padding),
+            58 => self.slide_i8x64::<58>(a, padding),
+            59 => self.slide_i8x64::<59>(a, padding),
+            60 => self.slide_i8x64::<60>(a, padding),
+            61 => self.slide_i8x64::<61>(a, padding),
+            62 => self.slide_i8x64::<62>(a, padding),
+            63 => self.slide_i8x64::<63>(a, padding),
+            64 => self.slide_i8x64::<64>(a, padding),
+            _ => self.slide_i8x64::<64>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x64<const OFFSET: usize>(
@@ -11284,12 +11462,6 @@ impl Simd for Avx512 {
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_i8x64(padding);
         match OFFSET {
             0 => self.slide_i8x64::<64>(padding, a),
@@ -11357,7 +11529,7 @@ impl Simd for Avx512 {
             62 => self.slide_i8x64::<2>(padding, a),
             63 => self.slide_i8x64::<1>(padding, a),
             64 => self.slide_i8x64::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x64::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -11949,23 +12121,77 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        self.slide_u8x64::<OFFSET>(a, a)
+        match OFFSET % 64 {
+            0 => self.slide_u8x64::<0>(a, a),
+            1 => self.slide_u8x64::<1>(a, a),
+            2 => self.slide_u8x64::<2>(a, a),
+            3 => self.slide_u8x64::<3>(a, a),
+            4 => self.slide_u8x64::<4>(a, a),
+            5 => self.slide_u8x64::<5>(a, a),
+            6 => self.slide_u8x64::<6>(a, a),
+            7 => self.slide_u8x64::<7>(a, a),
+            8 => self.slide_u8x64::<8>(a, a),
+            9 => self.slide_u8x64::<9>(a, a),
+            10 => self.slide_u8x64::<10>(a, a),
+            11 => self.slide_u8x64::<11>(a, a),
+            12 => self.slide_u8x64::<12>(a, a),
+            13 => self.slide_u8x64::<13>(a, a),
+            14 => self.slide_u8x64::<14>(a, a),
+            15 => self.slide_u8x64::<15>(a, a),
+            16 => self.slide_u8x64::<16>(a, a),
+            17 => self.slide_u8x64::<17>(a, a),
+            18 => self.slide_u8x64::<18>(a, a),
+            19 => self.slide_u8x64::<19>(a, a),
+            20 => self.slide_u8x64::<20>(a, a),
+            21 => self.slide_u8x64::<21>(a, a),
+            22 => self.slide_u8x64::<22>(a, a),
+            23 => self.slide_u8x64::<23>(a, a),
+            24 => self.slide_u8x64::<24>(a, a),
+            25 => self.slide_u8x64::<25>(a, a),
+            26 => self.slide_u8x64::<26>(a, a),
+            27 => self.slide_u8x64::<27>(a, a),
+            28 => self.slide_u8x64::<28>(a, a),
+            29 => self.slide_u8x64::<29>(a, a),
+            30 => self.slide_u8x64::<30>(a, a),
+            31 => self.slide_u8x64::<31>(a, a),
+            32 => self.slide_u8x64::<32>(a, a),
+            33 => self.slide_u8x64::<33>(a, a),
+            34 => self.slide_u8x64::<34>(a, a),
+            35 => self.slide_u8x64::<35>(a, a),
+            36 => self.slide_u8x64::<36>(a, a),
+            37 => self.slide_u8x64::<37>(a, a),
+            38 => self.slide_u8x64::<38>(a, a),
+            39 => self.slide_u8x64::<39>(a, a),
+            40 => self.slide_u8x64::<40>(a, a),
+            41 => self.slide_u8x64::<41>(a, a),
+            42 => self.slide_u8x64::<42>(a, a),
+            43 => self.slide_u8x64::<43>(a, a),
+            44 => self.slide_u8x64::<44>(a, a),
+            45 => self.slide_u8x64::<45>(a, a),
+            46 => self.slide_u8x64::<46>(a, a),
+            47 => self.slide_u8x64::<47>(a, a),
+            48 => self.slide_u8x64::<48>(a, a),
+            49 => self.slide_u8x64::<49>(a, a),
+            50 => self.slide_u8x64::<50>(a, a),
+            51 => self.slide_u8x64::<51>(a, a),
+            52 => self.slide_u8x64::<52>(a, a),
+            53 => self.slide_u8x64::<53>(a, a),
+            54 => self.slide_u8x64::<54>(a, a),
+            55 => self.slide_u8x64::<55>(a, a),
+            56 => self.slide_u8x64::<56>(a, a),
+            57 => self.slide_u8x64::<57>(a, a),
+            58 => self.slide_u8x64::<58>(a, a),
+            59 => self.slide_u8x64::<59>(a, a),
+            60 => self.slide_u8x64::<60>(a, a),
+            61 => self.slide_u8x64::<61>(a, a),
+            62 => self.slide_u8x64::<62>(a, a),
+            63 => self.slide_u8x64::<63>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        match OFFSET {
+        match OFFSET % 64 {
             0 => self.slide_u8x64::<64>(a, a),
             1 => self.slide_u8x64::<63>(a, a),
             2 => self.slide_u8x64::<62>(a, a),
@@ -12030,7 +12256,6 @@ impl Simd for Avx512 {
             61 => self.slide_u8x64::<3>(a, a),
             62 => self.slide_u8x64::<2>(a, a),
             63 => self.slide_u8x64::<1>(a, a),
-            64 => self.slide_u8x64::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -12040,14 +12265,75 @@ impl Simd for Avx512 {
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_u8x64(padding);
-        self.slide_u8x64::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x64::<0>(a, padding),
+            1 => self.slide_u8x64::<1>(a, padding),
+            2 => self.slide_u8x64::<2>(a, padding),
+            3 => self.slide_u8x64::<3>(a, padding),
+            4 => self.slide_u8x64::<4>(a, padding),
+            5 => self.slide_u8x64::<5>(a, padding),
+            6 => self.slide_u8x64::<6>(a, padding),
+            7 => self.slide_u8x64::<7>(a, padding),
+            8 => self.slide_u8x64::<8>(a, padding),
+            9 => self.slide_u8x64::<9>(a, padding),
+            10 => self.slide_u8x64::<10>(a, padding),
+            11 => self.slide_u8x64::<11>(a, padding),
+            12 => self.slide_u8x64::<12>(a, padding),
+            13 => self.slide_u8x64::<13>(a, padding),
+            14 => self.slide_u8x64::<14>(a, padding),
+            15 => self.slide_u8x64::<15>(a, padding),
+            16 => self.slide_u8x64::<16>(a, padding),
+            17 => self.slide_u8x64::<17>(a, padding),
+            18 => self.slide_u8x64::<18>(a, padding),
+            19 => self.slide_u8x64::<19>(a, padding),
+            20 => self.slide_u8x64::<20>(a, padding),
+            21 => self.slide_u8x64::<21>(a, padding),
+            22 => self.slide_u8x64::<22>(a, padding),
+            23 => self.slide_u8x64::<23>(a, padding),
+            24 => self.slide_u8x64::<24>(a, padding),
+            25 => self.slide_u8x64::<25>(a, padding),
+            26 => self.slide_u8x64::<26>(a, padding),
+            27 => self.slide_u8x64::<27>(a, padding),
+            28 => self.slide_u8x64::<28>(a, padding),
+            29 => self.slide_u8x64::<29>(a, padding),
+            30 => self.slide_u8x64::<30>(a, padding),
+            31 => self.slide_u8x64::<31>(a, padding),
+            32 => self.slide_u8x64::<32>(a, padding),
+            33 => self.slide_u8x64::<33>(a, padding),
+            34 => self.slide_u8x64::<34>(a, padding),
+            35 => self.slide_u8x64::<35>(a, padding),
+            36 => self.slide_u8x64::<36>(a, padding),
+            37 => self.slide_u8x64::<37>(a, padding),
+            38 => self.slide_u8x64::<38>(a, padding),
+            39 => self.slide_u8x64::<39>(a, padding),
+            40 => self.slide_u8x64::<40>(a, padding),
+            41 => self.slide_u8x64::<41>(a, padding),
+            42 => self.slide_u8x64::<42>(a, padding),
+            43 => self.slide_u8x64::<43>(a, padding),
+            44 => self.slide_u8x64::<44>(a, padding),
+            45 => self.slide_u8x64::<45>(a, padding),
+            46 => self.slide_u8x64::<46>(a, padding),
+            47 => self.slide_u8x64::<47>(a, padding),
+            48 => self.slide_u8x64::<48>(a, padding),
+            49 => self.slide_u8x64::<49>(a, padding),
+            50 => self.slide_u8x64::<50>(a, padding),
+            51 => self.slide_u8x64::<51>(a, padding),
+            52 => self.slide_u8x64::<52>(a, padding),
+            53 => self.slide_u8x64::<53>(a, padding),
+            54 => self.slide_u8x64::<54>(a, padding),
+            55 => self.slide_u8x64::<55>(a, padding),
+            56 => self.slide_u8x64::<56>(a, padding),
+            57 => self.slide_u8x64::<57>(a, padding),
+            58 => self.slide_u8x64::<58>(a, padding),
+            59 => self.slide_u8x64::<59>(a, padding),
+            60 => self.slide_u8x64::<60>(a, padding),
+            61 => self.slide_u8x64::<61>(a, padding),
+            62 => self.slide_u8x64::<62>(a, padding),
+            63 => self.slide_u8x64::<63>(a, padding),
+            64 => self.slide_u8x64::<64>(a, padding),
+            _ => self.slide_u8x64::<64>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x64<const OFFSET: usize>(
@@ -12055,12 +12341,6 @@ impl Simd for Avx512 {
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_u8x64(padding);
         match OFFSET {
             0 => self.slide_u8x64::<64>(padding, a),
@@ -12128,7 +12408,7 @@ impl Simd for Avx512 {
             62 => self.slide_u8x64::<2>(padding, a),
             63 => self.slide_u8x64::<1>(padding, a),
             64 => self.slide_u8x64::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x64::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -12869,23 +13149,45 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_i16x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_i16x32::<0>(a, a),
+            1 => self.slide_i16x32::<1>(a, a),
+            2 => self.slide_i16x32::<2>(a, a),
+            3 => self.slide_i16x32::<3>(a, a),
+            4 => self.slide_i16x32::<4>(a, a),
+            5 => self.slide_i16x32::<5>(a, a),
+            6 => self.slide_i16x32::<6>(a, a),
+            7 => self.slide_i16x32::<7>(a, a),
+            8 => self.slide_i16x32::<8>(a, a),
+            9 => self.slide_i16x32::<9>(a, a),
+            10 => self.slide_i16x32::<10>(a, a),
+            11 => self.slide_i16x32::<11>(a, a),
+            12 => self.slide_i16x32::<12>(a, a),
+            13 => self.slide_i16x32::<13>(a, a),
+            14 => self.slide_i16x32::<14>(a, a),
+            15 => self.slide_i16x32::<15>(a, a),
+            16 => self.slide_i16x32::<16>(a, a),
+            17 => self.slide_i16x32::<17>(a, a),
+            18 => self.slide_i16x32::<18>(a, a),
+            19 => self.slide_i16x32::<19>(a, a),
+            20 => self.slide_i16x32::<20>(a, a),
+            21 => self.slide_i16x32::<21>(a, a),
+            22 => self.slide_i16x32::<22>(a, a),
+            23 => self.slide_i16x32::<23>(a, a),
+            24 => self.slide_i16x32::<24>(a, a),
+            25 => self.slide_i16x32::<25>(a, a),
+            26 => self.slide_i16x32::<26>(a, a),
+            27 => self.slide_i16x32::<27>(a, a),
+            28 => self.slide_i16x32::<28>(a, a),
+            29 => self.slide_i16x32::<29>(a, a),
+            30 => self.slide_i16x32::<30>(a, a),
+            31 => self.slide_i16x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_i16x32::<32>(a, a),
             1 => self.slide_i16x32::<31>(a, a),
             2 => self.slide_i16x32::<30>(a, a),
@@ -12918,7 +13220,6 @@ impl Simd for Avx512 {
             29 => self.slide_i16x32::<3>(a, a),
             30 => self.slide_i16x32::<2>(a, a),
             31 => self.slide_i16x32::<1>(a, a),
-            32 => self.slide_i16x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -12928,14 +13229,43 @@ impl Simd for Avx512 {
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i16x32(padding);
-        self.slide_i16x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x32::<0>(a, padding),
+            1 => self.slide_i16x32::<1>(a, padding),
+            2 => self.slide_i16x32::<2>(a, padding),
+            3 => self.slide_i16x32::<3>(a, padding),
+            4 => self.slide_i16x32::<4>(a, padding),
+            5 => self.slide_i16x32::<5>(a, padding),
+            6 => self.slide_i16x32::<6>(a, padding),
+            7 => self.slide_i16x32::<7>(a, padding),
+            8 => self.slide_i16x32::<8>(a, padding),
+            9 => self.slide_i16x32::<9>(a, padding),
+            10 => self.slide_i16x32::<10>(a, padding),
+            11 => self.slide_i16x32::<11>(a, padding),
+            12 => self.slide_i16x32::<12>(a, padding),
+            13 => self.slide_i16x32::<13>(a, padding),
+            14 => self.slide_i16x32::<14>(a, padding),
+            15 => self.slide_i16x32::<15>(a, padding),
+            16 => self.slide_i16x32::<16>(a, padding),
+            17 => self.slide_i16x32::<17>(a, padding),
+            18 => self.slide_i16x32::<18>(a, padding),
+            19 => self.slide_i16x32::<19>(a, padding),
+            20 => self.slide_i16x32::<20>(a, padding),
+            21 => self.slide_i16x32::<21>(a, padding),
+            22 => self.slide_i16x32::<22>(a, padding),
+            23 => self.slide_i16x32::<23>(a, padding),
+            24 => self.slide_i16x32::<24>(a, padding),
+            25 => self.slide_i16x32::<25>(a, padding),
+            26 => self.slide_i16x32::<26>(a, padding),
+            27 => self.slide_i16x32::<27>(a, padding),
+            28 => self.slide_i16x32::<28>(a, padding),
+            29 => self.slide_i16x32::<29>(a, padding),
+            30 => self.slide_i16x32::<30>(a, padding),
+            31 => self.slide_i16x32::<31>(a, padding),
+            32 => self.slide_i16x32::<32>(a, padding),
+            _ => self.slide_i16x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x32<const OFFSET: usize>(
@@ -12943,12 +13273,6 @@ impl Simd for Avx512 {
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i16x32(padding);
         match OFFSET {
             0 => self.slide_i16x32::<32>(padding, a),
@@ -12984,7 +13308,7 @@ impl Simd for Avx512 {
             30 => self.slide_i16x32::<2>(padding, a),
             31 => self.slide_i16x32::<1>(padding, a),
             32 => self.slide_i16x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -13506,23 +13830,45 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_u16x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_u16x32::<0>(a, a),
+            1 => self.slide_u16x32::<1>(a, a),
+            2 => self.slide_u16x32::<2>(a, a),
+            3 => self.slide_u16x32::<3>(a, a),
+            4 => self.slide_u16x32::<4>(a, a),
+            5 => self.slide_u16x32::<5>(a, a),
+            6 => self.slide_u16x32::<6>(a, a),
+            7 => self.slide_u16x32::<7>(a, a),
+            8 => self.slide_u16x32::<8>(a, a),
+            9 => self.slide_u16x32::<9>(a, a),
+            10 => self.slide_u16x32::<10>(a, a),
+            11 => self.slide_u16x32::<11>(a, a),
+            12 => self.slide_u16x32::<12>(a, a),
+            13 => self.slide_u16x32::<13>(a, a),
+            14 => self.slide_u16x32::<14>(a, a),
+            15 => self.slide_u16x32::<15>(a, a),
+            16 => self.slide_u16x32::<16>(a, a),
+            17 => self.slide_u16x32::<17>(a, a),
+            18 => self.slide_u16x32::<18>(a, a),
+            19 => self.slide_u16x32::<19>(a, a),
+            20 => self.slide_u16x32::<20>(a, a),
+            21 => self.slide_u16x32::<21>(a, a),
+            22 => self.slide_u16x32::<22>(a, a),
+            23 => self.slide_u16x32::<23>(a, a),
+            24 => self.slide_u16x32::<24>(a, a),
+            25 => self.slide_u16x32::<25>(a, a),
+            26 => self.slide_u16x32::<26>(a, a),
+            27 => self.slide_u16x32::<27>(a, a),
+            28 => self.slide_u16x32::<28>(a, a),
+            29 => self.slide_u16x32::<29>(a, a),
+            30 => self.slide_u16x32::<30>(a, a),
+            31 => self.slide_u16x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_u16x32::<32>(a, a),
             1 => self.slide_u16x32::<31>(a, a),
             2 => self.slide_u16x32::<30>(a, a),
@@ -13555,7 +13901,6 @@ impl Simd for Avx512 {
             29 => self.slide_u16x32::<3>(a, a),
             30 => self.slide_u16x32::<2>(a, a),
             31 => self.slide_u16x32::<1>(a, a),
-            32 => self.slide_u16x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -13565,14 +13910,43 @@ impl Simd for Avx512 {
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u16x32(padding);
-        self.slide_u16x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x32::<0>(a, padding),
+            1 => self.slide_u16x32::<1>(a, padding),
+            2 => self.slide_u16x32::<2>(a, padding),
+            3 => self.slide_u16x32::<3>(a, padding),
+            4 => self.slide_u16x32::<4>(a, padding),
+            5 => self.slide_u16x32::<5>(a, padding),
+            6 => self.slide_u16x32::<6>(a, padding),
+            7 => self.slide_u16x32::<7>(a, padding),
+            8 => self.slide_u16x32::<8>(a, padding),
+            9 => self.slide_u16x32::<9>(a, padding),
+            10 => self.slide_u16x32::<10>(a, padding),
+            11 => self.slide_u16x32::<11>(a, padding),
+            12 => self.slide_u16x32::<12>(a, padding),
+            13 => self.slide_u16x32::<13>(a, padding),
+            14 => self.slide_u16x32::<14>(a, padding),
+            15 => self.slide_u16x32::<15>(a, padding),
+            16 => self.slide_u16x32::<16>(a, padding),
+            17 => self.slide_u16x32::<17>(a, padding),
+            18 => self.slide_u16x32::<18>(a, padding),
+            19 => self.slide_u16x32::<19>(a, padding),
+            20 => self.slide_u16x32::<20>(a, padding),
+            21 => self.slide_u16x32::<21>(a, padding),
+            22 => self.slide_u16x32::<22>(a, padding),
+            23 => self.slide_u16x32::<23>(a, padding),
+            24 => self.slide_u16x32::<24>(a, padding),
+            25 => self.slide_u16x32::<25>(a, padding),
+            26 => self.slide_u16x32::<26>(a, padding),
+            27 => self.slide_u16x32::<27>(a, padding),
+            28 => self.slide_u16x32::<28>(a, padding),
+            29 => self.slide_u16x32::<29>(a, padding),
+            30 => self.slide_u16x32::<30>(a, padding),
+            31 => self.slide_u16x32::<31>(a, padding),
+            32 => self.slide_u16x32::<32>(a, padding),
+            _ => self.slide_u16x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x32<const OFFSET: usize>(
@@ -13580,12 +13954,6 @@ impl Simd for Avx512 {
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u16x32(padding);
         match OFFSET {
             0 => self.slide_u16x32::<32>(padding, a),
@@ -13621,7 +13989,7 @@ impl Simd for Avx512 {
             30 => self.slide_u16x32::<2>(padding, a),
             31 => self.slide_u16x32::<1>(padding, a),
             32 => self.slide_u16x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -14320,23 +14688,29 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i32x16::<0>(a, a),
+            1 => self.slide_i32x16::<1>(a, a),
+            2 => self.slide_i32x16::<2>(a, a),
+            3 => self.slide_i32x16::<3>(a, a),
+            4 => self.slide_i32x16::<4>(a, a),
+            5 => self.slide_i32x16::<5>(a, a),
+            6 => self.slide_i32x16::<6>(a, a),
+            7 => self.slide_i32x16::<7>(a, a),
+            8 => self.slide_i32x16::<8>(a, a),
+            9 => self.slide_i32x16::<9>(a, a),
+            10 => self.slide_i32x16::<10>(a, a),
+            11 => self.slide_i32x16::<11>(a, a),
+            12 => self.slide_i32x16::<12>(a, a),
+            13 => self.slide_i32x16::<13>(a, a),
+            14 => self.slide_i32x16::<14>(a, a),
+            15 => self.slide_i32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i32x16::<16>(a, a),
             1 => self.slide_i32x16::<15>(a, a),
             2 => self.slide_i32x16::<14>(a, a),
@@ -14353,7 +14727,6 @@ impl Simd for Avx512 {
             13 => self.slide_i32x16::<3>(a, a),
             14 => self.slide_i32x16::<2>(a, a),
             15 => self.slide_i32x16::<1>(a, a),
-            16 => self.slide_i32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -14363,14 +14736,27 @@ impl Simd for Avx512 {
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i32x16(padding);
-        self.slide_i32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x16::<0>(a, padding),
+            1 => self.slide_i32x16::<1>(a, padding),
+            2 => self.slide_i32x16::<2>(a, padding),
+            3 => self.slide_i32x16::<3>(a, padding),
+            4 => self.slide_i32x16::<4>(a, padding),
+            5 => self.slide_i32x16::<5>(a, padding),
+            6 => self.slide_i32x16::<6>(a, padding),
+            7 => self.slide_i32x16::<7>(a, padding),
+            8 => self.slide_i32x16::<8>(a, padding),
+            9 => self.slide_i32x16::<9>(a, padding),
+            10 => self.slide_i32x16::<10>(a, padding),
+            11 => self.slide_i32x16::<11>(a, padding),
+            12 => self.slide_i32x16::<12>(a, padding),
+            13 => self.slide_i32x16::<13>(a, padding),
+            14 => self.slide_i32x16::<14>(a, padding),
+            15 => self.slide_i32x16::<15>(a, padding),
+            16 => self.slide_i32x16::<16>(a, padding),
+            _ => self.slide_i32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x16<const OFFSET: usize>(
@@ -14378,12 +14764,6 @@ impl Simd for Avx512 {
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i32x16(padding);
         match OFFSET {
             0 => self.slide_i32x16::<16>(padding, a),
@@ -14403,7 +14783,7 @@ impl Simd for Avx512 {
             14 => self.slide_i32x16::<2>(padding, a),
             15 => self.slide_i32x16::<1>(padding, a),
             16 => self.slide_i32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -14917,23 +15297,29 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u32x16::<0>(a, a),
+            1 => self.slide_u32x16::<1>(a, a),
+            2 => self.slide_u32x16::<2>(a, a),
+            3 => self.slide_u32x16::<3>(a, a),
+            4 => self.slide_u32x16::<4>(a, a),
+            5 => self.slide_u32x16::<5>(a, a),
+            6 => self.slide_u32x16::<6>(a, a),
+            7 => self.slide_u32x16::<7>(a, a),
+            8 => self.slide_u32x16::<8>(a, a),
+            9 => self.slide_u32x16::<9>(a, a),
+            10 => self.slide_u32x16::<10>(a, a),
+            11 => self.slide_u32x16::<11>(a, a),
+            12 => self.slide_u32x16::<12>(a, a),
+            13 => self.slide_u32x16::<13>(a, a),
+            14 => self.slide_u32x16::<14>(a, a),
+            15 => self.slide_u32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u32x16::<16>(a, a),
             1 => self.slide_u32x16::<15>(a, a),
             2 => self.slide_u32x16::<14>(a, a),
@@ -14950,7 +15336,6 @@ impl Simd for Avx512 {
             13 => self.slide_u32x16::<3>(a, a),
             14 => self.slide_u32x16::<2>(a, a),
             15 => self.slide_u32x16::<1>(a, a),
-            16 => self.slide_u32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -14960,14 +15345,27 @@ impl Simd for Avx512 {
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u32x16(padding);
-        self.slide_u32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x16::<0>(a, padding),
+            1 => self.slide_u32x16::<1>(a, padding),
+            2 => self.slide_u32x16::<2>(a, padding),
+            3 => self.slide_u32x16::<3>(a, padding),
+            4 => self.slide_u32x16::<4>(a, padding),
+            5 => self.slide_u32x16::<5>(a, padding),
+            6 => self.slide_u32x16::<6>(a, padding),
+            7 => self.slide_u32x16::<7>(a, padding),
+            8 => self.slide_u32x16::<8>(a, padding),
+            9 => self.slide_u32x16::<9>(a, padding),
+            10 => self.slide_u32x16::<10>(a, padding),
+            11 => self.slide_u32x16::<11>(a, padding),
+            12 => self.slide_u32x16::<12>(a, padding),
+            13 => self.slide_u32x16::<13>(a, padding),
+            14 => self.slide_u32x16::<14>(a, padding),
+            15 => self.slide_u32x16::<15>(a, padding),
+            16 => self.slide_u32x16::<16>(a, padding),
+            _ => self.slide_u32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x16<const OFFSET: usize>(
@@ -14975,12 +15373,6 @@ impl Simd for Avx512 {
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u32x16(padding);
         match OFFSET {
             0 => self.slide_u32x16::<16>(padding, a),
@@ -15000,7 +15392,7 @@ impl Simd for Avx512 {
             14 => self.slide_u32x16::<2>(padding, a),
             15 => self.slide_u32x16::<1>(padding, a),
             16 => self.slide_u32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -15665,23 +16057,21 @@ impl Simd for Avx512 {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_f64x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_f64x8::<0>(a, a),
+            1 => self.slide_f64x8::<1>(a, a),
+            2 => self.slide_f64x8::<2>(a, a),
+            3 => self.slide_f64x8::<3>(a, a),
+            4 => self.slide_f64x8::<4>(a, a),
+            5 => self.slide_f64x8::<5>(a, a),
+            6 => self.slide_f64x8::<6>(a, a),
+            7 => self.slide_f64x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_f64x8::<8>(a, a),
             1 => self.slide_f64x8::<7>(a, a),
             2 => self.slide_f64x8::<6>(a, a),
@@ -15690,7 +16080,6 @@ impl Simd for Avx512 {
             5 => self.slide_f64x8::<3>(a, a),
             6 => self.slide_f64x8::<2>(a, a),
             7 => self.slide_f64x8::<1>(a, a),
-            8 => self.slide_f64x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -15700,14 +16089,19 @@ impl Simd for Avx512 {
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f64x8(padding);
-        self.slide_f64x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x8::<0>(a, padding),
+            1 => self.slide_f64x8::<1>(a, padding),
+            2 => self.slide_f64x8::<2>(a, padding),
+            3 => self.slide_f64x8::<3>(a, padding),
+            4 => self.slide_f64x8::<4>(a, padding),
+            5 => self.slide_f64x8::<5>(a, padding),
+            6 => self.slide_f64x8::<6>(a, padding),
+            7 => self.slide_f64x8::<7>(a, padding),
+            8 => self.slide_f64x8::<8>(a, padding),
+            _ => self.slide_f64x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x8<const OFFSET: usize>(
@@ -15715,12 +16109,6 @@ impl Simd for Avx512 {
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f64x8(padding);
         match OFFSET {
             0 => self.slide_f64x8::<8>(padding, a),
@@ -15732,7 +16120,7 @@ impl Simd for Avx512 {
             6 => self.slide_f64x8::<2>(padding, a),
             7 => self.slide_f64x8::<1>(padding, a),
             8 => self.slide_f64x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x8::<0>(padding, a),
         }
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -183,6 +183,70 @@ impl Simd for Avx512 {
         self.slide_f32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_f32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_f32x4::<4>(a, a),
+            1 => self.slide_f32x4::<3>(a, a),
+            2 => self.slide_f32x4::<2>(a, a),
+            3 => self.slide_f32x4::<1>(a, a),
+            4 => self.slide_f32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f32x4(padding);
+        self.slide_f32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f32x4(padding);
+        match OFFSET {
+            0 => self.slide_f32x4::<4>(padding, a),
+            1 => self.slide_f32x4::<3>(padding, a),
+            2 => self.slide_f32x4::<2>(padding, a),
+            3 => self.slide_f32x4::<1>(padding, a),
+            4 => self.slide_f32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -717,6 +781,94 @@ impl Simd for Avx512 {
         self.slide_i8x16::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i8x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i8x16::<16>(a, a),
+            1 => self.slide_i8x16::<15>(a, a),
+            2 => self.slide_i8x16::<14>(a, a),
+            3 => self.slide_i8x16::<13>(a, a),
+            4 => self.slide_i8x16::<12>(a, a),
+            5 => self.slide_i8x16::<11>(a, a),
+            6 => self.slide_i8x16::<10>(a, a),
+            7 => self.slide_i8x16::<9>(a, a),
+            8 => self.slide_i8x16::<8>(a, a),
+            9 => self.slide_i8x16::<7>(a, a),
+            10 => self.slide_i8x16::<6>(a, a),
+            11 => self.slide_i8x16::<5>(a, a),
+            12 => self.slide_i8x16::<4>(a, a),
+            13 => self.slide_i8x16::<3>(a, a),
+            14 => self.slide_i8x16::<2>(a, a),
+            15 => self.slide_i8x16::<1>(a, a),
+            16 => self.slide_i8x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i8x16(padding);
+        self.slide_i8x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i8x16(padding);
+        match OFFSET {
+            0 => self.slide_i8x16::<16>(padding, a),
+            1 => self.slide_i8x16::<15>(padding, a),
+            2 => self.slide_i8x16::<14>(padding, a),
+            3 => self.slide_i8x16::<13>(padding, a),
+            4 => self.slide_i8x16::<12>(padding, a),
+            5 => self.slide_i8x16::<11>(padding, a),
+            6 => self.slide_i8x16::<10>(padding, a),
+            7 => self.slide_i8x16::<9>(padding, a),
+            8 => self.slide_i8x16::<8>(padding, a),
+            9 => self.slide_i8x16::<7>(padding, a),
+            10 => self.slide_i8x16::<6>(padding, a),
+            11 => self.slide_i8x16::<5>(padding, a),
+            12 => self.slide_i8x16::<4>(padding, a),
+            13 => self.slide_i8x16::<3>(padding, a),
+            14 => self.slide_i8x16::<2>(padding, a),
+            15 => self.slide_i8x16::<1>(padding, a),
+            16 => self.slide_i8x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1176,6 +1328,94 @@ impl Simd for Avx512 {
         b: u8x16<Self>,
     ) -> u8x16<Self> {
         self.slide_u8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u8x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u8x16::<16>(a, a),
+            1 => self.slide_u8x16::<15>(a, a),
+            2 => self.slide_u8x16::<14>(a, a),
+            3 => self.slide_u8x16::<13>(a, a),
+            4 => self.slide_u8x16::<12>(a, a),
+            5 => self.slide_u8x16::<11>(a, a),
+            6 => self.slide_u8x16::<10>(a, a),
+            7 => self.slide_u8x16::<9>(a, a),
+            8 => self.slide_u8x16::<8>(a, a),
+            9 => self.slide_u8x16::<7>(a, a),
+            10 => self.slide_u8x16::<6>(a, a),
+            11 => self.slide_u8x16::<5>(a, a),
+            12 => self.slide_u8x16::<4>(a, a),
+            13 => self.slide_u8x16::<3>(a, a),
+            14 => self.slide_u8x16::<2>(a, a),
+            15 => self.slide_u8x16::<1>(a, a),
+            16 => self.slide_u8x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u8x16(padding);
+        self.slide_u8x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u8x16(padding);
+        match OFFSET {
+            0 => self.slide_u8x16::<16>(padding, a),
+            1 => self.slide_u8x16::<15>(padding, a),
+            2 => self.slide_u8x16::<14>(padding, a),
+            3 => self.slide_u8x16::<13>(padding, a),
+            4 => self.slide_u8x16::<12>(padding, a),
+            5 => self.slide_u8x16::<11>(padding, a),
+            6 => self.slide_u8x16::<10>(padding, a),
+            7 => self.slide_u8x16::<9>(padding, a),
+            8 => self.slide_u8x16::<8>(padding, a),
+            9 => self.slide_u8x16::<7>(padding, a),
+            10 => self.slide_u8x16::<6>(padding, a),
+            11 => self.slide_u8x16::<5>(padding, a),
+            12 => self.slide_u8x16::<4>(padding, a),
+            13 => self.slide_u8x16::<3>(padding, a),
+            14 => self.slide_u8x16::<2>(padding, a),
+            15 => self.slide_u8x16::<1>(padding, a),
+            16 => self.slide_u8x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
@@ -1764,6 +2004,78 @@ impl Simd for Avx512 {
         self.slide_i16x8::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_i16x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_i16x8::<8>(a, a),
+            1 => self.slide_i16x8::<7>(a, a),
+            2 => self.slide_i16x8::<6>(a, a),
+            3 => self.slide_i16x8::<5>(a, a),
+            4 => self.slide_i16x8::<4>(a, a),
+            5 => self.slide_i16x8::<3>(a, a),
+            6 => self.slide_i16x8::<2>(a, a),
+            7 => self.slide_i16x8::<1>(a, a),
+            8 => self.slide_i16x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i16x8(padding);
+        self.slide_i16x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i16x8(padding);
+        match OFFSET {
+            0 => self.slide_i16x8::<8>(padding, a),
+            1 => self.slide_i16x8::<7>(padding, a),
+            2 => self.slide_i16x8::<6>(padding, a),
+            3 => self.slide_i16x8::<5>(padding, a),
+            4 => self.slide_i16x8::<4>(padding, a),
+            5 => self.slide_i16x8::<3>(padding, a),
+            6 => self.slide_i16x8::<2>(padding, a),
+            7 => self.slide_i16x8::<1>(padding, a),
+            8 => self.slide_i16x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2174,6 +2486,78 @@ impl Simd for Avx512 {
         b: u16x8<Self>,
     ) -> u16x8<Self> {
         self.slide_u16x8::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_u16x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_u16x8::<8>(a, a),
+            1 => self.slide_u16x8::<7>(a, a),
+            2 => self.slide_u16x8::<6>(a, a),
+            3 => self.slide_u16x8::<5>(a, a),
+            4 => self.slide_u16x8::<4>(a, a),
+            5 => self.slide_u16x8::<3>(a, a),
+            6 => self.slide_u16x8::<2>(a, a),
+            7 => self.slide_u16x8::<1>(a, a),
+            8 => self.slide_u16x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u16x8(padding);
+        self.slide_u16x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u16x8(padding);
+        match OFFSET {
+            0 => self.slide_u16x8::<8>(padding, a),
+            1 => self.slide_u16x8::<7>(padding, a),
+            2 => self.slide_u16x8::<6>(padding, a),
+            3 => self.slide_u16x8::<5>(padding, a),
+            4 => self.slide_u16x8::<4>(padding, a),
+            5 => self.slide_u16x8::<3>(padding, a),
+            6 => self.slide_u16x8::<2>(padding, a),
+            7 => self.slide_u16x8::<1>(padding, a),
+            8 => self.slide_u16x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
@@ -2713,6 +3097,70 @@ impl Simd for Avx512 {
         self.slide_i32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_i32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_i32x4::<4>(a, a),
+            1 => self.slide_i32x4::<3>(a, a),
+            2 => self.slide_i32x4::<2>(a, a),
+            3 => self.slide_i32x4::<1>(a, a),
+            4 => self.slide_i32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_i32x4(padding);
+        self.slide_i32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_i32x4(padding);
+        match OFFSET {
+            0 => self.slide_i32x4::<4>(padding, a),
+            1 => self.slide_i32x4::<3>(padding, a),
+            2 => self.slide_i32x4::<2>(padding, a),
+            3 => self.slide_i32x4::<1>(padding, a),
+            4 => self.slide_i32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3123,6 +3571,70 @@ impl Simd for Avx512 {
         b: u32x4<Self>,
     ) -> u32x4<Self> {
         self.slide_u32x4::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_u32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_u32x4::<4>(a, a),
+            1 => self.slide_u32x4::<3>(a, a),
+            2 => self.slide_u32x4::<2>(a, a),
+            3 => self.slide_u32x4::<1>(a, a),
+            4 => self.slide_u32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_u32x4(padding);
+        self.slide_u32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_u32x4(padding);
+        match OFFSET {
+            0 => self.slide_u32x4::<4>(padding, a),
+            1 => self.slide_u32x4::<3>(padding, a),
+            2 => self.slide_u32x4::<2>(padding, a),
+            3 => self.slide_u32x4::<1>(padding, a),
+            4 => self.slide_u32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
@@ -3651,6 +4163,66 @@ impl Simd for Avx512 {
         b: f64x2<Self>,
     ) -> f64x2<Self> {
         self.slide_f64x2::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        self.slide_f64x2::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        match OFFSET {
+            0 => self.slide_f64x2::<2>(a, a),
+            1 => self.slide_f64x2::<1>(a, a),
+            2 => self.slide_f64x2::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        let padding = self.splat_f64x2(padding);
+        self.slide_f64x2::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        let padding = self.splat_f64x2(padding);
+        match OFFSET {
+            0 => self.slide_f64x2::<2>(padding, a),
+            1 => self.slide_f64x2::<1>(padding, a),
+            2 => self.slide_f64x2::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
@@ -4266,6 +4838,78 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_f32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_f32x8::<8>(a, a),
+            1 => self.slide_f32x8::<7>(a, a),
+            2 => self.slide_f32x8::<6>(a, a),
+            3 => self.slide_f32x8::<5>(a, a),
+            4 => self.slide_f32x8::<4>(a, a),
+            5 => self.slide_f32x8::<3>(a, a),
+            6 => self.slide_f32x8::<2>(a, a),
+            7 => self.slide_f32x8::<1>(a, a),
+            8 => self.slide_f32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f32x8(padding);
+        self.slide_f32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f32x8(padding);
+        match OFFSET {
+            0 => self.slide_f32x8::<8>(padding, a),
+            1 => self.slide_f32x8::<7>(padding, a),
+            2 => self.slide_f32x8::<6>(padding, a),
+            3 => self.slide_f32x8::<5>(padding, a),
+            4 => self.slide_f32x8::<4>(padding, a),
+            5 => self.slide_f32x8::<3>(padding, a),
+            6 => self.slide_f32x8::<2>(padding, a),
+            7 => self.slide_f32x8::<1>(padding, a),
+            8 => self.slide_f32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
@@ -4903,6 +5547,126 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_i8x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_i8x32::<32>(a, a),
+            1 => self.slide_i8x32::<31>(a, a),
+            2 => self.slide_i8x32::<30>(a, a),
+            3 => self.slide_i8x32::<29>(a, a),
+            4 => self.slide_i8x32::<28>(a, a),
+            5 => self.slide_i8x32::<27>(a, a),
+            6 => self.slide_i8x32::<26>(a, a),
+            7 => self.slide_i8x32::<25>(a, a),
+            8 => self.slide_i8x32::<24>(a, a),
+            9 => self.slide_i8x32::<23>(a, a),
+            10 => self.slide_i8x32::<22>(a, a),
+            11 => self.slide_i8x32::<21>(a, a),
+            12 => self.slide_i8x32::<20>(a, a),
+            13 => self.slide_i8x32::<19>(a, a),
+            14 => self.slide_i8x32::<18>(a, a),
+            15 => self.slide_i8x32::<17>(a, a),
+            16 => self.slide_i8x32::<16>(a, a),
+            17 => self.slide_i8x32::<15>(a, a),
+            18 => self.slide_i8x32::<14>(a, a),
+            19 => self.slide_i8x32::<13>(a, a),
+            20 => self.slide_i8x32::<12>(a, a),
+            21 => self.slide_i8x32::<11>(a, a),
+            22 => self.slide_i8x32::<10>(a, a),
+            23 => self.slide_i8x32::<9>(a, a),
+            24 => self.slide_i8x32::<8>(a, a),
+            25 => self.slide_i8x32::<7>(a, a),
+            26 => self.slide_i8x32::<6>(a, a),
+            27 => self.slide_i8x32::<5>(a, a),
+            28 => self.slide_i8x32::<4>(a, a),
+            29 => self.slide_i8x32::<3>(a, a),
+            30 => self.slide_i8x32::<2>(a, a),
+            31 => self.slide_i8x32::<1>(a, a),
+            32 => self.slide_i8x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i8x32(padding);
+        self.slide_i8x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i8x32(padding);
+        match OFFSET {
+            0 => self.slide_i8x32::<32>(padding, a),
+            1 => self.slide_i8x32::<31>(padding, a),
+            2 => self.slide_i8x32::<30>(padding, a),
+            3 => self.slide_i8x32::<29>(padding, a),
+            4 => self.slide_i8x32::<28>(padding, a),
+            5 => self.slide_i8x32::<27>(padding, a),
+            6 => self.slide_i8x32::<26>(padding, a),
+            7 => self.slide_i8x32::<25>(padding, a),
+            8 => self.slide_i8x32::<24>(padding, a),
+            9 => self.slide_i8x32::<23>(padding, a),
+            10 => self.slide_i8x32::<22>(padding, a),
+            11 => self.slide_i8x32::<21>(padding, a),
+            12 => self.slide_i8x32::<20>(padding, a),
+            13 => self.slide_i8x32::<19>(padding, a),
+            14 => self.slide_i8x32::<18>(padding, a),
+            15 => self.slide_i8x32::<17>(padding, a),
+            16 => self.slide_i8x32::<16>(padding, a),
+            17 => self.slide_i8x32::<15>(padding, a),
+            18 => self.slide_i8x32::<14>(padding, a),
+            19 => self.slide_i8x32::<13>(padding, a),
+            20 => self.slide_i8x32::<12>(padding, a),
+            21 => self.slide_i8x32::<11>(padding, a),
+            22 => self.slide_i8x32::<10>(padding, a),
+            23 => self.slide_i8x32::<9>(padding, a),
+            24 => self.slide_i8x32::<8>(padding, a),
+            25 => self.slide_i8x32::<7>(padding, a),
+            26 => self.slide_i8x32::<6>(padding, a),
+            27 => self.slide_i8x32::<5>(padding, a),
+            28 => self.slide_i8x32::<4>(padding, a),
+            29 => self.slide_i8x32::<3>(padding, a),
+            30 => self.slide_i8x32::<2>(padding, a),
+            31 => self.slide_i8x32::<1>(padding, a),
+            32 => self.slide_i8x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5473,6 +6237,126 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_u8x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_u8x32::<32>(a, a),
+            1 => self.slide_u8x32::<31>(a, a),
+            2 => self.slide_u8x32::<30>(a, a),
+            3 => self.slide_u8x32::<29>(a, a),
+            4 => self.slide_u8x32::<28>(a, a),
+            5 => self.slide_u8x32::<27>(a, a),
+            6 => self.slide_u8x32::<26>(a, a),
+            7 => self.slide_u8x32::<25>(a, a),
+            8 => self.slide_u8x32::<24>(a, a),
+            9 => self.slide_u8x32::<23>(a, a),
+            10 => self.slide_u8x32::<22>(a, a),
+            11 => self.slide_u8x32::<21>(a, a),
+            12 => self.slide_u8x32::<20>(a, a),
+            13 => self.slide_u8x32::<19>(a, a),
+            14 => self.slide_u8x32::<18>(a, a),
+            15 => self.slide_u8x32::<17>(a, a),
+            16 => self.slide_u8x32::<16>(a, a),
+            17 => self.slide_u8x32::<15>(a, a),
+            18 => self.slide_u8x32::<14>(a, a),
+            19 => self.slide_u8x32::<13>(a, a),
+            20 => self.slide_u8x32::<12>(a, a),
+            21 => self.slide_u8x32::<11>(a, a),
+            22 => self.slide_u8x32::<10>(a, a),
+            23 => self.slide_u8x32::<9>(a, a),
+            24 => self.slide_u8x32::<8>(a, a),
+            25 => self.slide_u8x32::<7>(a, a),
+            26 => self.slide_u8x32::<6>(a, a),
+            27 => self.slide_u8x32::<5>(a, a),
+            28 => self.slide_u8x32::<4>(a, a),
+            29 => self.slide_u8x32::<3>(a, a),
+            30 => self.slide_u8x32::<2>(a, a),
+            31 => self.slide_u8x32::<1>(a, a),
+            32 => self.slide_u8x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u8x32(padding);
+        self.slide_u8x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u8x32(padding);
+        match OFFSET {
+            0 => self.slide_u8x32::<32>(padding, a),
+            1 => self.slide_u8x32::<31>(padding, a),
+            2 => self.slide_u8x32::<30>(padding, a),
+            3 => self.slide_u8x32::<29>(padding, a),
+            4 => self.slide_u8x32::<28>(padding, a),
+            5 => self.slide_u8x32::<27>(padding, a),
+            6 => self.slide_u8x32::<26>(padding, a),
+            7 => self.slide_u8x32::<25>(padding, a),
+            8 => self.slide_u8x32::<24>(padding, a),
+            9 => self.slide_u8x32::<23>(padding, a),
+            10 => self.slide_u8x32::<22>(padding, a),
+            11 => self.slide_u8x32::<21>(padding, a),
+            12 => self.slide_u8x32::<20>(padding, a),
+            13 => self.slide_u8x32::<19>(padding, a),
+            14 => self.slide_u8x32::<18>(padding, a),
+            15 => self.slide_u8x32::<17>(padding, a),
+            16 => self.slide_u8x32::<16>(padding, a),
+            17 => self.slide_u8x32::<15>(padding, a),
+            18 => self.slide_u8x32::<14>(padding, a),
+            19 => self.slide_u8x32::<13>(padding, a),
+            20 => self.slide_u8x32::<12>(padding, a),
+            21 => self.slide_u8x32::<11>(padding, a),
+            22 => self.slide_u8x32::<10>(padding, a),
+            23 => self.slide_u8x32::<9>(padding, a),
+            24 => self.slide_u8x32::<8>(padding, a),
+            25 => self.slide_u8x32::<7>(padding, a),
+            26 => self.slide_u8x32::<6>(padding, a),
+            27 => self.slide_u8x32::<5>(padding, a),
+            28 => self.slide_u8x32::<4>(padding, a),
+            29 => self.slide_u8x32::<3>(padding, a),
+            30 => self.slide_u8x32::<2>(padding, a),
+            31 => self.slide_u8x32::<1>(padding, a),
+            32 => self.slide_u8x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self> {
@@ -6182,6 +7066,94 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i16x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i16x16::<16>(a, a),
+            1 => self.slide_i16x16::<15>(a, a),
+            2 => self.slide_i16x16::<14>(a, a),
+            3 => self.slide_i16x16::<13>(a, a),
+            4 => self.slide_i16x16::<12>(a, a),
+            5 => self.slide_i16x16::<11>(a, a),
+            6 => self.slide_i16x16::<10>(a, a),
+            7 => self.slide_i16x16::<9>(a, a),
+            8 => self.slide_i16x16::<8>(a, a),
+            9 => self.slide_i16x16::<7>(a, a),
+            10 => self.slide_i16x16::<6>(a, a),
+            11 => self.slide_i16x16::<5>(a, a),
+            12 => self.slide_i16x16::<4>(a, a),
+            13 => self.slide_i16x16::<3>(a, a),
+            14 => self.slide_i16x16::<2>(a, a),
+            15 => self.slide_i16x16::<1>(a, a),
+            16 => self.slide_i16x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i16x16(padding);
+        self.slide_i16x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i16x16(padding);
+        match OFFSET {
+            0 => self.slide_i16x16::<16>(padding, a),
+            1 => self.slide_i16x16::<15>(padding, a),
+            2 => self.slide_i16x16::<14>(padding, a),
+            3 => self.slide_i16x16::<13>(padding, a),
+            4 => self.slide_i16x16::<12>(padding, a),
+            5 => self.slide_i16x16::<11>(padding, a),
+            6 => self.slide_i16x16::<10>(padding, a),
+            7 => self.slide_i16x16::<9>(padding, a),
+            8 => self.slide_i16x16::<8>(padding, a),
+            9 => self.slide_i16x16::<7>(padding, a),
+            10 => self.slide_i16x16::<6>(padding, a),
+            11 => self.slide_i16x16::<5>(padding, a),
+            12 => self.slide_i16x16::<4>(padding, a),
+            13 => self.slide_i16x16::<3>(padding, a),
+            14 => self.slide_i16x16::<2>(padding, a),
+            15 => self.slide_i16x16::<1>(padding, a),
+            16 => self.slide_i16x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x16(
         self,
         a: i16x16<Self>,
@@ -6687,6 +7659,94 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u16x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u16x16::<16>(a, a),
+            1 => self.slide_u16x16::<15>(a, a),
+            2 => self.slide_u16x16::<14>(a, a),
+            3 => self.slide_u16x16::<13>(a, a),
+            4 => self.slide_u16x16::<12>(a, a),
+            5 => self.slide_u16x16::<11>(a, a),
+            6 => self.slide_u16x16::<10>(a, a),
+            7 => self.slide_u16x16::<9>(a, a),
+            8 => self.slide_u16x16::<8>(a, a),
+            9 => self.slide_u16x16::<7>(a, a),
+            10 => self.slide_u16x16::<6>(a, a),
+            11 => self.slide_u16x16::<5>(a, a),
+            12 => self.slide_u16x16::<4>(a, a),
+            13 => self.slide_u16x16::<3>(a, a),
+            14 => self.slide_u16x16::<2>(a, a),
+            15 => self.slide_u16x16::<1>(a, a),
+            16 => self.slide_u16x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u16x16(padding);
+        self.slide_u16x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u16x16(padding);
+        match OFFSET {
+            0 => self.slide_u16x16::<16>(padding, a),
+            1 => self.slide_u16x16::<15>(padding, a),
+            2 => self.slide_u16x16::<14>(padding, a),
+            3 => self.slide_u16x16::<13>(padding, a),
+            4 => self.slide_u16x16::<12>(padding, a),
+            5 => self.slide_u16x16::<11>(padding, a),
+            6 => self.slide_u16x16::<10>(padding, a),
+            7 => self.slide_u16x16::<9>(padding, a),
+            8 => self.slide_u16x16::<8>(padding, a),
+            9 => self.slide_u16x16::<7>(padding, a),
+            10 => self.slide_u16x16::<6>(padding, a),
+            11 => self.slide_u16x16::<5>(padding, a),
+            12 => self.slide_u16x16::<4>(padding, a),
+            13 => self.slide_u16x16::<3>(padding, a),
+            14 => self.slide_u16x16::<2>(padding, a),
+            15 => self.slide_u16x16::<1>(padding, a),
+            16 => self.slide_u16x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x16(
@@ -7345,6 +8405,78 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_i32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_i32x8::<8>(a, a),
+            1 => self.slide_i32x8::<7>(a, a),
+            2 => self.slide_i32x8::<6>(a, a),
+            3 => self.slide_i32x8::<5>(a, a),
+            4 => self.slide_i32x8::<4>(a, a),
+            5 => self.slide_i32x8::<3>(a, a),
+            6 => self.slide_i32x8::<2>(a, a),
+            7 => self.slide_i32x8::<1>(a, a),
+            8 => self.slide_i32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i32x8(padding);
+        self.slide_i32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i32x8(padding);
+        match OFFSET {
+            0 => self.slide_i32x8::<8>(padding, a),
+            1 => self.slide_i32x8::<7>(padding, a),
+            2 => self.slide_i32x8::<6>(padding, a),
+            3 => self.slide_i32x8::<5>(padding, a),
+            4 => self.slide_i32x8::<4>(padding, a),
+            5 => self.slide_i32x8::<3>(padding, a),
+            6 => self.slide_i32x8::<2>(padding, a),
+            7 => self.slide_i32x8::<1>(padding, a),
+            8 => self.slide_i32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7834,6 +8966,78 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_u32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_u32x8::<8>(a, a),
+            1 => self.slide_u32x8::<7>(a, a),
+            2 => self.slide_u32x8::<6>(a, a),
+            3 => self.slide_u32x8::<5>(a, a),
+            4 => self.slide_u32x8::<4>(a, a),
+            5 => self.slide_u32x8::<3>(a, a),
+            6 => self.slide_u32x8::<2>(a, a),
+            7 => self.slide_u32x8::<1>(a, a),
+            8 => self.slide_u32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u32x8(padding);
+        self.slide_u32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u32x8(padding);
+        match OFFSET {
+            0 => self.slide_u32x8::<8>(padding, a),
+            1 => self.slide_u32x8::<7>(padding, a),
+            2 => self.slide_u32x8::<6>(padding, a),
+            3 => self.slide_u32x8::<5>(padding, a),
+            4 => self.slide_u32x8::<4>(padding, a),
+            5 => self.slide_u32x8::<3>(padding, a),
+            6 => self.slide_u32x8::<2>(padding, a),
+            7 => self.slide_u32x8::<1>(padding, a),
+            8 => self.slide_u32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
@@ -8455,6 +9659,70 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_f64x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_f64x4::<4>(a, a),
+            1 => self.slide_f64x4::<3>(a, a),
+            2 => self.slide_f64x4::<2>(a, a),
+            3 => self.slide_f64x4::<1>(a, a),
+            4 => self.slide_f64x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f64x4(padding);
+        self.slide_f64x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f64x4(padding);
+        match OFFSET {
+            0 => self.slide_f64x4::<4>(padding, a),
+            1 => self.slide_f64x4::<3>(padding, a),
+            2 => self.slide_f64x4::<2>(padding, a),
+            3 => self.slide_f64x4::<1>(padding, a),
+            4 => self.slide_f64x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
@@ -9136,6 +10404,94 @@ impl Simd for Avx512 {
             val: crate::support::Aligned512(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_f32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_f32x16::<16>(a, a),
+            1 => self.slide_f32x16::<15>(a, a),
+            2 => self.slide_f32x16::<14>(a, a),
+            3 => self.slide_f32x16::<13>(a, a),
+            4 => self.slide_f32x16::<12>(a, a),
+            5 => self.slide_f32x16::<11>(a, a),
+            6 => self.slide_f32x16::<10>(a, a),
+            7 => self.slide_f32x16::<9>(a, a),
+            8 => self.slide_f32x16::<8>(a, a),
+            9 => self.slide_f32x16::<7>(a, a),
+            10 => self.slide_f32x16::<6>(a, a),
+            11 => self.slide_f32x16::<5>(a, a),
+            12 => self.slide_f32x16::<4>(a, a),
+            13 => self.slide_f32x16::<3>(a, a),
+            14 => self.slide_f32x16::<2>(a, a),
+            15 => self.slide_f32x16::<1>(a, a),
+            16 => self.slide_f32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_f32x16(padding);
+        self.slide_f32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_f32x16(padding);
+        match OFFSET {
+            0 => self.slide_f32x16::<16>(padding, a),
+            1 => self.slide_f32x16::<15>(padding, a),
+            2 => self.slide_f32x16::<14>(padding, a),
+            3 => self.slide_f32x16::<13>(padding, a),
+            4 => self.slide_f32x16::<12>(padding, a),
+            5 => self.slide_f32x16::<11>(padding, a),
+            6 => self.slide_f32x16::<10>(padding, a),
+            7 => self.slide_f32x16::<9>(padding, a),
+            8 => self.slide_f32x16::<8>(padding, a),
+            9 => self.slide_f32x16::<7>(padding, a),
+            10 => self.slide_f32x16::<6>(padding, a),
+            11 => self.slide_f32x16::<5>(padding, a),
+            12 => self.slide_f32x16::<4>(padding, a),
+            13 => self.slide_f32x16::<3>(padding, a),
+            14 => self.slide_f32x16::<2>(padding, a),
+            15 => self.slide_f32x16::<1>(padding, a),
+            16 => self.slide_f32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x16(
@@ -9821,6 +11177,190 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        self.slide_i8x64::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        match OFFSET {
+            0 => self.slide_i8x64::<64>(a, a),
+            1 => self.slide_i8x64::<63>(a, a),
+            2 => self.slide_i8x64::<62>(a, a),
+            3 => self.slide_i8x64::<61>(a, a),
+            4 => self.slide_i8x64::<60>(a, a),
+            5 => self.slide_i8x64::<59>(a, a),
+            6 => self.slide_i8x64::<58>(a, a),
+            7 => self.slide_i8x64::<57>(a, a),
+            8 => self.slide_i8x64::<56>(a, a),
+            9 => self.slide_i8x64::<55>(a, a),
+            10 => self.slide_i8x64::<54>(a, a),
+            11 => self.slide_i8x64::<53>(a, a),
+            12 => self.slide_i8x64::<52>(a, a),
+            13 => self.slide_i8x64::<51>(a, a),
+            14 => self.slide_i8x64::<50>(a, a),
+            15 => self.slide_i8x64::<49>(a, a),
+            16 => self.slide_i8x64::<48>(a, a),
+            17 => self.slide_i8x64::<47>(a, a),
+            18 => self.slide_i8x64::<46>(a, a),
+            19 => self.slide_i8x64::<45>(a, a),
+            20 => self.slide_i8x64::<44>(a, a),
+            21 => self.slide_i8x64::<43>(a, a),
+            22 => self.slide_i8x64::<42>(a, a),
+            23 => self.slide_i8x64::<41>(a, a),
+            24 => self.slide_i8x64::<40>(a, a),
+            25 => self.slide_i8x64::<39>(a, a),
+            26 => self.slide_i8x64::<38>(a, a),
+            27 => self.slide_i8x64::<37>(a, a),
+            28 => self.slide_i8x64::<36>(a, a),
+            29 => self.slide_i8x64::<35>(a, a),
+            30 => self.slide_i8x64::<34>(a, a),
+            31 => self.slide_i8x64::<33>(a, a),
+            32 => self.slide_i8x64::<32>(a, a),
+            33 => self.slide_i8x64::<31>(a, a),
+            34 => self.slide_i8x64::<30>(a, a),
+            35 => self.slide_i8x64::<29>(a, a),
+            36 => self.slide_i8x64::<28>(a, a),
+            37 => self.slide_i8x64::<27>(a, a),
+            38 => self.slide_i8x64::<26>(a, a),
+            39 => self.slide_i8x64::<25>(a, a),
+            40 => self.slide_i8x64::<24>(a, a),
+            41 => self.slide_i8x64::<23>(a, a),
+            42 => self.slide_i8x64::<22>(a, a),
+            43 => self.slide_i8x64::<21>(a, a),
+            44 => self.slide_i8x64::<20>(a, a),
+            45 => self.slide_i8x64::<19>(a, a),
+            46 => self.slide_i8x64::<18>(a, a),
+            47 => self.slide_i8x64::<17>(a, a),
+            48 => self.slide_i8x64::<16>(a, a),
+            49 => self.slide_i8x64::<15>(a, a),
+            50 => self.slide_i8x64::<14>(a, a),
+            51 => self.slide_i8x64::<13>(a, a),
+            52 => self.slide_i8x64::<12>(a, a),
+            53 => self.slide_i8x64::<11>(a, a),
+            54 => self.slide_i8x64::<10>(a, a),
+            55 => self.slide_i8x64::<9>(a, a),
+            56 => self.slide_i8x64::<8>(a, a),
+            57 => self.slide_i8x64::<7>(a, a),
+            58 => self.slide_i8x64::<6>(a, a),
+            59 => self.slide_i8x64::<5>(a, a),
+            60 => self.slide_i8x64::<4>(a, a),
+            61 => self.slide_i8x64::<3>(a, a),
+            62 => self.slide_i8x64::<2>(a, a),
+            63 => self.slide_i8x64::<1>(a, a),
+            64 => self.slide_i8x64::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_i8x64(padding);
+        self.slide_i8x64::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_i8x64(padding);
+        match OFFSET {
+            0 => self.slide_i8x64::<64>(padding, a),
+            1 => self.slide_i8x64::<63>(padding, a),
+            2 => self.slide_i8x64::<62>(padding, a),
+            3 => self.slide_i8x64::<61>(padding, a),
+            4 => self.slide_i8x64::<60>(padding, a),
+            5 => self.slide_i8x64::<59>(padding, a),
+            6 => self.slide_i8x64::<58>(padding, a),
+            7 => self.slide_i8x64::<57>(padding, a),
+            8 => self.slide_i8x64::<56>(padding, a),
+            9 => self.slide_i8x64::<55>(padding, a),
+            10 => self.slide_i8x64::<54>(padding, a),
+            11 => self.slide_i8x64::<53>(padding, a),
+            12 => self.slide_i8x64::<52>(padding, a),
+            13 => self.slide_i8x64::<51>(padding, a),
+            14 => self.slide_i8x64::<50>(padding, a),
+            15 => self.slide_i8x64::<49>(padding, a),
+            16 => self.slide_i8x64::<48>(padding, a),
+            17 => self.slide_i8x64::<47>(padding, a),
+            18 => self.slide_i8x64::<46>(padding, a),
+            19 => self.slide_i8x64::<45>(padding, a),
+            20 => self.slide_i8x64::<44>(padding, a),
+            21 => self.slide_i8x64::<43>(padding, a),
+            22 => self.slide_i8x64::<42>(padding, a),
+            23 => self.slide_i8x64::<41>(padding, a),
+            24 => self.slide_i8x64::<40>(padding, a),
+            25 => self.slide_i8x64::<39>(padding, a),
+            26 => self.slide_i8x64::<38>(padding, a),
+            27 => self.slide_i8x64::<37>(padding, a),
+            28 => self.slide_i8x64::<36>(padding, a),
+            29 => self.slide_i8x64::<35>(padding, a),
+            30 => self.slide_i8x64::<34>(padding, a),
+            31 => self.slide_i8x64::<33>(padding, a),
+            32 => self.slide_i8x64::<32>(padding, a),
+            33 => self.slide_i8x64::<31>(padding, a),
+            34 => self.slide_i8x64::<30>(padding, a),
+            35 => self.slide_i8x64::<29>(padding, a),
+            36 => self.slide_i8x64::<28>(padding, a),
+            37 => self.slide_i8x64::<27>(padding, a),
+            38 => self.slide_i8x64::<26>(padding, a),
+            39 => self.slide_i8x64::<25>(padding, a),
+            40 => self.slide_i8x64::<24>(padding, a),
+            41 => self.slide_i8x64::<23>(padding, a),
+            42 => self.slide_i8x64::<22>(padding, a),
+            43 => self.slide_i8x64::<21>(padding, a),
+            44 => self.slide_i8x64::<20>(padding, a),
+            45 => self.slide_i8x64::<19>(padding, a),
+            46 => self.slide_i8x64::<18>(padding, a),
+            47 => self.slide_i8x64::<17>(padding, a),
+            48 => self.slide_i8x64::<16>(padding, a),
+            49 => self.slide_i8x64::<15>(padding, a),
+            50 => self.slide_i8x64::<14>(padding, a),
+            51 => self.slide_i8x64::<13>(padding, a),
+            52 => self.slide_i8x64::<12>(padding, a),
+            53 => self.slide_i8x64::<11>(padding, a),
+            54 => self.slide_i8x64::<10>(padding, a),
+            55 => self.slide_i8x64::<9>(padding, a),
+            56 => self.slide_i8x64::<8>(padding, a),
+            57 => self.slide_i8x64::<7>(padding, a),
+            58 => self.slide_i8x64::<6>(padding, a),
+            59 => self.slide_i8x64::<5>(padding, a),
+            60 => self.slide_i8x64::<4>(padding, a),
+            61 => self.slide_i8x64::<3>(padding, a),
+            62 => self.slide_i8x64::<2>(padding, a),
+            63 => self.slide_i8x64::<1>(padding, a),
+            64 => self.slide_i8x64::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -10406,6 +11946,190 @@ impl Simd for Avx512 {
             val: crate::support::Aligned512(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        self.slide_u8x64::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        match OFFSET {
+            0 => self.slide_u8x64::<64>(a, a),
+            1 => self.slide_u8x64::<63>(a, a),
+            2 => self.slide_u8x64::<62>(a, a),
+            3 => self.slide_u8x64::<61>(a, a),
+            4 => self.slide_u8x64::<60>(a, a),
+            5 => self.slide_u8x64::<59>(a, a),
+            6 => self.slide_u8x64::<58>(a, a),
+            7 => self.slide_u8x64::<57>(a, a),
+            8 => self.slide_u8x64::<56>(a, a),
+            9 => self.slide_u8x64::<55>(a, a),
+            10 => self.slide_u8x64::<54>(a, a),
+            11 => self.slide_u8x64::<53>(a, a),
+            12 => self.slide_u8x64::<52>(a, a),
+            13 => self.slide_u8x64::<51>(a, a),
+            14 => self.slide_u8x64::<50>(a, a),
+            15 => self.slide_u8x64::<49>(a, a),
+            16 => self.slide_u8x64::<48>(a, a),
+            17 => self.slide_u8x64::<47>(a, a),
+            18 => self.slide_u8x64::<46>(a, a),
+            19 => self.slide_u8x64::<45>(a, a),
+            20 => self.slide_u8x64::<44>(a, a),
+            21 => self.slide_u8x64::<43>(a, a),
+            22 => self.slide_u8x64::<42>(a, a),
+            23 => self.slide_u8x64::<41>(a, a),
+            24 => self.slide_u8x64::<40>(a, a),
+            25 => self.slide_u8x64::<39>(a, a),
+            26 => self.slide_u8x64::<38>(a, a),
+            27 => self.slide_u8x64::<37>(a, a),
+            28 => self.slide_u8x64::<36>(a, a),
+            29 => self.slide_u8x64::<35>(a, a),
+            30 => self.slide_u8x64::<34>(a, a),
+            31 => self.slide_u8x64::<33>(a, a),
+            32 => self.slide_u8x64::<32>(a, a),
+            33 => self.slide_u8x64::<31>(a, a),
+            34 => self.slide_u8x64::<30>(a, a),
+            35 => self.slide_u8x64::<29>(a, a),
+            36 => self.slide_u8x64::<28>(a, a),
+            37 => self.slide_u8x64::<27>(a, a),
+            38 => self.slide_u8x64::<26>(a, a),
+            39 => self.slide_u8x64::<25>(a, a),
+            40 => self.slide_u8x64::<24>(a, a),
+            41 => self.slide_u8x64::<23>(a, a),
+            42 => self.slide_u8x64::<22>(a, a),
+            43 => self.slide_u8x64::<21>(a, a),
+            44 => self.slide_u8x64::<20>(a, a),
+            45 => self.slide_u8x64::<19>(a, a),
+            46 => self.slide_u8x64::<18>(a, a),
+            47 => self.slide_u8x64::<17>(a, a),
+            48 => self.slide_u8x64::<16>(a, a),
+            49 => self.slide_u8x64::<15>(a, a),
+            50 => self.slide_u8x64::<14>(a, a),
+            51 => self.slide_u8x64::<13>(a, a),
+            52 => self.slide_u8x64::<12>(a, a),
+            53 => self.slide_u8x64::<11>(a, a),
+            54 => self.slide_u8x64::<10>(a, a),
+            55 => self.slide_u8x64::<9>(a, a),
+            56 => self.slide_u8x64::<8>(a, a),
+            57 => self.slide_u8x64::<7>(a, a),
+            58 => self.slide_u8x64::<6>(a, a),
+            59 => self.slide_u8x64::<5>(a, a),
+            60 => self.slide_u8x64::<4>(a, a),
+            61 => self.slide_u8x64::<3>(a, a),
+            62 => self.slide_u8x64::<2>(a, a),
+            63 => self.slide_u8x64::<1>(a, a),
+            64 => self.slide_u8x64::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_u8x64(padding);
+        self.slide_u8x64::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_u8x64(padding);
+        match OFFSET {
+            0 => self.slide_u8x64::<64>(padding, a),
+            1 => self.slide_u8x64::<63>(padding, a),
+            2 => self.slide_u8x64::<62>(padding, a),
+            3 => self.slide_u8x64::<61>(padding, a),
+            4 => self.slide_u8x64::<60>(padding, a),
+            5 => self.slide_u8x64::<59>(padding, a),
+            6 => self.slide_u8x64::<58>(padding, a),
+            7 => self.slide_u8x64::<57>(padding, a),
+            8 => self.slide_u8x64::<56>(padding, a),
+            9 => self.slide_u8x64::<55>(padding, a),
+            10 => self.slide_u8x64::<54>(padding, a),
+            11 => self.slide_u8x64::<53>(padding, a),
+            12 => self.slide_u8x64::<52>(padding, a),
+            13 => self.slide_u8x64::<51>(padding, a),
+            14 => self.slide_u8x64::<50>(padding, a),
+            15 => self.slide_u8x64::<49>(padding, a),
+            16 => self.slide_u8x64::<48>(padding, a),
+            17 => self.slide_u8x64::<47>(padding, a),
+            18 => self.slide_u8x64::<46>(padding, a),
+            19 => self.slide_u8x64::<45>(padding, a),
+            20 => self.slide_u8x64::<44>(padding, a),
+            21 => self.slide_u8x64::<43>(padding, a),
+            22 => self.slide_u8x64::<42>(padding, a),
+            23 => self.slide_u8x64::<41>(padding, a),
+            24 => self.slide_u8x64::<40>(padding, a),
+            25 => self.slide_u8x64::<39>(padding, a),
+            26 => self.slide_u8x64::<38>(padding, a),
+            27 => self.slide_u8x64::<37>(padding, a),
+            28 => self.slide_u8x64::<36>(padding, a),
+            29 => self.slide_u8x64::<35>(padding, a),
+            30 => self.slide_u8x64::<34>(padding, a),
+            31 => self.slide_u8x64::<33>(padding, a),
+            32 => self.slide_u8x64::<32>(padding, a),
+            33 => self.slide_u8x64::<31>(padding, a),
+            34 => self.slide_u8x64::<30>(padding, a),
+            35 => self.slide_u8x64::<29>(padding, a),
+            36 => self.slide_u8x64::<28>(padding, a),
+            37 => self.slide_u8x64::<27>(padding, a),
+            38 => self.slide_u8x64::<26>(padding, a),
+            39 => self.slide_u8x64::<25>(padding, a),
+            40 => self.slide_u8x64::<24>(padding, a),
+            41 => self.slide_u8x64::<23>(padding, a),
+            42 => self.slide_u8x64::<22>(padding, a),
+            43 => self.slide_u8x64::<21>(padding, a),
+            44 => self.slide_u8x64::<20>(padding, a),
+            45 => self.slide_u8x64::<19>(padding, a),
+            46 => self.slide_u8x64::<18>(padding, a),
+            47 => self.slide_u8x64::<17>(padding, a),
+            48 => self.slide_u8x64::<16>(padding, a),
+            49 => self.slide_u8x64::<15>(padding, a),
+            50 => self.slide_u8x64::<14>(padding, a),
+            51 => self.slide_u8x64::<13>(padding, a),
+            52 => self.slide_u8x64::<12>(padding, a),
+            53 => self.slide_u8x64::<11>(padding, a),
+            54 => self.slide_u8x64::<10>(padding, a),
+            55 => self.slide_u8x64::<9>(padding, a),
+            56 => self.slide_u8x64::<8>(padding, a),
+            57 => self.slide_u8x64::<7>(padding, a),
+            58 => self.slide_u8x64::<6>(padding, a),
+            59 => self.slide_u8x64::<5>(padding, a),
+            60 => self.slide_u8x64::<4>(padding, a),
+            61 => self.slide_u8x64::<3>(padding, a),
+            62 => self.slide_u8x64::<2>(padding, a),
+            63 => self.slide_u8x64::<1>(padding, a),
+            64 => self.slide_u8x64::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self> {
@@ -11144,6 +12868,126 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_i16x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_i16x32::<32>(a, a),
+            1 => self.slide_i16x32::<31>(a, a),
+            2 => self.slide_i16x32::<30>(a, a),
+            3 => self.slide_i16x32::<29>(a, a),
+            4 => self.slide_i16x32::<28>(a, a),
+            5 => self.slide_i16x32::<27>(a, a),
+            6 => self.slide_i16x32::<26>(a, a),
+            7 => self.slide_i16x32::<25>(a, a),
+            8 => self.slide_i16x32::<24>(a, a),
+            9 => self.slide_i16x32::<23>(a, a),
+            10 => self.slide_i16x32::<22>(a, a),
+            11 => self.slide_i16x32::<21>(a, a),
+            12 => self.slide_i16x32::<20>(a, a),
+            13 => self.slide_i16x32::<19>(a, a),
+            14 => self.slide_i16x32::<18>(a, a),
+            15 => self.slide_i16x32::<17>(a, a),
+            16 => self.slide_i16x32::<16>(a, a),
+            17 => self.slide_i16x32::<15>(a, a),
+            18 => self.slide_i16x32::<14>(a, a),
+            19 => self.slide_i16x32::<13>(a, a),
+            20 => self.slide_i16x32::<12>(a, a),
+            21 => self.slide_i16x32::<11>(a, a),
+            22 => self.slide_i16x32::<10>(a, a),
+            23 => self.slide_i16x32::<9>(a, a),
+            24 => self.slide_i16x32::<8>(a, a),
+            25 => self.slide_i16x32::<7>(a, a),
+            26 => self.slide_i16x32::<6>(a, a),
+            27 => self.slide_i16x32::<5>(a, a),
+            28 => self.slide_i16x32::<4>(a, a),
+            29 => self.slide_i16x32::<3>(a, a),
+            30 => self.slide_i16x32::<2>(a, a),
+            31 => self.slide_i16x32::<1>(a, a),
+            32 => self.slide_i16x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i16x32(padding);
+        self.slide_i16x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i16x32(padding);
+        match OFFSET {
+            0 => self.slide_i16x32::<32>(padding, a),
+            1 => self.slide_i16x32::<31>(padding, a),
+            2 => self.slide_i16x32::<30>(padding, a),
+            3 => self.slide_i16x32::<29>(padding, a),
+            4 => self.slide_i16x32::<28>(padding, a),
+            5 => self.slide_i16x32::<27>(padding, a),
+            6 => self.slide_i16x32::<26>(padding, a),
+            7 => self.slide_i16x32::<25>(padding, a),
+            8 => self.slide_i16x32::<24>(padding, a),
+            9 => self.slide_i16x32::<23>(padding, a),
+            10 => self.slide_i16x32::<22>(padding, a),
+            11 => self.slide_i16x32::<21>(padding, a),
+            12 => self.slide_i16x32::<20>(padding, a),
+            13 => self.slide_i16x32::<19>(padding, a),
+            14 => self.slide_i16x32::<18>(padding, a),
+            15 => self.slide_i16x32::<17>(padding, a),
+            16 => self.slide_i16x32::<16>(padding, a),
+            17 => self.slide_i16x32::<15>(padding, a),
+            18 => self.slide_i16x32::<14>(padding, a),
+            19 => self.slide_i16x32::<13>(padding, a),
+            20 => self.slide_i16x32::<12>(padding, a),
+            21 => self.slide_i16x32::<11>(padding, a),
+            22 => self.slide_i16x32::<10>(padding, a),
+            23 => self.slide_i16x32::<9>(padding, a),
+            24 => self.slide_i16x32::<8>(padding, a),
+            25 => self.slide_i16x32::<7>(padding, a),
+            26 => self.slide_i16x32::<6>(padding, a),
+            27 => self.slide_i16x32::<5>(padding, a),
+            28 => self.slide_i16x32::<4>(padding, a),
+            29 => self.slide_i16x32::<3>(padding, a),
+            30 => self.slide_i16x32::<2>(padding, a),
+            31 => self.slide_i16x32::<1>(padding, a),
+            32 => self.slide_i16x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x32(
         self,
         a: i16x32<Self>,
@@ -11659,6 +13503,126 @@ impl Simd for Avx512 {
             val: crate::support::Aligned512(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_u16x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_u16x32::<32>(a, a),
+            1 => self.slide_u16x32::<31>(a, a),
+            2 => self.slide_u16x32::<30>(a, a),
+            3 => self.slide_u16x32::<29>(a, a),
+            4 => self.slide_u16x32::<28>(a, a),
+            5 => self.slide_u16x32::<27>(a, a),
+            6 => self.slide_u16x32::<26>(a, a),
+            7 => self.slide_u16x32::<25>(a, a),
+            8 => self.slide_u16x32::<24>(a, a),
+            9 => self.slide_u16x32::<23>(a, a),
+            10 => self.slide_u16x32::<22>(a, a),
+            11 => self.slide_u16x32::<21>(a, a),
+            12 => self.slide_u16x32::<20>(a, a),
+            13 => self.slide_u16x32::<19>(a, a),
+            14 => self.slide_u16x32::<18>(a, a),
+            15 => self.slide_u16x32::<17>(a, a),
+            16 => self.slide_u16x32::<16>(a, a),
+            17 => self.slide_u16x32::<15>(a, a),
+            18 => self.slide_u16x32::<14>(a, a),
+            19 => self.slide_u16x32::<13>(a, a),
+            20 => self.slide_u16x32::<12>(a, a),
+            21 => self.slide_u16x32::<11>(a, a),
+            22 => self.slide_u16x32::<10>(a, a),
+            23 => self.slide_u16x32::<9>(a, a),
+            24 => self.slide_u16x32::<8>(a, a),
+            25 => self.slide_u16x32::<7>(a, a),
+            26 => self.slide_u16x32::<6>(a, a),
+            27 => self.slide_u16x32::<5>(a, a),
+            28 => self.slide_u16x32::<4>(a, a),
+            29 => self.slide_u16x32::<3>(a, a),
+            30 => self.slide_u16x32::<2>(a, a),
+            31 => self.slide_u16x32::<1>(a, a),
+            32 => self.slide_u16x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u16x32(padding);
+        self.slide_u16x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u16x32(padding);
+        match OFFSET {
+            0 => self.slide_u16x32::<32>(padding, a),
+            1 => self.slide_u16x32::<31>(padding, a),
+            2 => self.slide_u16x32::<30>(padding, a),
+            3 => self.slide_u16x32::<29>(padding, a),
+            4 => self.slide_u16x32::<28>(padding, a),
+            5 => self.slide_u16x32::<27>(padding, a),
+            6 => self.slide_u16x32::<26>(padding, a),
+            7 => self.slide_u16x32::<25>(padding, a),
+            8 => self.slide_u16x32::<24>(padding, a),
+            9 => self.slide_u16x32::<23>(padding, a),
+            10 => self.slide_u16x32::<22>(padding, a),
+            11 => self.slide_u16x32::<21>(padding, a),
+            12 => self.slide_u16x32::<20>(padding, a),
+            13 => self.slide_u16x32::<19>(padding, a),
+            14 => self.slide_u16x32::<18>(padding, a),
+            15 => self.slide_u16x32::<17>(padding, a),
+            16 => self.slide_u16x32::<16>(padding, a),
+            17 => self.slide_u16x32::<15>(padding, a),
+            18 => self.slide_u16x32::<14>(padding, a),
+            19 => self.slide_u16x32::<13>(padding, a),
+            20 => self.slide_u16x32::<12>(padding, a),
+            21 => self.slide_u16x32::<11>(padding, a),
+            22 => self.slide_u16x32::<10>(padding, a),
+            23 => self.slide_u16x32::<9>(padding, a),
+            24 => self.slide_u16x32::<8>(padding, a),
+            25 => self.slide_u16x32::<7>(padding, a),
+            26 => self.slide_u16x32::<6>(padding, a),
+            27 => self.slide_u16x32::<5>(padding, a),
+            28 => self.slide_u16x32::<4>(padding, a),
+            29 => self.slide_u16x32::<3>(padding, a),
+            30 => self.slide_u16x32::<2>(padding, a),
+            31 => self.slide_u16x32::<1>(padding, a),
+            32 => self.slide_u16x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x32(
@@ -12355,6 +14319,94 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i32x16::<16>(a, a),
+            1 => self.slide_i32x16::<15>(a, a),
+            2 => self.slide_i32x16::<14>(a, a),
+            3 => self.slide_i32x16::<13>(a, a),
+            4 => self.slide_i32x16::<12>(a, a),
+            5 => self.slide_i32x16::<11>(a, a),
+            6 => self.slide_i32x16::<10>(a, a),
+            7 => self.slide_i32x16::<9>(a, a),
+            8 => self.slide_i32x16::<8>(a, a),
+            9 => self.slide_i32x16::<7>(a, a),
+            10 => self.slide_i32x16::<6>(a, a),
+            11 => self.slide_i32x16::<5>(a, a),
+            12 => self.slide_i32x16::<4>(a, a),
+            13 => self.slide_i32x16::<3>(a, a),
+            14 => self.slide_i32x16::<2>(a, a),
+            15 => self.slide_i32x16::<1>(a, a),
+            16 => self.slide_i32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i32x16(padding);
+        self.slide_i32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i32x16(padding);
+        match OFFSET {
+            0 => self.slide_i32x16::<16>(padding, a),
+            1 => self.slide_i32x16::<15>(padding, a),
+            2 => self.slide_i32x16::<14>(padding, a),
+            3 => self.slide_i32x16::<13>(padding, a),
+            4 => self.slide_i32x16::<12>(padding, a),
+            5 => self.slide_i32x16::<11>(padding, a),
+            6 => self.slide_i32x16::<10>(padding, a),
+            7 => self.slide_i32x16::<9>(padding, a),
+            8 => self.slide_i32x16::<8>(padding, a),
+            9 => self.slide_i32x16::<7>(padding, a),
+            10 => self.slide_i32x16::<6>(padding, a),
+            11 => self.slide_i32x16::<5>(padding, a),
+            12 => self.slide_i32x16::<4>(padding, a),
+            13 => self.slide_i32x16::<3>(padding, a),
+            14 => self.slide_i32x16::<2>(padding, a),
+            15 => self.slide_i32x16::<1>(padding, a),
+            16 => self.slide_i32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x16(
         self,
         a: i32x16<Self>,
@@ -12862,6 +14914,94 @@ impl Simd for Avx512 {
             val: crate::support::Aligned512(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u32x16::<16>(a, a),
+            1 => self.slide_u32x16::<15>(a, a),
+            2 => self.slide_u32x16::<14>(a, a),
+            3 => self.slide_u32x16::<13>(a, a),
+            4 => self.slide_u32x16::<12>(a, a),
+            5 => self.slide_u32x16::<11>(a, a),
+            6 => self.slide_u32x16::<10>(a, a),
+            7 => self.slide_u32x16::<9>(a, a),
+            8 => self.slide_u32x16::<8>(a, a),
+            9 => self.slide_u32x16::<7>(a, a),
+            10 => self.slide_u32x16::<6>(a, a),
+            11 => self.slide_u32x16::<5>(a, a),
+            12 => self.slide_u32x16::<4>(a, a),
+            13 => self.slide_u32x16::<3>(a, a),
+            14 => self.slide_u32x16::<2>(a, a),
+            15 => self.slide_u32x16::<1>(a, a),
+            16 => self.slide_u32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u32x16(padding);
+        self.slide_u32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u32x16(padding);
+        match OFFSET {
+            0 => self.slide_u32x16::<16>(padding, a),
+            1 => self.slide_u32x16::<15>(padding, a),
+            2 => self.slide_u32x16::<14>(padding, a),
+            3 => self.slide_u32x16::<13>(padding, a),
+            4 => self.slide_u32x16::<12>(padding, a),
+            5 => self.slide_u32x16::<11>(padding, a),
+            6 => self.slide_u32x16::<10>(padding, a),
+            7 => self.slide_u32x16::<9>(padding, a),
+            8 => self.slide_u32x16::<8>(padding, a),
+            9 => self.slide_u32x16::<7>(padding, a),
+            10 => self.slide_u32x16::<6>(padding, a),
+            11 => self.slide_u32x16::<5>(padding, a),
+            12 => self.slide_u32x16::<4>(padding, a),
+            13 => self.slide_u32x16::<3>(padding, a),
+            14 => self.slide_u32x16::<2>(padding, a),
+            15 => self.slide_u32x16::<1>(padding, a),
+            16 => self.slide_u32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x16(
@@ -13522,6 +15662,78 @@ impl Simd for Avx512 {
             val: crate::support::Aligned512(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_f64x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_f64x8::<8>(a, a),
+            1 => self.slide_f64x8::<7>(a, a),
+            2 => self.slide_f64x8::<6>(a, a),
+            3 => self.slide_f64x8::<5>(a, a),
+            4 => self.slide_f64x8::<4>(a, a),
+            5 => self.slide_f64x8::<3>(a, a),
+            6 => self.slide_f64x8::<2>(a, a),
+            7 => self.slide_f64x8::<1>(a, a),
+            8 => self.slide_f64x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f64x8(padding);
+        self.slide_f64x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f64x8(padding);
+        match OFFSET {
+            0 => self.slide_f64x8::<8>(padding, a),
+            1 => self.slide_f64x8::<7>(padding, a),
+            2 => self.slide_f64x8::<6>(padding, a),
+            3 => self.slide_f64x8::<5>(padding, a),
+            4 => self.slide_f64x8::<4>(padding, a),
+            5 => self.slide_f64x8::<3>(padding, a),
+            6 => self.slide_f64x8::<2>(padding, a),
+            7 => self.slide_f64x8::<1>(padding, a),
+            8 => self.slide_f64x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -215,6 +215,70 @@ impl Simd for Fallback {
         self.slide_f32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_f32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_f32x4::<4>(a, a),
+            1 => self.slide_f32x4::<3>(a, a),
+            2 => self.slide_f32x4::<2>(a, a),
+            3 => self.slide_f32x4::<1>(a, a),
+            4 => self.slide_f32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f32x4(padding);
+        self.slide_f32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f32x4(padding);
+        match OFFSET {
+            0 => self.slide_f32x4::<4>(padding, a),
+            1 => self.slide_f32x4::<3>(padding, a),
+            2 => self.slide_f32x4::<2>(padding, a),
+            3 => self.slide_f32x4::<1>(padding, a),
+            4 => self.slide_f32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
         let bytes = self.cvt_to_bytes_f32x4(a);
         let result: u8x16<Self> = [
@@ -681,6 +745,94 @@ impl Simd for Fallback {
         b: i8x16<Self>,
     ) -> i8x16<Self> {
         self.slide_i8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i8x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i8x16::<16>(a, a),
+            1 => self.slide_i8x16::<15>(a, a),
+            2 => self.slide_i8x16::<14>(a, a),
+            3 => self.slide_i8x16::<13>(a, a),
+            4 => self.slide_i8x16::<12>(a, a),
+            5 => self.slide_i8x16::<11>(a, a),
+            6 => self.slide_i8x16::<10>(a, a),
+            7 => self.slide_i8x16::<9>(a, a),
+            8 => self.slide_i8x16::<8>(a, a),
+            9 => self.slide_i8x16::<7>(a, a),
+            10 => self.slide_i8x16::<6>(a, a),
+            11 => self.slide_i8x16::<5>(a, a),
+            12 => self.slide_i8x16::<4>(a, a),
+            13 => self.slide_i8x16::<3>(a, a),
+            14 => self.slide_i8x16::<2>(a, a),
+            15 => self.slide_i8x16::<1>(a, a),
+            16 => self.slide_i8x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i8x16(padding);
+        self.slide_i8x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i8x16(padding);
+        match OFFSET {
+            0 => self.slide_i8x16::<16>(padding, a),
+            1 => self.slide_i8x16::<15>(padding, a),
+            2 => self.slide_i8x16::<14>(padding, a),
+            3 => self.slide_i8x16::<13>(padding, a),
+            4 => self.slide_i8x16::<12>(padding, a),
+            5 => self.slide_i8x16::<11>(padding, a),
+            6 => self.slide_i8x16::<10>(padding, a),
+            7 => self.slide_i8x16::<9>(padding, a),
+            8 => self.slide_i8x16::<8>(padding, a),
+            9 => self.slide_i8x16::<7>(padding, a),
+            10 => self.slide_i8x16::<6>(padding, a),
+            11 => self.slide_i8x16::<5>(padding, a),
+            12 => self.slide_i8x16::<4>(padding, a),
+            13 => self.slide_i8x16::<3>(padding, a),
+            14 => self.slide_i8x16::<2>(padding, a),
+            15 => self.slide_i8x16::<1>(padding, a),
+            16 => self.slide_i8x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
@@ -1378,6 +1530,94 @@ impl Simd for Fallback {
         b: u8x16<Self>,
     ) -> u8x16<Self> {
         self.slide_u8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u8x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u8x16::<16>(a, a),
+            1 => self.slide_u8x16::<15>(a, a),
+            2 => self.slide_u8x16::<14>(a, a),
+            3 => self.slide_u8x16::<13>(a, a),
+            4 => self.slide_u8x16::<12>(a, a),
+            5 => self.slide_u8x16::<11>(a, a),
+            6 => self.slide_u8x16::<10>(a, a),
+            7 => self.slide_u8x16::<9>(a, a),
+            8 => self.slide_u8x16::<8>(a, a),
+            9 => self.slide_u8x16::<7>(a, a),
+            10 => self.slide_u8x16::<6>(a, a),
+            11 => self.slide_u8x16::<5>(a, a),
+            12 => self.slide_u8x16::<4>(a, a),
+            13 => self.slide_u8x16::<3>(a, a),
+            14 => self.slide_u8x16::<2>(a, a),
+            15 => self.slide_u8x16::<1>(a, a),
+            16 => self.slide_u8x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u8x16(padding);
+        self.slide_u8x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u8x16(padding);
+        match OFFSET {
+            0 => self.slide_u8x16::<16>(padding, a),
+            1 => self.slide_u8x16::<15>(padding, a),
+            2 => self.slide_u8x16::<14>(padding, a),
+            3 => self.slide_u8x16::<13>(padding, a),
+            4 => self.slide_u8x16::<12>(padding, a),
+            5 => self.slide_u8x16::<11>(padding, a),
+            6 => self.slide_u8x16::<10>(padding, a),
+            7 => self.slide_u8x16::<9>(padding, a),
+            8 => self.slide_u8x16::<8>(padding, a),
+            9 => self.slide_u8x16::<7>(padding, a),
+            10 => self.slide_u8x16::<6>(padding, a),
+            11 => self.slide_u8x16::<5>(padding, a),
+            12 => self.slide_u8x16::<4>(padding, a),
+            13 => self.slide_u8x16::<3>(padding, a),
+            14 => self.slide_u8x16::<2>(padding, a),
+            15 => self.slide_u8x16::<1>(padding, a),
+            16 => self.slide_u8x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
@@ -2403,6 +2643,78 @@ impl Simd for Fallback {
         self.slide_i16x8::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_i16x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_i16x8::<8>(a, a),
+            1 => self.slide_i16x8::<7>(a, a),
+            2 => self.slide_i16x8::<6>(a, a),
+            3 => self.slide_i16x8::<5>(a, a),
+            4 => self.slide_i16x8::<4>(a, a),
+            5 => self.slide_i16x8::<3>(a, a),
+            6 => self.slide_i16x8::<2>(a, a),
+            7 => self.slide_i16x8::<1>(a, a),
+            8 => self.slide_i16x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i16x8(padding);
+        self.slide_i16x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i16x8(padding);
+        match OFFSET {
+            0 => self.slide_i16x8::<8>(padding, a),
+            1 => self.slide_i16x8::<7>(padding, a),
+            2 => self.slide_i16x8::<6>(padding, a),
+            3 => self.slide_i16x8::<5>(padding, a),
+            4 => self.slide_i16x8::<4>(padding, a),
+            5 => self.slide_i16x8::<3>(padding, a),
+            6 => self.slide_i16x8::<2>(padding, a),
+            7 => self.slide_i16x8::<1>(padding, a),
+            8 => self.slide_i16x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
         let bytes = self.cvt_to_bytes_i16x8(a);
         let result: u8x16<Self> = [
@@ -2899,6 +3211,78 @@ impl Simd for Fallback {
         b: u16x8<Self>,
     ) -> u16x8<Self> {
         self.slide_u16x8::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_u16x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_u16x8::<8>(a, a),
+            1 => self.slide_u16x8::<7>(a, a),
+            2 => self.slide_u16x8::<6>(a, a),
+            3 => self.slide_u16x8::<5>(a, a),
+            4 => self.slide_u16x8::<4>(a, a),
+            5 => self.slide_u16x8::<3>(a, a),
+            6 => self.slide_u16x8::<2>(a, a),
+            7 => self.slide_u16x8::<1>(a, a),
+            8 => self.slide_u16x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u16x8(padding);
+        self.slide_u16x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u16x8(padding);
+        match OFFSET {
+            0 => self.slide_u16x8::<8>(padding, a),
+            1 => self.slide_u16x8::<7>(padding, a),
+            2 => self.slide_u16x8::<6>(padding, a),
+            3 => self.slide_u16x8::<5>(padding, a),
+            4 => self.slide_u16x8::<4>(padding, a),
+            5 => self.slide_u16x8::<3>(padding, a),
+            6 => self.slide_u16x8::<2>(padding, a),
+            7 => self.slide_u16x8::<1>(padding, a),
+            8 => self.slide_u16x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
@@ -3603,6 +3987,70 @@ impl Simd for Fallback {
         self.slide_i32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_i32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_i32x4::<4>(a, a),
+            1 => self.slide_i32x4::<3>(a, a),
+            2 => self.slide_i32x4::<2>(a, a),
+            3 => self.slide_i32x4::<1>(a, a),
+            4 => self.slide_i32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_i32x4(padding);
+        self.slide_i32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_i32x4(padding);
+        match OFFSET {
+            0 => self.slide_i32x4::<4>(padding, a),
+            1 => self.slide_i32x4::<3>(padding, a),
+            2 => self.slide_i32x4::<2>(padding, a),
+            3 => self.slide_i32x4::<1>(padding, a),
+            4 => self.slide_i32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
         let bytes = self.cvt_to_bytes_i32x4(a);
         let result: u8x16<Self> = [
@@ -4001,6 +4449,70 @@ impl Simd for Fallback {
         b: u32x4<Self>,
     ) -> u32x4<Self> {
         self.slide_u32x4::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_u32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_u32x4::<4>(a, a),
+            1 => self.slide_u32x4::<3>(a, a),
+            2 => self.slide_u32x4::<2>(a, a),
+            3 => self.slide_u32x4::<1>(a, a),
+            4 => self.slide_u32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_u32x4(padding);
+        self.slide_u32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_u32x4(padding);
+        match OFFSET {
+            0 => self.slide_u32x4::<4>(padding, a),
+            1 => self.slide_u32x4::<3>(padding, a),
+            2 => self.slide_u32x4::<2>(padding, a),
+            3 => self.slide_u32x4::<1>(padding, a),
+            4 => self.slide_u32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
@@ -4539,6 +5051,66 @@ impl Simd for Fallback {
         self.slide_f64x2::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        self.slide_f64x2::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        match OFFSET {
+            0 => self.slide_f64x2::<2>(a, a),
+            1 => self.slide_f64x2::<1>(a, a),
+            2 => self.slide_f64x2::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        let padding = self.splat_f64x2(padding);
+        self.slide_f64x2::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        let padding = self.splat_f64x2(padding);
+        match OFFSET {
+            0 => self.slide_f64x2::<2>(padding, a),
+            1 => self.slide_f64x2::<1>(padding, a),
+            2 => self.slide_f64x2::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
         let bytes = self.cvt_to_bytes_f64x2(a);
         let result: u8x16<Self> = [
@@ -5017,6 +5589,78 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_f32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_f32x8::<8>(a, a),
+            1 => self.slide_f32x8::<7>(a, a),
+            2 => self.slide_f32x8::<6>(a, a),
+            3 => self.slide_f32x8::<5>(a, a),
+            4 => self.slide_f32x8::<4>(a, a),
+            5 => self.slide_f32x8::<3>(a, a),
+            6 => self.slide_f32x8::<2>(a, a),
+            7 => self.slide_f32x8::<1>(a, a),
+            8 => self.slide_f32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f32x8(padding);
+        self.slide_f32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f32x8(padding);
+        match OFFSET {
+            0 => self.slide_f32x8::<8>(padding, a),
+            1 => self.slide_f32x8::<7>(padding, a),
+            2 => self.slide_f32x8::<6>(padding, a),
+            3 => self.slide_f32x8::<5>(padding, a),
+            4 => self.slide_f32x8::<4>(padding, a),
+            5 => self.slide_f32x8::<3>(padding, a),
+            6 => self.slide_f32x8::<2>(padding, a),
+            7 => self.slide_f32x8::<1>(padding, a),
+            8 => self.slide_f32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         let (indices0, indices1) = self.split_u8x32(indices);
@@ -5383,6 +6027,126 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_i8x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_i8x32::<32>(a, a),
+            1 => self.slide_i8x32::<31>(a, a),
+            2 => self.slide_i8x32::<30>(a, a),
+            3 => self.slide_i8x32::<29>(a, a),
+            4 => self.slide_i8x32::<28>(a, a),
+            5 => self.slide_i8x32::<27>(a, a),
+            6 => self.slide_i8x32::<26>(a, a),
+            7 => self.slide_i8x32::<25>(a, a),
+            8 => self.slide_i8x32::<24>(a, a),
+            9 => self.slide_i8x32::<23>(a, a),
+            10 => self.slide_i8x32::<22>(a, a),
+            11 => self.slide_i8x32::<21>(a, a),
+            12 => self.slide_i8x32::<20>(a, a),
+            13 => self.slide_i8x32::<19>(a, a),
+            14 => self.slide_i8x32::<18>(a, a),
+            15 => self.slide_i8x32::<17>(a, a),
+            16 => self.slide_i8x32::<16>(a, a),
+            17 => self.slide_i8x32::<15>(a, a),
+            18 => self.slide_i8x32::<14>(a, a),
+            19 => self.slide_i8x32::<13>(a, a),
+            20 => self.slide_i8x32::<12>(a, a),
+            21 => self.slide_i8x32::<11>(a, a),
+            22 => self.slide_i8x32::<10>(a, a),
+            23 => self.slide_i8x32::<9>(a, a),
+            24 => self.slide_i8x32::<8>(a, a),
+            25 => self.slide_i8x32::<7>(a, a),
+            26 => self.slide_i8x32::<6>(a, a),
+            27 => self.slide_i8x32::<5>(a, a),
+            28 => self.slide_i8x32::<4>(a, a),
+            29 => self.slide_i8x32::<3>(a, a),
+            30 => self.slide_i8x32::<2>(a, a),
+            31 => self.slide_i8x32::<1>(a, a),
+            32 => self.slide_i8x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i8x32(padding);
+        self.slide_i8x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i8x32(padding);
+        match OFFSET {
+            0 => self.slide_i8x32::<32>(padding, a),
+            1 => self.slide_i8x32::<31>(padding, a),
+            2 => self.slide_i8x32::<30>(padding, a),
+            3 => self.slide_i8x32::<29>(padding, a),
+            4 => self.slide_i8x32::<28>(padding, a),
+            5 => self.slide_i8x32::<27>(padding, a),
+            6 => self.slide_i8x32::<26>(padding, a),
+            7 => self.slide_i8x32::<25>(padding, a),
+            8 => self.slide_i8x32::<24>(padding, a),
+            9 => self.slide_i8x32::<23>(padding, a),
+            10 => self.slide_i8x32::<22>(padding, a),
+            11 => self.slide_i8x32::<21>(padding, a),
+            12 => self.slide_i8x32::<20>(padding, a),
+            13 => self.slide_i8x32::<19>(padding, a),
+            14 => self.slide_i8x32::<18>(padding, a),
+            15 => self.slide_i8x32::<17>(padding, a),
+            16 => self.slide_i8x32::<16>(padding, a),
+            17 => self.slide_i8x32::<15>(padding, a),
+            18 => self.slide_i8x32::<14>(padding, a),
+            19 => self.slide_i8x32::<13>(padding, a),
+            20 => self.slide_i8x32::<12>(padding, a),
+            21 => self.slide_i8x32::<11>(padding, a),
+            22 => self.slide_i8x32::<10>(padding, a),
+            23 => self.slide_i8x32::<9>(padding, a),
+            24 => self.slide_i8x32::<8>(padding, a),
+            25 => self.slide_i8x32::<7>(padding, a),
+            26 => self.slide_i8x32::<6>(padding, a),
+            27 => self.slide_i8x32::<5>(padding, a),
+            28 => self.slide_i8x32::<4>(padding, a),
+            29 => self.slide_i8x32::<3>(padding, a),
+            30 => self.slide_i8x32::<2>(padding, a),
+            31 => self.slide_i8x32::<1>(padding, a),
+            32 => self.slide_i8x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
         let (indices0, indices1) = self.split_u8x32(indices);
@@ -5654,6 +6418,126 @@ impl Simd for Fallback {
             self.slide_within_blocks_u8x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x16::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_u8x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_u8x32::<32>(a, a),
+            1 => self.slide_u8x32::<31>(a, a),
+            2 => self.slide_u8x32::<30>(a, a),
+            3 => self.slide_u8x32::<29>(a, a),
+            4 => self.slide_u8x32::<28>(a, a),
+            5 => self.slide_u8x32::<27>(a, a),
+            6 => self.slide_u8x32::<26>(a, a),
+            7 => self.slide_u8x32::<25>(a, a),
+            8 => self.slide_u8x32::<24>(a, a),
+            9 => self.slide_u8x32::<23>(a, a),
+            10 => self.slide_u8x32::<22>(a, a),
+            11 => self.slide_u8x32::<21>(a, a),
+            12 => self.slide_u8x32::<20>(a, a),
+            13 => self.slide_u8x32::<19>(a, a),
+            14 => self.slide_u8x32::<18>(a, a),
+            15 => self.slide_u8x32::<17>(a, a),
+            16 => self.slide_u8x32::<16>(a, a),
+            17 => self.slide_u8x32::<15>(a, a),
+            18 => self.slide_u8x32::<14>(a, a),
+            19 => self.slide_u8x32::<13>(a, a),
+            20 => self.slide_u8x32::<12>(a, a),
+            21 => self.slide_u8x32::<11>(a, a),
+            22 => self.slide_u8x32::<10>(a, a),
+            23 => self.slide_u8x32::<9>(a, a),
+            24 => self.slide_u8x32::<8>(a, a),
+            25 => self.slide_u8x32::<7>(a, a),
+            26 => self.slide_u8x32::<6>(a, a),
+            27 => self.slide_u8x32::<5>(a, a),
+            28 => self.slide_u8x32::<4>(a, a),
+            29 => self.slide_u8x32::<3>(a, a),
+            30 => self.slide_u8x32::<2>(a, a),
+            31 => self.slide_u8x32::<1>(a, a),
+            32 => self.slide_u8x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u8x32(padding);
+        self.slide_u8x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u8x32(padding);
+        match OFFSET {
+            0 => self.slide_u8x32::<32>(padding, a),
+            1 => self.slide_u8x32::<31>(padding, a),
+            2 => self.slide_u8x32::<30>(padding, a),
+            3 => self.slide_u8x32::<29>(padding, a),
+            4 => self.slide_u8x32::<28>(padding, a),
+            5 => self.slide_u8x32::<27>(padding, a),
+            6 => self.slide_u8x32::<26>(padding, a),
+            7 => self.slide_u8x32::<25>(padding, a),
+            8 => self.slide_u8x32::<24>(padding, a),
+            9 => self.slide_u8x32::<23>(padding, a),
+            10 => self.slide_u8x32::<22>(padding, a),
+            11 => self.slide_u8x32::<21>(padding, a),
+            12 => self.slide_u8x32::<20>(padding, a),
+            13 => self.slide_u8x32::<19>(padding, a),
+            14 => self.slide_u8x32::<18>(padding, a),
+            15 => self.slide_u8x32::<17>(padding, a),
+            16 => self.slide_u8x32::<16>(padding, a),
+            17 => self.slide_u8x32::<15>(padding, a),
+            18 => self.slide_u8x32::<14>(padding, a),
+            19 => self.slide_u8x32::<13>(padding, a),
+            20 => self.slide_u8x32::<12>(padding, a),
+            21 => self.slide_u8x32::<11>(padding, a),
+            22 => self.slide_u8x32::<10>(padding, a),
+            23 => self.slide_u8x32::<9>(padding, a),
+            24 => self.slide_u8x32::<8>(padding, a),
+            25 => self.slide_u8x32::<7>(padding, a),
+            26 => self.slide_u8x32::<6>(padding, a),
+            27 => self.slide_u8x32::<5>(padding, a),
+            28 => self.slide_u8x32::<4>(padding, a),
+            29 => self.slide_u8x32::<3>(padding, a),
+            30 => self.slide_u8x32::<2>(padding, a),
+            31 => self.slide_u8x32::<1>(padding, a),
+            32 => self.slide_u8x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self> {
@@ -6043,6 +6927,94 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i16x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i16x16::<16>(a, a),
+            1 => self.slide_i16x16::<15>(a, a),
+            2 => self.slide_i16x16::<14>(a, a),
+            3 => self.slide_i16x16::<13>(a, a),
+            4 => self.slide_i16x16::<12>(a, a),
+            5 => self.slide_i16x16::<11>(a, a),
+            6 => self.slide_i16x16::<10>(a, a),
+            7 => self.slide_i16x16::<9>(a, a),
+            8 => self.slide_i16x16::<8>(a, a),
+            9 => self.slide_i16x16::<7>(a, a),
+            10 => self.slide_i16x16::<6>(a, a),
+            11 => self.slide_i16x16::<5>(a, a),
+            12 => self.slide_i16x16::<4>(a, a),
+            13 => self.slide_i16x16::<3>(a, a),
+            14 => self.slide_i16x16::<2>(a, a),
+            15 => self.slide_i16x16::<1>(a, a),
+            16 => self.slide_i16x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i16x16(padding);
+        self.slide_i16x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i16x16(padding);
+        match OFFSET {
+            0 => self.slide_i16x16::<16>(padding, a),
+            1 => self.slide_i16x16::<15>(padding, a),
+            2 => self.slide_i16x16::<14>(padding, a),
+            3 => self.slide_i16x16::<13>(padding, a),
+            4 => self.slide_i16x16::<12>(padding, a),
+            5 => self.slide_i16x16::<11>(padding, a),
+            6 => self.slide_i16x16::<10>(padding, a),
+            7 => self.slide_i16x16::<9>(padding, a),
+            8 => self.slide_i16x16::<8>(padding, a),
+            9 => self.slide_i16x16::<7>(padding, a),
+            10 => self.slide_i16x16::<6>(padding, a),
+            11 => self.slide_i16x16::<5>(padding, a),
+            12 => self.slide_i16x16::<4>(padding, a),
+            13 => self.slide_i16x16::<3>(padding, a),
+            14 => self.slide_i16x16::<2>(padding, a),
+            15 => self.slide_i16x16::<1>(padding, a),
+            16 => self.slide_i16x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x16(
         self,
         a: i16x16<Self>,
@@ -6318,6 +7290,94 @@ impl Simd for Fallback {
             self.slide_within_blocks_u16x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x8::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u16x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u16x16::<16>(a, a),
+            1 => self.slide_u16x16::<15>(a, a),
+            2 => self.slide_u16x16::<14>(a, a),
+            3 => self.slide_u16x16::<13>(a, a),
+            4 => self.slide_u16x16::<12>(a, a),
+            5 => self.slide_u16x16::<11>(a, a),
+            6 => self.slide_u16x16::<10>(a, a),
+            7 => self.slide_u16x16::<9>(a, a),
+            8 => self.slide_u16x16::<8>(a, a),
+            9 => self.slide_u16x16::<7>(a, a),
+            10 => self.slide_u16x16::<6>(a, a),
+            11 => self.slide_u16x16::<5>(a, a),
+            12 => self.slide_u16x16::<4>(a, a),
+            13 => self.slide_u16x16::<3>(a, a),
+            14 => self.slide_u16x16::<2>(a, a),
+            15 => self.slide_u16x16::<1>(a, a),
+            16 => self.slide_u16x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u16x16(padding);
+        self.slide_u16x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u16x16(padding);
+        match OFFSET {
+            0 => self.slide_u16x16::<16>(padding, a),
+            1 => self.slide_u16x16::<15>(padding, a),
+            2 => self.slide_u16x16::<14>(padding, a),
+            3 => self.slide_u16x16::<13>(padding, a),
+            4 => self.slide_u16x16::<12>(padding, a),
+            5 => self.slide_u16x16::<11>(padding, a),
+            6 => self.slide_u16x16::<10>(padding, a),
+            7 => self.slide_u16x16::<9>(padding, a),
+            8 => self.slide_u16x16::<8>(padding, a),
+            9 => self.slide_u16x16::<7>(padding, a),
+            10 => self.slide_u16x16::<6>(padding, a),
+            11 => self.slide_u16x16::<5>(padding, a),
+            12 => self.slide_u16x16::<4>(padding, a),
+            13 => self.slide_u16x16::<3>(padding, a),
+            14 => self.slide_u16x16::<2>(padding, a),
+            15 => self.slide_u16x16::<1>(padding, a),
+            16 => self.slide_u16x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x16(
@@ -6733,6 +7793,78 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_i32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_i32x8::<8>(a, a),
+            1 => self.slide_i32x8::<7>(a, a),
+            2 => self.slide_i32x8::<6>(a, a),
+            3 => self.slide_i32x8::<5>(a, a),
+            4 => self.slide_i32x8::<4>(a, a),
+            5 => self.slide_i32x8::<3>(a, a),
+            6 => self.slide_i32x8::<2>(a, a),
+            7 => self.slide_i32x8::<1>(a, a),
+            8 => self.slide_i32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i32x8(padding);
+        self.slide_i32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i32x8(padding);
+        match OFFSET {
+            0 => self.slide_i32x8::<8>(padding, a),
+            1 => self.slide_i32x8::<7>(padding, a),
+            2 => self.slide_i32x8::<6>(padding, a),
+            3 => self.slide_i32x8::<5>(padding, a),
+            4 => self.slide_i32x8::<4>(padding, a),
+            5 => self.slide_i32x8::<3>(padding, a),
+            6 => self.slide_i32x8::<2>(padding, a),
+            7 => self.slide_i32x8::<1>(padding, a),
+            8 => self.slide_i32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
         let (indices0, indices1) = self.split_u8x32(indices);
@@ -7009,6 +8141,78 @@ impl Simd for Fallback {
             self.slide_within_blocks_u32x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x4::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_u32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_u32x8::<8>(a, a),
+            1 => self.slide_u32x8::<7>(a, a),
+            2 => self.slide_u32x8::<6>(a, a),
+            3 => self.slide_u32x8::<5>(a, a),
+            4 => self.slide_u32x8::<4>(a, a),
+            5 => self.slide_u32x8::<3>(a, a),
+            6 => self.slide_u32x8::<2>(a, a),
+            7 => self.slide_u32x8::<1>(a, a),
+            8 => self.slide_u32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u32x8(padding);
+        self.slide_u32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u32x8(padding);
+        match OFFSET {
+            0 => self.slide_u32x8::<8>(padding, a),
+            1 => self.slide_u32x8::<7>(padding, a),
+            2 => self.slide_u32x8::<6>(padding, a),
+            3 => self.slide_u32x8::<5>(padding, a),
+            4 => self.slide_u32x8::<4>(padding, a),
+            5 => self.slide_u32x8::<3>(padding, a),
+            6 => self.slide_u32x8::<2>(padding, a),
+            7 => self.slide_u32x8::<1>(padding, a),
+            8 => self.slide_u32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
@@ -7393,6 +8597,70 @@ impl Simd for Fallback {
             self.slide_within_blocks_f64x2::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x2::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_f64x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_f64x4::<4>(a, a),
+            1 => self.slide_f64x4::<3>(a, a),
+            2 => self.slide_f64x4::<2>(a, a),
+            3 => self.slide_f64x4::<1>(a, a),
+            4 => self.slide_f64x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f64x4(padding);
+        self.slide_f64x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f64x4(padding);
+        match OFFSET {
+            0 => self.slide_f64x4::<4>(padding, a),
+            1 => self.slide_f64x4::<3>(padding, a),
+            2 => self.slide_f64x4::<2>(padding, a),
+            3 => self.slide_f64x4::<1>(padding, a),
+            4 => self.slide_f64x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
@@ -7833,6 +9101,94 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_f32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_f32x16::<16>(a, a),
+            1 => self.slide_f32x16::<15>(a, a),
+            2 => self.slide_f32x16::<14>(a, a),
+            3 => self.slide_f32x16::<13>(a, a),
+            4 => self.slide_f32x16::<12>(a, a),
+            5 => self.slide_f32x16::<11>(a, a),
+            6 => self.slide_f32x16::<10>(a, a),
+            7 => self.slide_f32x16::<9>(a, a),
+            8 => self.slide_f32x16::<8>(a, a),
+            9 => self.slide_f32x16::<7>(a, a),
+            10 => self.slide_f32x16::<6>(a, a),
+            11 => self.slide_f32x16::<5>(a, a),
+            12 => self.slide_f32x16::<4>(a, a),
+            13 => self.slide_f32x16::<3>(a, a),
+            14 => self.slide_f32x16::<2>(a, a),
+            15 => self.slide_f32x16::<1>(a, a),
+            16 => self.slide_f32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_f32x16(padding);
+        self.slide_f32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_f32x16(padding);
+        match OFFSET {
+            0 => self.slide_f32x16::<16>(padding, a),
+            1 => self.slide_f32x16::<15>(padding, a),
+            2 => self.slide_f32x16::<14>(padding, a),
+            3 => self.slide_f32x16::<13>(padding, a),
+            4 => self.slide_f32x16::<12>(padding, a),
+            5 => self.slide_f32x16::<11>(padding, a),
+            6 => self.slide_f32x16::<10>(padding, a),
+            7 => self.slide_f32x16::<9>(padding, a),
+            8 => self.slide_f32x16::<8>(padding, a),
+            9 => self.slide_f32x16::<7>(padding, a),
+            10 => self.slide_f32x16::<6>(padding, a),
+            11 => self.slide_f32x16::<5>(padding, a),
+            12 => self.slide_f32x16::<4>(padding, a),
+            13 => self.slide_f32x16::<3>(padding, a),
+            14 => self.slide_f32x16::<2>(padding, a),
+            15 => self.slide_f32x16::<1>(padding, a),
+            16 => self.slide_f32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x16(
         self,
         a: f32x16<Self>,
@@ -8226,6 +9582,190 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        self.slide_i8x64::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        match OFFSET {
+            0 => self.slide_i8x64::<64>(a, a),
+            1 => self.slide_i8x64::<63>(a, a),
+            2 => self.slide_i8x64::<62>(a, a),
+            3 => self.slide_i8x64::<61>(a, a),
+            4 => self.slide_i8x64::<60>(a, a),
+            5 => self.slide_i8x64::<59>(a, a),
+            6 => self.slide_i8x64::<58>(a, a),
+            7 => self.slide_i8x64::<57>(a, a),
+            8 => self.slide_i8x64::<56>(a, a),
+            9 => self.slide_i8x64::<55>(a, a),
+            10 => self.slide_i8x64::<54>(a, a),
+            11 => self.slide_i8x64::<53>(a, a),
+            12 => self.slide_i8x64::<52>(a, a),
+            13 => self.slide_i8x64::<51>(a, a),
+            14 => self.slide_i8x64::<50>(a, a),
+            15 => self.slide_i8x64::<49>(a, a),
+            16 => self.slide_i8x64::<48>(a, a),
+            17 => self.slide_i8x64::<47>(a, a),
+            18 => self.slide_i8x64::<46>(a, a),
+            19 => self.slide_i8x64::<45>(a, a),
+            20 => self.slide_i8x64::<44>(a, a),
+            21 => self.slide_i8x64::<43>(a, a),
+            22 => self.slide_i8x64::<42>(a, a),
+            23 => self.slide_i8x64::<41>(a, a),
+            24 => self.slide_i8x64::<40>(a, a),
+            25 => self.slide_i8x64::<39>(a, a),
+            26 => self.slide_i8x64::<38>(a, a),
+            27 => self.slide_i8x64::<37>(a, a),
+            28 => self.slide_i8x64::<36>(a, a),
+            29 => self.slide_i8x64::<35>(a, a),
+            30 => self.slide_i8x64::<34>(a, a),
+            31 => self.slide_i8x64::<33>(a, a),
+            32 => self.slide_i8x64::<32>(a, a),
+            33 => self.slide_i8x64::<31>(a, a),
+            34 => self.slide_i8x64::<30>(a, a),
+            35 => self.slide_i8x64::<29>(a, a),
+            36 => self.slide_i8x64::<28>(a, a),
+            37 => self.slide_i8x64::<27>(a, a),
+            38 => self.slide_i8x64::<26>(a, a),
+            39 => self.slide_i8x64::<25>(a, a),
+            40 => self.slide_i8x64::<24>(a, a),
+            41 => self.slide_i8x64::<23>(a, a),
+            42 => self.slide_i8x64::<22>(a, a),
+            43 => self.slide_i8x64::<21>(a, a),
+            44 => self.slide_i8x64::<20>(a, a),
+            45 => self.slide_i8x64::<19>(a, a),
+            46 => self.slide_i8x64::<18>(a, a),
+            47 => self.slide_i8x64::<17>(a, a),
+            48 => self.slide_i8x64::<16>(a, a),
+            49 => self.slide_i8x64::<15>(a, a),
+            50 => self.slide_i8x64::<14>(a, a),
+            51 => self.slide_i8x64::<13>(a, a),
+            52 => self.slide_i8x64::<12>(a, a),
+            53 => self.slide_i8x64::<11>(a, a),
+            54 => self.slide_i8x64::<10>(a, a),
+            55 => self.slide_i8x64::<9>(a, a),
+            56 => self.slide_i8x64::<8>(a, a),
+            57 => self.slide_i8x64::<7>(a, a),
+            58 => self.slide_i8x64::<6>(a, a),
+            59 => self.slide_i8x64::<5>(a, a),
+            60 => self.slide_i8x64::<4>(a, a),
+            61 => self.slide_i8x64::<3>(a, a),
+            62 => self.slide_i8x64::<2>(a, a),
+            63 => self.slide_i8x64::<1>(a, a),
+            64 => self.slide_i8x64::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_i8x64(padding);
+        self.slide_i8x64::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_i8x64(padding);
+        match OFFSET {
+            0 => self.slide_i8x64::<64>(padding, a),
+            1 => self.slide_i8x64::<63>(padding, a),
+            2 => self.slide_i8x64::<62>(padding, a),
+            3 => self.slide_i8x64::<61>(padding, a),
+            4 => self.slide_i8x64::<60>(padding, a),
+            5 => self.slide_i8x64::<59>(padding, a),
+            6 => self.slide_i8x64::<58>(padding, a),
+            7 => self.slide_i8x64::<57>(padding, a),
+            8 => self.slide_i8x64::<56>(padding, a),
+            9 => self.slide_i8x64::<55>(padding, a),
+            10 => self.slide_i8x64::<54>(padding, a),
+            11 => self.slide_i8x64::<53>(padding, a),
+            12 => self.slide_i8x64::<52>(padding, a),
+            13 => self.slide_i8x64::<51>(padding, a),
+            14 => self.slide_i8x64::<50>(padding, a),
+            15 => self.slide_i8x64::<49>(padding, a),
+            16 => self.slide_i8x64::<48>(padding, a),
+            17 => self.slide_i8x64::<47>(padding, a),
+            18 => self.slide_i8x64::<46>(padding, a),
+            19 => self.slide_i8x64::<45>(padding, a),
+            20 => self.slide_i8x64::<44>(padding, a),
+            21 => self.slide_i8x64::<43>(padding, a),
+            22 => self.slide_i8x64::<42>(padding, a),
+            23 => self.slide_i8x64::<41>(padding, a),
+            24 => self.slide_i8x64::<40>(padding, a),
+            25 => self.slide_i8x64::<39>(padding, a),
+            26 => self.slide_i8x64::<38>(padding, a),
+            27 => self.slide_i8x64::<37>(padding, a),
+            28 => self.slide_i8x64::<36>(padding, a),
+            29 => self.slide_i8x64::<35>(padding, a),
+            30 => self.slide_i8x64::<34>(padding, a),
+            31 => self.slide_i8x64::<33>(padding, a),
+            32 => self.slide_i8x64::<32>(padding, a),
+            33 => self.slide_i8x64::<31>(padding, a),
+            34 => self.slide_i8x64::<30>(padding, a),
+            35 => self.slide_i8x64::<29>(padding, a),
+            36 => self.slide_i8x64::<28>(padding, a),
+            37 => self.slide_i8x64::<27>(padding, a),
+            38 => self.slide_i8x64::<26>(padding, a),
+            39 => self.slide_i8x64::<25>(padding, a),
+            40 => self.slide_i8x64::<24>(padding, a),
+            41 => self.slide_i8x64::<23>(padding, a),
+            42 => self.slide_i8x64::<22>(padding, a),
+            43 => self.slide_i8x64::<21>(padding, a),
+            44 => self.slide_i8x64::<20>(padding, a),
+            45 => self.slide_i8x64::<19>(padding, a),
+            46 => self.slide_i8x64::<18>(padding, a),
+            47 => self.slide_i8x64::<17>(padding, a),
+            48 => self.slide_i8x64::<16>(padding, a),
+            49 => self.slide_i8x64::<15>(padding, a),
+            50 => self.slide_i8x64::<14>(padding, a),
+            51 => self.slide_i8x64::<13>(padding, a),
+            52 => self.slide_i8x64::<12>(padding, a),
+            53 => self.slide_i8x64::<11>(padding, a),
+            54 => self.slide_i8x64::<10>(padding, a),
+            55 => self.slide_i8x64::<9>(padding, a),
+            56 => self.slide_i8x64::<8>(padding, a),
+            57 => self.slide_i8x64::<7>(padding, a),
+            58 => self.slide_i8x64::<6>(padding, a),
+            59 => self.slide_i8x64::<5>(padding, a),
+            60 => self.slide_i8x64::<4>(padding, a),
+            61 => self.slide_i8x64::<3>(padding, a),
+            62 => self.slide_i8x64::<2>(padding, a),
+            63 => self.slide_i8x64::<1>(padding, a),
+            64 => self.slide_i8x64::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
         let (indices0, indices1) = self.split_u8x64(indices);
@@ -8490,6 +10030,190 @@ impl Simd for Fallback {
             self.slide_within_blocks_u8x32::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x32::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        self.slide_u8x64::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        match OFFSET {
+            0 => self.slide_u8x64::<64>(a, a),
+            1 => self.slide_u8x64::<63>(a, a),
+            2 => self.slide_u8x64::<62>(a, a),
+            3 => self.slide_u8x64::<61>(a, a),
+            4 => self.slide_u8x64::<60>(a, a),
+            5 => self.slide_u8x64::<59>(a, a),
+            6 => self.slide_u8x64::<58>(a, a),
+            7 => self.slide_u8x64::<57>(a, a),
+            8 => self.slide_u8x64::<56>(a, a),
+            9 => self.slide_u8x64::<55>(a, a),
+            10 => self.slide_u8x64::<54>(a, a),
+            11 => self.slide_u8x64::<53>(a, a),
+            12 => self.slide_u8x64::<52>(a, a),
+            13 => self.slide_u8x64::<51>(a, a),
+            14 => self.slide_u8x64::<50>(a, a),
+            15 => self.slide_u8x64::<49>(a, a),
+            16 => self.slide_u8x64::<48>(a, a),
+            17 => self.slide_u8x64::<47>(a, a),
+            18 => self.slide_u8x64::<46>(a, a),
+            19 => self.slide_u8x64::<45>(a, a),
+            20 => self.slide_u8x64::<44>(a, a),
+            21 => self.slide_u8x64::<43>(a, a),
+            22 => self.slide_u8x64::<42>(a, a),
+            23 => self.slide_u8x64::<41>(a, a),
+            24 => self.slide_u8x64::<40>(a, a),
+            25 => self.slide_u8x64::<39>(a, a),
+            26 => self.slide_u8x64::<38>(a, a),
+            27 => self.slide_u8x64::<37>(a, a),
+            28 => self.slide_u8x64::<36>(a, a),
+            29 => self.slide_u8x64::<35>(a, a),
+            30 => self.slide_u8x64::<34>(a, a),
+            31 => self.slide_u8x64::<33>(a, a),
+            32 => self.slide_u8x64::<32>(a, a),
+            33 => self.slide_u8x64::<31>(a, a),
+            34 => self.slide_u8x64::<30>(a, a),
+            35 => self.slide_u8x64::<29>(a, a),
+            36 => self.slide_u8x64::<28>(a, a),
+            37 => self.slide_u8x64::<27>(a, a),
+            38 => self.slide_u8x64::<26>(a, a),
+            39 => self.slide_u8x64::<25>(a, a),
+            40 => self.slide_u8x64::<24>(a, a),
+            41 => self.slide_u8x64::<23>(a, a),
+            42 => self.slide_u8x64::<22>(a, a),
+            43 => self.slide_u8x64::<21>(a, a),
+            44 => self.slide_u8x64::<20>(a, a),
+            45 => self.slide_u8x64::<19>(a, a),
+            46 => self.slide_u8x64::<18>(a, a),
+            47 => self.slide_u8x64::<17>(a, a),
+            48 => self.slide_u8x64::<16>(a, a),
+            49 => self.slide_u8x64::<15>(a, a),
+            50 => self.slide_u8x64::<14>(a, a),
+            51 => self.slide_u8x64::<13>(a, a),
+            52 => self.slide_u8x64::<12>(a, a),
+            53 => self.slide_u8x64::<11>(a, a),
+            54 => self.slide_u8x64::<10>(a, a),
+            55 => self.slide_u8x64::<9>(a, a),
+            56 => self.slide_u8x64::<8>(a, a),
+            57 => self.slide_u8x64::<7>(a, a),
+            58 => self.slide_u8x64::<6>(a, a),
+            59 => self.slide_u8x64::<5>(a, a),
+            60 => self.slide_u8x64::<4>(a, a),
+            61 => self.slide_u8x64::<3>(a, a),
+            62 => self.slide_u8x64::<2>(a, a),
+            63 => self.slide_u8x64::<1>(a, a),
+            64 => self.slide_u8x64::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_u8x64(padding);
+        self.slide_u8x64::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_u8x64(padding);
+        match OFFSET {
+            0 => self.slide_u8x64::<64>(padding, a),
+            1 => self.slide_u8x64::<63>(padding, a),
+            2 => self.slide_u8x64::<62>(padding, a),
+            3 => self.slide_u8x64::<61>(padding, a),
+            4 => self.slide_u8x64::<60>(padding, a),
+            5 => self.slide_u8x64::<59>(padding, a),
+            6 => self.slide_u8x64::<58>(padding, a),
+            7 => self.slide_u8x64::<57>(padding, a),
+            8 => self.slide_u8x64::<56>(padding, a),
+            9 => self.slide_u8x64::<55>(padding, a),
+            10 => self.slide_u8x64::<54>(padding, a),
+            11 => self.slide_u8x64::<53>(padding, a),
+            12 => self.slide_u8x64::<52>(padding, a),
+            13 => self.slide_u8x64::<51>(padding, a),
+            14 => self.slide_u8x64::<50>(padding, a),
+            15 => self.slide_u8x64::<49>(padding, a),
+            16 => self.slide_u8x64::<48>(padding, a),
+            17 => self.slide_u8x64::<47>(padding, a),
+            18 => self.slide_u8x64::<46>(padding, a),
+            19 => self.slide_u8x64::<45>(padding, a),
+            20 => self.slide_u8x64::<44>(padding, a),
+            21 => self.slide_u8x64::<43>(padding, a),
+            22 => self.slide_u8x64::<42>(padding, a),
+            23 => self.slide_u8x64::<41>(padding, a),
+            24 => self.slide_u8x64::<40>(padding, a),
+            25 => self.slide_u8x64::<39>(padding, a),
+            26 => self.slide_u8x64::<38>(padding, a),
+            27 => self.slide_u8x64::<37>(padding, a),
+            28 => self.slide_u8x64::<36>(padding, a),
+            29 => self.slide_u8x64::<35>(padding, a),
+            30 => self.slide_u8x64::<34>(padding, a),
+            31 => self.slide_u8x64::<33>(padding, a),
+            32 => self.slide_u8x64::<32>(padding, a),
+            33 => self.slide_u8x64::<31>(padding, a),
+            34 => self.slide_u8x64::<30>(padding, a),
+            35 => self.slide_u8x64::<29>(padding, a),
+            36 => self.slide_u8x64::<28>(padding, a),
+            37 => self.slide_u8x64::<27>(padding, a),
+            38 => self.slide_u8x64::<26>(padding, a),
+            39 => self.slide_u8x64::<25>(padding, a),
+            40 => self.slide_u8x64::<24>(padding, a),
+            41 => self.slide_u8x64::<23>(padding, a),
+            42 => self.slide_u8x64::<22>(padding, a),
+            43 => self.slide_u8x64::<21>(padding, a),
+            44 => self.slide_u8x64::<20>(padding, a),
+            45 => self.slide_u8x64::<19>(padding, a),
+            46 => self.slide_u8x64::<18>(padding, a),
+            47 => self.slide_u8x64::<17>(padding, a),
+            48 => self.slide_u8x64::<16>(padding, a),
+            49 => self.slide_u8x64::<15>(padding, a),
+            50 => self.slide_u8x64::<14>(padding, a),
+            51 => self.slide_u8x64::<13>(padding, a),
+            52 => self.slide_u8x64::<12>(padding, a),
+            53 => self.slide_u8x64::<11>(padding, a),
+            54 => self.slide_u8x64::<10>(padding, a),
+            55 => self.slide_u8x64::<9>(padding, a),
+            56 => self.slide_u8x64::<8>(padding, a),
+            57 => self.slide_u8x64::<7>(padding, a),
+            58 => self.slide_u8x64::<6>(padding, a),
+            59 => self.slide_u8x64::<5>(padding, a),
+            60 => self.slide_u8x64::<4>(padding, a),
+            61 => self.slide_u8x64::<3>(padding, a),
+            62 => self.slide_u8x64::<2>(padding, a),
+            63 => self.slide_u8x64::<1>(padding, a),
+            64 => self.slide_u8x64::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self> {
@@ -8945,6 +10669,126 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_i16x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_i16x32::<32>(a, a),
+            1 => self.slide_i16x32::<31>(a, a),
+            2 => self.slide_i16x32::<30>(a, a),
+            3 => self.slide_i16x32::<29>(a, a),
+            4 => self.slide_i16x32::<28>(a, a),
+            5 => self.slide_i16x32::<27>(a, a),
+            6 => self.slide_i16x32::<26>(a, a),
+            7 => self.slide_i16x32::<25>(a, a),
+            8 => self.slide_i16x32::<24>(a, a),
+            9 => self.slide_i16x32::<23>(a, a),
+            10 => self.slide_i16x32::<22>(a, a),
+            11 => self.slide_i16x32::<21>(a, a),
+            12 => self.slide_i16x32::<20>(a, a),
+            13 => self.slide_i16x32::<19>(a, a),
+            14 => self.slide_i16x32::<18>(a, a),
+            15 => self.slide_i16x32::<17>(a, a),
+            16 => self.slide_i16x32::<16>(a, a),
+            17 => self.slide_i16x32::<15>(a, a),
+            18 => self.slide_i16x32::<14>(a, a),
+            19 => self.slide_i16x32::<13>(a, a),
+            20 => self.slide_i16x32::<12>(a, a),
+            21 => self.slide_i16x32::<11>(a, a),
+            22 => self.slide_i16x32::<10>(a, a),
+            23 => self.slide_i16x32::<9>(a, a),
+            24 => self.slide_i16x32::<8>(a, a),
+            25 => self.slide_i16x32::<7>(a, a),
+            26 => self.slide_i16x32::<6>(a, a),
+            27 => self.slide_i16x32::<5>(a, a),
+            28 => self.slide_i16x32::<4>(a, a),
+            29 => self.slide_i16x32::<3>(a, a),
+            30 => self.slide_i16x32::<2>(a, a),
+            31 => self.slide_i16x32::<1>(a, a),
+            32 => self.slide_i16x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i16x32(padding);
+        self.slide_i16x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i16x32(padding);
+        match OFFSET {
+            0 => self.slide_i16x32::<32>(padding, a),
+            1 => self.slide_i16x32::<31>(padding, a),
+            2 => self.slide_i16x32::<30>(padding, a),
+            3 => self.slide_i16x32::<29>(padding, a),
+            4 => self.slide_i16x32::<28>(padding, a),
+            5 => self.slide_i16x32::<27>(padding, a),
+            6 => self.slide_i16x32::<26>(padding, a),
+            7 => self.slide_i16x32::<25>(padding, a),
+            8 => self.slide_i16x32::<24>(padding, a),
+            9 => self.slide_i16x32::<23>(padding, a),
+            10 => self.slide_i16x32::<22>(padding, a),
+            11 => self.slide_i16x32::<21>(padding, a),
+            12 => self.slide_i16x32::<20>(padding, a),
+            13 => self.slide_i16x32::<19>(padding, a),
+            14 => self.slide_i16x32::<18>(padding, a),
+            15 => self.slide_i16x32::<17>(padding, a),
+            16 => self.slide_i16x32::<16>(padding, a),
+            17 => self.slide_i16x32::<15>(padding, a),
+            18 => self.slide_i16x32::<14>(padding, a),
+            19 => self.slide_i16x32::<13>(padding, a),
+            20 => self.slide_i16x32::<12>(padding, a),
+            21 => self.slide_i16x32::<11>(padding, a),
+            22 => self.slide_i16x32::<10>(padding, a),
+            23 => self.slide_i16x32::<9>(padding, a),
+            24 => self.slide_i16x32::<8>(padding, a),
+            25 => self.slide_i16x32::<7>(padding, a),
+            26 => self.slide_i16x32::<6>(padding, a),
+            27 => self.slide_i16x32::<5>(padding, a),
+            28 => self.slide_i16x32::<4>(padding, a),
+            29 => self.slide_i16x32::<3>(padding, a),
+            30 => self.slide_i16x32::<2>(padding, a),
+            31 => self.slide_i16x32::<1>(padding, a),
+            32 => self.slide_i16x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x32(
         self,
         a: i16x32<Self>,
@@ -9222,6 +11066,126 @@ impl Simd for Fallback {
             self.slide_within_blocks_u16x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x16::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_u16x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_u16x32::<32>(a, a),
+            1 => self.slide_u16x32::<31>(a, a),
+            2 => self.slide_u16x32::<30>(a, a),
+            3 => self.slide_u16x32::<29>(a, a),
+            4 => self.slide_u16x32::<28>(a, a),
+            5 => self.slide_u16x32::<27>(a, a),
+            6 => self.slide_u16x32::<26>(a, a),
+            7 => self.slide_u16x32::<25>(a, a),
+            8 => self.slide_u16x32::<24>(a, a),
+            9 => self.slide_u16x32::<23>(a, a),
+            10 => self.slide_u16x32::<22>(a, a),
+            11 => self.slide_u16x32::<21>(a, a),
+            12 => self.slide_u16x32::<20>(a, a),
+            13 => self.slide_u16x32::<19>(a, a),
+            14 => self.slide_u16x32::<18>(a, a),
+            15 => self.slide_u16x32::<17>(a, a),
+            16 => self.slide_u16x32::<16>(a, a),
+            17 => self.slide_u16x32::<15>(a, a),
+            18 => self.slide_u16x32::<14>(a, a),
+            19 => self.slide_u16x32::<13>(a, a),
+            20 => self.slide_u16x32::<12>(a, a),
+            21 => self.slide_u16x32::<11>(a, a),
+            22 => self.slide_u16x32::<10>(a, a),
+            23 => self.slide_u16x32::<9>(a, a),
+            24 => self.slide_u16x32::<8>(a, a),
+            25 => self.slide_u16x32::<7>(a, a),
+            26 => self.slide_u16x32::<6>(a, a),
+            27 => self.slide_u16x32::<5>(a, a),
+            28 => self.slide_u16x32::<4>(a, a),
+            29 => self.slide_u16x32::<3>(a, a),
+            30 => self.slide_u16x32::<2>(a, a),
+            31 => self.slide_u16x32::<1>(a, a),
+            32 => self.slide_u16x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u16x32(padding);
+        self.slide_u16x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u16x32(padding);
+        match OFFSET {
+            0 => self.slide_u16x32::<32>(padding, a),
+            1 => self.slide_u16x32::<31>(padding, a),
+            2 => self.slide_u16x32::<30>(padding, a),
+            3 => self.slide_u16x32::<29>(padding, a),
+            4 => self.slide_u16x32::<28>(padding, a),
+            5 => self.slide_u16x32::<27>(padding, a),
+            6 => self.slide_u16x32::<26>(padding, a),
+            7 => self.slide_u16x32::<25>(padding, a),
+            8 => self.slide_u16x32::<24>(padding, a),
+            9 => self.slide_u16x32::<23>(padding, a),
+            10 => self.slide_u16x32::<22>(padding, a),
+            11 => self.slide_u16x32::<21>(padding, a),
+            12 => self.slide_u16x32::<20>(padding, a),
+            13 => self.slide_u16x32::<19>(padding, a),
+            14 => self.slide_u16x32::<18>(padding, a),
+            15 => self.slide_u16x32::<17>(padding, a),
+            16 => self.slide_u16x32::<16>(padding, a),
+            17 => self.slide_u16x32::<15>(padding, a),
+            18 => self.slide_u16x32::<14>(padding, a),
+            19 => self.slide_u16x32::<13>(padding, a),
+            20 => self.slide_u16x32::<12>(padding, a),
+            21 => self.slide_u16x32::<11>(padding, a),
+            22 => self.slide_u16x32::<10>(padding, a),
+            23 => self.slide_u16x32::<9>(padding, a),
+            24 => self.slide_u16x32::<8>(padding, a),
+            25 => self.slide_u16x32::<7>(padding, a),
+            26 => self.slide_u16x32::<6>(padding, a),
+            27 => self.slide_u16x32::<5>(padding, a),
+            28 => self.slide_u16x32::<4>(padding, a),
+            29 => self.slide_u16x32::<3>(padding, a),
+            30 => self.slide_u16x32::<2>(padding, a),
+            31 => self.slide_u16x32::<1>(padding, a),
+            32 => self.slide_u16x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x32(
@@ -9666,6 +11630,94 @@ impl Simd for Fallback {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i32x16::<16>(a, a),
+            1 => self.slide_i32x16::<15>(a, a),
+            2 => self.slide_i32x16::<14>(a, a),
+            3 => self.slide_i32x16::<13>(a, a),
+            4 => self.slide_i32x16::<12>(a, a),
+            5 => self.slide_i32x16::<11>(a, a),
+            6 => self.slide_i32x16::<10>(a, a),
+            7 => self.slide_i32x16::<9>(a, a),
+            8 => self.slide_i32x16::<8>(a, a),
+            9 => self.slide_i32x16::<7>(a, a),
+            10 => self.slide_i32x16::<6>(a, a),
+            11 => self.slide_i32x16::<5>(a, a),
+            12 => self.slide_i32x16::<4>(a, a),
+            13 => self.slide_i32x16::<3>(a, a),
+            14 => self.slide_i32x16::<2>(a, a),
+            15 => self.slide_i32x16::<1>(a, a),
+            16 => self.slide_i32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i32x16(padding);
+        self.slide_i32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i32x16(padding);
+        match OFFSET {
+            0 => self.slide_i32x16::<16>(padding, a),
+            1 => self.slide_i32x16::<15>(padding, a),
+            2 => self.slide_i32x16::<14>(padding, a),
+            3 => self.slide_i32x16::<13>(padding, a),
+            4 => self.slide_i32x16::<12>(padding, a),
+            5 => self.slide_i32x16::<11>(padding, a),
+            6 => self.slide_i32x16::<10>(padding, a),
+            7 => self.slide_i32x16::<9>(padding, a),
+            8 => self.slide_i32x16::<8>(padding, a),
+            9 => self.slide_i32x16::<7>(padding, a),
+            10 => self.slide_i32x16::<6>(padding, a),
+            11 => self.slide_i32x16::<5>(padding, a),
+            12 => self.slide_i32x16::<4>(padding, a),
+            13 => self.slide_i32x16::<3>(padding, a),
+            14 => self.slide_i32x16::<2>(padding, a),
+            15 => self.slide_i32x16::<1>(padding, a),
+            16 => self.slide_i32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x16(
         self,
         a: i32x16<Self>,
@@ -9939,6 +11991,94 @@ impl Simd for Fallback {
             self.slide_within_blocks_u32x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x8::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u32x16::<16>(a, a),
+            1 => self.slide_u32x16::<15>(a, a),
+            2 => self.slide_u32x16::<14>(a, a),
+            3 => self.slide_u32x16::<13>(a, a),
+            4 => self.slide_u32x16::<12>(a, a),
+            5 => self.slide_u32x16::<11>(a, a),
+            6 => self.slide_u32x16::<10>(a, a),
+            7 => self.slide_u32x16::<9>(a, a),
+            8 => self.slide_u32x16::<8>(a, a),
+            9 => self.slide_u32x16::<7>(a, a),
+            10 => self.slide_u32x16::<6>(a, a),
+            11 => self.slide_u32x16::<5>(a, a),
+            12 => self.slide_u32x16::<4>(a, a),
+            13 => self.slide_u32x16::<3>(a, a),
+            14 => self.slide_u32x16::<2>(a, a),
+            15 => self.slide_u32x16::<1>(a, a),
+            16 => self.slide_u32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u32x16(padding);
+        self.slide_u32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u32x16(padding);
+        match OFFSET {
+            0 => self.slide_u32x16::<16>(padding, a),
+            1 => self.slide_u32x16::<15>(padding, a),
+            2 => self.slide_u32x16::<14>(padding, a),
+            3 => self.slide_u32x16::<13>(padding, a),
+            4 => self.slide_u32x16::<12>(padding, a),
+            5 => self.slide_u32x16::<11>(padding, a),
+            6 => self.slide_u32x16::<10>(padding, a),
+            7 => self.slide_u32x16::<9>(padding, a),
+            8 => self.slide_u32x16::<8>(padding, a),
+            9 => self.slide_u32x16::<7>(padding, a),
+            10 => self.slide_u32x16::<6>(padding, a),
+            11 => self.slide_u32x16::<5>(padding, a),
+            12 => self.slide_u32x16::<4>(padding, a),
+            13 => self.slide_u32x16::<3>(padding, a),
+            14 => self.slide_u32x16::<2>(padding, a),
+            15 => self.slide_u32x16::<1>(padding, a),
+            16 => self.slide_u32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x16(
@@ -10343,6 +12483,78 @@ impl Simd for Fallback {
             self.slide_within_blocks_f64x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x4::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_f64x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_f64x8::<8>(a, a),
+            1 => self.slide_f64x8::<7>(a, a),
+            2 => self.slide_f64x8::<6>(a, a),
+            3 => self.slide_f64x8::<5>(a, a),
+            4 => self.slide_f64x8::<4>(a, a),
+            5 => self.slide_f64x8::<3>(a, a),
+            6 => self.slide_f64x8::<2>(a, a),
+            7 => self.slide_f64x8::<1>(a, a),
+            8 => self.slide_f64x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f64x8(padding);
+        self.slide_f64x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f64x8(padding);
+        match OFFSET {
+            0 => self.slide_f64x8::<8>(padding, a),
+            1 => self.slide_f64x8::<7>(padding, a),
+            2 => self.slide_f64x8::<6>(padding, a),
+            3 => self.slide_f64x8::<5>(padding, a),
+            4 => self.slide_f64x8::<4>(padding, a),
+            5 => self.slide_f64x8::<3>(padding, a),
+            6 => self.slide_f64x8::<2>(padding, a),
+            7 => self.slide_f64x8::<1>(padding, a),
+            8 => self.slide_f64x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -216,28 +216,21 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_f32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_f32x4::<0>(a, a),
+            1 => self.slide_f32x4::<1>(a, a),
+            2 => self.slide_f32x4::<2>(a, a),
+            3 => self.slide_f32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_f32x4::<4>(a, a),
             1 => self.slide_f32x4::<3>(a, a),
             2 => self.slide_f32x4::<2>(a, a),
             3 => self.slide_f32x4::<1>(a, a),
-            4 => self.slide_f32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -247,14 +240,15 @@ impl Simd for Fallback {
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f32x4(padding);
-        self.slide_f32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x4::<0>(a, padding),
+            1 => self.slide_f32x4::<1>(a, padding),
+            2 => self.slide_f32x4::<2>(a, padding),
+            3 => self.slide_f32x4::<3>(a, padding),
+            4 => self.slide_f32x4::<4>(a, padding),
+            _ => self.slide_f32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x4<const OFFSET: usize>(
@@ -262,12 +256,6 @@ impl Simd for Fallback {
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f32x4(padding);
         match OFFSET {
             0 => self.slide_f32x4::<4>(padding, a),
@@ -275,7 +263,7 @@ impl Simd for Fallback {
             2 => self.slide_f32x4::<2>(padding, a),
             3 => self.slide_f32x4::<1>(padding, a),
             4 => self.slide_f32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -748,23 +736,29 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i8x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i8x16::<0>(a, a),
+            1 => self.slide_i8x16::<1>(a, a),
+            2 => self.slide_i8x16::<2>(a, a),
+            3 => self.slide_i8x16::<3>(a, a),
+            4 => self.slide_i8x16::<4>(a, a),
+            5 => self.slide_i8x16::<5>(a, a),
+            6 => self.slide_i8x16::<6>(a, a),
+            7 => self.slide_i8x16::<7>(a, a),
+            8 => self.slide_i8x16::<8>(a, a),
+            9 => self.slide_i8x16::<9>(a, a),
+            10 => self.slide_i8x16::<10>(a, a),
+            11 => self.slide_i8x16::<11>(a, a),
+            12 => self.slide_i8x16::<12>(a, a),
+            13 => self.slide_i8x16::<13>(a, a),
+            14 => self.slide_i8x16::<14>(a, a),
+            15 => self.slide_i8x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i8x16::<16>(a, a),
             1 => self.slide_i8x16::<15>(a, a),
             2 => self.slide_i8x16::<14>(a, a),
@@ -781,7 +775,6 @@ impl Simd for Fallback {
             13 => self.slide_i8x16::<3>(a, a),
             14 => self.slide_i8x16::<2>(a, a),
             15 => self.slide_i8x16::<1>(a, a),
-            16 => self.slide_i8x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -791,14 +784,27 @@ impl Simd for Fallback {
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i8x16(padding);
-        self.slide_i8x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x16::<0>(a, padding),
+            1 => self.slide_i8x16::<1>(a, padding),
+            2 => self.slide_i8x16::<2>(a, padding),
+            3 => self.slide_i8x16::<3>(a, padding),
+            4 => self.slide_i8x16::<4>(a, padding),
+            5 => self.slide_i8x16::<5>(a, padding),
+            6 => self.slide_i8x16::<6>(a, padding),
+            7 => self.slide_i8x16::<7>(a, padding),
+            8 => self.slide_i8x16::<8>(a, padding),
+            9 => self.slide_i8x16::<9>(a, padding),
+            10 => self.slide_i8x16::<10>(a, padding),
+            11 => self.slide_i8x16::<11>(a, padding),
+            12 => self.slide_i8x16::<12>(a, padding),
+            13 => self.slide_i8x16::<13>(a, padding),
+            14 => self.slide_i8x16::<14>(a, padding),
+            15 => self.slide_i8x16::<15>(a, padding),
+            16 => self.slide_i8x16::<16>(a, padding),
+            _ => self.slide_i8x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x16<const OFFSET: usize>(
@@ -806,12 +812,6 @@ impl Simd for Fallback {
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i8x16(padding);
         match OFFSET {
             0 => self.slide_i8x16::<16>(padding, a),
@@ -831,7 +831,7 @@ impl Simd for Fallback {
             14 => self.slide_i8x16::<2>(padding, a),
             15 => self.slide_i8x16::<1>(padding, a),
             16 => self.slide_i8x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -1533,23 +1533,29 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u8x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u8x16::<0>(a, a),
+            1 => self.slide_u8x16::<1>(a, a),
+            2 => self.slide_u8x16::<2>(a, a),
+            3 => self.slide_u8x16::<3>(a, a),
+            4 => self.slide_u8x16::<4>(a, a),
+            5 => self.slide_u8x16::<5>(a, a),
+            6 => self.slide_u8x16::<6>(a, a),
+            7 => self.slide_u8x16::<7>(a, a),
+            8 => self.slide_u8x16::<8>(a, a),
+            9 => self.slide_u8x16::<9>(a, a),
+            10 => self.slide_u8x16::<10>(a, a),
+            11 => self.slide_u8x16::<11>(a, a),
+            12 => self.slide_u8x16::<12>(a, a),
+            13 => self.slide_u8x16::<13>(a, a),
+            14 => self.slide_u8x16::<14>(a, a),
+            15 => self.slide_u8x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u8x16::<16>(a, a),
             1 => self.slide_u8x16::<15>(a, a),
             2 => self.slide_u8x16::<14>(a, a),
@@ -1566,7 +1572,6 @@ impl Simd for Fallback {
             13 => self.slide_u8x16::<3>(a, a),
             14 => self.slide_u8x16::<2>(a, a),
             15 => self.slide_u8x16::<1>(a, a),
-            16 => self.slide_u8x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -1576,14 +1581,27 @@ impl Simd for Fallback {
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u8x16(padding);
-        self.slide_u8x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x16::<0>(a, padding),
+            1 => self.slide_u8x16::<1>(a, padding),
+            2 => self.slide_u8x16::<2>(a, padding),
+            3 => self.slide_u8x16::<3>(a, padding),
+            4 => self.slide_u8x16::<4>(a, padding),
+            5 => self.slide_u8x16::<5>(a, padding),
+            6 => self.slide_u8x16::<6>(a, padding),
+            7 => self.slide_u8x16::<7>(a, padding),
+            8 => self.slide_u8x16::<8>(a, padding),
+            9 => self.slide_u8x16::<9>(a, padding),
+            10 => self.slide_u8x16::<10>(a, padding),
+            11 => self.slide_u8x16::<11>(a, padding),
+            12 => self.slide_u8x16::<12>(a, padding),
+            13 => self.slide_u8x16::<13>(a, padding),
+            14 => self.slide_u8x16::<14>(a, padding),
+            15 => self.slide_u8x16::<15>(a, padding),
+            16 => self.slide_u8x16::<16>(a, padding),
+            _ => self.slide_u8x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x16<const OFFSET: usize>(
@@ -1591,12 +1609,6 @@ impl Simd for Fallback {
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u8x16(padding);
         match OFFSET {
             0 => self.slide_u8x16::<16>(padding, a),
@@ -1616,7 +1628,7 @@ impl Simd for Fallback {
             14 => self.slide_u8x16::<2>(padding, a),
             15 => self.slide_u8x16::<1>(padding, a),
             16 => self.slide_u8x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -2644,23 +2656,21 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_i16x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_i16x8::<0>(a, a),
+            1 => self.slide_i16x8::<1>(a, a),
+            2 => self.slide_i16x8::<2>(a, a),
+            3 => self.slide_i16x8::<3>(a, a),
+            4 => self.slide_i16x8::<4>(a, a),
+            5 => self.slide_i16x8::<5>(a, a),
+            6 => self.slide_i16x8::<6>(a, a),
+            7 => self.slide_i16x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_i16x8::<8>(a, a),
             1 => self.slide_i16x8::<7>(a, a),
             2 => self.slide_i16x8::<6>(a, a),
@@ -2669,7 +2679,6 @@ impl Simd for Fallback {
             5 => self.slide_i16x8::<3>(a, a),
             6 => self.slide_i16x8::<2>(a, a),
             7 => self.slide_i16x8::<1>(a, a),
-            8 => self.slide_i16x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -2679,14 +2688,19 @@ impl Simd for Fallback {
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i16x8(padding);
-        self.slide_i16x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x8::<0>(a, padding),
+            1 => self.slide_i16x8::<1>(a, padding),
+            2 => self.slide_i16x8::<2>(a, padding),
+            3 => self.slide_i16x8::<3>(a, padding),
+            4 => self.slide_i16x8::<4>(a, padding),
+            5 => self.slide_i16x8::<5>(a, padding),
+            6 => self.slide_i16x8::<6>(a, padding),
+            7 => self.slide_i16x8::<7>(a, padding),
+            8 => self.slide_i16x8::<8>(a, padding),
+            _ => self.slide_i16x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x8<const OFFSET: usize>(
@@ -2694,12 +2708,6 @@ impl Simd for Fallback {
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i16x8(padding);
         match OFFSET {
             0 => self.slide_i16x8::<8>(padding, a),
@@ -2711,7 +2719,7 @@ impl Simd for Fallback {
             6 => self.slide_i16x8::<2>(padding, a),
             7 => self.slide_i16x8::<1>(padding, a),
             8 => self.slide_i16x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -3214,23 +3222,21 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_u16x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_u16x8::<0>(a, a),
+            1 => self.slide_u16x8::<1>(a, a),
+            2 => self.slide_u16x8::<2>(a, a),
+            3 => self.slide_u16x8::<3>(a, a),
+            4 => self.slide_u16x8::<4>(a, a),
+            5 => self.slide_u16x8::<5>(a, a),
+            6 => self.slide_u16x8::<6>(a, a),
+            7 => self.slide_u16x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_u16x8::<8>(a, a),
             1 => self.slide_u16x8::<7>(a, a),
             2 => self.slide_u16x8::<6>(a, a),
@@ -3239,7 +3245,6 @@ impl Simd for Fallback {
             5 => self.slide_u16x8::<3>(a, a),
             6 => self.slide_u16x8::<2>(a, a),
             7 => self.slide_u16x8::<1>(a, a),
-            8 => self.slide_u16x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -3249,14 +3254,19 @@ impl Simd for Fallback {
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u16x8(padding);
-        self.slide_u16x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x8::<0>(a, padding),
+            1 => self.slide_u16x8::<1>(a, padding),
+            2 => self.slide_u16x8::<2>(a, padding),
+            3 => self.slide_u16x8::<3>(a, padding),
+            4 => self.slide_u16x8::<4>(a, padding),
+            5 => self.slide_u16x8::<5>(a, padding),
+            6 => self.slide_u16x8::<6>(a, padding),
+            7 => self.slide_u16x8::<7>(a, padding),
+            8 => self.slide_u16x8::<8>(a, padding),
+            _ => self.slide_u16x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x8<const OFFSET: usize>(
@@ -3264,12 +3274,6 @@ impl Simd for Fallback {
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u16x8(padding);
         match OFFSET {
             0 => self.slide_u16x8::<8>(padding, a),
@@ -3281,7 +3285,7 @@ impl Simd for Fallback {
             6 => self.slide_u16x8::<2>(padding, a),
             7 => self.slide_u16x8::<1>(padding, a),
             8 => self.slide_u16x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -3988,28 +3992,21 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_i32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_i32x4::<0>(a, a),
+            1 => self.slide_i32x4::<1>(a, a),
+            2 => self.slide_i32x4::<2>(a, a),
+            3 => self.slide_i32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_i32x4::<4>(a, a),
             1 => self.slide_i32x4::<3>(a, a),
             2 => self.slide_i32x4::<2>(a, a),
             3 => self.slide_i32x4::<1>(a, a),
-            4 => self.slide_i32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -4019,14 +4016,15 @@ impl Simd for Fallback {
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_i32x4(padding);
-        self.slide_i32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x4::<0>(a, padding),
+            1 => self.slide_i32x4::<1>(a, padding),
+            2 => self.slide_i32x4::<2>(a, padding),
+            3 => self.slide_i32x4::<3>(a, padding),
+            4 => self.slide_i32x4::<4>(a, padding),
+            _ => self.slide_i32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x4<const OFFSET: usize>(
@@ -4034,12 +4032,6 @@ impl Simd for Fallback {
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_i32x4(padding);
         match OFFSET {
             0 => self.slide_i32x4::<4>(padding, a),
@@ -4047,7 +4039,7 @@ impl Simd for Fallback {
             2 => self.slide_i32x4::<2>(padding, a),
             3 => self.slide_i32x4::<1>(padding, a),
             4 => self.slide_i32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -4452,28 +4444,21 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_u32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_u32x4::<0>(a, a),
+            1 => self.slide_u32x4::<1>(a, a),
+            2 => self.slide_u32x4::<2>(a, a),
+            3 => self.slide_u32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_u32x4::<4>(a, a),
             1 => self.slide_u32x4::<3>(a, a),
             2 => self.slide_u32x4::<2>(a, a),
             3 => self.slide_u32x4::<1>(a, a),
-            4 => self.slide_u32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -4483,14 +4468,15 @@ impl Simd for Fallback {
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_u32x4(padding);
-        self.slide_u32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x4::<0>(a, padding),
+            1 => self.slide_u32x4::<1>(a, padding),
+            2 => self.slide_u32x4::<2>(a, padding),
+            3 => self.slide_u32x4::<3>(a, padding),
+            4 => self.slide_u32x4::<4>(a, padding),
+            _ => self.slide_u32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x4<const OFFSET: usize>(
@@ -4498,12 +4484,6 @@ impl Simd for Fallback {
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_u32x4(padding);
         match OFFSET {
             0 => self.slide_u32x4::<4>(padding, a),
@@ -4511,7 +4491,7 @@ impl Simd for Fallback {
             2 => self.slide_u32x4::<2>(padding, a),
             3 => self.slide_u32x4::<1>(padding, a),
             4 => self.slide_u32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -5052,26 +5032,17 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
-        self.slide_f64x2::<OFFSET>(a, a)
+        match OFFSET % 2 {
+            0 => self.slide_f64x2::<0>(a, a),
+            1 => self.slide_f64x2::<1>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
-        match OFFSET {
+        match OFFSET % 2 {
             0 => self.slide_f64x2::<2>(a, a),
             1 => self.slide_f64x2::<1>(a, a),
-            2 => self.slide_f64x2::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -5081,14 +5052,13 @@ impl Simd for Fallback {
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
         let padding = self.splat_f64x2(padding);
-        self.slide_f64x2::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x2::<0>(a, padding),
+            1 => self.slide_f64x2::<1>(a, padding),
+            2 => self.slide_f64x2::<2>(a, padding),
+            _ => self.slide_f64x2::<2>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x2<const OFFSET: usize>(
@@ -5096,18 +5066,12 @@ impl Simd for Fallback {
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
         let padding = self.splat_f64x2(padding);
         match OFFSET {
             0 => self.slide_f64x2::<2>(padding, a),
             1 => self.slide_f64x2::<1>(padding, a),
             2 => self.slide_f64x2::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x2::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -5590,23 +5554,21 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_f32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_f32x8::<0>(a, a),
+            1 => self.slide_f32x8::<1>(a, a),
+            2 => self.slide_f32x8::<2>(a, a),
+            3 => self.slide_f32x8::<3>(a, a),
+            4 => self.slide_f32x8::<4>(a, a),
+            5 => self.slide_f32x8::<5>(a, a),
+            6 => self.slide_f32x8::<6>(a, a),
+            7 => self.slide_f32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_f32x8::<8>(a, a),
             1 => self.slide_f32x8::<7>(a, a),
             2 => self.slide_f32x8::<6>(a, a),
@@ -5615,7 +5577,6 @@ impl Simd for Fallback {
             5 => self.slide_f32x8::<3>(a, a),
             6 => self.slide_f32x8::<2>(a, a),
             7 => self.slide_f32x8::<1>(a, a),
-            8 => self.slide_f32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -5625,14 +5586,19 @@ impl Simd for Fallback {
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f32x8(padding);
-        self.slide_f32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x8::<0>(a, padding),
+            1 => self.slide_f32x8::<1>(a, padding),
+            2 => self.slide_f32x8::<2>(a, padding),
+            3 => self.slide_f32x8::<3>(a, padding),
+            4 => self.slide_f32x8::<4>(a, padding),
+            5 => self.slide_f32x8::<5>(a, padding),
+            6 => self.slide_f32x8::<6>(a, padding),
+            7 => self.slide_f32x8::<7>(a, padding),
+            8 => self.slide_f32x8::<8>(a, padding),
+            _ => self.slide_f32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x8<const OFFSET: usize>(
@@ -5640,12 +5606,6 @@ impl Simd for Fallback {
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f32x8(padding);
         match OFFSET {
             0 => self.slide_f32x8::<8>(padding, a),
@@ -5657,7 +5617,7 @@ impl Simd for Fallback {
             6 => self.slide_f32x8::<2>(padding, a),
             7 => self.slide_f32x8::<1>(padding, a),
             8 => self.slide_f32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -6028,23 +5988,45 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_i8x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_i8x32::<0>(a, a),
+            1 => self.slide_i8x32::<1>(a, a),
+            2 => self.slide_i8x32::<2>(a, a),
+            3 => self.slide_i8x32::<3>(a, a),
+            4 => self.slide_i8x32::<4>(a, a),
+            5 => self.slide_i8x32::<5>(a, a),
+            6 => self.slide_i8x32::<6>(a, a),
+            7 => self.slide_i8x32::<7>(a, a),
+            8 => self.slide_i8x32::<8>(a, a),
+            9 => self.slide_i8x32::<9>(a, a),
+            10 => self.slide_i8x32::<10>(a, a),
+            11 => self.slide_i8x32::<11>(a, a),
+            12 => self.slide_i8x32::<12>(a, a),
+            13 => self.slide_i8x32::<13>(a, a),
+            14 => self.slide_i8x32::<14>(a, a),
+            15 => self.slide_i8x32::<15>(a, a),
+            16 => self.slide_i8x32::<16>(a, a),
+            17 => self.slide_i8x32::<17>(a, a),
+            18 => self.slide_i8x32::<18>(a, a),
+            19 => self.slide_i8x32::<19>(a, a),
+            20 => self.slide_i8x32::<20>(a, a),
+            21 => self.slide_i8x32::<21>(a, a),
+            22 => self.slide_i8x32::<22>(a, a),
+            23 => self.slide_i8x32::<23>(a, a),
+            24 => self.slide_i8x32::<24>(a, a),
+            25 => self.slide_i8x32::<25>(a, a),
+            26 => self.slide_i8x32::<26>(a, a),
+            27 => self.slide_i8x32::<27>(a, a),
+            28 => self.slide_i8x32::<28>(a, a),
+            29 => self.slide_i8x32::<29>(a, a),
+            30 => self.slide_i8x32::<30>(a, a),
+            31 => self.slide_i8x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_i8x32::<32>(a, a),
             1 => self.slide_i8x32::<31>(a, a),
             2 => self.slide_i8x32::<30>(a, a),
@@ -6077,7 +6059,6 @@ impl Simd for Fallback {
             29 => self.slide_i8x32::<3>(a, a),
             30 => self.slide_i8x32::<2>(a, a),
             31 => self.slide_i8x32::<1>(a, a),
-            32 => self.slide_i8x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -6087,14 +6068,43 @@ impl Simd for Fallback {
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i8x32(padding);
-        self.slide_i8x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x32::<0>(a, padding),
+            1 => self.slide_i8x32::<1>(a, padding),
+            2 => self.slide_i8x32::<2>(a, padding),
+            3 => self.slide_i8x32::<3>(a, padding),
+            4 => self.slide_i8x32::<4>(a, padding),
+            5 => self.slide_i8x32::<5>(a, padding),
+            6 => self.slide_i8x32::<6>(a, padding),
+            7 => self.slide_i8x32::<7>(a, padding),
+            8 => self.slide_i8x32::<8>(a, padding),
+            9 => self.slide_i8x32::<9>(a, padding),
+            10 => self.slide_i8x32::<10>(a, padding),
+            11 => self.slide_i8x32::<11>(a, padding),
+            12 => self.slide_i8x32::<12>(a, padding),
+            13 => self.slide_i8x32::<13>(a, padding),
+            14 => self.slide_i8x32::<14>(a, padding),
+            15 => self.slide_i8x32::<15>(a, padding),
+            16 => self.slide_i8x32::<16>(a, padding),
+            17 => self.slide_i8x32::<17>(a, padding),
+            18 => self.slide_i8x32::<18>(a, padding),
+            19 => self.slide_i8x32::<19>(a, padding),
+            20 => self.slide_i8x32::<20>(a, padding),
+            21 => self.slide_i8x32::<21>(a, padding),
+            22 => self.slide_i8x32::<22>(a, padding),
+            23 => self.slide_i8x32::<23>(a, padding),
+            24 => self.slide_i8x32::<24>(a, padding),
+            25 => self.slide_i8x32::<25>(a, padding),
+            26 => self.slide_i8x32::<26>(a, padding),
+            27 => self.slide_i8x32::<27>(a, padding),
+            28 => self.slide_i8x32::<28>(a, padding),
+            29 => self.slide_i8x32::<29>(a, padding),
+            30 => self.slide_i8x32::<30>(a, padding),
+            31 => self.slide_i8x32::<31>(a, padding),
+            32 => self.slide_i8x32::<32>(a, padding),
+            _ => self.slide_i8x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x32<const OFFSET: usize>(
@@ -6102,12 +6112,6 @@ impl Simd for Fallback {
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i8x32(padding);
         match OFFSET {
             0 => self.slide_i8x32::<32>(padding, a),
@@ -6143,7 +6147,7 @@ impl Simd for Fallback {
             30 => self.slide_i8x32::<2>(padding, a),
             31 => self.slide_i8x32::<1>(padding, a),
             32 => self.slide_i8x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -6421,23 +6425,45 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_u8x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_u8x32::<0>(a, a),
+            1 => self.slide_u8x32::<1>(a, a),
+            2 => self.slide_u8x32::<2>(a, a),
+            3 => self.slide_u8x32::<3>(a, a),
+            4 => self.slide_u8x32::<4>(a, a),
+            5 => self.slide_u8x32::<5>(a, a),
+            6 => self.slide_u8x32::<6>(a, a),
+            7 => self.slide_u8x32::<7>(a, a),
+            8 => self.slide_u8x32::<8>(a, a),
+            9 => self.slide_u8x32::<9>(a, a),
+            10 => self.slide_u8x32::<10>(a, a),
+            11 => self.slide_u8x32::<11>(a, a),
+            12 => self.slide_u8x32::<12>(a, a),
+            13 => self.slide_u8x32::<13>(a, a),
+            14 => self.slide_u8x32::<14>(a, a),
+            15 => self.slide_u8x32::<15>(a, a),
+            16 => self.slide_u8x32::<16>(a, a),
+            17 => self.slide_u8x32::<17>(a, a),
+            18 => self.slide_u8x32::<18>(a, a),
+            19 => self.slide_u8x32::<19>(a, a),
+            20 => self.slide_u8x32::<20>(a, a),
+            21 => self.slide_u8x32::<21>(a, a),
+            22 => self.slide_u8x32::<22>(a, a),
+            23 => self.slide_u8x32::<23>(a, a),
+            24 => self.slide_u8x32::<24>(a, a),
+            25 => self.slide_u8x32::<25>(a, a),
+            26 => self.slide_u8x32::<26>(a, a),
+            27 => self.slide_u8x32::<27>(a, a),
+            28 => self.slide_u8x32::<28>(a, a),
+            29 => self.slide_u8x32::<29>(a, a),
+            30 => self.slide_u8x32::<30>(a, a),
+            31 => self.slide_u8x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_u8x32::<32>(a, a),
             1 => self.slide_u8x32::<31>(a, a),
             2 => self.slide_u8x32::<30>(a, a),
@@ -6470,7 +6496,6 @@ impl Simd for Fallback {
             29 => self.slide_u8x32::<3>(a, a),
             30 => self.slide_u8x32::<2>(a, a),
             31 => self.slide_u8x32::<1>(a, a),
-            32 => self.slide_u8x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -6480,14 +6505,43 @@ impl Simd for Fallback {
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u8x32(padding);
-        self.slide_u8x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x32::<0>(a, padding),
+            1 => self.slide_u8x32::<1>(a, padding),
+            2 => self.slide_u8x32::<2>(a, padding),
+            3 => self.slide_u8x32::<3>(a, padding),
+            4 => self.slide_u8x32::<4>(a, padding),
+            5 => self.slide_u8x32::<5>(a, padding),
+            6 => self.slide_u8x32::<6>(a, padding),
+            7 => self.slide_u8x32::<7>(a, padding),
+            8 => self.slide_u8x32::<8>(a, padding),
+            9 => self.slide_u8x32::<9>(a, padding),
+            10 => self.slide_u8x32::<10>(a, padding),
+            11 => self.slide_u8x32::<11>(a, padding),
+            12 => self.slide_u8x32::<12>(a, padding),
+            13 => self.slide_u8x32::<13>(a, padding),
+            14 => self.slide_u8x32::<14>(a, padding),
+            15 => self.slide_u8x32::<15>(a, padding),
+            16 => self.slide_u8x32::<16>(a, padding),
+            17 => self.slide_u8x32::<17>(a, padding),
+            18 => self.slide_u8x32::<18>(a, padding),
+            19 => self.slide_u8x32::<19>(a, padding),
+            20 => self.slide_u8x32::<20>(a, padding),
+            21 => self.slide_u8x32::<21>(a, padding),
+            22 => self.slide_u8x32::<22>(a, padding),
+            23 => self.slide_u8x32::<23>(a, padding),
+            24 => self.slide_u8x32::<24>(a, padding),
+            25 => self.slide_u8x32::<25>(a, padding),
+            26 => self.slide_u8x32::<26>(a, padding),
+            27 => self.slide_u8x32::<27>(a, padding),
+            28 => self.slide_u8x32::<28>(a, padding),
+            29 => self.slide_u8x32::<29>(a, padding),
+            30 => self.slide_u8x32::<30>(a, padding),
+            31 => self.slide_u8x32::<31>(a, padding),
+            32 => self.slide_u8x32::<32>(a, padding),
+            _ => self.slide_u8x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x32<const OFFSET: usize>(
@@ -6495,12 +6549,6 @@ impl Simd for Fallback {
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u8x32(padding);
         match OFFSET {
             0 => self.slide_u8x32::<32>(padding, a),
@@ -6536,7 +6584,7 @@ impl Simd for Fallback {
             30 => self.slide_u8x32::<2>(padding, a),
             31 => self.slide_u8x32::<1>(padding, a),
             32 => self.slide_u8x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -6928,23 +6976,29 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i16x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i16x16::<0>(a, a),
+            1 => self.slide_i16x16::<1>(a, a),
+            2 => self.slide_i16x16::<2>(a, a),
+            3 => self.slide_i16x16::<3>(a, a),
+            4 => self.slide_i16x16::<4>(a, a),
+            5 => self.slide_i16x16::<5>(a, a),
+            6 => self.slide_i16x16::<6>(a, a),
+            7 => self.slide_i16x16::<7>(a, a),
+            8 => self.slide_i16x16::<8>(a, a),
+            9 => self.slide_i16x16::<9>(a, a),
+            10 => self.slide_i16x16::<10>(a, a),
+            11 => self.slide_i16x16::<11>(a, a),
+            12 => self.slide_i16x16::<12>(a, a),
+            13 => self.slide_i16x16::<13>(a, a),
+            14 => self.slide_i16x16::<14>(a, a),
+            15 => self.slide_i16x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i16x16::<16>(a, a),
             1 => self.slide_i16x16::<15>(a, a),
             2 => self.slide_i16x16::<14>(a, a),
@@ -6961,7 +7015,6 @@ impl Simd for Fallback {
             13 => self.slide_i16x16::<3>(a, a),
             14 => self.slide_i16x16::<2>(a, a),
             15 => self.slide_i16x16::<1>(a, a),
-            16 => self.slide_i16x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -6971,14 +7024,27 @@ impl Simd for Fallback {
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i16x16(padding);
-        self.slide_i16x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x16::<0>(a, padding),
+            1 => self.slide_i16x16::<1>(a, padding),
+            2 => self.slide_i16x16::<2>(a, padding),
+            3 => self.slide_i16x16::<3>(a, padding),
+            4 => self.slide_i16x16::<4>(a, padding),
+            5 => self.slide_i16x16::<5>(a, padding),
+            6 => self.slide_i16x16::<6>(a, padding),
+            7 => self.slide_i16x16::<7>(a, padding),
+            8 => self.slide_i16x16::<8>(a, padding),
+            9 => self.slide_i16x16::<9>(a, padding),
+            10 => self.slide_i16x16::<10>(a, padding),
+            11 => self.slide_i16x16::<11>(a, padding),
+            12 => self.slide_i16x16::<12>(a, padding),
+            13 => self.slide_i16x16::<13>(a, padding),
+            14 => self.slide_i16x16::<14>(a, padding),
+            15 => self.slide_i16x16::<15>(a, padding),
+            16 => self.slide_i16x16::<16>(a, padding),
+            _ => self.slide_i16x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x16<const OFFSET: usize>(
@@ -6986,12 +7052,6 @@ impl Simd for Fallback {
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i16x16(padding);
         match OFFSET {
             0 => self.slide_i16x16::<16>(padding, a),
@@ -7011,7 +7071,7 @@ impl Simd for Fallback {
             14 => self.slide_i16x16::<2>(padding, a),
             15 => self.slide_i16x16::<1>(padding, a),
             16 => self.slide_i16x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7293,23 +7353,29 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u16x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u16x16::<0>(a, a),
+            1 => self.slide_u16x16::<1>(a, a),
+            2 => self.slide_u16x16::<2>(a, a),
+            3 => self.slide_u16x16::<3>(a, a),
+            4 => self.slide_u16x16::<4>(a, a),
+            5 => self.slide_u16x16::<5>(a, a),
+            6 => self.slide_u16x16::<6>(a, a),
+            7 => self.slide_u16x16::<7>(a, a),
+            8 => self.slide_u16x16::<8>(a, a),
+            9 => self.slide_u16x16::<9>(a, a),
+            10 => self.slide_u16x16::<10>(a, a),
+            11 => self.slide_u16x16::<11>(a, a),
+            12 => self.slide_u16x16::<12>(a, a),
+            13 => self.slide_u16x16::<13>(a, a),
+            14 => self.slide_u16x16::<14>(a, a),
+            15 => self.slide_u16x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u16x16::<16>(a, a),
             1 => self.slide_u16x16::<15>(a, a),
             2 => self.slide_u16x16::<14>(a, a),
@@ -7326,7 +7392,6 @@ impl Simd for Fallback {
             13 => self.slide_u16x16::<3>(a, a),
             14 => self.slide_u16x16::<2>(a, a),
             15 => self.slide_u16x16::<1>(a, a),
-            16 => self.slide_u16x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -7336,14 +7401,27 @@ impl Simd for Fallback {
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u16x16(padding);
-        self.slide_u16x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x16::<0>(a, padding),
+            1 => self.slide_u16x16::<1>(a, padding),
+            2 => self.slide_u16x16::<2>(a, padding),
+            3 => self.slide_u16x16::<3>(a, padding),
+            4 => self.slide_u16x16::<4>(a, padding),
+            5 => self.slide_u16x16::<5>(a, padding),
+            6 => self.slide_u16x16::<6>(a, padding),
+            7 => self.slide_u16x16::<7>(a, padding),
+            8 => self.slide_u16x16::<8>(a, padding),
+            9 => self.slide_u16x16::<9>(a, padding),
+            10 => self.slide_u16x16::<10>(a, padding),
+            11 => self.slide_u16x16::<11>(a, padding),
+            12 => self.slide_u16x16::<12>(a, padding),
+            13 => self.slide_u16x16::<13>(a, padding),
+            14 => self.slide_u16x16::<14>(a, padding),
+            15 => self.slide_u16x16::<15>(a, padding),
+            16 => self.slide_u16x16::<16>(a, padding),
+            _ => self.slide_u16x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x16<const OFFSET: usize>(
@@ -7351,12 +7429,6 @@ impl Simd for Fallback {
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u16x16(padding);
         match OFFSET {
             0 => self.slide_u16x16::<16>(padding, a),
@@ -7376,7 +7448,7 @@ impl Simd for Fallback {
             14 => self.slide_u16x16::<2>(padding, a),
             15 => self.slide_u16x16::<1>(padding, a),
             16 => self.slide_u16x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7794,23 +7866,21 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_i32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_i32x8::<0>(a, a),
+            1 => self.slide_i32x8::<1>(a, a),
+            2 => self.slide_i32x8::<2>(a, a),
+            3 => self.slide_i32x8::<3>(a, a),
+            4 => self.slide_i32x8::<4>(a, a),
+            5 => self.slide_i32x8::<5>(a, a),
+            6 => self.slide_i32x8::<6>(a, a),
+            7 => self.slide_i32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_i32x8::<8>(a, a),
             1 => self.slide_i32x8::<7>(a, a),
             2 => self.slide_i32x8::<6>(a, a),
@@ -7819,7 +7889,6 @@ impl Simd for Fallback {
             5 => self.slide_i32x8::<3>(a, a),
             6 => self.slide_i32x8::<2>(a, a),
             7 => self.slide_i32x8::<1>(a, a),
-            8 => self.slide_i32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -7829,14 +7898,19 @@ impl Simd for Fallback {
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i32x8(padding);
-        self.slide_i32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x8::<0>(a, padding),
+            1 => self.slide_i32x8::<1>(a, padding),
+            2 => self.slide_i32x8::<2>(a, padding),
+            3 => self.slide_i32x8::<3>(a, padding),
+            4 => self.slide_i32x8::<4>(a, padding),
+            5 => self.slide_i32x8::<5>(a, padding),
+            6 => self.slide_i32x8::<6>(a, padding),
+            7 => self.slide_i32x8::<7>(a, padding),
+            8 => self.slide_i32x8::<8>(a, padding),
+            _ => self.slide_i32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x8<const OFFSET: usize>(
@@ -7844,12 +7918,6 @@ impl Simd for Fallback {
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i32x8(padding);
         match OFFSET {
             0 => self.slide_i32x8::<8>(padding, a),
@@ -7861,7 +7929,7 @@ impl Simd for Fallback {
             6 => self.slide_i32x8::<2>(padding, a),
             7 => self.slide_i32x8::<1>(padding, a),
             8 => self.slide_i32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -8144,23 +8212,21 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_u32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_u32x8::<0>(a, a),
+            1 => self.slide_u32x8::<1>(a, a),
+            2 => self.slide_u32x8::<2>(a, a),
+            3 => self.slide_u32x8::<3>(a, a),
+            4 => self.slide_u32x8::<4>(a, a),
+            5 => self.slide_u32x8::<5>(a, a),
+            6 => self.slide_u32x8::<6>(a, a),
+            7 => self.slide_u32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_u32x8::<8>(a, a),
             1 => self.slide_u32x8::<7>(a, a),
             2 => self.slide_u32x8::<6>(a, a),
@@ -8169,7 +8235,6 @@ impl Simd for Fallback {
             5 => self.slide_u32x8::<3>(a, a),
             6 => self.slide_u32x8::<2>(a, a),
             7 => self.slide_u32x8::<1>(a, a),
-            8 => self.slide_u32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -8179,14 +8244,19 @@ impl Simd for Fallback {
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u32x8(padding);
-        self.slide_u32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x8::<0>(a, padding),
+            1 => self.slide_u32x8::<1>(a, padding),
+            2 => self.slide_u32x8::<2>(a, padding),
+            3 => self.slide_u32x8::<3>(a, padding),
+            4 => self.slide_u32x8::<4>(a, padding),
+            5 => self.slide_u32x8::<5>(a, padding),
+            6 => self.slide_u32x8::<6>(a, padding),
+            7 => self.slide_u32x8::<7>(a, padding),
+            8 => self.slide_u32x8::<8>(a, padding),
+            _ => self.slide_u32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x8<const OFFSET: usize>(
@@ -8194,12 +8264,6 @@ impl Simd for Fallback {
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u32x8(padding);
         match OFFSET {
             0 => self.slide_u32x8::<8>(padding, a),
@@ -8211,7 +8275,7 @@ impl Simd for Fallback {
             6 => self.slide_u32x8::<2>(padding, a),
             7 => self.slide_u32x8::<1>(padding, a),
             8 => self.slide_u32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -8600,28 +8664,21 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_f64x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_f64x4::<0>(a, a),
+            1 => self.slide_f64x4::<1>(a, a),
+            2 => self.slide_f64x4::<2>(a, a),
+            3 => self.slide_f64x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_f64x4::<4>(a, a),
             1 => self.slide_f64x4::<3>(a, a),
             2 => self.slide_f64x4::<2>(a, a),
             3 => self.slide_f64x4::<1>(a, a),
-            4 => self.slide_f64x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -8631,14 +8688,15 @@ impl Simd for Fallback {
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f64x4(padding);
-        self.slide_f64x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x4::<0>(a, padding),
+            1 => self.slide_f64x4::<1>(a, padding),
+            2 => self.slide_f64x4::<2>(a, padding),
+            3 => self.slide_f64x4::<3>(a, padding),
+            4 => self.slide_f64x4::<4>(a, padding),
+            _ => self.slide_f64x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x4<const OFFSET: usize>(
@@ -8646,12 +8704,6 @@ impl Simd for Fallback {
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f64x4(padding);
         match OFFSET {
             0 => self.slide_f64x4::<4>(padding, a),
@@ -8659,7 +8711,7 @@ impl Simd for Fallback {
             2 => self.slide_f64x4::<2>(padding, a),
             3 => self.slide_f64x4::<1>(padding, a),
             4 => self.slide_f64x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -9102,23 +9154,29 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_f32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_f32x16::<0>(a, a),
+            1 => self.slide_f32x16::<1>(a, a),
+            2 => self.slide_f32x16::<2>(a, a),
+            3 => self.slide_f32x16::<3>(a, a),
+            4 => self.slide_f32x16::<4>(a, a),
+            5 => self.slide_f32x16::<5>(a, a),
+            6 => self.slide_f32x16::<6>(a, a),
+            7 => self.slide_f32x16::<7>(a, a),
+            8 => self.slide_f32x16::<8>(a, a),
+            9 => self.slide_f32x16::<9>(a, a),
+            10 => self.slide_f32x16::<10>(a, a),
+            11 => self.slide_f32x16::<11>(a, a),
+            12 => self.slide_f32x16::<12>(a, a),
+            13 => self.slide_f32x16::<13>(a, a),
+            14 => self.slide_f32x16::<14>(a, a),
+            15 => self.slide_f32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_f32x16::<16>(a, a),
             1 => self.slide_f32x16::<15>(a, a),
             2 => self.slide_f32x16::<14>(a, a),
@@ -9135,7 +9193,6 @@ impl Simd for Fallback {
             13 => self.slide_f32x16::<3>(a, a),
             14 => self.slide_f32x16::<2>(a, a),
             15 => self.slide_f32x16::<1>(a, a),
-            16 => self.slide_f32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -9145,14 +9202,27 @@ impl Simd for Fallback {
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_f32x16(padding);
-        self.slide_f32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x16::<0>(a, padding),
+            1 => self.slide_f32x16::<1>(a, padding),
+            2 => self.slide_f32x16::<2>(a, padding),
+            3 => self.slide_f32x16::<3>(a, padding),
+            4 => self.slide_f32x16::<4>(a, padding),
+            5 => self.slide_f32x16::<5>(a, padding),
+            6 => self.slide_f32x16::<6>(a, padding),
+            7 => self.slide_f32x16::<7>(a, padding),
+            8 => self.slide_f32x16::<8>(a, padding),
+            9 => self.slide_f32x16::<9>(a, padding),
+            10 => self.slide_f32x16::<10>(a, padding),
+            11 => self.slide_f32x16::<11>(a, padding),
+            12 => self.slide_f32x16::<12>(a, padding),
+            13 => self.slide_f32x16::<13>(a, padding),
+            14 => self.slide_f32x16::<14>(a, padding),
+            15 => self.slide_f32x16::<15>(a, padding),
+            16 => self.slide_f32x16::<16>(a, padding),
+            _ => self.slide_f32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x16<const OFFSET: usize>(
@@ -9160,12 +9230,6 @@ impl Simd for Fallback {
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_f32x16(padding);
         match OFFSET {
             0 => self.slide_f32x16::<16>(padding, a),
@@ -9185,7 +9249,7 @@ impl Simd for Fallback {
             14 => self.slide_f32x16::<2>(padding, a),
             15 => self.slide_f32x16::<1>(padding, a),
             16 => self.slide_f32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -9583,23 +9647,77 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        self.slide_i8x64::<OFFSET>(a, a)
+        match OFFSET % 64 {
+            0 => self.slide_i8x64::<0>(a, a),
+            1 => self.slide_i8x64::<1>(a, a),
+            2 => self.slide_i8x64::<2>(a, a),
+            3 => self.slide_i8x64::<3>(a, a),
+            4 => self.slide_i8x64::<4>(a, a),
+            5 => self.slide_i8x64::<5>(a, a),
+            6 => self.slide_i8x64::<6>(a, a),
+            7 => self.slide_i8x64::<7>(a, a),
+            8 => self.slide_i8x64::<8>(a, a),
+            9 => self.slide_i8x64::<9>(a, a),
+            10 => self.slide_i8x64::<10>(a, a),
+            11 => self.slide_i8x64::<11>(a, a),
+            12 => self.slide_i8x64::<12>(a, a),
+            13 => self.slide_i8x64::<13>(a, a),
+            14 => self.slide_i8x64::<14>(a, a),
+            15 => self.slide_i8x64::<15>(a, a),
+            16 => self.slide_i8x64::<16>(a, a),
+            17 => self.slide_i8x64::<17>(a, a),
+            18 => self.slide_i8x64::<18>(a, a),
+            19 => self.slide_i8x64::<19>(a, a),
+            20 => self.slide_i8x64::<20>(a, a),
+            21 => self.slide_i8x64::<21>(a, a),
+            22 => self.slide_i8x64::<22>(a, a),
+            23 => self.slide_i8x64::<23>(a, a),
+            24 => self.slide_i8x64::<24>(a, a),
+            25 => self.slide_i8x64::<25>(a, a),
+            26 => self.slide_i8x64::<26>(a, a),
+            27 => self.slide_i8x64::<27>(a, a),
+            28 => self.slide_i8x64::<28>(a, a),
+            29 => self.slide_i8x64::<29>(a, a),
+            30 => self.slide_i8x64::<30>(a, a),
+            31 => self.slide_i8x64::<31>(a, a),
+            32 => self.slide_i8x64::<32>(a, a),
+            33 => self.slide_i8x64::<33>(a, a),
+            34 => self.slide_i8x64::<34>(a, a),
+            35 => self.slide_i8x64::<35>(a, a),
+            36 => self.slide_i8x64::<36>(a, a),
+            37 => self.slide_i8x64::<37>(a, a),
+            38 => self.slide_i8x64::<38>(a, a),
+            39 => self.slide_i8x64::<39>(a, a),
+            40 => self.slide_i8x64::<40>(a, a),
+            41 => self.slide_i8x64::<41>(a, a),
+            42 => self.slide_i8x64::<42>(a, a),
+            43 => self.slide_i8x64::<43>(a, a),
+            44 => self.slide_i8x64::<44>(a, a),
+            45 => self.slide_i8x64::<45>(a, a),
+            46 => self.slide_i8x64::<46>(a, a),
+            47 => self.slide_i8x64::<47>(a, a),
+            48 => self.slide_i8x64::<48>(a, a),
+            49 => self.slide_i8x64::<49>(a, a),
+            50 => self.slide_i8x64::<50>(a, a),
+            51 => self.slide_i8x64::<51>(a, a),
+            52 => self.slide_i8x64::<52>(a, a),
+            53 => self.slide_i8x64::<53>(a, a),
+            54 => self.slide_i8x64::<54>(a, a),
+            55 => self.slide_i8x64::<55>(a, a),
+            56 => self.slide_i8x64::<56>(a, a),
+            57 => self.slide_i8x64::<57>(a, a),
+            58 => self.slide_i8x64::<58>(a, a),
+            59 => self.slide_i8x64::<59>(a, a),
+            60 => self.slide_i8x64::<60>(a, a),
+            61 => self.slide_i8x64::<61>(a, a),
+            62 => self.slide_i8x64::<62>(a, a),
+            63 => self.slide_i8x64::<63>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        match OFFSET {
+        match OFFSET % 64 {
             0 => self.slide_i8x64::<64>(a, a),
             1 => self.slide_i8x64::<63>(a, a),
             2 => self.slide_i8x64::<62>(a, a),
@@ -9664,7 +9782,6 @@ impl Simd for Fallback {
             61 => self.slide_i8x64::<3>(a, a),
             62 => self.slide_i8x64::<2>(a, a),
             63 => self.slide_i8x64::<1>(a, a),
-            64 => self.slide_i8x64::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -9674,14 +9791,75 @@ impl Simd for Fallback {
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_i8x64(padding);
-        self.slide_i8x64::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x64::<0>(a, padding),
+            1 => self.slide_i8x64::<1>(a, padding),
+            2 => self.slide_i8x64::<2>(a, padding),
+            3 => self.slide_i8x64::<3>(a, padding),
+            4 => self.slide_i8x64::<4>(a, padding),
+            5 => self.slide_i8x64::<5>(a, padding),
+            6 => self.slide_i8x64::<6>(a, padding),
+            7 => self.slide_i8x64::<7>(a, padding),
+            8 => self.slide_i8x64::<8>(a, padding),
+            9 => self.slide_i8x64::<9>(a, padding),
+            10 => self.slide_i8x64::<10>(a, padding),
+            11 => self.slide_i8x64::<11>(a, padding),
+            12 => self.slide_i8x64::<12>(a, padding),
+            13 => self.slide_i8x64::<13>(a, padding),
+            14 => self.slide_i8x64::<14>(a, padding),
+            15 => self.slide_i8x64::<15>(a, padding),
+            16 => self.slide_i8x64::<16>(a, padding),
+            17 => self.slide_i8x64::<17>(a, padding),
+            18 => self.slide_i8x64::<18>(a, padding),
+            19 => self.slide_i8x64::<19>(a, padding),
+            20 => self.slide_i8x64::<20>(a, padding),
+            21 => self.slide_i8x64::<21>(a, padding),
+            22 => self.slide_i8x64::<22>(a, padding),
+            23 => self.slide_i8x64::<23>(a, padding),
+            24 => self.slide_i8x64::<24>(a, padding),
+            25 => self.slide_i8x64::<25>(a, padding),
+            26 => self.slide_i8x64::<26>(a, padding),
+            27 => self.slide_i8x64::<27>(a, padding),
+            28 => self.slide_i8x64::<28>(a, padding),
+            29 => self.slide_i8x64::<29>(a, padding),
+            30 => self.slide_i8x64::<30>(a, padding),
+            31 => self.slide_i8x64::<31>(a, padding),
+            32 => self.slide_i8x64::<32>(a, padding),
+            33 => self.slide_i8x64::<33>(a, padding),
+            34 => self.slide_i8x64::<34>(a, padding),
+            35 => self.slide_i8x64::<35>(a, padding),
+            36 => self.slide_i8x64::<36>(a, padding),
+            37 => self.slide_i8x64::<37>(a, padding),
+            38 => self.slide_i8x64::<38>(a, padding),
+            39 => self.slide_i8x64::<39>(a, padding),
+            40 => self.slide_i8x64::<40>(a, padding),
+            41 => self.slide_i8x64::<41>(a, padding),
+            42 => self.slide_i8x64::<42>(a, padding),
+            43 => self.slide_i8x64::<43>(a, padding),
+            44 => self.slide_i8x64::<44>(a, padding),
+            45 => self.slide_i8x64::<45>(a, padding),
+            46 => self.slide_i8x64::<46>(a, padding),
+            47 => self.slide_i8x64::<47>(a, padding),
+            48 => self.slide_i8x64::<48>(a, padding),
+            49 => self.slide_i8x64::<49>(a, padding),
+            50 => self.slide_i8x64::<50>(a, padding),
+            51 => self.slide_i8x64::<51>(a, padding),
+            52 => self.slide_i8x64::<52>(a, padding),
+            53 => self.slide_i8x64::<53>(a, padding),
+            54 => self.slide_i8x64::<54>(a, padding),
+            55 => self.slide_i8x64::<55>(a, padding),
+            56 => self.slide_i8x64::<56>(a, padding),
+            57 => self.slide_i8x64::<57>(a, padding),
+            58 => self.slide_i8x64::<58>(a, padding),
+            59 => self.slide_i8x64::<59>(a, padding),
+            60 => self.slide_i8x64::<60>(a, padding),
+            61 => self.slide_i8x64::<61>(a, padding),
+            62 => self.slide_i8x64::<62>(a, padding),
+            63 => self.slide_i8x64::<63>(a, padding),
+            64 => self.slide_i8x64::<64>(a, padding),
+            _ => self.slide_i8x64::<64>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x64<const OFFSET: usize>(
@@ -9689,12 +9867,6 @@ impl Simd for Fallback {
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_i8x64(padding);
         match OFFSET {
             0 => self.slide_i8x64::<64>(padding, a),
@@ -9762,7 +9934,7 @@ impl Simd for Fallback {
             62 => self.slide_i8x64::<2>(padding, a),
             63 => self.slide_i8x64::<1>(padding, a),
             64 => self.slide_i8x64::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x64::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -10033,23 +10205,77 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        self.slide_u8x64::<OFFSET>(a, a)
+        match OFFSET % 64 {
+            0 => self.slide_u8x64::<0>(a, a),
+            1 => self.slide_u8x64::<1>(a, a),
+            2 => self.slide_u8x64::<2>(a, a),
+            3 => self.slide_u8x64::<3>(a, a),
+            4 => self.slide_u8x64::<4>(a, a),
+            5 => self.slide_u8x64::<5>(a, a),
+            6 => self.slide_u8x64::<6>(a, a),
+            7 => self.slide_u8x64::<7>(a, a),
+            8 => self.slide_u8x64::<8>(a, a),
+            9 => self.slide_u8x64::<9>(a, a),
+            10 => self.slide_u8x64::<10>(a, a),
+            11 => self.slide_u8x64::<11>(a, a),
+            12 => self.slide_u8x64::<12>(a, a),
+            13 => self.slide_u8x64::<13>(a, a),
+            14 => self.slide_u8x64::<14>(a, a),
+            15 => self.slide_u8x64::<15>(a, a),
+            16 => self.slide_u8x64::<16>(a, a),
+            17 => self.slide_u8x64::<17>(a, a),
+            18 => self.slide_u8x64::<18>(a, a),
+            19 => self.slide_u8x64::<19>(a, a),
+            20 => self.slide_u8x64::<20>(a, a),
+            21 => self.slide_u8x64::<21>(a, a),
+            22 => self.slide_u8x64::<22>(a, a),
+            23 => self.slide_u8x64::<23>(a, a),
+            24 => self.slide_u8x64::<24>(a, a),
+            25 => self.slide_u8x64::<25>(a, a),
+            26 => self.slide_u8x64::<26>(a, a),
+            27 => self.slide_u8x64::<27>(a, a),
+            28 => self.slide_u8x64::<28>(a, a),
+            29 => self.slide_u8x64::<29>(a, a),
+            30 => self.slide_u8x64::<30>(a, a),
+            31 => self.slide_u8x64::<31>(a, a),
+            32 => self.slide_u8x64::<32>(a, a),
+            33 => self.slide_u8x64::<33>(a, a),
+            34 => self.slide_u8x64::<34>(a, a),
+            35 => self.slide_u8x64::<35>(a, a),
+            36 => self.slide_u8x64::<36>(a, a),
+            37 => self.slide_u8x64::<37>(a, a),
+            38 => self.slide_u8x64::<38>(a, a),
+            39 => self.slide_u8x64::<39>(a, a),
+            40 => self.slide_u8x64::<40>(a, a),
+            41 => self.slide_u8x64::<41>(a, a),
+            42 => self.slide_u8x64::<42>(a, a),
+            43 => self.slide_u8x64::<43>(a, a),
+            44 => self.slide_u8x64::<44>(a, a),
+            45 => self.slide_u8x64::<45>(a, a),
+            46 => self.slide_u8x64::<46>(a, a),
+            47 => self.slide_u8x64::<47>(a, a),
+            48 => self.slide_u8x64::<48>(a, a),
+            49 => self.slide_u8x64::<49>(a, a),
+            50 => self.slide_u8x64::<50>(a, a),
+            51 => self.slide_u8x64::<51>(a, a),
+            52 => self.slide_u8x64::<52>(a, a),
+            53 => self.slide_u8x64::<53>(a, a),
+            54 => self.slide_u8x64::<54>(a, a),
+            55 => self.slide_u8x64::<55>(a, a),
+            56 => self.slide_u8x64::<56>(a, a),
+            57 => self.slide_u8x64::<57>(a, a),
+            58 => self.slide_u8x64::<58>(a, a),
+            59 => self.slide_u8x64::<59>(a, a),
+            60 => self.slide_u8x64::<60>(a, a),
+            61 => self.slide_u8x64::<61>(a, a),
+            62 => self.slide_u8x64::<62>(a, a),
+            63 => self.slide_u8x64::<63>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        match OFFSET {
+        match OFFSET % 64 {
             0 => self.slide_u8x64::<64>(a, a),
             1 => self.slide_u8x64::<63>(a, a),
             2 => self.slide_u8x64::<62>(a, a),
@@ -10114,7 +10340,6 @@ impl Simd for Fallback {
             61 => self.slide_u8x64::<3>(a, a),
             62 => self.slide_u8x64::<2>(a, a),
             63 => self.slide_u8x64::<1>(a, a),
-            64 => self.slide_u8x64::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -10124,14 +10349,75 @@ impl Simd for Fallback {
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_u8x64(padding);
-        self.slide_u8x64::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x64::<0>(a, padding),
+            1 => self.slide_u8x64::<1>(a, padding),
+            2 => self.slide_u8x64::<2>(a, padding),
+            3 => self.slide_u8x64::<3>(a, padding),
+            4 => self.slide_u8x64::<4>(a, padding),
+            5 => self.slide_u8x64::<5>(a, padding),
+            6 => self.slide_u8x64::<6>(a, padding),
+            7 => self.slide_u8x64::<7>(a, padding),
+            8 => self.slide_u8x64::<8>(a, padding),
+            9 => self.slide_u8x64::<9>(a, padding),
+            10 => self.slide_u8x64::<10>(a, padding),
+            11 => self.slide_u8x64::<11>(a, padding),
+            12 => self.slide_u8x64::<12>(a, padding),
+            13 => self.slide_u8x64::<13>(a, padding),
+            14 => self.slide_u8x64::<14>(a, padding),
+            15 => self.slide_u8x64::<15>(a, padding),
+            16 => self.slide_u8x64::<16>(a, padding),
+            17 => self.slide_u8x64::<17>(a, padding),
+            18 => self.slide_u8x64::<18>(a, padding),
+            19 => self.slide_u8x64::<19>(a, padding),
+            20 => self.slide_u8x64::<20>(a, padding),
+            21 => self.slide_u8x64::<21>(a, padding),
+            22 => self.slide_u8x64::<22>(a, padding),
+            23 => self.slide_u8x64::<23>(a, padding),
+            24 => self.slide_u8x64::<24>(a, padding),
+            25 => self.slide_u8x64::<25>(a, padding),
+            26 => self.slide_u8x64::<26>(a, padding),
+            27 => self.slide_u8x64::<27>(a, padding),
+            28 => self.slide_u8x64::<28>(a, padding),
+            29 => self.slide_u8x64::<29>(a, padding),
+            30 => self.slide_u8x64::<30>(a, padding),
+            31 => self.slide_u8x64::<31>(a, padding),
+            32 => self.slide_u8x64::<32>(a, padding),
+            33 => self.slide_u8x64::<33>(a, padding),
+            34 => self.slide_u8x64::<34>(a, padding),
+            35 => self.slide_u8x64::<35>(a, padding),
+            36 => self.slide_u8x64::<36>(a, padding),
+            37 => self.slide_u8x64::<37>(a, padding),
+            38 => self.slide_u8x64::<38>(a, padding),
+            39 => self.slide_u8x64::<39>(a, padding),
+            40 => self.slide_u8x64::<40>(a, padding),
+            41 => self.slide_u8x64::<41>(a, padding),
+            42 => self.slide_u8x64::<42>(a, padding),
+            43 => self.slide_u8x64::<43>(a, padding),
+            44 => self.slide_u8x64::<44>(a, padding),
+            45 => self.slide_u8x64::<45>(a, padding),
+            46 => self.slide_u8x64::<46>(a, padding),
+            47 => self.slide_u8x64::<47>(a, padding),
+            48 => self.slide_u8x64::<48>(a, padding),
+            49 => self.slide_u8x64::<49>(a, padding),
+            50 => self.slide_u8x64::<50>(a, padding),
+            51 => self.slide_u8x64::<51>(a, padding),
+            52 => self.slide_u8x64::<52>(a, padding),
+            53 => self.slide_u8x64::<53>(a, padding),
+            54 => self.slide_u8x64::<54>(a, padding),
+            55 => self.slide_u8x64::<55>(a, padding),
+            56 => self.slide_u8x64::<56>(a, padding),
+            57 => self.slide_u8x64::<57>(a, padding),
+            58 => self.slide_u8x64::<58>(a, padding),
+            59 => self.slide_u8x64::<59>(a, padding),
+            60 => self.slide_u8x64::<60>(a, padding),
+            61 => self.slide_u8x64::<61>(a, padding),
+            62 => self.slide_u8x64::<62>(a, padding),
+            63 => self.slide_u8x64::<63>(a, padding),
+            64 => self.slide_u8x64::<64>(a, padding),
+            _ => self.slide_u8x64::<64>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x64<const OFFSET: usize>(
@@ -10139,12 +10425,6 @@ impl Simd for Fallback {
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_u8x64(padding);
         match OFFSET {
             0 => self.slide_u8x64::<64>(padding, a),
@@ -10212,7 +10492,7 @@ impl Simd for Fallback {
             62 => self.slide_u8x64::<2>(padding, a),
             63 => self.slide_u8x64::<1>(padding, a),
             64 => self.slide_u8x64::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x64::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -10670,23 +10950,45 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_i16x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_i16x32::<0>(a, a),
+            1 => self.slide_i16x32::<1>(a, a),
+            2 => self.slide_i16x32::<2>(a, a),
+            3 => self.slide_i16x32::<3>(a, a),
+            4 => self.slide_i16x32::<4>(a, a),
+            5 => self.slide_i16x32::<5>(a, a),
+            6 => self.slide_i16x32::<6>(a, a),
+            7 => self.slide_i16x32::<7>(a, a),
+            8 => self.slide_i16x32::<8>(a, a),
+            9 => self.slide_i16x32::<9>(a, a),
+            10 => self.slide_i16x32::<10>(a, a),
+            11 => self.slide_i16x32::<11>(a, a),
+            12 => self.slide_i16x32::<12>(a, a),
+            13 => self.slide_i16x32::<13>(a, a),
+            14 => self.slide_i16x32::<14>(a, a),
+            15 => self.slide_i16x32::<15>(a, a),
+            16 => self.slide_i16x32::<16>(a, a),
+            17 => self.slide_i16x32::<17>(a, a),
+            18 => self.slide_i16x32::<18>(a, a),
+            19 => self.slide_i16x32::<19>(a, a),
+            20 => self.slide_i16x32::<20>(a, a),
+            21 => self.slide_i16x32::<21>(a, a),
+            22 => self.slide_i16x32::<22>(a, a),
+            23 => self.slide_i16x32::<23>(a, a),
+            24 => self.slide_i16x32::<24>(a, a),
+            25 => self.slide_i16x32::<25>(a, a),
+            26 => self.slide_i16x32::<26>(a, a),
+            27 => self.slide_i16x32::<27>(a, a),
+            28 => self.slide_i16x32::<28>(a, a),
+            29 => self.slide_i16x32::<29>(a, a),
+            30 => self.slide_i16x32::<30>(a, a),
+            31 => self.slide_i16x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_i16x32::<32>(a, a),
             1 => self.slide_i16x32::<31>(a, a),
             2 => self.slide_i16x32::<30>(a, a),
@@ -10719,7 +11021,6 @@ impl Simd for Fallback {
             29 => self.slide_i16x32::<3>(a, a),
             30 => self.slide_i16x32::<2>(a, a),
             31 => self.slide_i16x32::<1>(a, a),
-            32 => self.slide_i16x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -10729,14 +11030,43 @@ impl Simd for Fallback {
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i16x32(padding);
-        self.slide_i16x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x32::<0>(a, padding),
+            1 => self.slide_i16x32::<1>(a, padding),
+            2 => self.slide_i16x32::<2>(a, padding),
+            3 => self.slide_i16x32::<3>(a, padding),
+            4 => self.slide_i16x32::<4>(a, padding),
+            5 => self.slide_i16x32::<5>(a, padding),
+            6 => self.slide_i16x32::<6>(a, padding),
+            7 => self.slide_i16x32::<7>(a, padding),
+            8 => self.slide_i16x32::<8>(a, padding),
+            9 => self.slide_i16x32::<9>(a, padding),
+            10 => self.slide_i16x32::<10>(a, padding),
+            11 => self.slide_i16x32::<11>(a, padding),
+            12 => self.slide_i16x32::<12>(a, padding),
+            13 => self.slide_i16x32::<13>(a, padding),
+            14 => self.slide_i16x32::<14>(a, padding),
+            15 => self.slide_i16x32::<15>(a, padding),
+            16 => self.slide_i16x32::<16>(a, padding),
+            17 => self.slide_i16x32::<17>(a, padding),
+            18 => self.slide_i16x32::<18>(a, padding),
+            19 => self.slide_i16x32::<19>(a, padding),
+            20 => self.slide_i16x32::<20>(a, padding),
+            21 => self.slide_i16x32::<21>(a, padding),
+            22 => self.slide_i16x32::<22>(a, padding),
+            23 => self.slide_i16x32::<23>(a, padding),
+            24 => self.slide_i16x32::<24>(a, padding),
+            25 => self.slide_i16x32::<25>(a, padding),
+            26 => self.slide_i16x32::<26>(a, padding),
+            27 => self.slide_i16x32::<27>(a, padding),
+            28 => self.slide_i16x32::<28>(a, padding),
+            29 => self.slide_i16x32::<29>(a, padding),
+            30 => self.slide_i16x32::<30>(a, padding),
+            31 => self.slide_i16x32::<31>(a, padding),
+            32 => self.slide_i16x32::<32>(a, padding),
+            _ => self.slide_i16x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x32<const OFFSET: usize>(
@@ -10744,12 +11074,6 @@ impl Simd for Fallback {
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i16x32(padding);
         match OFFSET {
             0 => self.slide_i16x32::<32>(padding, a),
@@ -10785,7 +11109,7 @@ impl Simd for Fallback {
             30 => self.slide_i16x32::<2>(padding, a),
             31 => self.slide_i16x32::<1>(padding, a),
             32 => self.slide_i16x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -11069,23 +11393,45 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_u16x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_u16x32::<0>(a, a),
+            1 => self.slide_u16x32::<1>(a, a),
+            2 => self.slide_u16x32::<2>(a, a),
+            3 => self.slide_u16x32::<3>(a, a),
+            4 => self.slide_u16x32::<4>(a, a),
+            5 => self.slide_u16x32::<5>(a, a),
+            6 => self.slide_u16x32::<6>(a, a),
+            7 => self.slide_u16x32::<7>(a, a),
+            8 => self.slide_u16x32::<8>(a, a),
+            9 => self.slide_u16x32::<9>(a, a),
+            10 => self.slide_u16x32::<10>(a, a),
+            11 => self.slide_u16x32::<11>(a, a),
+            12 => self.slide_u16x32::<12>(a, a),
+            13 => self.slide_u16x32::<13>(a, a),
+            14 => self.slide_u16x32::<14>(a, a),
+            15 => self.slide_u16x32::<15>(a, a),
+            16 => self.slide_u16x32::<16>(a, a),
+            17 => self.slide_u16x32::<17>(a, a),
+            18 => self.slide_u16x32::<18>(a, a),
+            19 => self.slide_u16x32::<19>(a, a),
+            20 => self.slide_u16x32::<20>(a, a),
+            21 => self.slide_u16x32::<21>(a, a),
+            22 => self.slide_u16x32::<22>(a, a),
+            23 => self.slide_u16x32::<23>(a, a),
+            24 => self.slide_u16x32::<24>(a, a),
+            25 => self.slide_u16x32::<25>(a, a),
+            26 => self.slide_u16x32::<26>(a, a),
+            27 => self.slide_u16x32::<27>(a, a),
+            28 => self.slide_u16x32::<28>(a, a),
+            29 => self.slide_u16x32::<29>(a, a),
+            30 => self.slide_u16x32::<30>(a, a),
+            31 => self.slide_u16x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_u16x32::<32>(a, a),
             1 => self.slide_u16x32::<31>(a, a),
             2 => self.slide_u16x32::<30>(a, a),
@@ -11118,7 +11464,6 @@ impl Simd for Fallback {
             29 => self.slide_u16x32::<3>(a, a),
             30 => self.slide_u16x32::<2>(a, a),
             31 => self.slide_u16x32::<1>(a, a),
-            32 => self.slide_u16x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -11128,14 +11473,43 @@ impl Simd for Fallback {
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u16x32(padding);
-        self.slide_u16x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x32::<0>(a, padding),
+            1 => self.slide_u16x32::<1>(a, padding),
+            2 => self.slide_u16x32::<2>(a, padding),
+            3 => self.slide_u16x32::<3>(a, padding),
+            4 => self.slide_u16x32::<4>(a, padding),
+            5 => self.slide_u16x32::<5>(a, padding),
+            6 => self.slide_u16x32::<6>(a, padding),
+            7 => self.slide_u16x32::<7>(a, padding),
+            8 => self.slide_u16x32::<8>(a, padding),
+            9 => self.slide_u16x32::<9>(a, padding),
+            10 => self.slide_u16x32::<10>(a, padding),
+            11 => self.slide_u16x32::<11>(a, padding),
+            12 => self.slide_u16x32::<12>(a, padding),
+            13 => self.slide_u16x32::<13>(a, padding),
+            14 => self.slide_u16x32::<14>(a, padding),
+            15 => self.slide_u16x32::<15>(a, padding),
+            16 => self.slide_u16x32::<16>(a, padding),
+            17 => self.slide_u16x32::<17>(a, padding),
+            18 => self.slide_u16x32::<18>(a, padding),
+            19 => self.slide_u16x32::<19>(a, padding),
+            20 => self.slide_u16x32::<20>(a, padding),
+            21 => self.slide_u16x32::<21>(a, padding),
+            22 => self.slide_u16x32::<22>(a, padding),
+            23 => self.slide_u16x32::<23>(a, padding),
+            24 => self.slide_u16x32::<24>(a, padding),
+            25 => self.slide_u16x32::<25>(a, padding),
+            26 => self.slide_u16x32::<26>(a, padding),
+            27 => self.slide_u16x32::<27>(a, padding),
+            28 => self.slide_u16x32::<28>(a, padding),
+            29 => self.slide_u16x32::<29>(a, padding),
+            30 => self.slide_u16x32::<30>(a, padding),
+            31 => self.slide_u16x32::<31>(a, padding),
+            32 => self.slide_u16x32::<32>(a, padding),
+            _ => self.slide_u16x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x32<const OFFSET: usize>(
@@ -11143,12 +11517,6 @@ impl Simd for Fallback {
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u16x32(padding);
         match OFFSET {
             0 => self.slide_u16x32::<32>(padding, a),
@@ -11184,7 +11552,7 @@ impl Simd for Fallback {
             30 => self.slide_u16x32::<2>(padding, a),
             31 => self.slide_u16x32::<1>(padding, a),
             32 => self.slide_u16x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -11631,23 +11999,29 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i32x16::<0>(a, a),
+            1 => self.slide_i32x16::<1>(a, a),
+            2 => self.slide_i32x16::<2>(a, a),
+            3 => self.slide_i32x16::<3>(a, a),
+            4 => self.slide_i32x16::<4>(a, a),
+            5 => self.slide_i32x16::<5>(a, a),
+            6 => self.slide_i32x16::<6>(a, a),
+            7 => self.slide_i32x16::<7>(a, a),
+            8 => self.slide_i32x16::<8>(a, a),
+            9 => self.slide_i32x16::<9>(a, a),
+            10 => self.slide_i32x16::<10>(a, a),
+            11 => self.slide_i32x16::<11>(a, a),
+            12 => self.slide_i32x16::<12>(a, a),
+            13 => self.slide_i32x16::<13>(a, a),
+            14 => self.slide_i32x16::<14>(a, a),
+            15 => self.slide_i32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i32x16::<16>(a, a),
             1 => self.slide_i32x16::<15>(a, a),
             2 => self.slide_i32x16::<14>(a, a),
@@ -11664,7 +12038,6 @@ impl Simd for Fallback {
             13 => self.slide_i32x16::<3>(a, a),
             14 => self.slide_i32x16::<2>(a, a),
             15 => self.slide_i32x16::<1>(a, a),
-            16 => self.slide_i32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -11674,14 +12047,27 @@ impl Simd for Fallback {
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i32x16(padding);
-        self.slide_i32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x16::<0>(a, padding),
+            1 => self.slide_i32x16::<1>(a, padding),
+            2 => self.slide_i32x16::<2>(a, padding),
+            3 => self.slide_i32x16::<3>(a, padding),
+            4 => self.slide_i32x16::<4>(a, padding),
+            5 => self.slide_i32x16::<5>(a, padding),
+            6 => self.slide_i32x16::<6>(a, padding),
+            7 => self.slide_i32x16::<7>(a, padding),
+            8 => self.slide_i32x16::<8>(a, padding),
+            9 => self.slide_i32x16::<9>(a, padding),
+            10 => self.slide_i32x16::<10>(a, padding),
+            11 => self.slide_i32x16::<11>(a, padding),
+            12 => self.slide_i32x16::<12>(a, padding),
+            13 => self.slide_i32x16::<13>(a, padding),
+            14 => self.slide_i32x16::<14>(a, padding),
+            15 => self.slide_i32x16::<15>(a, padding),
+            16 => self.slide_i32x16::<16>(a, padding),
+            _ => self.slide_i32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x16<const OFFSET: usize>(
@@ -11689,12 +12075,6 @@ impl Simd for Fallback {
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i32x16(padding);
         match OFFSET {
             0 => self.slide_i32x16::<16>(padding, a),
@@ -11714,7 +12094,7 @@ impl Simd for Fallback {
             14 => self.slide_i32x16::<2>(padding, a),
             15 => self.slide_i32x16::<1>(padding, a),
             16 => self.slide_i32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -11994,23 +12374,29 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u32x16::<0>(a, a),
+            1 => self.slide_u32x16::<1>(a, a),
+            2 => self.slide_u32x16::<2>(a, a),
+            3 => self.slide_u32x16::<3>(a, a),
+            4 => self.slide_u32x16::<4>(a, a),
+            5 => self.slide_u32x16::<5>(a, a),
+            6 => self.slide_u32x16::<6>(a, a),
+            7 => self.slide_u32x16::<7>(a, a),
+            8 => self.slide_u32x16::<8>(a, a),
+            9 => self.slide_u32x16::<9>(a, a),
+            10 => self.slide_u32x16::<10>(a, a),
+            11 => self.slide_u32x16::<11>(a, a),
+            12 => self.slide_u32x16::<12>(a, a),
+            13 => self.slide_u32x16::<13>(a, a),
+            14 => self.slide_u32x16::<14>(a, a),
+            15 => self.slide_u32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u32x16::<16>(a, a),
             1 => self.slide_u32x16::<15>(a, a),
             2 => self.slide_u32x16::<14>(a, a),
@@ -12027,7 +12413,6 @@ impl Simd for Fallback {
             13 => self.slide_u32x16::<3>(a, a),
             14 => self.slide_u32x16::<2>(a, a),
             15 => self.slide_u32x16::<1>(a, a),
-            16 => self.slide_u32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -12037,14 +12422,27 @@ impl Simd for Fallback {
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u32x16(padding);
-        self.slide_u32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x16::<0>(a, padding),
+            1 => self.slide_u32x16::<1>(a, padding),
+            2 => self.slide_u32x16::<2>(a, padding),
+            3 => self.slide_u32x16::<3>(a, padding),
+            4 => self.slide_u32x16::<4>(a, padding),
+            5 => self.slide_u32x16::<5>(a, padding),
+            6 => self.slide_u32x16::<6>(a, padding),
+            7 => self.slide_u32x16::<7>(a, padding),
+            8 => self.slide_u32x16::<8>(a, padding),
+            9 => self.slide_u32x16::<9>(a, padding),
+            10 => self.slide_u32x16::<10>(a, padding),
+            11 => self.slide_u32x16::<11>(a, padding),
+            12 => self.slide_u32x16::<12>(a, padding),
+            13 => self.slide_u32x16::<13>(a, padding),
+            14 => self.slide_u32x16::<14>(a, padding),
+            15 => self.slide_u32x16::<15>(a, padding),
+            16 => self.slide_u32x16::<16>(a, padding),
+            _ => self.slide_u32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x16<const OFFSET: usize>(
@@ -12052,12 +12450,6 @@ impl Simd for Fallback {
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u32x16(padding);
         match OFFSET {
             0 => self.slide_u32x16::<16>(padding, a),
@@ -12077,7 +12469,7 @@ impl Simd for Fallback {
             14 => self.slide_u32x16::<2>(padding, a),
             15 => self.slide_u32x16::<1>(padding, a),
             16 => self.slide_u32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -12486,23 +12878,21 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_f64x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_f64x8::<0>(a, a),
+            1 => self.slide_f64x8::<1>(a, a),
+            2 => self.slide_f64x8::<2>(a, a),
+            3 => self.slide_f64x8::<3>(a, a),
+            4 => self.slide_f64x8::<4>(a, a),
+            5 => self.slide_f64x8::<5>(a, a),
+            6 => self.slide_f64x8::<6>(a, a),
+            7 => self.slide_f64x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_f64x8::<8>(a, a),
             1 => self.slide_f64x8::<7>(a, a),
             2 => self.slide_f64x8::<6>(a, a),
@@ -12511,7 +12901,6 @@ impl Simd for Fallback {
             5 => self.slide_f64x8::<3>(a, a),
             6 => self.slide_f64x8::<2>(a, a),
             7 => self.slide_f64x8::<1>(a, a),
-            8 => self.slide_f64x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -12521,14 +12910,19 @@ impl Simd for Fallback {
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f64x8(padding);
-        self.slide_f64x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x8::<0>(a, padding),
+            1 => self.slide_f64x8::<1>(a, padding),
+            2 => self.slide_f64x8::<2>(a, padding),
+            3 => self.slide_f64x8::<3>(a, padding),
+            4 => self.slide_f64x8::<4>(a, padding),
+            5 => self.slide_f64x8::<5>(a, padding),
+            6 => self.slide_f64x8::<6>(a, padding),
+            7 => self.slide_f64x8::<7>(a, padding),
+            8 => self.slide_f64x8::<8>(a, padding),
+            _ => self.slide_f64x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x8<const OFFSET: usize>(
@@ -12536,12 +12930,6 @@ impl Simd for Fallback {
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f64x8(padding);
         match OFFSET {
             0 => self.slide_f64x8::<8>(padding, a),
@@ -12553,7 +12941,7 @@ impl Simd for Fallback {
             6 => self.slide_f64x8::<2>(padding, a),
             7 => self.slide_f64x8::<1>(padding, a),
             8 => self.slide_f64x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x8::<0>(padding, a),
         }
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -166,28 +166,21 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_f32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_f32x4::<0>(a, a),
+            1 => self.slide_f32x4::<1>(a, a),
+            2 => self.slide_f32x4::<2>(a, a),
+            3 => self.slide_f32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_f32x4::<4>(a, a),
             1 => self.slide_f32x4::<3>(a, a),
             2 => self.slide_f32x4::<2>(a, a),
             3 => self.slide_f32x4::<1>(a, a),
-            4 => self.slide_f32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -197,14 +190,15 @@ impl Simd for Neon {
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f32x4(padding);
-        self.slide_f32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x4::<0>(a, padding),
+            1 => self.slide_f32x4::<1>(a, padding),
+            2 => self.slide_f32x4::<2>(a, padding),
+            3 => self.slide_f32x4::<3>(a, padding),
+            4 => self.slide_f32x4::<4>(a, padding),
+            _ => self.slide_f32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x4<const OFFSET: usize>(
@@ -212,12 +206,6 @@ impl Simd for Neon {
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f32x4(padding);
         match OFFSET {
             0 => self.slide_f32x4::<4>(padding, a),
@@ -225,7 +213,7 @@ impl Simd for Neon {
             2 => self.slide_f32x4::<2>(padding, a),
             3 => self.slide_f32x4::<1>(padding, a),
             4 => self.slide_f32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -721,23 +709,29 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i8x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i8x16::<0>(a, a),
+            1 => self.slide_i8x16::<1>(a, a),
+            2 => self.slide_i8x16::<2>(a, a),
+            3 => self.slide_i8x16::<3>(a, a),
+            4 => self.slide_i8x16::<4>(a, a),
+            5 => self.slide_i8x16::<5>(a, a),
+            6 => self.slide_i8x16::<6>(a, a),
+            7 => self.slide_i8x16::<7>(a, a),
+            8 => self.slide_i8x16::<8>(a, a),
+            9 => self.slide_i8x16::<9>(a, a),
+            10 => self.slide_i8x16::<10>(a, a),
+            11 => self.slide_i8x16::<11>(a, a),
+            12 => self.slide_i8x16::<12>(a, a),
+            13 => self.slide_i8x16::<13>(a, a),
+            14 => self.slide_i8x16::<14>(a, a),
+            15 => self.slide_i8x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i8x16::<16>(a, a),
             1 => self.slide_i8x16::<15>(a, a),
             2 => self.slide_i8x16::<14>(a, a),
@@ -754,7 +748,6 @@ impl Simd for Neon {
             13 => self.slide_i8x16::<3>(a, a),
             14 => self.slide_i8x16::<2>(a, a),
             15 => self.slide_i8x16::<1>(a, a),
-            16 => self.slide_i8x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -764,14 +757,27 @@ impl Simd for Neon {
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i8x16(padding);
-        self.slide_i8x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x16::<0>(a, padding),
+            1 => self.slide_i8x16::<1>(a, padding),
+            2 => self.slide_i8x16::<2>(a, padding),
+            3 => self.slide_i8x16::<3>(a, padding),
+            4 => self.slide_i8x16::<4>(a, padding),
+            5 => self.slide_i8x16::<5>(a, padding),
+            6 => self.slide_i8x16::<6>(a, padding),
+            7 => self.slide_i8x16::<7>(a, padding),
+            8 => self.slide_i8x16::<8>(a, padding),
+            9 => self.slide_i8x16::<9>(a, padding),
+            10 => self.slide_i8x16::<10>(a, padding),
+            11 => self.slide_i8x16::<11>(a, padding),
+            12 => self.slide_i8x16::<12>(a, padding),
+            13 => self.slide_i8x16::<13>(a, padding),
+            14 => self.slide_i8x16::<14>(a, padding),
+            15 => self.slide_i8x16::<15>(a, padding),
+            16 => self.slide_i8x16::<16>(a, padding),
+            _ => self.slide_i8x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x16<const OFFSET: usize>(
@@ -779,12 +785,6 @@ impl Simd for Neon {
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i8x16(padding);
         match OFFSET {
             0 => self.slide_i8x16::<16>(padding, a),
@@ -804,7 +804,7 @@ impl Simd for Neon {
             14 => self.slide_i8x16::<2>(padding, a),
             15 => self.slide_i8x16::<1>(padding, a),
             16 => self.slide_i8x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -1189,23 +1189,29 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u8x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u8x16::<0>(a, a),
+            1 => self.slide_u8x16::<1>(a, a),
+            2 => self.slide_u8x16::<2>(a, a),
+            3 => self.slide_u8x16::<3>(a, a),
+            4 => self.slide_u8x16::<4>(a, a),
+            5 => self.slide_u8x16::<5>(a, a),
+            6 => self.slide_u8x16::<6>(a, a),
+            7 => self.slide_u8x16::<7>(a, a),
+            8 => self.slide_u8x16::<8>(a, a),
+            9 => self.slide_u8x16::<9>(a, a),
+            10 => self.slide_u8x16::<10>(a, a),
+            11 => self.slide_u8x16::<11>(a, a),
+            12 => self.slide_u8x16::<12>(a, a),
+            13 => self.slide_u8x16::<13>(a, a),
+            14 => self.slide_u8x16::<14>(a, a),
+            15 => self.slide_u8x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u8x16::<16>(a, a),
             1 => self.slide_u8x16::<15>(a, a),
             2 => self.slide_u8x16::<14>(a, a),
@@ -1222,7 +1228,6 @@ impl Simd for Neon {
             13 => self.slide_u8x16::<3>(a, a),
             14 => self.slide_u8x16::<2>(a, a),
             15 => self.slide_u8x16::<1>(a, a),
-            16 => self.slide_u8x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -1232,14 +1237,27 @@ impl Simd for Neon {
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u8x16(padding);
-        self.slide_u8x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x16::<0>(a, padding),
+            1 => self.slide_u8x16::<1>(a, padding),
+            2 => self.slide_u8x16::<2>(a, padding),
+            3 => self.slide_u8x16::<3>(a, padding),
+            4 => self.slide_u8x16::<4>(a, padding),
+            5 => self.slide_u8x16::<5>(a, padding),
+            6 => self.slide_u8x16::<6>(a, padding),
+            7 => self.slide_u8x16::<7>(a, padding),
+            8 => self.slide_u8x16::<8>(a, padding),
+            9 => self.slide_u8x16::<9>(a, padding),
+            10 => self.slide_u8x16::<10>(a, padding),
+            11 => self.slide_u8x16::<11>(a, padding),
+            12 => self.slide_u8x16::<12>(a, padding),
+            13 => self.slide_u8x16::<13>(a, padding),
+            14 => self.slide_u8x16::<14>(a, padding),
+            15 => self.slide_u8x16::<15>(a, padding),
+            16 => self.slide_u8x16::<16>(a, padding),
+            _ => self.slide_u8x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x16<const OFFSET: usize>(
@@ -1247,12 +1265,6 @@ impl Simd for Neon {
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u8x16(padding);
         match OFFSET {
             0 => self.slide_u8x16::<16>(padding, a),
@@ -1272,7 +1284,7 @@ impl Simd for Neon {
             14 => self.slide_u8x16::<2>(padding, a),
             15 => self.slide_u8x16::<1>(padding, a),
             16 => self.slide_u8x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -1836,23 +1848,21 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_i16x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_i16x8::<0>(a, a),
+            1 => self.slide_i16x8::<1>(a, a),
+            2 => self.slide_i16x8::<2>(a, a),
+            3 => self.slide_i16x8::<3>(a, a),
+            4 => self.slide_i16x8::<4>(a, a),
+            5 => self.slide_i16x8::<5>(a, a),
+            6 => self.slide_i16x8::<6>(a, a),
+            7 => self.slide_i16x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_i16x8::<8>(a, a),
             1 => self.slide_i16x8::<7>(a, a),
             2 => self.slide_i16x8::<6>(a, a),
@@ -1861,7 +1871,6 @@ impl Simd for Neon {
             5 => self.slide_i16x8::<3>(a, a),
             6 => self.slide_i16x8::<2>(a, a),
             7 => self.slide_i16x8::<1>(a, a),
-            8 => self.slide_i16x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -1871,14 +1880,19 @@ impl Simd for Neon {
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i16x8(padding);
-        self.slide_i16x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x8::<0>(a, padding),
+            1 => self.slide_i16x8::<1>(a, padding),
+            2 => self.slide_i16x8::<2>(a, padding),
+            3 => self.slide_i16x8::<3>(a, padding),
+            4 => self.slide_i16x8::<4>(a, padding),
+            5 => self.slide_i16x8::<5>(a, padding),
+            6 => self.slide_i16x8::<6>(a, padding),
+            7 => self.slide_i16x8::<7>(a, padding),
+            8 => self.slide_i16x8::<8>(a, padding),
+            _ => self.slide_i16x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x8<const OFFSET: usize>(
@@ -1886,12 +1900,6 @@ impl Simd for Neon {
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i16x8(padding);
         match OFFSET {
             0 => self.slide_i16x8::<8>(padding, a),
@@ -1903,7 +1911,7 @@ impl Simd for Neon {
             6 => self.slide_i16x8::<2>(padding, a),
             7 => self.slide_i16x8::<1>(padding, a),
             8 => self.slide_i16x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -2288,23 +2296,21 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_u16x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_u16x8::<0>(a, a),
+            1 => self.slide_u16x8::<1>(a, a),
+            2 => self.slide_u16x8::<2>(a, a),
+            3 => self.slide_u16x8::<3>(a, a),
+            4 => self.slide_u16x8::<4>(a, a),
+            5 => self.slide_u16x8::<5>(a, a),
+            6 => self.slide_u16x8::<6>(a, a),
+            7 => self.slide_u16x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_u16x8::<8>(a, a),
             1 => self.slide_u16x8::<7>(a, a),
             2 => self.slide_u16x8::<6>(a, a),
@@ -2313,7 +2319,6 @@ impl Simd for Neon {
             5 => self.slide_u16x8::<3>(a, a),
             6 => self.slide_u16x8::<2>(a, a),
             7 => self.slide_u16x8::<1>(a, a),
-            8 => self.slide_u16x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -2323,14 +2328,19 @@ impl Simd for Neon {
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u16x8(padding);
-        self.slide_u16x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x8::<0>(a, padding),
+            1 => self.slide_u16x8::<1>(a, padding),
+            2 => self.slide_u16x8::<2>(a, padding),
+            3 => self.slide_u16x8::<3>(a, padding),
+            4 => self.slide_u16x8::<4>(a, padding),
+            5 => self.slide_u16x8::<5>(a, padding),
+            6 => self.slide_u16x8::<6>(a, padding),
+            7 => self.slide_u16x8::<7>(a, padding),
+            8 => self.slide_u16x8::<8>(a, padding),
+            _ => self.slide_u16x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x8<const OFFSET: usize>(
@@ -2338,12 +2348,6 @@ impl Simd for Neon {
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u16x8(padding);
         match OFFSET {
             0 => self.slide_u16x8::<8>(padding, a),
@@ -2355,7 +2359,7 @@ impl Simd for Neon {
             6 => self.slide_u16x8::<2>(padding, a),
             7 => self.slide_u16x8::<1>(padding, a),
             8 => self.slide_u16x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -2909,28 +2913,21 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_i32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_i32x4::<0>(a, a),
+            1 => self.slide_i32x4::<1>(a, a),
+            2 => self.slide_i32x4::<2>(a, a),
+            3 => self.slide_i32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_i32x4::<4>(a, a),
             1 => self.slide_i32x4::<3>(a, a),
             2 => self.slide_i32x4::<2>(a, a),
             3 => self.slide_i32x4::<1>(a, a),
-            4 => self.slide_i32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -2940,14 +2937,15 @@ impl Simd for Neon {
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_i32x4(padding);
-        self.slide_i32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x4::<0>(a, padding),
+            1 => self.slide_i32x4::<1>(a, padding),
+            2 => self.slide_i32x4::<2>(a, padding),
+            3 => self.slide_i32x4::<3>(a, padding),
+            4 => self.slide_i32x4::<4>(a, padding),
+            _ => self.slide_i32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x4<const OFFSET: usize>(
@@ -2955,12 +2953,6 @@ impl Simd for Neon {
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_i32x4(padding);
         match OFFSET {
             0 => self.slide_i32x4::<4>(padding, a),
@@ -2968,7 +2960,7 @@ impl Simd for Neon {
             2 => self.slide_i32x4::<2>(padding, a),
             3 => self.slide_i32x4::<1>(padding, a),
             4 => self.slide_i32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -3363,28 +3355,21 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_u32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_u32x4::<0>(a, a),
+            1 => self.slide_u32x4::<1>(a, a),
+            2 => self.slide_u32x4::<2>(a, a),
+            3 => self.slide_u32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_u32x4::<4>(a, a),
             1 => self.slide_u32x4::<3>(a, a),
             2 => self.slide_u32x4::<2>(a, a),
             3 => self.slide_u32x4::<1>(a, a),
-            4 => self.slide_u32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -3394,14 +3379,15 @@ impl Simd for Neon {
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_u32x4(padding);
-        self.slide_u32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x4::<0>(a, padding),
+            1 => self.slide_u32x4::<1>(a, padding),
+            2 => self.slide_u32x4::<2>(a, padding),
+            3 => self.slide_u32x4::<3>(a, padding),
+            4 => self.slide_u32x4::<4>(a, padding),
+            _ => self.slide_u32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x4<const OFFSET: usize>(
@@ -3409,12 +3395,6 @@ impl Simd for Neon {
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_u32x4(padding);
         match OFFSET {
             0 => self.slide_u32x4::<4>(padding, a),
@@ -3422,7 +3402,7 @@ impl Simd for Neon {
             2 => self.slide_u32x4::<2>(padding, a),
             3 => self.slide_u32x4::<1>(padding, a),
             4 => self.slide_u32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -3975,26 +3955,17 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
-        self.slide_f64x2::<OFFSET>(a, a)
+        match OFFSET % 2 {
+            0 => self.slide_f64x2::<0>(a, a),
+            1 => self.slide_f64x2::<1>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
-        match OFFSET {
+        match OFFSET % 2 {
             0 => self.slide_f64x2::<2>(a, a),
             1 => self.slide_f64x2::<1>(a, a),
-            2 => self.slide_f64x2::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -4004,14 +3975,13 @@ impl Simd for Neon {
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
         let padding = self.splat_f64x2(padding);
-        self.slide_f64x2::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x2::<0>(a, padding),
+            1 => self.slide_f64x2::<1>(a, padding),
+            2 => self.slide_f64x2::<2>(a, padding),
+            _ => self.slide_f64x2::<2>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x2<const OFFSET: usize>(
@@ -4019,18 +3989,12 @@ impl Simd for Neon {
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
         let padding = self.splat_f64x2(padding);
         match OFFSET {
             0 => self.slide_f64x2::<2>(padding, a),
             1 => self.slide_f64x2::<1>(padding, a),
             2 => self.slide_f64x2::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x2::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -4666,23 +4630,21 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_f32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_f32x8::<0>(a, a),
+            1 => self.slide_f32x8::<1>(a, a),
+            2 => self.slide_f32x8::<2>(a, a),
+            3 => self.slide_f32x8::<3>(a, a),
+            4 => self.slide_f32x8::<4>(a, a),
+            5 => self.slide_f32x8::<5>(a, a),
+            6 => self.slide_f32x8::<6>(a, a),
+            7 => self.slide_f32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_f32x8::<8>(a, a),
             1 => self.slide_f32x8::<7>(a, a),
             2 => self.slide_f32x8::<6>(a, a),
@@ -4691,7 +4653,6 @@ impl Simd for Neon {
             5 => self.slide_f32x8::<3>(a, a),
             6 => self.slide_f32x8::<2>(a, a),
             7 => self.slide_f32x8::<1>(a, a),
-            8 => self.slide_f32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -4701,14 +4662,19 @@ impl Simd for Neon {
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f32x8(padding);
-        self.slide_f32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x8::<0>(a, padding),
+            1 => self.slide_f32x8::<1>(a, padding),
+            2 => self.slide_f32x8::<2>(a, padding),
+            3 => self.slide_f32x8::<3>(a, padding),
+            4 => self.slide_f32x8::<4>(a, padding),
+            5 => self.slide_f32x8::<5>(a, padding),
+            6 => self.slide_f32x8::<6>(a, padding),
+            7 => self.slide_f32x8::<7>(a, padding),
+            8 => self.slide_f32x8::<8>(a, padding),
+            _ => self.slide_f32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x8<const OFFSET: usize>(
@@ -4716,12 +4682,6 @@ impl Simd for Neon {
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f32x8(padding);
         match OFFSET {
             0 => self.slide_f32x8::<8>(padding, a),
@@ -4733,7 +4693,7 @@ impl Simd for Neon {
             6 => self.slide_f32x8::<2>(padding, a),
             7 => self.slide_f32x8::<1>(padding, a),
             8 => self.slide_f32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -5141,23 +5101,45 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_i8x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_i8x32::<0>(a, a),
+            1 => self.slide_i8x32::<1>(a, a),
+            2 => self.slide_i8x32::<2>(a, a),
+            3 => self.slide_i8x32::<3>(a, a),
+            4 => self.slide_i8x32::<4>(a, a),
+            5 => self.slide_i8x32::<5>(a, a),
+            6 => self.slide_i8x32::<6>(a, a),
+            7 => self.slide_i8x32::<7>(a, a),
+            8 => self.slide_i8x32::<8>(a, a),
+            9 => self.slide_i8x32::<9>(a, a),
+            10 => self.slide_i8x32::<10>(a, a),
+            11 => self.slide_i8x32::<11>(a, a),
+            12 => self.slide_i8x32::<12>(a, a),
+            13 => self.slide_i8x32::<13>(a, a),
+            14 => self.slide_i8x32::<14>(a, a),
+            15 => self.slide_i8x32::<15>(a, a),
+            16 => self.slide_i8x32::<16>(a, a),
+            17 => self.slide_i8x32::<17>(a, a),
+            18 => self.slide_i8x32::<18>(a, a),
+            19 => self.slide_i8x32::<19>(a, a),
+            20 => self.slide_i8x32::<20>(a, a),
+            21 => self.slide_i8x32::<21>(a, a),
+            22 => self.slide_i8x32::<22>(a, a),
+            23 => self.slide_i8x32::<23>(a, a),
+            24 => self.slide_i8x32::<24>(a, a),
+            25 => self.slide_i8x32::<25>(a, a),
+            26 => self.slide_i8x32::<26>(a, a),
+            27 => self.slide_i8x32::<27>(a, a),
+            28 => self.slide_i8x32::<28>(a, a),
+            29 => self.slide_i8x32::<29>(a, a),
+            30 => self.slide_i8x32::<30>(a, a),
+            31 => self.slide_i8x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_i8x32::<32>(a, a),
             1 => self.slide_i8x32::<31>(a, a),
             2 => self.slide_i8x32::<30>(a, a),
@@ -5190,7 +5172,6 @@ impl Simd for Neon {
             29 => self.slide_i8x32::<3>(a, a),
             30 => self.slide_i8x32::<2>(a, a),
             31 => self.slide_i8x32::<1>(a, a),
-            32 => self.slide_i8x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -5200,14 +5181,43 @@ impl Simd for Neon {
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i8x32(padding);
-        self.slide_i8x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x32::<0>(a, padding),
+            1 => self.slide_i8x32::<1>(a, padding),
+            2 => self.slide_i8x32::<2>(a, padding),
+            3 => self.slide_i8x32::<3>(a, padding),
+            4 => self.slide_i8x32::<4>(a, padding),
+            5 => self.slide_i8x32::<5>(a, padding),
+            6 => self.slide_i8x32::<6>(a, padding),
+            7 => self.slide_i8x32::<7>(a, padding),
+            8 => self.slide_i8x32::<8>(a, padding),
+            9 => self.slide_i8x32::<9>(a, padding),
+            10 => self.slide_i8x32::<10>(a, padding),
+            11 => self.slide_i8x32::<11>(a, padding),
+            12 => self.slide_i8x32::<12>(a, padding),
+            13 => self.slide_i8x32::<13>(a, padding),
+            14 => self.slide_i8x32::<14>(a, padding),
+            15 => self.slide_i8x32::<15>(a, padding),
+            16 => self.slide_i8x32::<16>(a, padding),
+            17 => self.slide_i8x32::<17>(a, padding),
+            18 => self.slide_i8x32::<18>(a, padding),
+            19 => self.slide_i8x32::<19>(a, padding),
+            20 => self.slide_i8x32::<20>(a, padding),
+            21 => self.slide_i8x32::<21>(a, padding),
+            22 => self.slide_i8x32::<22>(a, padding),
+            23 => self.slide_i8x32::<23>(a, padding),
+            24 => self.slide_i8x32::<24>(a, padding),
+            25 => self.slide_i8x32::<25>(a, padding),
+            26 => self.slide_i8x32::<26>(a, padding),
+            27 => self.slide_i8x32::<27>(a, padding),
+            28 => self.slide_i8x32::<28>(a, padding),
+            29 => self.slide_i8x32::<29>(a, padding),
+            30 => self.slide_i8x32::<30>(a, padding),
+            31 => self.slide_i8x32::<31>(a, padding),
+            32 => self.slide_i8x32::<32>(a, padding),
+            _ => self.slide_i8x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x32<const OFFSET: usize>(
@@ -5215,12 +5225,6 @@ impl Simd for Neon {
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i8x32(padding);
         match OFFSET {
             0 => self.slide_i8x32::<32>(padding, a),
@@ -5256,7 +5260,7 @@ impl Simd for Neon {
             30 => self.slide_i8x32::<2>(padding, a),
             31 => self.slide_i8x32::<1>(padding, a),
             32 => self.slide_i8x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -5571,23 +5575,45 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_u8x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_u8x32::<0>(a, a),
+            1 => self.slide_u8x32::<1>(a, a),
+            2 => self.slide_u8x32::<2>(a, a),
+            3 => self.slide_u8x32::<3>(a, a),
+            4 => self.slide_u8x32::<4>(a, a),
+            5 => self.slide_u8x32::<5>(a, a),
+            6 => self.slide_u8x32::<6>(a, a),
+            7 => self.slide_u8x32::<7>(a, a),
+            8 => self.slide_u8x32::<8>(a, a),
+            9 => self.slide_u8x32::<9>(a, a),
+            10 => self.slide_u8x32::<10>(a, a),
+            11 => self.slide_u8x32::<11>(a, a),
+            12 => self.slide_u8x32::<12>(a, a),
+            13 => self.slide_u8x32::<13>(a, a),
+            14 => self.slide_u8x32::<14>(a, a),
+            15 => self.slide_u8x32::<15>(a, a),
+            16 => self.slide_u8x32::<16>(a, a),
+            17 => self.slide_u8x32::<17>(a, a),
+            18 => self.slide_u8x32::<18>(a, a),
+            19 => self.slide_u8x32::<19>(a, a),
+            20 => self.slide_u8x32::<20>(a, a),
+            21 => self.slide_u8x32::<21>(a, a),
+            22 => self.slide_u8x32::<22>(a, a),
+            23 => self.slide_u8x32::<23>(a, a),
+            24 => self.slide_u8x32::<24>(a, a),
+            25 => self.slide_u8x32::<25>(a, a),
+            26 => self.slide_u8x32::<26>(a, a),
+            27 => self.slide_u8x32::<27>(a, a),
+            28 => self.slide_u8x32::<28>(a, a),
+            29 => self.slide_u8x32::<29>(a, a),
+            30 => self.slide_u8x32::<30>(a, a),
+            31 => self.slide_u8x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_u8x32::<32>(a, a),
             1 => self.slide_u8x32::<31>(a, a),
             2 => self.slide_u8x32::<30>(a, a),
@@ -5620,7 +5646,6 @@ impl Simd for Neon {
             29 => self.slide_u8x32::<3>(a, a),
             30 => self.slide_u8x32::<2>(a, a),
             31 => self.slide_u8x32::<1>(a, a),
-            32 => self.slide_u8x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -5630,14 +5655,43 @@ impl Simd for Neon {
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u8x32(padding);
-        self.slide_u8x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x32::<0>(a, padding),
+            1 => self.slide_u8x32::<1>(a, padding),
+            2 => self.slide_u8x32::<2>(a, padding),
+            3 => self.slide_u8x32::<3>(a, padding),
+            4 => self.slide_u8x32::<4>(a, padding),
+            5 => self.slide_u8x32::<5>(a, padding),
+            6 => self.slide_u8x32::<6>(a, padding),
+            7 => self.slide_u8x32::<7>(a, padding),
+            8 => self.slide_u8x32::<8>(a, padding),
+            9 => self.slide_u8x32::<9>(a, padding),
+            10 => self.slide_u8x32::<10>(a, padding),
+            11 => self.slide_u8x32::<11>(a, padding),
+            12 => self.slide_u8x32::<12>(a, padding),
+            13 => self.slide_u8x32::<13>(a, padding),
+            14 => self.slide_u8x32::<14>(a, padding),
+            15 => self.slide_u8x32::<15>(a, padding),
+            16 => self.slide_u8x32::<16>(a, padding),
+            17 => self.slide_u8x32::<17>(a, padding),
+            18 => self.slide_u8x32::<18>(a, padding),
+            19 => self.slide_u8x32::<19>(a, padding),
+            20 => self.slide_u8x32::<20>(a, padding),
+            21 => self.slide_u8x32::<21>(a, padding),
+            22 => self.slide_u8x32::<22>(a, padding),
+            23 => self.slide_u8x32::<23>(a, padding),
+            24 => self.slide_u8x32::<24>(a, padding),
+            25 => self.slide_u8x32::<25>(a, padding),
+            26 => self.slide_u8x32::<26>(a, padding),
+            27 => self.slide_u8x32::<27>(a, padding),
+            28 => self.slide_u8x32::<28>(a, padding),
+            29 => self.slide_u8x32::<29>(a, padding),
+            30 => self.slide_u8x32::<30>(a, padding),
+            31 => self.slide_u8x32::<31>(a, padding),
+            32 => self.slide_u8x32::<32>(a, padding),
+            _ => self.slide_u8x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x32<const OFFSET: usize>(
@@ -5645,12 +5699,6 @@ impl Simd for Neon {
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u8x32(padding);
         match OFFSET {
             0 => self.slide_u8x32::<32>(padding, a),
@@ -5686,7 +5734,7 @@ impl Simd for Neon {
             30 => self.slide_u8x32::<2>(padding, a),
             31 => self.slide_u8x32::<1>(padding, a),
             32 => self.slide_u8x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -6122,23 +6170,29 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i16x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i16x16::<0>(a, a),
+            1 => self.slide_i16x16::<1>(a, a),
+            2 => self.slide_i16x16::<2>(a, a),
+            3 => self.slide_i16x16::<3>(a, a),
+            4 => self.slide_i16x16::<4>(a, a),
+            5 => self.slide_i16x16::<5>(a, a),
+            6 => self.slide_i16x16::<6>(a, a),
+            7 => self.slide_i16x16::<7>(a, a),
+            8 => self.slide_i16x16::<8>(a, a),
+            9 => self.slide_i16x16::<9>(a, a),
+            10 => self.slide_i16x16::<10>(a, a),
+            11 => self.slide_i16x16::<11>(a, a),
+            12 => self.slide_i16x16::<12>(a, a),
+            13 => self.slide_i16x16::<13>(a, a),
+            14 => self.slide_i16x16::<14>(a, a),
+            15 => self.slide_i16x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i16x16::<16>(a, a),
             1 => self.slide_i16x16::<15>(a, a),
             2 => self.slide_i16x16::<14>(a, a),
@@ -6155,7 +6209,6 @@ impl Simd for Neon {
             13 => self.slide_i16x16::<3>(a, a),
             14 => self.slide_i16x16::<2>(a, a),
             15 => self.slide_i16x16::<1>(a, a),
-            16 => self.slide_i16x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -6165,14 +6218,27 @@ impl Simd for Neon {
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i16x16(padding);
-        self.slide_i16x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x16::<0>(a, padding),
+            1 => self.slide_i16x16::<1>(a, padding),
+            2 => self.slide_i16x16::<2>(a, padding),
+            3 => self.slide_i16x16::<3>(a, padding),
+            4 => self.slide_i16x16::<4>(a, padding),
+            5 => self.slide_i16x16::<5>(a, padding),
+            6 => self.slide_i16x16::<6>(a, padding),
+            7 => self.slide_i16x16::<7>(a, padding),
+            8 => self.slide_i16x16::<8>(a, padding),
+            9 => self.slide_i16x16::<9>(a, padding),
+            10 => self.slide_i16x16::<10>(a, padding),
+            11 => self.slide_i16x16::<11>(a, padding),
+            12 => self.slide_i16x16::<12>(a, padding),
+            13 => self.slide_i16x16::<13>(a, padding),
+            14 => self.slide_i16x16::<14>(a, padding),
+            15 => self.slide_i16x16::<15>(a, padding),
+            16 => self.slide_i16x16::<16>(a, padding),
+            _ => self.slide_i16x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x16<const OFFSET: usize>(
@@ -6180,12 +6246,6 @@ impl Simd for Neon {
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i16x16(padding);
         match OFFSET {
             0 => self.slide_i16x16::<16>(padding, a),
@@ -6205,7 +6265,7 @@ impl Simd for Neon {
             14 => self.slide_i16x16::<2>(padding, a),
             15 => self.slide_i16x16::<1>(padding, a),
             16 => self.slide_i16x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -6524,23 +6584,29 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u16x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u16x16::<0>(a, a),
+            1 => self.slide_u16x16::<1>(a, a),
+            2 => self.slide_u16x16::<2>(a, a),
+            3 => self.slide_u16x16::<3>(a, a),
+            4 => self.slide_u16x16::<4>(a, a),
+            5 => self.slide_u16x16::<5>(a, a),
+            6 => self.slide_u16x16::<6>(a, a),
+            7 => self.slide_u16x16::<7>(a, a),
+            8 => self.slide_u16x16::<8>(a, a),
+            9 => self.slide_u16x16::<9>(a, a),
+            10 => self.slide_u16x16::<10>(a, a),
+            11 => self.slide_u16x16::<11>(a, a),
+            12 => self.slide_u16x16::<12>(a, a),
+            13 => self.slide_u16x16::<13>(a, a),
+            14 => self.slide_u16x16::<14>(a, a),
+            15 => self.slide_u16x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u16x16::<16>(a, a),
             1 => self.slide_u16x16::<15>(a, a),
             2 => self.slide_u16x16::<14>(a, a),
@@ -6557,7 +6623,6 @@ impl Simd for Neon {
             13 => self.slide_u16x16::<3>(a, a),
             14 => self.slide_u16x16::<2>(a, a),
             15 => self.slide_u16x16::<1>(a, a),
-            16 => self.slide_u16x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -6567,14 +6632,27 @@ impl Simd for Neon {
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u16x16(padding);
-        self.slide_u16x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x16::<0>(a, padding),
+            1 => self.slide_u16x16::<1>(a, padding),
+            2 => self.slide_u16x16::<2>(a, padding),
+            3 => self.slide_u16x16::<3>(a, padding),
+            4 => self.slide_u16x16::<4>(a, padding),
+            5 => self.slide_u16x16::<5>(a, padding),
+            6 => self.slide_u16x16::<6>(a, padding),
+            7 => self.slide_u16x16::<7>(a, padding),
+            8 => self.slide_u16x16::<8>(a, padding),
+            9 => self.slide_u16x16::<9>(a, padding),
+            10 => self.slide_u16x16::<10>(a, padding),
+            11 => self.slide_u16x16::<11>(a, padding),
+            12 => self.slide_u16x16::<12>(a, padding),
+            13 => self.slide_u16x16::<13>(a, padding),
+            14 => self.slide_u16x16::<14>(a, padding),
+            15 => self.slide_u16x16::<15>(a, padding),
+            16 => self.slide_u16x16::<16>(a, padding),
+            _ => self.slide_u16x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x16<const OFFSET: usize>(
@@ -6582,12 +6660,6 @@ impl Simd for Neon {
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u16x16(padding);
         match OFFSET {
             0 => self.slide_u16x16::<16>(padding, a),
@@ -6607,7 +6679,7 @@ impl Simd for Neon {
             14 => self.slide_u16x16::<2>(padding, a),
             15 => self.slide_u16x16::<1>(padding, a),
             16 => self.slide_u16x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7060,23 +7132,21 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_i32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_i32x8::<0>(a, a),
+            1 => self.slide_i32x8::<1>(a, a),
+            2 => self.slide_i32x8::<2>(a, a),
+            3 => self.slide_i32x8::<3>(a, a),
+            4 => self.slide_i32x8::<4>(a, a),
+            5 => self.slide_i32x8::<5>(a, a),
+            6 => self.slide_i32x8::<6>(a, a),
+            7 => self.slide_i32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_i32x8::<8>(a, a),
             1 => self.slide_i32x8::<7>(a, a),
             2 => self.slide_i32x8::<6>(a, a),
@@ -7085,7 +7155,6 @@ impl Simd for Neon {
             5 => self.slide_i32x8::<3>(a, a),
             6 => self.slide_i32x8::<2>(a, a),
             7 => self.slide_i32x8::<1>(a, a),
-            8 => self.slide_i32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -7095,14 +7164,19 @@ impl Simd for Neon {
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i32x8(padding);
-        self.slide_i32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x8::<0>(a, padding),
+            1 => self.slide_i32x8::<1>(a, padding),
+            2 => self.slide_i32x8::<2>(a, padding),
+            3 => self.slide_i32x8::<3>(a, padding),
+            4 => self.slide_i32x8::<4>(a, padding),
+            5 => self.slide_i32x8::<5>(a, padding),
+            6 => self.slide_i32x8::<6>(a, padding),
+            7 => self.slide_i32x8::<7>(a, padding),
+            8 => self.slide_i32x8::<8>(a, padding),
+            _ => self.slide_i32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x8<const OFFSET: usize>(
@@ -7110,12 +7184,6 @@ impl Simd for Neon {
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i32x8(padding);
         match OFFSET {
             0 => self.slide_i32x8::<8>(padding, a),
@@ -7127,7 +7195,7 @@ impl Simd for Neon {
             6 => self.slide_i32x8::<2>(padding, a),
             7 => self.slide_i32x8::<1>(padding, a),
             8 => self.slide_i32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7447,23 +7515,21 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_u32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_u32x8::<0>(a, a),
+            1 => self.slide_u32x8::<1>(a, a),
+            2 => self.slide_u32x8::<2>(a, a),
+            3 => self.slide_u32x8::<3>(a, a),
+            4 => self.slide_u32x8::<4>(a, a),
+            5 => self.slide_u32x8::<5>(a, a),
+            6 => self.slide_u32x8::<6>(a, a),
+            7 => self.slide_u32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_u32x8::<8>(a, a),
             1 => self.slide_u32x8::<7>(a, a),
             2 => self.slide_u32x8::<6>(a, a),
@@ -7472,7 +7538,6 @@ impl Simd for Neon {
             5 => self.slide_u32x8::<3>(a, a),
             6 => self.slide_u32x8::<2>(a, a),
             7 => self.slide_u32x8::<1>(a, a),
-            8 => self.slide_u32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -7482,14 +7547,19 @@ impl Simd for Neon {
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u32x8(padding);
-        self.slide_u32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x8::<0>(a, padding),
+            1 => self.slide_u32x8::<1>(a, padding),
+            2 => self.slide_u32x8::<2>(a, padding),
+            3 => self.slide_u32x8::<3>(a, padding),
+            4 => self.slide_u32x8::<4>(a, padding),
+            5 => self.slide_u32x8::<5>(a, padding),
+            6 => self.slide_u32x8::<6>(a, padding),
+            7 => self.slide_u32x8::<7>(a, padding),
+            8 => self.slide_u32x8::<8>(a, padding),
+            _ => self.slide_u32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x8<const OFFSET: usize>(
@@ -7497,12 +7567,6 @@ impl Simd for Neon {
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u32x8(padding);
         match OFFSET {
             0 => self.slide_u32x8::<8>(padding, a),
@@ -7514,7 +7578,7 @@ impl Simd for Neon {
             6 => self.slide_u32x8::<2>(padding, a),
             7 => self.slide_u32x8::<1>(padding, a),
             8 => self.slide_u32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7947,28 +8011,21 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_f64x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_f64x4::<0>(a, a),
+            1 => self.slide_f64x4::<1>(a, a),
+            2 => self.slide_f64x4::<2>(a, a),
+            3 => self.slide_f64x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_f64x4::<4>(a, a),
             1 => self.slide_f64x4::<3>(a, a),
             2 => self.slide_f64x4::<2>(a, a),
             3 => self.slide_f64x4::<1>(a, a),
-            4 => self.slide_f64x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -7978,14 +8035,15 @@ impl Simd for Neon {
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f64x4(padding);
-        self.slide_f64x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x4::<0>(a, padding),
+            1 => self.slide_f64x4::<1>(a, padding),
+            2 => self.slide_f64x4::<2>(a, padding),
+            3 => self.slide_f64x4::<3>(a, padding),
+            4 => self.slide_f64x4::<4>(a, padding),
+            _ => self.slide_f64x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x4<const OFFSET: usize>(
@@ -7993,12 +8051,6 @@ impl Simd for Neon {
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f64x4(padding);
         match OFFSET {
             0 => self.slide_f64x4::<4>(padding, a),
@@ -8006,7 +8058,7 @@ impl Simd for Neon {
             2 => self.slide_f64x4::<2>(padding, a),
             3 => self.slide_f64x4::<1>(padding, a),
             4 => self.slide_f64x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -8511,23 +8563,29 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_f32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_f32x16::<0>(a, a),
+            1 => self.slide_f32x16::<1>(a, a),
+            2 => self.slide_f32x16::<2>(a, a),
+            3 => self.slide_f32x16::<3>(a, a),
+            4 => self.slide_f32x16::<4>(a, a),
+            5 => self.slide_f32x16::<5>(a, a),
+            6 => self.slide_f32x16::<6>(a, a),
+            7 => self.slide_f32x16::<7>(a, a),
+            8 => self.slide_f32x16::<8>(a, a),
+            9 => self.slide_f32x16::<9>(a, a),
+            10 => self.slide_f32x16::<10>(a, a),
+            11 => self.slide_f32x16::<11>(a, a),
+            12 => self.slide_f32x16::<12>(a, a),
+            13 => self.slide_f32x16::<13>(a, a),
+            14 => self.slide_f32x16::<14>(a, a),
+            15 => self.slide_f32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_f32x16::<16>(a, a),
             1 => self.slide_f32x16::<15>(a, a),
             2 => self.slide_f32x16::<14>(a, a),
@@ -8544,7 +8602,6 @@ impl Simd for Neon {
             13 => self.slide_f32x16::<3>(a, a),
             14 => self.slide_f32x16::<2>(a, a),
             15 => self.slide_f32x16::<1>(a, a),
-            16 => self.slide_f32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -8554,14 +8611,27 @@ impl Simd for Neon {
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_f32x16(padding);
-        self.slide_f32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x16::<0>(a, padding),
+            1 => self.slide_f32x16::<1>(a, padding),
+            2 => self.slide_f32x16::<2>(a, padding),
+            3 => self.slide_f32x16::<3>(a, padding),
+            4 => self.slide_f32x16::<4>(a, padding),
+            5 => self.slide_f32x16::<5>(a, padding),
+            6 => self.slide_f32x16::<6>(a, padding),
+            7 => self.slide_f32x16::<7>(a, padding),
+            8 => self.slide_f32x16::<8>(a, padding),
+            9 => self.slide_f32x16::<9>(a, padding),
+            10 => self.slide_f32x16::<10>(a, padding),
+            11 => self.slide_f32x16::<11>(a, padding),
+            12 => self.slide_f32x16::<12>(a, padding),
+            13 => self.slide_f32x16::<13>(a, padding),
+            14 => self.slide_f32x16::<14>(a, padding),
+            15 => self.slide_f32x16::<15>(a, padding),
+            16 => self.slide_f32x16::<16>(a, padding),
+            _ => self.slide_f32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x16<const OFFSET: usize>(
@@ -8569,12 +8639,6 @@ impl Simd for Neon {
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_f32x16(padding);
         match OFFSET {
             0 => self.slide_f32x16::<16>(padding, a),
@@ -8594,7 +8658,7 @@ impl Simd for Neon {
             14 => self.slide_f32x16::<2>(padding, a),
             15 => self.slide_f32x16::<1>(padding, a),
             16 => self.slide_f32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -9023,23 +9087,77 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        self.slide_i8x64::<OFFSET>(a, a)
+        match OFFSET % 64 {
+            0 => self.slide_i8x64::<0>(a, a),
+            1 => self.slide_i8x64::<1>(a, a),
+            2 => self.slide_i8x64::<2>(a, a),
+            3 => self.slide_i8x64::<3>(a, a),
+            4 => self.slide_i8x64::<4>(a, a),
+            5 => self.slide_i8x64::<5>(a, a),
+            6 => self.slide_i8x64::<6>(a, a),
+            7 => self.slide_i8x64::<7>(a, a),
+            8 => self.slide_i8x64::<8>(a, a),
+            9 => self.slide_i8x64::<9>(a, a),
+            10 => self.slide_i8x64::<10>(a, a),
+            11 => self.slide_i8x64::<11>(a, a),
+            12 => self.slide_i8x64::<12>(a, a),
+            13 => self.slide_i8x64::<13>(a, a),
+            14 => self.slide_i8x64::<14>(a, a),
+            15 => self.slide_i8x64::<15>(a, a),
+            16 => self.slide_i8x64::<16>(a, a),
+            17 => self.slide_i8x64::<17>(a, a),
+            18 => self.slide_i8x64::<18>(a, a),
+            19 => self.slide_i8x64::<19>(a, a),
+            20 => self.slide_i8x64::<20>(a, a),
+            21 => self.slide_i8x64::<21>(a, a),
+            22 => self.slide_i8x64::<22>(a, a),
+            23 => self.slide_i8x64::<23>(a, a),
+            24 => self.slide_i8x64::<24>(a, a),
+            25 => self.slide_i8x64::<25>(a, a),
+            26 => self.slide_i8x64::<26>(a, a),
+            27 => self.slide_i8x64::<27>(a, a),
+            28 => self.slide_i8x64::<28>(a, a),
+            29 => self.slide_i8x64::<29>(a, a),
+            30 => self.slide_i8x64::<30>(a, a),
+            31 => self.slide_i8x64::<31>(a, a),
+            32 => self.slide_i8x64::<32>(a, a),
+            33 => self.slide_i8x64::<33>(a, a),
+            34 => self.slide_i8x64::<34>(a, a),
+            35 => self.slide_i8x64::<35>(a, a),
+            36 => self.slide_i8x64::<36>(a, a),
+            37 => self.slide_i8x64::<37>(a, a),
+            38 => self.slide_i8x64::<38>(a, a),
+            39 => self.slide_i8x64::<39>(a, a),
+            40 => self.slide_i8x64::<40>(a, a),
+            41 => self.slide_i8x64::<41>(a, a),
+            42 => self.slide_i8x64::<42>(a, a),
+            43 => self.slide_i8x64::<43>(a, a),
+            44 => self.slide_i8x64::<44>(a, a),
+            45 => self.slide_i8x64::<45>(a, a),
+            46 => self.slide_i8x64::<46>(a, a),
+            47 => self.slide_i8x64::<47>(a, a),
+            48 => self.slide_i8x64::<48>(a, a),
+            49 => self.slide_i8x64::<49>(a, a),
+            50 => self.slide_i8x64::<50>(a, a),
+            51 => self.slide_i8x64::<51>(a, a),
+            52 => self.slide_i8x64::<52>(a, a),
+            53 => self.slide_i8x64::<53>(a, a),
+            54 => self.slide_i8x64::<54>(a, a),
+            55 => self.slide_i8x64::<55>(a, a),
+            56 => self.slide_i8x64::<56>(a, a),
+            57 => self.slide_i8x64::<57>(a, a),
+            58 => self.slide_i8x64::<58>(a, a),
+            59 => self.slide_i8x64::<59>(a, a),
+            60 => self.slide_i8x64::<60>(a, a),
+            61 => self.slide_i8x64::<61>(a, a),
+            62 => self.slide_i8x64::<62>(a, a),
+            63 => self.slide_i8x64::<63>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        match OFFSET {
+        match OFFSET % 64 {
             0 => self.slide_i8x64::<64>(a, a),
             1 => self.slide_i8x64::<63>(a, a),
             2 => self.slide_i8x64::<62>(a, a),
@@ -9104,7 +9222,6 @@ impl Simd for Neon {
             61 => self.slide_i8x64::<3>(a, a),
             62 => self.slide_i8x64::<2>(a, a),
             63 => self.slide_i8x64::<1>(a, a),
-            64 => self.slide_i8x64::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -9114,14 +9231,75 @@ impl Simd for Neon {
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_i8x64(padding);
-        self.slide_i8x64::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x64::<0>(a, padding),
+            1 => self.slide_i8x64::<1>(a, padding),
+            2 => self.slide_i8x64::<2>(a, padding),
+            3 => self.slide_i8x64::<3>(a, padding),
+            4 => self.slide_i8x64::<4>(a, padding),
+            5 => self.slide_i8x64::<5>(a, padding),
+            6 => self.slide_i8x64::<6>(a, padding),
+            7 => self.slide_i8x64::<7>(a, padding),
+            8 => self.slide_i8x64::<8>(a, padding),
+            9 => self.slide_i8x64::<9>(a, padding),
+            10 => self.slide_i8x64::<10>(a, padding),
+            11 => self.slide_i8x64::<11>(a, padding),
+            12 => self.slide_i8x64::<12>(a, padding),
+            13 => self.slide_i8x64::<13>(a, padding),
+            14 => self.slide_i8x64::<14>(a, padding),
+            15 => self.slide_i8x64::<15>(a, padding),
+            16 => self.slide_i8x64::<16>(a, padding),
+            17 => self.slide_i8x64::<17>(a, padding),
+            18 => self.slide_i8x64::<18>(a, padding),
+            19 => self.slide_i8x64::<19>(a, padding),
+            20 => self.slide_i8x64::<20>(a, padding),
+            21 => self.slide_i8x64::<21>(a, padding),
+            22 => self.slide_i8x64::<22>(a, padding),
+            23 => self.slide_i8x64::<23>(a, padding),
+            24 => self.slide_i8x64::<24>(a, padding),
+            25 => self.slide_i8x64::<25>(a, padding),
+            26 => self.slide_i8x64::<26>(a, padding),
+            27 => self.slide_i8x64::<27>(a, padding),
+            28 => self.slide_i8x64::<28>(a, padding),
+            29 => self.slide_i8x64::<29>(a, padding),
+            30 => self.slide_i8x64::<30>(a, padding),
+            31 => self.slide_i8x64::<31>(a, padding),
+            32 => self.slide_i8x64::<32>(a, padding),
+            33 => self.slide_i8x64::<33>(a, padding),
+            34 => self.slide_i8x64::<34>(a, padding),
+            35 => self.slide_i8x64::<35>(a, padding),
+            36 => self.slide_i8x64::<36>(a, padding),
+            37 => self.slide_i8x64::<37>(a, padding),
+            38 => self.slide_i8x64::<38>(a, padding),
+            39 => self.slide_i8x64::<39>(a, padding),
+            40 => self.slide_i8x64::<40>(a, padding),
+            41 => self.slide_i8x64::<41>(a, padding),
+            42 => self.slide_i8x64::<42>(a, padding),
+            43 => self.slide_i8x64::<43>(a, padding),
+            44 => self.slide_i8x64::<44>(a, padding),
+            45 => self.slide_i8x64::<45>(a, padding),
+            46 => self.slide_i8x64::<46>(a, padding),
+            47 => self.slide_i8x64::<47>(a, padding),
+            48 => self.slide_i8x64::<48>(a, padding),
+            49 => self.slide_i8x64::<49>(a, padding),
+            50 => self.slide_i8x64::<50>(a, padding),
+            51 => self.slide_i8x64::<51>(a, padding),
+            52 => self.slide_i8x64::<52>(a, padding),
+            53 => self.slide_i8x64::<53>(a, padding),
+            54 => self.slide_i8x64::<54>(a, padding),
+            55 => self.slide_i8x64::<55>(a, padding),
+            56 => self.slide_i8x64::<56>(a, padding),
+            57 => self.slide_i8x64::<57>(a, padding),
+            58 => self.slide_i8x64::<58>(a, padding),
+            59 => self.slide_i8x64::<59>(a, padding),
+            60 => self.slide_i8x64::<60>(a, padding),
+            61 => self.slide_i8x64::<61>(a, padding),
+            62 => self.slide_i8x64::<62>(a, padding),
+            63 => self.slide_i8x64::<63>(a, padding),
+            64 => self.slide_i8x64::<64>(a, padding),
+            _ => self.slide_i8x64::<64>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x64<const OFFSET: usize>(
@@ -9129,12 +9307,6 @@ impl Simd for Neon {
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_i8x64(padding);
         match OFFSET {
             0 => self.slide_i8x64::<64>(padding, a),
@@ -9202,7 +9374,7 @@ impl Simd for Neon {
             62 => self.slide_i8x64::<2>(padding, a),
             63 => self.slide_i8x64::<1>(padding, a),
             64 => self.slide_i8x64::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x64::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -9526,23 +9698,77 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        self.slide_u8x64::<OFFSET>(a, a)
+        match OFFSET % 64 {
+            0 => self.slide_u8x64::<0>(a, a),
+            1 => self.slide_u8x64::<1>(a, a),
+            2 => self.slide_u8x64::<2>(a, a),
+            3 => self.slide_u8x64::<3>(a, a),
+            4 => self.slide_u8x64::<4>(a, a),
+            5 => self.slide_u8x64::<5>(a, a),
+            6 => self.slide_u8x64::<6>(a, a),
+            7 => self.slide_u8x64::<7>(a, a),
+            8 => self.slide_u8x64::<8>(a, a),
+            9 => self.slide_u8x64::<9>(a, a),
+            10 => self.slide_u8x64::<10>(a, a),
+            11 => self.slide_u8x64::<11>(a, a),
+            12 => self.slide_u8x64::<12>(a, a),
+            13 => self.slide_u8x64::<13>(a, a),
+            14 => self.slide_u8x64::<14>(a, a),
+            15 => self.slide_u8x64::<15>(a, a),
+            16 => self.slide_u8x64::<16>(a, a),
+            17 => self.slide_u8x64::<17>(a, a),
+            18 => self.slide_u8x64::<18>(a, a),
+            19 => self.slide_u8x64::<19>(a, a),
+            20 => self.slide_u8x64::<20>(a, a),
+            21 => self.slide_u8x64::<21>(a, a),
+            22 => self.slide_u8x64::<22>(a, a),
+            23 => self.slide_u8x64::<23>(a, a),
+            24 => self.slide_u8x64::<24>(a, a),
+            25 => self.slide_u8x64::<25>(a, a),
+            26 => self.slide_u8x64::<26>(a, a),
+            27 => self.slide_u8x64::<27>(a, a),
+            28 => self.slide_u8x64::<28>(a, a),
+            29 => self.slide_u8x64::<29>(a, a),
+            30 => self.slide_u8x64::<30>(a, a),
+            31 => self.slide_u8x64::<31>(a, a),
+            32 => self.slide_u8x64::<32>(a, a),
+            33 => self.slide_u8x64::<33>(a, a),
+            34 => self.slide_u8x64::<34>(a, a),
+            35 => self.slide_u8x64::<35>(a, a),
+            36 => self.slide_u8x64::<36>(a, a),
+            37 => self.slide_u8x64::<37>(a, a),
+            38 => self.slide_u8x64::<38>(a, a),
+            39 => self.slide_u8x64::<39>(a, a),
+            40 => self.slide_u8x64::<40>(a, a),
+            41 => self.slide_u8x64::<41>(a, a),
+            42 => self.slide_u8x64::<42>(a, a),
+            43 => self.slide_u8x64::<43>(a, a),
+            44 => self.slide_u8x64::<44>(a, a),
+            45 => self.slide_u8x64::<45>(a, a),
+            46 => self.slide_u8x64::<46>(a, a),
+            47 => self.slide_u8x64::<47>(a, a),
+            48 => self.slide_u8x64::<48>(a, a),
+            49 => self.slide_u8x64::<49>(a, a),
+            50 => self.slide_u8x64::<50>(a, a),
+            51 => self.slide_u8x64::<51>(a, a),
+            52 => self.slide_u8x64::<52>(a, a),
+            53 => self.slide_u8x64::<53>(a, a),
+            54 => self.slide_u8x64::<54>(a, a),
+            55 => self.slide_u8x64::<55>(a, a),
+            56 => self.slide_u8x64::<56>(a, a),
+            57 => self.slide_u8x64::<57>(a, a),
+            58 => self.slide_u8x64::<58>(a, a),
+            59 => self.slide_u8x64::<59>(a, a),
+            60 => self.slide_u8x64::<60>(a, a),
+            61 => self.slide_u8x64::<61>(a, a),
+            62 => self.slide_u8x64::<62>(a, a),
+            63 => self.slide_u8x64::<63>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        match OFFSET {
+        match OFFSET % 64 {
             0 => self.slide_u8x64::<64>(a, a),
             1 => self.slide_u8x64::<63>(a, a),
             2 => self.slide_u8x64::<62>(a, a),
@@ -9607,7 +9833,6 @@ impl Simd for Neon {
             61 => self.slide_u8x64::<3>(a, a),
             62 => self.slide_u8x64::<2>(a, a),
             63 => self.slide_u8x64::<1>(a, a),
-            64 => self.slide_u8x64::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -9617,14 +9842,75 @@ impl Simd for Neon {
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_u8x64(padding);
-        self.slide_u8x64::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x64::<0>(a, padding),
+            1 => self.slide_u8x64::<1>(a, padding),
+            2 => self.slide_u8x64::<2>(a, padding),
+            3 => self.slide_u8x64::<3>(a, padding),
+            4 => self.slide_u8x64::<4>(a, padding),
+            5 => self.slide_u8x64::<5>(a, padding),
+            6 => self.slide_u8x64::<6>(a, padding),
+            7 => self.slide_u8x64::<7>(a, padding),
+            8 => self.slide_u8x64::<8>(a, padding),
+            9 => self.slide_u8x64::<9>(a, padding),
+            10 => self.slide_u8x64::<10>(a, padding),
+            11 => self.slide_u8x64::<11>(a, padding),
+            12 => self.slide_u8x64::<12>(a, padding),
+            13 => self.slide_u8x64::<13>(a, padding),
+            14 => self.slide_u8x64::<14>(a, padding),
+            15 => self.slide_u8x64::<15>(a, padding),
+            16 => self.slide_u8x64::<16>(a, padding),
+            17 => self.slide_u8x64::<17>(a, padding),
+            18 => self.slide_u8x64::<18>(a, padding),
+            19 => self.slide_u8x64::<19>(a, padding),
+            20 => self.slide_u8x64::<20>(a, padding),
+            21 => self.slide_u8x64::<21>(a, padding),
+            22 => self.slide_u8x64::<22>(a, padding),
+            23 => self.slide_u8x64::<23>(a, padding),
+            24 => self.slide_u8x64::<24>(a, padding),
+            25 => self.slide_u8x64::<25>(a, padding),
+            26 => self.slide_u8x64::<26>(a, padding),
+            27 => self.slide_u8x64::<27>(a, padding),
+            28 => self.slide_u8x64::<28>(a, padding),
+            29 => self.slide_u8x64::<29>(a, padding),
+            30 => self.slide_u8x64::<30>(a, padding),
+            31 => self.slide_u8x64::<31>(a, padding),
+            32 => self.slide_u8x64::<32>(a, padding),
+            33 => self.slide_u8x64::<33>(a, padding),
+            34 => self.slide_u8x64::<34>(a, padding),
+            35 => self.slide_u8x64::<35>(a, padding),
+            36 => self.slide_u8x64::<36>(a, padding),
+            37 => self.slide_u8x64::<37>(a, padding),
+            38 => self.slide_u8x64::<38>(a, padding),
+            39 => self.slide_u8x64::<39>(a, padding),
+            40 => self.slide_u8x64::<40>(a, padding),
+            41 => self.slide_u8x64::<41>(a, padding),
+            42 => self.slide_u8x64::<42>(a, padding),
+            43 => self.slide_u8x64::<43>(a, padding),
+            44 => self.slide_u8x64::<44>(a, padding),
+            45 => self.slide_u8x64::<45>(a, padding),
+            46 => self.slide_u8x64::<46>(a, padding),
+            47 => self.slide_u8x64::<47>(a, padding),
+            48 => self.slide_u8x64::<48>(a, padding),
+            49 => self.slide_u8x64::<49>(a, padding),
+            50 => self.slide_u8x64::<50>(a, padding),
+            51 => self.slide_u8x64::<51>(a, padding),
+            52 => self.slide_u8x64::<52>(a, padding),
+            53 => self.slide_u8x64::<53>(a, padding),
+            54 => self.slide_u8x64::<54>(a, padding),
+            55 => self.slide_u8x64::<55>(a, padding),
+            56 => self.slide_u8x64::<56>(a, padding),
+            57 => self.slide_u8x64::<57>(a, padding),
+            58 => self.slide_u8x64::<58>(a, padding),
+            59 => self.slide_u8x64::<59>(a, padding),
+            60 => self.slide_u8x64::<60>(a, padding),
+            61 => self.slide_u8x64::<61>(a, padding),
+            62 => self.slide_u8x64::<62>(a, padding),
+            63 => self.slide_u8x64::<63>(a, padding),
+            64 => self.slide_u8x64::<64>(a, padding),
+            _ => self.slide_u8x64::<64>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x64<const OFFSET: usize>(
@@ -9632,12 +9918,6 @@ impl Simd for Neon {
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_u8x64(padding);
         match OFFSET {
             0 => self.slide_u8x64::<64>(padding, a),
@@ -9705,7 +9985,7 @@ impl Simd for Neon {
             62 => self.slide_u8x64::<2>(padding, a),
             63 => self.slide_u8x64::<1>(padding, a),
             64 => self.slide_u8x64::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x64::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -10144,23 +10424,45 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_i16x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_i16x32::<0>(a, a),
+            1 => self.slide_i16x32::<1>(a, a),
+            2 => self.slide_i16x32::<2>(a, a),
+            3 => self.slide_i16x32::<3>(a, a),
+            4 => self.slide_i16x32::<4>(a, a),
+            5 => self.slide_i16x32::<5>(a, a),
+            6 => self.slide_i16x32::<6>(a, a),
+            7 => self.slide_i16x32::<7>(a, a),
+            8 => self.slide_i16x32::<8>(a, a),
+            9 => self.slide_i16x32::<9>(a, a),
+            10 => self.slide_i16x32::<10>(a, a),
+            11 => self.slide_i16x32::<11>(a, a),
+            12 => self.slide_i16x32::<12>(a, a),
+            13 => self.slide_i16x32::<13>(a, a),
+            14 => self.slide_i16x32::<14>(a, a),
+            15 => self.slide_i16x32::<15>(a, a),
+            16 => self.slide_i16x32::<16>(a, a),
+            17 => self.slide_i16x32::<17>(a, a),
+            18 => self.slide_i16x32::<18>(a, a),
+            19 => self.slide_i16x32::<19>(a, a),
+            20 => self.slide_i16x32::<20>(a, a),
+            21 => self.slide_i16x32::<21>(a, a),
+            22 => self.slide_i16x32::<22>(a, a),
+            23 => self.slide_i16x32::<23>(a, a),
+            24 => self.slide_i16x32::<24>(a, a),
+            25 => self.slide_i16x32::<25>(a, a),
+            26 => self.slide_i16x32::<26>(a, a),
+            27 => self.slide_i16x32::<27>(a, a),
+            28 => self.slide_i16x32::<28>(a, a),
+            29 => self.slide_i16x32::<29>(a, a),
+            30 => self.slide_i16x32::<30>(a, a),
+            31 => self.slide_i16x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_i16x32::<32>(a, a),
             1 => self.slide_i16x32::<31>(a, a),
             2 => self.slide_i16x32::<30>(a, a),
@@ -10193,7 +10495,6 @@ impl Simd for Neon {
             29 => self.slide_i16x32::<3>(a, a),
             30 => self.slide_i16x32::<2>(a, a),
             31 => self.slide_i16x32::<1>(a, a),
-            32 => self.slide_i16x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -10203,14 +10504,43 @@ impl Simd for Neon {
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i16x32(padding);
-        self.slide_i16x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x32::<0>(a, padding),
+            1 => self.slide_i16x32::<1>(a, padding),
+            2 => self.slide_i16x32::<2>(a, padding),
+            3 => self.slide_i16x32::<3>(a, padding),
+            4 => self.slide_i16x32::<4>(a, padding),
+            5 => self.slide_i16x32::<5>(a, padding),
+            6 => self.slide_i16x32::<6>(a, padding),
+            7 => self.slide_i16x32::<7>(a, padding),
+            8 => self.slide_i16x32::<8>(a, padding),
+            9 => self.slide_i16x32::<9>(a, padding),
+            10 => self.slide_i16x32::<10>(a, padding),
+            11 => self.slide_i16x32::<11>(a, padding),
+            12 => self.slide_i16x32::<12>(a, padding),
+            13 => self.slide_i16x32::<13>(a, padding),
+            14 => self.slide_i16x32::<14>(a, padding),
+            15 => self.slide_i16x32::<15>(a, padding),
+            16 => self.slide_i16x32::<16>(a, padding),
+            17 => self.slide_i16x32::<17>(a, padding),
+            18 => self.slide_i16x32::<18>(a, padding),
+            19 => self.slide_i16x32::<19>(a, padding),
+            20 => self.slide_i16x32::<20>(a, padding),
+            21 => self.slide_i16x32::<21>(a, padding),
+            22 => self.slide_i16x32::<22>(a, padding),
+            23 => self.slide_i16x32::<23>(a, padding),
+            24 => self.slide_i16x32::<24>(a, padding),
+            25 => self.slide_i16x32::<25>(a, padding),
+            26 => self.slide_i16x32::<26>(a, padding),
+            27 => self.slide_i16x32::<27>(a, padding),
+            28 => self.slide_i16x32::<28>(a, padding),
+            29 => self.slide_i16x32::<29>(a, padding),
+            30 => self.slide_i16x32::<30>(a, padding),
+            31 => self.slide_i16x32::<31>(a, padding),
+            32 => self.slide_i16x32::<32>(a, padding),
+            _ => self.slide_i16x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x32<const OFFSET: usize>(
@@ -10218,12 +10548,6 @@ impl Simd for Neon {
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i16x32(padding);
         match OFFSET {
             0 => self.slide_i16x32::<32>(padding, a),
@@ -10259,7 +10583,7 @@ impl Simd for Neon {
             30 => self.slide_i16x32::<2>(padding, a),
             31 => self.slide_i16x32::<1>(padding, a),
             32 => self.slide_i16x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -10596,23 +10920,45 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_u16x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_u16x32::<0>(a, a),
+            1 => self.slide_u16x32::<1>(a, a),
+            2 => self.slide_u16x32::<2>(a, a),
+            3 => self.slide_u16x32::<3>(a, a),
+            4 => self.slide_u16x32::<4>(a, a),
+            5 => self.slide_u16x32::<5>(a, a),
+            6 => self.slide_u16x32::<6>(a, a),
+            7 => self.slide_u16x32::<7>(a, a),
+            8 => self.slide_u16x32::<8>(a, a),
+            9 => self.slide_u16x32::<9>(a, a),
+            10 => self.slide_u16x32::<10>(a, a),
+            11 => self.slide_u16x32::<11>(a, a),
+            12 => self.slide_u16x32::<12>(a, a),
+            13 => self.slide_u16x32::<13>(a, a),
+            14 => self.slide_u16x32::<14>(a, a),
+            15 => self.slide_u16x32::<15>(a, a),
+            16 => self.slide_u16x32::<16>(a, a),
+            17 => self.slide_u16x32::<17>(a, a),
+            18 => self.slide_u16x32::<18>(a, a),
+            19 => self.slide_u16x32::<19>(a, a),
+            20 => self.slide_u16x32::<20>(a, a),
+            21 => self.slide_u16x32::<21>(a, a),
+            22 => self.slide_u16x32::<22>(a, a),
+            23 => self.slide_u16x32::<23>(a, a),
+            24 => self.slide_u16x32::<24>(a, a),
+            25 => self.slide_u16x32::<25>(a, a),
+            26 => self.slide_u16x32::<26>(a, a),
+            27 => self.slide_u16x32::<27>(a, a),
+            28 => self.slide_u16x32::<28>(a, a),
+            29 => self.slide_u16x32::<29>(a, a),
+            30 => self.slide_u16x32::<30>(a, a),
+            31 => self.slide_u16x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_u16x32::<32>(a, a),
             1 => self.slide_u16x32::<31>(a, a),
             2 => self.slide_u16x32::<30>(a, a),
@@ -10645,7 +10991,6 @@ impl Simd for Neon {
             29 => self.slide_u16x32::<3>(a, a),
             30 => self.slide_u16x32::<2>(a, a),
             31 => self.slide_u16x32::<1>(a, a),
-            32 => self.slide_u16x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -10655,14 +11000,43 @@ impl Simd for Neon {
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u16x32(padding);
-        self.slide_u16x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x32::<0>(a, padding),
+            1 => self.slide_u16x32::<1>(a, padding),
+            2 => self.slide_u16x32::<2>(a, padding),
+            3 => self.slide_u16x32::<3>(a, padding),
+            4 => self.slide_u16x32::<4>(a, padding),
+            5 => self.slide_u16x32::<5>(a, padding),
+            6 => self.slide_u16x32::<6>(a, padding),
+            7 => self.slide_u16x32::<7>(a, padding),
+            8 => self.slide_u16x32::<8>(a, padding),
+            9 => self.slide_u16x32::<9>(a, padding),
+            10 => self.slide_u16x32::<10>(a, padding),
+            11 => self.slide_u16x32::<11>(a, padding),
+            12 => self.slide_u16x32::<12>(a, padding),
+            13 => self.slide_u16x32::<13>(a, padding),
+            14 => self.slide_u16x32::<14>(a, padding),
+            15 => self.slide_u16x32::<15>(a, padding),
+            16 => self.slide_u16x32::<16>(a, padding),
+            17 => self.slide_u16x32::<17>(a, padding),
+            18 => self.slide_u16x32::<18>(a, padding),
+            19 => self.slide_u16x32::<19>(a, padding),
+            20 => self.slide_u16x32::<20>(a, padding),
+            21 => self.slide_u16x32::<21>(a, padding),
+            22 => self.slide_u16x32::<22>(a, padding),
+            23 => self.slide_u16x32::<23>(a, padding),
+            24 => self.slide_u16x32::<24>(a, padding),
+            25 => self.slide_u16x32::<25>(a, padding),
+            26 => self.slide_u16x32::<26>(a, padding),
+            27 => self.slide_u16x32::<27>(a, padding),
+            28 => self.slide_u16x32::<28>(a, padding),
+            29 => self.slide_u16x32::<29>(a, padding),
+            30 => self.slide_u16x32::<30>(a, padding),
+            31 => self.slide_u16x32::<31>(a, padding),
+            32 => self.slide_u16x32::<32>(a, padding),
+            _ => self.slide_u16x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x32<const OFFSET: usize>(
@@ -10670,12 +11044,6 @@ impl Simd for Neon {
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u16x32(padding);
         match OFFSET {
             0 => self.slide_u16x32::<32>(padding, a),
@@ -10711,7 +11079,7 @@ impl Simd for Neon {
             30 => self.slide_u16x32::<2>(padding, a),
             31 => self.slide_u16x32::<1>(padding, a),
             32 => self.slide_u16x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -11176,23 +11544,29 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i32x16::<0>(a, a),
+            1 => self.slide_i32x16::<1>(a, a),
+            2 => self.slide_i32x16::<2>(a, a),
+            3 => self.slide_i32x16::<3>(a, a),
+            4 => self.slide_i32x16::<4>(a, a),
+            5 => self.slide_i32x16::<5>(a, a),
+            6 => self.slide_i32x16::<6>(a, a),
+            7 => self.slide_i32x16::<7>(a, a),
+            8 => self.slide_i32x16::<8>(a, a),
+            9 => self.slide_i32x16::<9>(a, a),
+            10 => self.slide_i32x16::<10>(a, a),
+            11 => self.slide_i32x16::<11>(a, a),
+            12 => self.slide_i32x16::<12>(a, a),
+            13 => self.slide_i32x16::<13>(a, a),
+            14 => self.slide_i32x16::<14>(a, a),
+            15 => self.slide_i32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i32x16::<16>(a, a),
             1 => self.slide_i32x16::<15>(a, a),
             2 => self.slide_i32x16::<14>(a, a),
@@ -11209,7 +11583,6 @@ impl Simd for Neon {
             13 => self.slide_i32x16::<3>(a, a),
             14 => self.slide_i32x16::<2>(a, a),
             15 => self.slide_i32x16::<1>(a, a),
-            16 => self.slide_i32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -11219,14 +11592,27 @@ impl Simd for Neon {
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i32x16(padding);
-        self.slide_i32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x16::<0>(a, padding),
+            1 => self.slide_i32x16::<1>(a, padding),
+            2 => self.slide_i32x16::<2>(a, padding),
+            3 => self.slide_i32x16::<3>(a, padding),
+            4 => self.slide_i32x16::<4>(a, padding),
+            5 => self.slide_i32x16::<5>(a, padding),
+            6 => self.slide_i32x16::<6>(a, padding),
+            7 => self.slide_i32x16::<7>(a, padding),
+            8 => self.slide_i32x16::<8>(a, padding),
+            9 => self.slide_i32x16::<9>(a, padding),
+            10 => self.slide_i32x16::<10>(a, padding),
+            11 => self.slide_i32x16::<11>(a, padding),
+            12 => self.slide_i32x16::<12>(a, padding),
+            13 => self.slide_i32x16::<13>(a, padding),
+            14 => self.slide_i32x16::<14>(a, padding),
+            15 => self.slide_i32x16::<15>(a, padding),
+            16 => self.slide_i32x16::<16>(a, padding),
+            _ => self.slide_i32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x16<const OFFSET: usize>(
@@ -11234,12 +11620,6 @@ impl Simd for Neon {
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i32x16(padding);
         match OFFSET {
             0 => self.slide_i32x16::<16>(padding, a),
@@ -11259,7 +11639,7 @@ impl Simd for Neon {
             14 => self.slide_i32x16::<2>(padding, a),
             15 => self.slide_i32x16::<1>(padding, a),
             16 => self.slide_i32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -11592,23 +11972,29 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u32x16::<0>(a, a),
+            1 => self.slide_u32x16::<1>(a, a),
+            2 => self.slide_u32x16::<2>(a, a),
+            3 => self.slide_u32x16::<3>(a, a),
+            4 => self.slide_u32x16::<4>(a, a),
+            5 => self.slide_u32x16::<5>(a, a),
+            6 => self.slide_u32x16::<6>(a, a),
+            7 => self.slide_u32x16::<7>(a, a),
+            8 => self.slide_u32x16::<8>(a, a),
+            9 => self.slide_u32x16::<9>(a, a),
+            10 => self.slide_u32x16::<10>(a, a),
+            11 => self.slide_u32x16::<11>(a, a),
+            12 => self.slide_u32x16::<12>(a, a),
+            13 => self.slide_u32x16::<13>(a, a),
+            14 => self.slide_u32x16::<14>(a, a),
+            15 => self.slide_u32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u32x16::<16>(a, a),
             1 => self.slide_u32x16::<15>(a, a),
             2 => self.slide_u32x16::<14>(a, a),
@@ -11625,7 +12011,6 @@ impl Simd for Neon {
             13 => self.slide_u32x16::<3>(a, a),
             14 => self.slide_u32x16::<2>(a, a),
             15 => self.slide_u32x16::<1>(a, a),
-            16 => self.slide_u32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -11635,14 +12020,27 @@ impl Simd for Neon {
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u32x16(padding);
-        self.slide_u32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x16::<0>(a, padding),
+            1 => self.slide_u32x16::<1>(a, padding),
+            2 => self.slide_u32x16::<2>(a, padding),
+            3 => self.slide_u32x16::<3>(a, padding),
+            4 => self.slide_u32x16::<4>(a, padding),
+            5 => self.slide_u32x16::<5>(a, padding),
+            6 => self.slide_u32x16::<6>(a, padding),
+            7 => self.slide_u32x16::<7>(a, padding),
+            8 => self.slide_u32x16::<8>(a, padding),
+            9 => self.slide_u32x16::<9>(a, padding),
+            10 => self.slide_u32x16::<10>(a, padding),
+            11 => self.slide_u32x16::<11>(a, padding),
+            12 => self.slide_u32x16::<12>(a, padding),
+            13 => self.slide_u32x16::<13>(a, padding),
+            14 => self.slide_u32x16::<14>(a, padding),
+            15 => self.slide_u32x16::<15>(a, padding),
+            16 => self.slide_u32x16::<16>(a, padding),
+            _ => self.slide_u32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x16<const OFFSET: usize>(
@@ -11650,12 +12048,6 @@ impl Simd for Neon {
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u32x16(padding);
         match OFFSET {
             0 => self.slide_u32x16::<16>(padding, a),
@@ -11675,7 +12067,7 @@ impl Simd for Neon {
             14 => self.slide_u32x16::<2>(padding, a),
             15 => self.slide_u32x16::<1>(padding, a),
             16 => self.slide_u32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -12120,23 +12512,21 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_f64x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_f64x8::<0>(a, a),
+            1 => self.slide_f64x8::<1>(a, a),
+            2 => self.slide_f64x8::<2>(a, a),
+            3 => self.slide_f64x8::<3>(a, a),
+            4 => self.slide_f64x8::<4>(a, a),
+            5 => self.slide_f64x8::<5>(a, a),
+            6 => self.slide_f64x8::<6>(a, a),
+            7 => self.slide_f64x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_f64x8::<8>(a, a),
             1 => self.slide_f64x8::<7>(a, a),
             2 => self.slide_f64x8::<6>(a, a),
@@ -12145,7 +12535,6 @@ impl Simd for Neon {
             5 => self.slide_f64x8::<3>(a, a),
             6 => self.slide_f64x8::<2>(a, a),
             7 => self.slide_f64x8::<1>(a, a),
-            8 => self.slide_f64x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -12155,14 +12544,19 @@ impl Simd for Neon {
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f64x8(padding);
-        self.slide_f64x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x8::<0>(a, padding),
+            1 => self.slide_f64x8::<1>(a, padding),
+            2 => self.slide_f64x8::<2>(a, padding),
+            3 => self.slide_f64x8::<3>(a, padding),
+            4 => self.slide_f64x8::<4>(a, padding),
+            5 => self.slide_f64x8::<5>(a, padding),
+            6 => self.slide_f64x8::<6>(a, padding),
+            7 => self.slide_f64x8::<7>(a, padding),
+            8 => self.slide_f64x8::<8>(a, padding),
+            _ => self.slide_f64x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x8<const OFFSET: usize>(
@@ -12170,12 +12564,6 @@ impl Simd for Neon {
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f64x8(padding);
         match OFFSET {
             0 => self.slide_f64x8::<8>(padding, a),
@@ -12187,7 +12575,7 @@ impl Simd for Neon {
             6 => self.slide_f64x8::<2>(padding, a),
             7 => self.slide_f64x8::<1>(padding, a),
             8 => self.slide_f64x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x8::<0>(padding, a),
         }
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -165,6 +165,70 @@ impl Simd for Neon {
         self.slide_f32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_f32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_f32x4::<4>(a, a),
+            1 => self.slide_f32x4::<3>(a, a),
+            2 => self.slide_f32x4::<2>(a, a),
+            3 => self.slide_f32x4::<1>(a, a),
+            4 => self.slide_f32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f32x4(padding);
+        self.slide_f32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f32x4(padding);
+        match OFFSET {
+            0 => self.slide_f32x4::<4>(padding, a),
+            1 => self.slide_f32x4::<3>(padding, a),
+            2 => self.slide_f32x4::<2>(padding, a),
+            3 => self.slide_f32x4::<1>(padding, a),
+            4 => self.slide_f32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -656,6 +720,94 @@ impl Simd for Neon {
         self.slide_i8x16::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i8x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i8x16::<16>(a, a),
+            1 => self.slide_i8x16::<15>(a, a),
+            2 => self.slide_i8x16::<14>(a, a),
+            3 => self.slide_i8x16::<13>(a, a),
+            4 => self.slide_i8x16::<12>(a, a),
+            5 => self.slide_i8x16::<11>(a, a),
+            6 => self.slide_i8x16::<10>(a, a),
+            7 => self.slide_i8x16::<9>(a, a),
+            8 => self.slide_i8x16::<8>(a, a),
+            9 => self.slide_i8x16::<7>(a, a),
+            10 => self.slide_i8x16::<6>(a, a),
+            11 => self.slide_i8x16::<5>(a, a),
+            12 => self.slide_i8x16::<4>(a, a),
+            13 => self.slide_i8x16::<3>(a, a),
+            14 => self.slide_i8x16::<2>(a, a),
+            15 => self.slide_i8x16::<1>(a, a),
+            16 => self.slide_i8x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i8x16(padding);
+        self.slide_i8x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i8x16(padding);
+        match OFFSET {
+            0 => self.slide_i8x16::<16>(padding, a),
+            1 => self.slide_i8x16::<15>(padding, a),
+            2 => self.slide_i8x16::<14>(padding, a),
+            3 => self.slide_i8x16::<13>(padding, a),
+            4 => self.slide_i8x16::<12>(padding, a),
+            5 => self.slide_i8x16::<11>(padding, a),
+            6 => self.slide_i8x16::<10>(padding, a),
+            7 => self.slide_i8x16::<9>(padding, a),
+            8 => self.slide_i8x16::<8>(padding, a),
+            9 => self.slide_i8x16::<7>(padding, a),
+            10 => self.slide_i8x16::<6>(padding, a),
+            11 => self.slide_i8x16::<5>(padding, a),
+            12 => self.slide_i8x16::<4>(padding, a),
+            13 => self.slide_i8x16::<3>(padding, a),
+            14 => self.slide_i8x16::<2>(padding, a),
+            15 => self.slide_i8x16::<1>(padding, a),
+            16 => self.slide_i8x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1034,6 +1186,94 @@ impl Simd for Neon {
         b: u8x16<Self>,
     ) -> u8x16<Self> {
         self.slide_u8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u8x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u8x16::<16>(a, a),
+            1 => self.slide_u8x16::<15>(a, a),
+            2 => self.slide_u8x16::<14>(a, a),
+            3 => self.slide_u8x16::<13>(a, a),
+            4 => self.slide_u8x16::<12>(a, a),
+            5 => self.slide_u8x16::<11>(a, a),
+            6 => self.slide_u8x16::<10>(a, a),
+            7 => self.slide_u8x16::<9>(a, a),
+            8 => self.slide_u8x16::<8>(a, a),
+            9 => self.slide_u8x16::<7>(a, a),
+            10 => self.slide_u8x16::<6>(a, a),
+            11 => self.slide_u8x16::<5>(a, a),
+            12 => self.slide_u8x16::<4>(a, a),
+            13 => self.slide_u8x16::<3>(a, a),
+            14 => self.slide_u8x16::<2>(a, a),
+            15 => self.slide_u8x16::<1>(a, a),
+            16 => self.slide_u8x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u8x16(padding);
+        self.slide_u8x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u8x16(padding);
+        match OFFSET {
+            0 => self.slide_u8x16::<16>(padding, a),
+            1 => self.slide_u8x16::<15>(padding, a),
+            2 => self.slide_u8x16::<14>(padding, a),
+            3 => self.slide_u8x16::<13>(padding, a),
+            4 => self.slide_u8x16::<12>(padding, a),
+            5 => self.slide_u8x16::<11>(padding, a),
+            6 => self.slide_u8x16::<10>(padding, a),
+            7 => self.slide_u8x16::<9>(padding, a),
+            8 => self.slide_u8x16::<8>(padding, a),
+            9 => self.slide_u8x16::<7>(padding, a),
+            10 => self.slide_u8x16::<6>(padding, a),
+            11 => self.slide_u8x16::<5>(padding, a),
+            12 => self.slide_u8x16::<4>(padding, a),
+            13 => self.slide_u8x16::<3>(padding, a),
+            14 => self.slide_u8x16::<2>(padding, a),
+            15 => self.slide_u8x16::<1>(padding, a),
+            16 => self.slide_u8x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
@@ -1595,6 +1835,78 @@ impl Simd for Neon {
         self.slide_i16x8::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_i16x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_i16x8::<8>(a, a),
+            1 => self.slide_i16x8::<7>(a, a),
+            2 => self.slide_i16x8::<6>(a, a),
+            3 => self.slide_i16x8::<5>(a, a),
+            4 => self.slide_i16x8::<4>(a, a),
+            5 => self.slide_i16x8::<3>(a, a),
+            6 => self.slide_i16x8::<2>(a, a),
+            7 => self.slide_i16x8::<1>(a, a),
+            8 => self.slide_i16x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i16x8(padding);
+        self.slide_i16x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i16x8(padding);
+        match OFFSET {
+            0 => self.slide_i16x8::<8>(padding, a),
+            1 => self.slide_i16x8::<7>(padding, a),
+            2 => self.slide_i16x8::<6>(padding, a),
+            3 => self.slide_i16x8::<5>(padding, a),
+            4 => self.slide_i16x8::<4>(padding, a),
+            5 => self.slide_i16x8::<3>(padding, a),
+            6 => self.slide_i16x8::<2>(padding, a),
+            7 => self.slide_i16x8::<1>(padding, a),
+            8 => self.slide_i16x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1973,6 +2285,78 @@ impl Simd for Neon {
         b: u16x8<Self>,
     ) -> u16x8<Self> {
         self.slide_u16x8::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_u16x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_u16x8::<8>(a, a),
+            1 => self.slide_u16x8::<7>(a, a),
+            2 => self.slide_u16x8::<6>(a, a),
+            3 => self.slide_u16x8::<5>(a, a),
+            4 => self.slide_u16x8::<4>(a, a),
+            5 => self.slide_u16x8::<3>(a, a),
+            6 => self.slide_u16x8::<2>(a, a),
+            7 => self.slide_u16x8::<1>(a, a),
+            8 => self.slide_u16x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u16x8(padding);
+        self.slide_u16x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u16x8(padding);
+        match OFFSET {
+            0 => self.slide_u16x8::<8>(padding, a),
+            1 => self.slide_u16x8::<7>(padding, a),
+            2 => self.slide_u16x8::<6>(padding, a),
+            3 => self.slide_u16x8::<5>(padding, a),
+            4 => self.slide_u16x8::<4>(padding, a),
+            5 => self.slide_u16x8::<3>(padding, a),
+            6 => self.slide_u16x8::<2>(padding, a),
+            7 => self.slide_u16x8::<1>(padding, a),
+            8 => self.slide_u16x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
@@ -2524,6 +2908,70 @@ impl Simd for Neon {
         self.slide_i32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_i32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_i32x4::<4>(a, a),
+            1 => self.slide_i32x4::<3>(a, a),
+            2 => self.slide_i32x4::<2>(a, a),
+            3 => self.slide_i32x4::<1>(a, a),
+            4 => self.slide_i32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_i32x4(padding);
+        self.slide_i32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_i32x4(padding);
+        match OFFSET {
+            0 => self.slide_i32x4::<4>(padding, a),
+            1 => self.slide_i32x4::<3>(padding, a),
+            2 => self.slide_i32x4::<2>(padding, a),
+            3 => self.slide_i32x4::<1>(padding, a),
+            4 => self.slide_i32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2912,6 +3360,70 @@ impl Simd for Neon {
         b: u32x4<Self>,
     ) -> u32x4<Self> {
         self.slide_u32x4::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_u32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_u32x4::<4>(a, a),
+            1 => self.slide_u32x4::<3>(a, a),
+            2 => self.slide_u32x4::<2>(a, a),
+            3 => self.slide_u32x4::<1>(a, a),
+            4 => self.slide_u32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_u32x4(padding);
+        self.slide_u32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_u32x4(padding);
+        match OFFSET {
+            0 => self.slide_u32x4::<4>(padding, a),
+            1 => self.slide_u32x4::<3>(padding, a),
+            2 => self.slide_u32x4::<2>(padding, a),
+            3 => self.slide_u32x4::<1>(padding, a),
+            4 => self.slide_u32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
@@ -3460,6 +3972,66 @@ impl Simd for Neon {
         b: f64x2<Self>,
     ) -> f64x2<Self> {
         self.slide_f64x2::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        self.slide_f64x2::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        match OFFSET {
+            0 => self.slide_f64x2::<2>(a, a),
+            1 => self.slide_f64x2::<1>(a, a),
+            2 => self.slide_f64x2::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        let padding = self.splat_f64x2(padding);
+        self.slide_f64x2::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        let padding = self.splat_f64x2(padding);
+        match OFFSET {
+            0 => self.slide_f64x2::<2>(padding, a),
+            1 => self.slide_f64x2::<1>(padding, a),
+            2 => self.slide_f64x2::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
@@ -4093,6 +4665,78 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_f32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_f32x8::<8>(a, a),
+            1 => self.slide_f32x8::<7>(a, a),
+            2 => self.slide_f32x8::<6>(a, a),
+            3 => self.slide_f32x8::<5>(a, a),
+            4 => self.slide_f32x8::<4>(a, a),
+            5 => self.slide_f32x8::<3>(a, a),
+            6 => self.slide_f32x8::<2>(a, a),
+            7 => self.slide_f32x8::<1>(a, a),
+            8 => self.slide_f32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f32x8(padding);
+        self.slide_f32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f32x8(padding);
+        match OFFSET {
+            0 => self.slide_f32x8::<8>(padding, a),
+            1 => self.slide_f32x8::<7>(padding, a),
+            2 => self.slide_f32x8::<6>(padding, a),
+            3 => self.slide_f32x8::<5>(padding, a),
+            4 => self.slide_f32x8::<4>(padding, a),
+            5 => self.slide_f32x8::<3>(padding, a),
+            6 => self.slide_f32x8::<2>(padding, a),
+            7 => self.slide_f32x8::<1>(padding, a),
+            8 => self.slide_f32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         let (indices0, indices1) = self.split_u8x32(indices);
@@ -4496,6 +5140,126 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_i8x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_i8x32::<32>(a, a),
+            1 => self.slide_i8x32::<31>(a, a),
+            2 => self.slide_i8x32::<30>(a, a),
+            3 => self.slide_i8x32::<29>(a, a),
+            4 => self.slide_i8x32::<28>(a, a),
+            5 => self.slide_i8x32::<27>(a, a),
+            6 => self.slide_i8x32::<26>(a, a),
+            7 => self.slide_i8x32::<25>(a, a),
+            8 => self.slide_i8x32::<24>(a, a),
+            9 => self.slide_i8x32::<23>(a, a),
+            10 => self.slide_i8x32::<22>(a, a),
+            11 => self.slide_i8x32::<21>(a, a),
+            12 => self.slide_i8x32::<20>(a, a),
+            13 => self.slide_i8x32::<19>(a, a),
+            14 => self.slide_i8x32::<18>(a, a),
+            15 => self.slide_i8x32::<17>(a, a),
+            16 => self.slide_i8x32::<16>(a, a),
+            17 => self.slide_i8x32::<15>(a, a),
+            18 => self.slide_i8x32::<14>(a, a),
+            19 => self.slide_i8x32::<13>(a, a),
+            20 => self.slide_i8x32::<12>(a, a),
+            21 => self.slide_i8x32::<11>(a, a),
+            22 => self.slide_i8x32::<10>(a, a),
+            23 => self.slide_i8x32::<9>(a, a),
+            24 => self.slide_i8x32::<8>(a, a),
+            25 => self.slide_i8x32::<7>(a, a),
+            26 => self.slide_i8x32::<6>(a, a),
+            27 => self.slide_i8x32::<5>(a, a),
+            28 => self.slide_i8x32::<4>(a, a),
+            29 => self.slide_i8x32::<3>(a, a),
+            30 => self.slide_i8x32::<2>(a, a),
+            31 => self.slide_i8x32::<1>(a, a),
+            32 => self.slide_i8x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i8x32(padding);
+        self.slide_i8x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i8x32(padding);
+        match OFFSET {
+            0 => self.slide_i8x32::<32>(padding, a),
+            1 => self.slide_i8x32::<31>(padding, a),
+            2 => self.slide_i8x32::<30>(padding, a),
+            3 => self.slide_i8x32::<29>(padding, a),
+            4 => self.slide_i8x32::<28>(padding, a),
+            5 => self.slide_i8x32::<27>(padding, a),
+            6 => self.slide_i8x32::<26>(padding, a),
+            7 => self.slide_i8x32::<25>(padding, a),
+            8 => self.slide_i8x32::<24>(padding, a),
+            9 => self.slide_i8x32::<23>(padding, a),
+            10 => self.slide_i8x32::<22>(padding, a),
+            11 => self.slide_i8x32::<21>(padding, a),
+            12 => self.slide_i8x32::<20>(padding, a),
+            13 => self.slide_i8x32::<19>(padding, a),
+            14 => self.slide_i8x32::<18>(padding, a),
+            15 => self.slide_i8x32::<17>(padding, a),
+            16 => self.slide_i8x32::<16>(padding, a),
+            17 => self.slide_i8x32::<15>(padding, a),
+            18 => self.slide_i8x32::<14>(padding, a),
+            19 => self.slide_i8x32::<13>(padding, a),
+            20 => self.slide_i8x32::<12>(padding, a),
+            21 => self.slide_i8x32::<11>(padding, a),
+            22 => self.slide_i8x32::<10>(padding, a),
+            23 => self.slide_i8x32::<9>(padding, a),
+            24 => self.slide_i8x32::<8>(padding, a),
+            25 => self.slide_i8x32::<7>(padding, a),
+            26 => self.slide_i8x32::<6>(padding, a),
+            27 => self.slide_i8x32::<5>(padding, a),
+            28 => self.slide_i8x32::<4>(padding, a),
+            29 => self.slide_i8x32::<3>(padding, a),
+            30 => self.slide_i8x32::<2>(padding, a),
+            31 => self.slide_i8x32::<1>(padding, a),
+            32 => self.slide_i8x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
         let (indices0, indices1) = self.split_u8x32(indices);
@@ -4804,6 +5568,126 @@ impl Simd for Neon {
             self.slide_within_blocks_u8x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x16::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_u8x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_u8x32::<32>(a, a),
+            1 => self.slide_u8x32::<31>(a, a),
+            2 => self.slide_u8x32::<30>(a, a),
+            3 => self.slide_u8x32::<29>(a, a),
+            4 => self.slide_u8x32::<28>(a, a),
+            5 => self.slide_u8x32::<27>(a, a),
+            6 => self.slide_u8x32::<26>(a, a),
+            7 => self.slide_u8x32::<25>(a, a),
+            8 => self.slide_u8x32::<24>(a, a),
+            9 => self.slide_u8x32::<23>(a, a),
+            10 => self.slide_u8x32::<22>(a, a),
+            11 => self.slide_u8x32::<21>(a, a),
+            12 => self.slide_u8x32::<20>(a, a),
+            13 => self.slide_u8x32::<19>(a, a),
+            14 => self.slide_u8x32::<18>(a, a),
+            15 => self.slide_u8x32::<17>(a, a),
+            16 => self.slide_u8x32::<16>(a, a),
+            17 => self.slide_u8x32::<15>(a, a),
+            18 => self.slide_u8x32::<14>(a, a),
+            19 => self.slide_u8x32::<13>(a, a),
+            20 => self.slide_u8x32::<12>(a, a),
+            21 => self.slide_u8x32::<11>(a, a),
+            22 => self.slide_u8x32::<10>(a, a),
+            23 => self.slide_u8x32::<9>(a, a),
+            24 => self.slide_u8x32::<8>(a, a),
+            25 => self.slide_u8x32::<7>(a, a),
+            26 => self.slide_u8x32::<6>(a, a),
+            27 => self.slide_u8x32::<5>(a, a),
+            28 => self.slide_u8x32::<4>(a, a),
+            29 => self.slide_u8x32::<3>(a, a),
+            30 => self.slide_u8x32::<2>(a, a),
+            31 => self.slide_u8x32::<1>(a, a),
+            32 => self.slide_u8x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u8x32(padding);
+        self.slide_u8x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u8x32(padding);
+        match OFFSET {
+            0 => self.slide_u8x32::<32>(padding, a),
+            1 => self.slide_u8x32::<31>(padding, a),
+            2 => self.slide_u8x32::<30>(padding, a),
+            3 => self.slide_u8x32::<29>(padding, a),
+            4 => self.slide_u8x32::<28>(padding, a),
+            5 => self.slide_u8x32::<27>(padding, a),
+            6 => self.slide_u8x32::<26>(padding, a),
+            7 => self.slide_u8x32::<25>(padding, a),
+            8 => self.slide_u8x32::<24>(padding, a),
+            9 => self.slide_u8x32::<23>(padding, a),
+            10 => self.slide_u8x32::<22>(padding, a),
+            11 => self.slide_u8x32::<21>(padding, a),
+            12 => self.slide_u8x32::<20>(padding, a),
+            13 => self.slide_u8x32::<19>(padding, a),
+            14 => self.slide_u8x32::<18>(padding, a),
+            15 => self.slide_u8x32::<17>(padding, a),
+            16 => self.slide_u8x32::<16>(padding, a),
+            17 => self.slide_u8x32::<15>(padding, a),
+            18 => self.slide_u8x32::<14>(padding, a),
+            19 => self.slide_u8x32::<13>(padding, a),
+            20 => self.slide_u8x32::<12>(padding, a),
+            21 => self.slide_u8x32::<11>(padding, a),
+            22 => self.slide_u8x32::<10>(padding, a),
+            23 => self.slide_u8x32::<9>(padding, a),
+            24 => self.slide_u8x32::<8>(padding, a),
+            25 => self.slide_u8x32::<7>(padding, a),
+            26 => self.slide_u8x32::<6>(padding, a),
+            27 => self.slide_u8x32::<5>(padding, a),
+            28 => self.slide_u8x32::<4>(padding, a),
+            29 => self.slide_u8x32::<3>(padding, a),
+            30 => self.slide_u8x32::<2>(padding, a),
+            31 => self.slide_u8x32::<1>(padding, a),
+            32 => self.slide_u8x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self> {
@@ -5237,6 +6121,94 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i16x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i16x16::<16>(a, a),
+            1 => self.slide_i16x16::<15>(a, a),
+            2 => self.slide_i16x16::<14>(a, a),
+            3 => self.slide_i16x16::<13>(a, a),
+            4 => self.slide_i16x16::<12>(a, a),
+            5 => self.slide_i16x16::<11>(a, a),
+            6 => self.slide_i16x16::<10>(a, a),
+            7 => self.slide_i16x16::<9>(a, a),
+            8 => self.slide_i16x16::<8>(a, a),
+            9 => self.slide_i16x16::<7>(a, a),
+            10 => self.slide_i16x16::<6>(a, a),
+            11 => self.slide_i16x16::<5>(a, a),
+            12 => self.slide_i16x16::<4>(a, a),
+            13 => self.slide_i16x16::<3>(a, a),
+            14 => self.slide_i16x16::<2>(a, a),
+            15 => self.slide_i16x16::<1>(a, a),
+            16 => self.slide_i16x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i16x16(padding);
+        self.slide_i16x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i16x16(padding);
+        match OFFSET {
+            0 => self.slide_i16x16::<16>(padding, a),
+            1 => self.slide_i16x16::<15>(padding, a),
+            2 => self.slide_i16x16::<14>(padding, a),
+            3 => self.slide_i16x16::<13>(padding, a),
+            4 => self.slide_i16x16::<12>(padding, a),
+            5 => self.slide_i16x16::<11>(padding, a),
+            6 => self.slide_i16x16::<10>(padding, a),
+            7 => self.slide_i16x16::<9>(padding, a),
+            8 => self.slide_i16x16::<8>(padding, a),
+            9 => self.slide_i16x16::<7>(padding, a),
+            10 => self.slide_i16x16::<6>(padding, a),
+            11 => self.slide_i16x16::<5>(padding, a),
+            12 => self.slide_i16x16::<4>(padding, a),
+            13 => self.slide_i16x16::<3>(padding, a),
+            14 => self.slide_i16x16::<2>(padding, a),
+            15 => self.slide_i16x16::<1>(padding, a),
+            16 => self.slide_i16x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x16(
         self,
         a: i16x16<Self>,
@@ -5549,6 +6521,94 @@ impl Simd for Neon {
             self.slide_within_blocks_u16x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x8::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u16x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u16x16::<16>(a, a),
+            1 => self.slide_u16x16::<15>(a, a),
+            2 => self.slide_u16x16::<14>(a, a),
+            3 => self.slide_u16x16::<13>(a, a),
+            4 => self.slide_u16x16::<12>(a, a),
+            5 => self.slide_u16x16::<11>(a, a),
+            6 => self.slide_u16x16::<10>(a, a),
+            7 => self.slide_u16x16::<9>(a, a),
+            8 => self.slide_u16x16::<8>(a, a),
+            9 => self.slide_u16x16::<7>(a, a),
+            10 => self.slide_u16x16::<6>(a, a),
+            11 => self.slide_u16x16::<5>(a, a),
+            12 => self.slide_u16x16::<4>(a, a),
+            13 => self.slide_u16x16::<3>(a, a),
+            14 => self.slide_u16x16::<2>(a, a),
+            15 => self.slide_u16x16::<1>(a, a),
+            16 => self.slide_u16x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u16x16(padding);
+        self.slide_u16x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u16x16(padding);
+        match OFFSET {
+            0 => self.slide_u16x16::<16>(padding, a),
+            1 => self.slide_u16x16::<15>(padding, a),
+            2 => self.slide_u16x16::<14>(padding, a),
+            3 => self.slide_u16x16::<13>(padding, a),
+            4 => self.slide_u16x16::<12>(padding, a),
+            5 => self.slide_u16x16::<11>(padding, a),
+            6 => self.slide_u16x16::<10>(padding, a),
+            7 => self.slide_u16x16::<9>(padding, a),
+            8 => self.slide_u16x16::<8>(padding, a),
+            9 => self.slide_u16x16::<7>(padding, a),
+            10 => self.slide_u16x16::<6>(padding, a),
+            11 => self.slide_u16x16::<5>(padding, a),
+            12 => self.slide_u16x16::<4>(padding, a),
+            13 => self.slide_u16x16::<3>(padding, a),
+            14 => self.slide_u16x16::<2>(padding, a),
+            15 => self.slide_u16x16::<1>(padding, a),
+            16 => self.slide_u16x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x16(
@@ -5999,6 +7059,78 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_i32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_i32x8::<8>(a, a),
+            1 => self.slide_i32x8::<7>(a, a),
+            2 => self.slide_i32x8::<6>(a, a),
+            3 => self.slide_i32x8::<5>(a, a),
+            4 => self.slide_i32x8::<4>(a, a),
+            5 => self.slide_i32x8::<3>(a, a),
+            6 => self.slide_i32x8::<2>(a, a),
+            7 => self.slide_i32x8::<1>(a, a),
+            8 => self.slide_i32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i32x8(padding);
+        self.slide_i32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i32x8(padding);
+        match OFFSET {
+            0 => self.slide_i32x8::<8>(padding, a),
+            1 => self.slide_i32x8::<7>(padding, a),
+            2 => self.slide_i32x8::<6>(padding, a),
+            3 => self.slide_i32x8::<5>(padding, a),
+            4 => self.slide_i32x8::<4>(padding, a),
+            5 => self.slide_i32x8::<3>(padding, a),
+            6 => self.slide_i32x8::<2>(padding, a),
+            7 => self.slide_i32x8::<1>(padding, a),
+            8 => self.slide_i32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
         let (indices0, indices1) = self.split_u8x32(indices);
@@ -6312,6 +7444,78 @@ impl Simd for Neon {
             self.slide_within_blocks_u32x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x4::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_u32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_u32x8::<8>(a, a),
+            1 => self.slide_u32x8::<7>(a, a),
+            2 => self.slide_u32x8::<6>(a, a),
+            3 => self.slide_u32x8::<5>(a, a),
+            4 => self.slide_u32x8::<4>(a, a),
+            5 => self.slide_u32x8::<3>(a, a),
+            6 => self.slide_u32x8::<2>(a, a),
+            7 => self.slide_u32x8::<1>(a, a),
+            8 => self.slide_u32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u32x8(padding);
+        self.slide_u32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u32x8(padding);
+        match OFFSET {
+            0 => self.slide_u32x8::<8>(padding, a),
+            1 => self.slide_u32x8::<7>(padding, a),
+            2 => self.slide_u32x8::<6>(padding, a),
+            3 => self.slide_u32x8::<5>(padding, a),
+            4 => self.slide_u32x8::<4>(padding, a),
+            5 => self.slide_u32x8::<3>(padding, a),
+            6 => self.slide_u32x8::<2>(padding, a),
+            7 => self.slide_u32x8::<1>(padding, a),
+            8 => self.slide_u32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
@@ -6740,6 +7944,70 @@ impl Simd for Neon {
             self.slide_within_blocks_f64x2::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x2::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_f64x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_f64x4::<4>(a, a),
+            1 => self.slide_f64x4::<3>(a, a),
+            2 => self.slide_f64x4::<2>(a, a),
+            3 => self.slide_f64x4::<1>(a, a),
+            4 => self.slide_f64x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f64x4(padding);
+        self.slide_f64x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f64x4(padding);
+        match OFFSET {
+            0 => self.slide_f64x4::<4>(padding, a),
+            1 => self.slide_f64x4::<3>(padding, a),
+            2 => self.slide_f64x4::<2>(padding, a),
+            3 => self.slide_f64x4::<1>(padding, a),
+            4 => self.slide_f64x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
@@ -7242,6 +8510,94 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_f32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_f32x16::<16>(a, a),
+            1 => self.slide_f32x16::<15>(a, a),
+            2 => self.slide_f32x16::<14>(a, a),
+            3 => self.slide_f32x16::<13>(a, a),
+            4 => self.slide_f32x16::<12>(a, a),
+            5 => self.slide_f32x16::<11>(a, a),
+            6 => self.slide_f32x16::<10>(a, a),
+            7 => self.slide_f32x16::<9>(a, a),
+            8 => self.slide_f32x16::<8>(a, a),
+            9 => self.slide_f32x16::<7>(a, a),
+            10 => self.slide_f32x16::<6>(a, a),
+            11 => self.slide_f32x16::<5>(a, a),
+            12 => self.slide_f32x16::<4>(a, a),
+            13 => self.slide_f32x16::<3>(a, a),
+            14 => self.slide_f32x16::<2>(a, a),
+            15 => self.slide_f32x16::<1>(a, a),
+            16 => self.slide_f32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_f32x16(padding);
+        self.slide_f32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_f32x16(padding);
+        match OFFSET {
+            0 => self.slide_f32x16::<16>(padding, a),
+            1 => self.slide_f32x16::<15>(padding, a),
+            2 => self.slide_f32x16::<14>(padding, a),
+            3 => self.slide_f32x16::<13>(padding, a),
+            4 => self.slide_f32x16::<12>(padding, a),
+            5 => self.slide_f32x16::<11>(padding, a),
+            6 => self.slide_f32x16::<10>(padding, a),
+            7 => self.slide_f32x16::<9>(padding, a),
+            8 => self.slide_f32x16::<8>(padding, a),
+            9 => self.slide_f32x16::<7>(padding, a),
+            10 => self.slide_f32x16::<6>(padding, a),
+            11 => self.slide_f32x16::<5>(padding, a),
+            12 => self.slide_f32x16::<4>(padding, a),
+            13 => self.slide_f32x16::<3>(padding, a),
+            14 => self.slide_f32x16::<2>(padding, a),
+            15 => self.slide_f32x16::<1>(padding, a),
+            16 => self.slide_f32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x16(
         self,
         a: f32x16<Self>,
@@ -7666,6 +9022,190 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        self.slide_i8x64::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        match OFFSET {
+            0 => self.slide_i8x64::<64>(a, a),
+            1 => self.slide_i8x64::<63>(a, a),
+            2 => self.slide_i8x64::<62>(a, a),
+            3 => self.slide_i8x64::<61>(a, a),
+            4 => self.slide_i8x64::<60>(a, a),
+            5 => self.slide_i8x64::<59>(a, a),
+            6 => self.slide_i8x64::<58>(a, a),
+            7 => self.slide_i8x64::<57>(a, a),
+            8 => self.slide_i8x64::<56>(a, a),
+            9 => self.slide_i8x64::<55>(a, a),
+            10 => self.slide_i8x64::<54>(a, a),
+            11 => self.slide_i8x64::<53>(a, a),
+            12 => self.slide_i8x64::<52>(a, a),
+            13 => self.slide_i8x64::<51>(a, a),
+            14 => self.slide_i8x64::<50>(a, a),
+            15 => self.slide_i8x64::<49>(a, a),
+            16 => self.slide_i8x64::<48>(a, a),
+            17 => self.slide_i8x64::<47>(a, a),
+            18 => self.slide_i8x64::<46>(a, a),
+            19 => self.slide_i8x64::<45>(a, a),
+            20 => self.slide_i8x64::<44>(a, a),
+            21 => self.slide_i8x64::<43>(a, a),
+            22 => self.slide_i8x64::<42>(a, a),
+            23 => self.slide_i8x64::<41>(a, a),
+            24 => self.slide_i8x64::<40>(a, a),
+            25 => self.slide_i8x64::<39>(a, a),
+            26 => self.slide_i8x64::<38>(a, a),
+            27 => self.slide_i8x64::<37>(a, a),
+            28 => self.slide_i8x64::<36>(a, a),
+            29 => self.slide_i8x64::<35>(a, a),
+            30 => self.slide_i8x64::<34>(a, a),
+            31 => self.slide_i8x64::<33>(a, a),
+            32 => self.slide_i8x64::<32>(a, a),
+            33 => self.slide_i8x64::<31>(a, a),
+            34 => self.slide_i8x64::<30>(a, a),
+            35 => self.slide_i8x64::<29>(a, a),
+            36 => self.slide_i8x64::<28>(a, a),
+            37 => self.slide_i8x64::<27>(a, a),
+            38 => self.slide_i8x64::<26>(a, a),
+            39 => self.slide_i8x64::<25>(a, a),
+            40 => self.slide_i8x64::<24>(a, a),
+            41 => self.slide_i8x64::<23>(a, a),
+            42 => self.slide_i8x64::<22>(a, a),
+            43 => self.slide_i8x64::<21>(a, a),
+            44 => self.slide_i8x64::<20>(a, a),
+            45 => self.slide_i8x64::<19>(a, a),
+            46 => self.slide_i8x64::<18>(a, a),
+            47 => self.slide_i8x64::<17>(a, a),
+            48 => self.slide_i8x64::<16>(a, a),
+            49 => self.slide_i8x64::<15>(a, a),
+            50 => self.slide_i8x64::<14>(a, a),
+            51 => self.slide_i8x64::<13>(a, a),
+            52 => self.slide_i8x64::<12>(a, a),
+            53 => self.slide_i8x64::<11>(a, a),
+            54 => self.slide_i8x64::<10>(a, a),
+            55 => self.slide_i8x64::<9>(a, a),
+            56 => self.slide_i8x64::<8>(a, a),
+            57 => self.slide_i8x64::<7>(a, a),
+            58 => self.slide_i8x64::<6>(a, a),
+            59 => self.slide_i8x64::<5>(a, a),
+            60 => self.slide_i8x64::<4>(a, a),
+            61 => self.slide_i8x64::<3>(a, a),
+            62 => self.slide_i8x64::<2>(a, a),
+            63 => self.slide_i8x64::<1>(a, a),
+            64 => self.slide_i8x64::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_i8x64(padding);
+        self.slide_i8x64::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_i8x64(padding);
+        match OFFSET {
+            0 => self.slide_i8x64::<64>(padding, a),
+            1 => self.slide_i8x64::<63>(padding, a),
+            2 => self.slide_i8x64::<62>(padding, a),
+            3 => self.slide_i8x64::<61>(padding, a),
+            4 => self.slide_i8x64::<60>(padding, a),
+            5 => self.slide_i8x64::<59>(padding, a),
+            6 => self.slide_i8x64::<58>(padding, a),
+            7 => self.slide_i8x64::<57>(padding, a),
+            8 => self.slide_i8x64::<56>(padding, a),
+            9 => self.slide_i8x64::<55>(padding, a),
+            10 => self.slide_i8x64::<54>(padding, a),
+            11 => self.slide_i8x64::<53>(padding, a),
+            12 => self.slide_i8x64::<52>(padding, a),
+            13 => self.slide_i8x64::<51>(padding, a),
+            14 => self.slide_i8x64::<50>(padding, a),
+            15 => self.slide_i8x64::<49>(padding, a),
+            16 => self.slide_i8x64::<48>(padding, a),
+            17 => self.slide_i8x64::<47>(padding, a),
+            18 => self.slide_i8x64::<46>(padding, a),
+            19 => self.slide_i8x64::<45>(padding, a),
+            20 => self.slide_i8x64::<44>(padding, a),
+            21 => self.slide_i8x64::<43>(padding, a),
+            22 => self.slide_i8x64::<42>(padding, a),
+            23 => self.slide_i8x64::<41>(padding, a),
+            24 => self.slide_i8x64::<40>(padding, a),
+            25 => self.slide_i8x64::<39>(padding, a),
+            26 => self.slide_i8x64::<38>(padding, a),
+            27 => self.slide_i8x64::<37>(padding, a),
+            28 => self.slide_i8x64::<36>(padding, a),
+            29 => self.slide_i8x64::<35>(padding, a),
+            30 => self.slide_i8x64::<34>(padding, a),
+            31 => self.slide_i8x64::<33>(padding, a),
+            32 => self.slide_i8x64::<32>(padding, a),
+            33 => self.slide_i8x64::<31>(padding, a),
+            34 => self.slide_i8x64::<30>(padding, a),
+            35 => self.slide_i8x64::<29>(padding, a),
+            36 => self.slide_i8x64::<28>(padding, a),
+            37 => self.slide_i8x64::<27>(padding, a),
+            38 => self.slide_i8x64::<26>(padding, a),
+            39 => self.slide_i8x64::<25>(padding, a),
+            40 => self.slide_i8x64::<24>(padding, a),
+            41 => self.slide_i8x64::<23>(padding, a),
+            42 => self.slide_i8x64::<22>(padding, a),
+            43 => self.slide_i8x64::<21>(padding, a),
+            44 => self.slide_i8x64::<20>(padding, a),
+            45 => self.slide_i8x64::<19>(padding, a),
+            46 => self.slide_i8x64::<18>(padding, a),
+            47 => self.slide_i8x64::<17>(padding, a),
+            48 => self.slide_i8x64::<16>(padding, a),
+            49 => self.slide_i8x64::<15>(padding, a),
+            50 => self.slide_i8x64::<14>(padding, a),
+            51 => self.slide_i8x64::<13>(padding, a),
+            52 => self.slide_i8x64::<12>(padding, a),
+            53 => self.slide_i8x64::<11>(padding, a),
+            54 => self.slide_i8x64::<10>(padding, a),
+            55 => self.slide_i8x64::<9>(padding, a),
+            56 => self.slide_i8x64::<8>(padding, a),
+            57 => self.slide_i8x64::<7>(padding, a),
+            58 => self.slide_i8x64::<6>(padding, a),
+            59 => self.slide_i8x64::<5>(padding, a),
+            60 => self.slide_i8x64::<4>(padding, a),
+            61 => self.slide_i8x64::<3>(padding, a),
+            62 => self.slide_i8x64::<2>(padding, a),
+            63 => self.slide_i8x64::<1>(padding, a),
+            64 => self.slide_i8x64::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
         let (indices0, indices1) = self.split_u8x64(indices);
@@ -7983,6 +9523,190 @@ impl Simd for Neon {
             self.slide_within_blocks_u8x32::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x32::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        self.slide_u8x64::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        match OFFSET {
+            0 => self.slide_u8x64::<64>(a, a),
+            1 => self.slide_u8x64::<63>(a, a),
+            2 => self.slide_u8x64::<62>(a, a),
+            3 => self.slide_u8x64::<61>(a, a),
+            4 => self.slide_u8x64::<60>(a, a),
+            5 => self.slide_u8x64::<59>(a, a),
+            6 => self.slide_u8x64::<58>(a, a),
+            7 => self.slide_u8x64::<57>(a, a),
+            8 => self.slide_u8x64::<56>(a, a),
+            9 => self.slide_u8x64::<55>(a, a),
+            10 => self.slide_u8x64::<54>(a, a),
+            11 => self.slide_u8x64::<53>(a, a),
+            12 => self.slide_u8x64::<52>(a, a),
+            13 => self.slide_u8x64::<51>(a, a),
+            14 => self.slide_u8x64::<50>(a, a),
+            15 => self.slide_u8x64::<49>(a, a),
+            16 => self.slide_u8x64::<48>(a, a),
+            17 => self.slide_u8x64::<47>(a, a),
+            18 => self.slide_u8x64::<46>(a, a),
+            19 => self.slide_u8x64::<45>(a, a),
+            20 => self.slide_u8x64::<44>(a, a),
+            21 => self.slide_u8x64::<43>(a, a),
+            22 => self.slide_u8x64::<42>(a, a),
+            23 => self.slide_u8x64::<41>(a, a),
+            24 => self.slide_u8x64::<40>(a, a),
+            25 => self.slide_u8x64::<39>(a, a),
+            26 => self.slide_u8x64::<38>(a, a),
+            27 => self.slide_u8x64::<37>(a, a),
+            28 => self.slide_u8x64::<36>(a, a),
+            29 => self.slide_u8x64::<35>(a, a),
+            30 => self.slide_u8x64::<34>(a, a),
+            31 => self.slide_u8x64::<33>(a, a),
+            32 => self.slide_u8x64::<32>(a, a),
+            33 => self.slide_u8x64::<31>(a, a),
+            34 => self.slide_u8x64::<30>(a, a),
+            35 => self.slide_u8x64::<29>(a, a),
+            36 => self.slide_u8x64::<28>(a, a),
+            37 => self.slide_u8x64::<27>(a, a),
+            38 => self.slide_u8x64::<26>(a, a),
+            39 => self.slide_u8x64::<25>(a, a),
+            40 => self.slide_u8x64::<24>(a, a),
+            41 => self.slide_u8x64::<23>(a, a),
+            42 => self.slide_u8x64::<22>(a, a),
+            43 => self.slide_u8x64::<21>(a, a),
+            44 => self.slide_u8x64::<20>(a, a),
+            45 => self.slide_u8x64::<19>(a, a),
+            46 => self.slide_u8x64::<18>(a, a),
+            47 => self.slide_u8x64::<17>(a, a),
+            48 => self.slide_u8x64::<16>(a, a),
+            49 => self.slide_u8x64::<15>(a, a),
+            50 => self.slide_u8x64::<14>(a, a),
+            51 => self.slide_u8x64::<13>(a, a),
+            52 => self.slide_u8x64::<12>(a, a),
+            53 => self.slide_u8x64::<11>(a, a),
+            54 => self.slide_u8x64::<10>(a, a),
+            55 => self.slide_u8x64::<9>(a, a),
+            56 => self.slide_u8x64::<8>(a, a),
+            57 => self.slide_u8x64::<7>(a, a),
+            58 => self.slide_u8x64::<6>(a, a),
+            59 => self.slide_u8x64::<5>(a, a),
+            60 => self.slide_u8x64::<4>(a, a),
+            61 => self.slide_u8x64::<3>(a, a),
+            62 => self.slide_u8x64::<2>(a, a),
+            63 => self.slide_u8x64::<1>(a, a),
+            64 => self.slide_u8x64::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_u8x64(padding);
+        self.slide_u8x64::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_u8x64(padding);
+        match OFFSET {
+            0 => self.slide_u8x64::<64>(padding, a),
+            1 => self.slide_u8x64::<63>(padding, a),
+            2 => self.slide_u8x64::<62>(padding, a),
+            3 => self.slide_u8x64::<61>(padding, a),
+            4 => self.slide_u8x64::<60>(padding, a),
+            5 => self.slide_u8x64::<59>(padding, a),
+            6 => self.slide_u8x64::<58>(padding, a),
+            7 => self.slide_u8x64::<57>(padding, a),
+            8 => self.slide_u8x64::<56>(padding, a),
+            9 => self.slide_u8x64::<55>(padding, a),
+            10 => self.slide_u8x64::<54>(padding, a),
+            11 => self.slide_u8x64::<53>(padding, a),
+            12 => self.slide_u8x64::<52>(padding, a),
+            13 => self.slide_u8x64::<51>(padding, a),
+            14 => self.slide_u8x64::<50>(padding, a),
+            15 => self.slide_u8x64::<49>(padding, a),
+            16 => self.slide_u8x64::<48>(padding, a),
+            17 => self.slide_u8x64::<47>(padding, a),
+            18 => self.slide_u8x64::<46>(padding, a),
+            19 => self.slide_u8x64::<45>(padding, a),
+            20 => self.slide_u8x64::<44>(padding, a),
+            21 => self.slide_u8x64::<43>(padding, a),
+            22 => self.slide_u8x64::<42>(padding, a),
+            23 => self.slide_u8x64::<41>(padding, a),
+            24 => self.slide_u8x64::<40>(padding, a),
+            25 => self.slide_u8x64::<39>(padding, a),
+            26 => self.slide_u8x64::<38>(padding, a),
+            27 => self.slide_u8x64::<37>(padding, a),
+            28 => self.slide_u8x64::<36>(padding, a),
+            29 => self.slide_u8x64::<35>(padding, a),
+            30 => self.slide_u8x64::<34>(padding, a),
+            31 => self.slide_u8x64::<33>(padding, a),
+            32 => self.slide_u8x64::<32>(padding, a),
+            33 => self.slide_u8x64::<31>(padding, a),
+            34 => self.slide_u8x64::<30>(padding, a),
+            35 => self.slide_u8x64::<29>(padding, a),
+            36 => self.slide_u8x64::<28>(padding, a),
+            37 => self.slide_u8x64::<27>(padding, a),
+            38 => self.slide_u8x64::<26>(padding, a),
+            39 => self.slide_u8x64::<25>(padding, a),
+            40 => self.slide_u8x64::<24>(padding, a),
+            41 => self.slide_u8x64::<23>(padding, a),
+            42 => self.slide_u8x64::<22>(padding, a),
+            43 => self.slide_u8x64::<21>(padding, a),
+            44 => self.slide_u8x64::<20>(padding, a),
+            45 => self.slide_u8x64::<19>(padding, a),
+            46 => self.slide_u8x64::<18>(padding, a),
+            47 => self.slide_u8x64::<17>(padding, a),
+            48 => self.slide_u8x64::<16>(padding, a),
+            49 => self.slide_u8x64::<15>(padding, a),
+            50 => self.slide_u8x64::<14>(padding, a),
+            51 => self.slide_u8x64::<13>(padding, a),
+            52 => self.slide_u8x64::<12>(padding, a),
+            53 => self.slide_u8x64::<11>(padding, a),
+            54 => self.slide_u8x64::<10>(padding, a),
+            55 => self.slide_u8x64::<9>(padding, a),
+            56 => self.slide_u8x64::<8>(padding, a),
+            57 => self.slide_u8x64::<7>(padding, a),
+            58 => self.slide_u8x64::<6>(padding, a),
+            59 => self.slide_u8x64::<5>(padding, a),
+            60 => self.slide_u8x64::<4>(padding, a),
+            61 => self.slide_u8x64::<3>(padding, a),
+            62 => self.slide_u8x64::<2>(padding, a),
+            63 => self.slide_u8x64::<1>(padding, a),
+            64 => self.slide_u8x64::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self> {
@@ -8419,6 +10143,126 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_i16x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_i16x32::<32>(a, a),
+            1 => self.slide_i16x32::<31>(a, a),
+            2 => self.slide_i16x32::<30>(a, a),
+            3 => self.slide_i16x32::<29>(a, a),
+            4 => self.slide_i16x32::<28>(a, a),
+            5 => self.slide_i16x32::<27>(a, a),
+            6 => self.slide_i16x32::<26>(a, a),
+            7 => self.slide_i16x32::<25>(a, a),
+            8 => self.slide_i16x32::<24>(a, a),
+            9 => self.slide_i16x32::<23>(a, a),
+            10 => self.slide_i16x32::<22>(a, a),
+            11 => self.slide_i16x32::<21>(a, a),
+            12 => self.slide_i16x32::<20>(a, a),
+            13 => self.slide_i16x32::<19>(a, a),
+            14 => self.slide_i16x32::<18>(a, a),
+            15 => self.slide_i16x32::<17>(a, a),
+            16 => self.slide_i16x32::<16>(a, a),
+            17 => self.slide_i16x32::<15>(a, a),
+            18 => self.slide_i16x32::<14>(a, a),
+            19 => self.slide_i16x32::<13>(a, a),
+            20 => self.slide_i16x32::<12>(a, a),
+            21 => self.slide_i16x32::<11>(a, a),
+            22 => self.slide_i16x32::<10>(a, a),
+            23 => self.slide_i16x32::<9>(a, a),
+            24 => self.slide_i16x32::<8>(a, a),
+            25 => self.slide_i16x32::<7>(a, a),
+            26 => self.slide_i16x32::<6>(a, a),
+            27 => self.slide_i16x32::<5>(a, a),
+            28 => self.slide_i16x32::<4>(a, a),
+            29 => self.slide_i16x32::<3>(a, a),
+            30 => self.slide_i16x32::<2>(a, a),
+            31 => self.slide_i16x32::<1>(a, a),
+            32 => self.slide_i16x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i16x32(padding);
+        self.slide_i16x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i16x32(padding);
+        match OFFSET {
+            0 => self.slide_i16x32::<32>(padding, a),
+            1 => self.slide_i16x32::<31>(padding, a),
+            2 => self.slide_i16x32::<30>(padding, a),
+            3 => self.slide_i16x32::<29>(padding, a),
+            4 => self.slide_i16x32::<28>(padding, a),
+            5 => self.slide_i16x32::<27>(padding, a),
+            6 => self.slide_i16x32::<26>(padding, a),
+            7 => self.slide_i16x32::<25>(padding, a),
+            8 => self.slide_i16x32::<24>(padding, a),
+            9 => self.slide_i16x32::<23>(padding, a),
+            10 => self.slide_i16x32::<22>(padding, a),
+            11 => self.slide_i16x32::<21>(padding, a),
+            12 => self.slide_i16x32::<20>(padding, a),
+            13 => self.slide_i16x32::<19>(padding, a),
+            14 => self.slide_i16x32::<18>(padding, a),
+            15 => self.slide_i16x32::<17>(padding, a),
+            16 => self.slide_i16x32::<16>(padding, a),
+            17 => self.slide_i16x32::<15>(padding, a),
+            18 => self.slide_i16x32::<14>(padding, a),
+            19 => self.slide_i16x32::<13>(padding, a),
+            20 => self.slide_i16x32::<12>(padding, a),
+            21 => self.slide_i16x32::<11>(padding, a),
+            22 => self.slide_i16x32::<10>(padding, a),
+            23 => self.slide_i16x32::<9>(padding, a),
+            24 => self.slide_i16x32::<8>(padding, a),
+            25 => self.slide_i16x32::<7>(padding, a),
+            26 => self.slide_i16x32::<6>(padding, a),
+            27 => self.slide_i16x32::<5>(padding, a),
+            28 => self.slide_i16x32::<4>(padding, a),
+            29 => self.slide_i16x32::<3>(padding, a),
+            30 => self.slide_i16x32::<2>(padding, a),
+            31 => self.slide_i16x32::<1>(padding, a),
+            32 => self.slide_i16x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x32(
         self,
         a: i16x32<Self>,
@@ -8749,6 +10593,126 @@ impl Simd for Neon {
             self.slide_within_blocks_u16x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x16::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_u16x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_u16x32::<32>(a, a),
+            1 => self.slide_u16x32::<31>(a, a),
+            2 => self.slide_u16x32::<30>(a, a),
+            3 => self.slide_u16x32::<29>(a, a),
+            4 => self.slide_u16x32::<28>(a, a),
+            5 => self.slide_u16x32::<27>(a, a),
+            6 => self.slide_u16x32::<26>(a, a),
+            7 => self.slide_u16x32::<25>(a, a),
+            8 => self.slide_u16x32::<24>(a, a),
+            9 => self.slide_u16x32::<23>(a, a),
+            10 => self.slide_u16x32::<22>(a, a),
+            11 => self.slide_u16x32::<21>(a, a),
+            12 => self.slide_u16x32::<20>(a, a),
+            13 => self.slide_u16x32::<19>(a, a),
+            14 => self.slide_u16x32::<18>(a, a),
+            15 => self.slide_u16x32::<17>(a, a),
+            16 => self.slide_u16x32::<16>(a, a),
+            17 => self.slide_u16x32::<15>(a, a),
+            18 => self.slide_u16x32::<14>(a, a),
+            19 => self.slide_u16x32::<13>(a, a),
+            20 => self.slide_u16x32::<12>(a, a),
+            21 => self.slide_u16x32::<11>(a, a),
+            22 => self.slide_u16x32::<10>(a, a),
+            23 => self.slide_u16x32::<9>(a, a),
+            24 => self.slide_u16x32::<8>(a, a),
+            25 => self.slide_u16x32::<7>(a, a),
+            26 => self.slide_u16x32::<6>(a, a),
+            27 => self.slide_u16x32::<5>(a, a),
+            28 => self.slide_u16x32::<4>(a, a),
+            29 => self.slide_u16x32::<3>(a, a),
+            30 => self.slide_u16x32::<2>(a, a),
+            31 => self.slide_u16x32::<1>(a, a),
+            32 => self.slide_u16x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u16x32(padding);
+        self.slide_u16x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u16x32(padding);
+        match OFFSET {
+            0 => self.slide_u16x32::<32>(padding, a),
+            1 => self.slide_u16x32::<31>(padding, a),
+            2 => self.slide_u16x32::<30>(padding, a),
+            3 => self.slide_u16x32::<29>(padding, a),
+            4 => self.slide_u16x32::<28>(padding, a),
+            5 => self.slide_u16x32::<27>(padding, a),
+            6 => self.slide_u16x32::<26>(padding, a),
+            7 => self.slide_u16x32::<25>(padding, a),
+            8 => self.slide_u16x32::<24>(padding, a),
+            9 => self.slide_u16x32::<23>(padding, a),
+            10 => self.slide_u16x32::<22>(padding, a),
+            11 => self.slide_u16x32::<21>(padding, a),
+            12 => self.slide_u16x32::<20>(padding, a),
+            13 => self.slide_u16x32::<19>(padding, a),
+            14 => self.slide_u16x32::<18>(padding, a),
+            15 => self.slide_u16x32::<17>(padding, a),
+            16 => self.slide_u16x32::<16>(padding, a),
+            17 => self.slide_u16x32::<15>(padding, a),
+            18 => self.slide_u16x32::<14>(padding, a),
+            19 => self.slide_u16x32::<13>(padding, a),
+            20 => self.slide_u16x32::<12>(padding, a),
+            21 => self.slide_u16x32::<11>(padding, a),
+            22 => self.slide_u16x32::<10>(padding, a),
+            23 => self.slide_u16x32::<9>(padding, a),
+            24 => self.slide_u16x32::<8>(padding, a),
+            25 => self.slide_u16x32::<7>(padding, a),
+            26 => self.slide_u16x32::<6>(padding, a),
+            27 => self.slide_u16x32::<5>(padding, a),
+            28 => self.slide_u16x32::<4>(padding, a),
+            29 => self.slide_u16x32::<3>(padding, a),
+            30 => self.slide_u16x32::<2>(padding, a),
+            31 => self.slide_u16x32::<1>(padding, a),
+            32 => self.slide_u16x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x32(
@@ -9211,6 +11175,94 @@ impl Simd for Neon {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i32x16::<16>(a, a),
+            1 => self.slide_i32x16::<15>(a, a),
+            2 => self.slide_i32x16::<14>(a, a),
+            3 => self.slide_i32x16::<13>(a, a),
+            4 => self.slide_i32x16::<12>(a, a),
+            5 => self.slide_i32x16::<11>(a, a),
+            6 => self.slide_i32x16::<10>(a, a),
+            7 => self.slide_i32x16::<9>(a, a),
+            8 => self.slide_i32x16::<8>(a, a),
+            9 => self.slide_i32x16::<7>(a, a),
+            10 => self.slide_i32x16::<6>(a, a),
+            11 => self.slide_i32x16::<5>(a, a),
+            12 => self.slide_i32x16::<4>(a, a),
+            13 => self.slide_i32x16::<3>(a, a),
+            14 => self.slide_i32x16::<2>(a, a),
+            15 => self.slide_i32x16::<1>(a, a),
+            16 => self.slide_i32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i32x16(padding);
+        self.slide_i32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i32x16(padding);
+        match OFFSET {
+            0 => self.slide_i32x16::<16>(padding, a),
+            1 => self.slide_i32x16::<15>(padding, a),
+            2 => self.slide_i32x16::<14>(padding, a),
+            3 => self.slide_i32x16::<13>(padding, a),
+            4 => self.slide_i32x16::<12>(padding, a),
+            5 => self.slide_i32x16::<11>(padding, a),
+            6 => self.slide_i32x16::<10>(padding, a),
+            7 => self.slide_i32x16::<9>(padding, a),
+            8 => self.slide_i32x16::<8>(padding, a),
+            9 => self.slide_i32x16::<7>(padding, a),
+            10 => self.slide_i32x16::<6>(padding, a),
+            11 => self.slide_i32x16::<5>(padding, a),
+            12 => self.slide_i32x16::<4>(padding, a),
+            13 => self.slide_i32x16::<3>(padding, a),
+            14 => self.slide_i32x16::<2>(padding, a),
+            15 => self.slide_i32x16::<1>(padding, a),
+            16 => self.slide_i32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x16(
         self,
         a: i32x16<Self>,
@@ -9537,6 +11589,94 @@ impl Simd for Neon {
             self.slide_within_blocks_u32x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x8::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u32x16::<16>(a, a),
+            1 => self.slide_u32x16::<15>(a, a),
+            2 => self.slide_u32x16::<14>(a, a),
+            3 => self.slide_u32x16::<13>(a, a),
+            4 => self.slide_u32x16::<12>(a, a),
+            5 => self.slide_u32x16::<11>(a, a),
+            6 => self.slide_u32x16::<10>(a, a),
+            7 => self.slide_u32x16::<9>(a, a),
+            8 => self.slide_u32x16::<8>(a, a),
+            9 => self.slide_u32x16::<7>(a, a),
+            10 => self.slide_u32x16::<6>(a, a),
+            11 => self.slide_u32x16::<5>(a, a),
+            12 => self.slide_u32x16::<4>(a, a),
+            13 => self.slide_u32x16::<3>(a, a),
+            14 => self.slide_u32x16::<2>(a, a),
+            15 => self.slide_u32x16::<1>(a, a),
+            16 => self.slide_u32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u32x16(padding);
+        self.slide_u32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u32x16(padding);
+        match OFFSET {
+            0 => self.slide_u32x16::<16>(padding, a),
+            1 => self.slide_u32x16::<15>(padding, a),
+            2 => self.slide_u32x16::<14>(padding, a),
+            3 => self.slide_u32x16::<13>(padding, a),
+            4 => self.slide_u32x16::<12>(padding, a),
+            5 => self.slide_u32x16::<11>(padding, a),
+            6 => self.slide_u32x16::<10>(padding, a),
+            7 => self.slide_u32x16::<9>(padding, a),
+            8 => self.slide_u32x16::<8>(padding, a),
+            9 => self.slide_u32x16::<7>(padding, a),
+            10 => self.slide_u32x16::<6>(padding, a),
+            11 => self.slide_u32x16::<5>(padding, a),
+            12 => self.slide_u32x16::<4>(padding, a),
+            13 => self.slide_u32x16::<3>(padding, a),
+            14 => self.slide_u32x16::<2>(padding, a),
+            15 => self.slide_u32x16::<1>(padding, a),
+            16 => self.slide_u32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x16(
@@ -9977,6 +12117,78 @@ impl Simd for Neon {
             self.slide_within_blocks_f64x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x4::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_f64x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_f64x8::<8>(a, a),
+            1 => self.slide_f64x8::<7>(a, a),
+            2 => self.slide_f64x8::<6>(a, a),
+            3 => self.slide_f64x8::<5>(a, a),
+            4 => self.slide_f64x8::<4>(a, a),
+            5 => self.slide_f64x8::<3>(a, a),
+            6 => self.slide_f64x8::<2>(a, a),
+            7 => self.slide_f64x8::<1>(a, a),
+            8 => self.slide_f64x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f64x8(padding);
+        self.slide_f64x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f64x8(padding);
+        match OFFSET {
+            0 => self.slide_f64x8::<8>(padding, a),
+            1 => self.slide_f64x8::<7>(padding, a),
+            2 => self.slide_f64x8::<6>(padding, a),
+            3 => self.slide_f64x8::<5>(padding, a),
+            4 => self.slide_f64x8::<4>(padding, a),
+            5 => self.slide_f64x8::<3>(padding, a),
+            6 => self.slide_f64x8::<2>(padding, a),
+            7 => self.slide_f64x8::<1>(padding, a),
+            8 => self.slide_f64x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -144,17 +144,17 @@ pub trait Simd:
         a: f32x4<Self>,
         b: f32x4<Self>,
     ) -> f32x4<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_f32x4<const OFFSET: usize>(
         self,
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_f32x4<const OFFSET: usize>(
         self,
         a: f32x4<Self>,
@@ -270,17 +270,17 @@ pub trait Simd:
         a: i8x16<Self>,
         b: i8x16<Self>,
     ) -> i8x16<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_i8x16<const OFFSET: usize>(
         self,
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_i8x16<const OFFSET: usize>(
         self,
         a: i8x16<Self>,
@@ -372,17 +372,17 @@ pub trait Simd:
         a: u8x16<Self>,
         b: u8x16<Self>,
     ) -> u8x16<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_u8x16<const OFFSET: usize>(
         self,
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_u8x16<const OFFSET: usize>(
         self,
         a: u8x16<Self>,
@@ -511,17 +511,17 @@ pub trait Simd:
         a: i16x8<Self>,
         b: i16x8<Self>,
     ) -> i16x8<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_i16x8<const OFFSET: usize>(
         self,
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_i16x8<const OFFSET: usize>(
         self,
         a: i16x8<Self>,
@@ -613,17 +613,17 @@ pub trait Simd:
         a: u16x8<Self>,
         b: u16x8<Self>,
     ) -> u16x8<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_u16x8<const OFFSET: usize>(
         self,
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_u16x8<const OFFSET: usize>(
         self,
         a: u16x8<Self>,
@@ -752,17 +752,17 @@ pub trait Simd:
         a: i32x4<Self>,
         b: i32x4<Self>,
     ) -> i32x4<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_i32x4<const OFFSET: usize>(
         self,
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_i32x4<const OFFSET: usize>(
         self,
         a: i32x4<Self>,
@@ -856,17 +856,17 @@ pub trait Simd:
         a: u32x4<Self>,
         b: u32x4<Self>,
     ) -> u32x4<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_u32x4<const OFFSET: usize>(
         self,
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_u32x4<const OFFSET: usize>(
         self,
         a: u32x4<Self>,
@@ -995,17 +995,17 @@ pub trait Simd:
         a: f64x2<Self>,
         b: f64x2<Self>,
     ) -> f64x2<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_f64x2<const OFFSET: usize>(
         self,
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_f64x2<const OFFSET: usize>(
         self,
         a: f64x2<Self>,
@@ -1146,17 +1146,17 @@ pub trait Simd:
         a: f32x8<Self>,
         b: f32x8<Self>,
     ) -> f32x8<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_f32x8<const OFFSET: usize>(
         self,
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_f32x8<const OFFSET: usize>(
         self,
         a: f32x8<Self>,
@@ -1274,17 +1274,17 @@ pub trait Simd:
         a: i8x32<Self>,
         b: i8x32<Self>,
     ) -> i8x32<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_i8x32<const OFFSET: usize>(
         self,
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_i8x32<const OFFSET: usize>(
         self,
         a: i8x32<Self>,
@@ -1378,17 +1378,17 @@ pub trait Simd:
         a: u8x32<Self>,
         b: u8x32<Self>,
     ) -> u8x32<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_u8x32<const OFFSET: usize>(
         self,
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_u8x32<const OFFSET: usize>(
         self,
         a: u8x32<Self>,
@@ -1521,17 +1521,17 @@ pub trait Simd:
         a: i16x16<Self>,
         b: i16x16<Self>,
     ) -> i16x16<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_i16x16<const OFFSET: usize>(
         self,
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_i16x16<const OFFSET: usize>(
         self,
         a: i16x16<Self>,
@@ -1629,17 +1629,17 @@ pub trait Simd:
         a: u16x16<Self>,
         b: u16x16<Self>,
     ) -> u16x16<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_u16x16<const OFFSET: usize>(
         self,
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_u16x16<const OFFSET: usize>(
         self,
         a: u16x16<Self>,
@@ -1778,17 +1778,17 @@ pub trait Simd:
         a: i32x8<Self>,
         b: i32x8<Self>,
     ) -> i32x8<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_i32x8<const OFFSET: usize>(
         self,
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_i32x8<const OFFSET: usize>(
         self,
         a: i32x8<Self>,
@@ -1884,17 +1884,17 @@ pub trait Simd:
         a: u32x8<Self>,
         b: u32x8<Self>,
     ) -> u32x8<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_u32x8<const OFFSET: usize>(
         self,
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_u32x8<const OFFSET: usize>(
         self,
         a: u32x8<Self>,
@@ -2027,17 +2027,17 @@ pub trait Simd:
         a: f64x4<Self>,
         b: f64x4<Self>,
     ) -> f64x4<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_f64x4<const OFFSET: usize>(
         self,
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_f64x4<const OFFSET: usize>(
         self,
         a: f64x4<Self>,
@@ -2182,17 +2182,17 @@ pub trait Simd:
         a: f32x16<Self>,
         b: f32x16<Self>,
     ) -> f32x16<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_f32x16<const OFFSET: usize>(
         self,
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_f32x16<const OFFSET: usize>(
         self,
         a: f32x16<Self>,
@@ -2316,17 +2316,17 @@ pub trait Simd:
         a: i8x64<Self>,
         b: i8x64<Self>,
     ) -> i8x64<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_i8x64<const OFFSET: usize>(
         self,
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_i8x64<const OFFSET: usize>(
         self,
         a: i8x64<Self>,
@@ -2418,17 +2418,17 @@ pub trait Simd:
         a: u8x64<Self>,
         b: u8x64<Self>,
     ) -> u8x64<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_u8x64<const OFFSET: usize>(
         self,
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_u8x64<const OFFSET: usize>(
         self,
         a: u8x64<Self>,
@@ -2559,17 +2559,17 @@ pub trait Simd:
         a: i16x32<Self>,
         b: i16x32<Self>,
     ) -> i16x32<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_i16x32<const OFFSET: usize>(
         self,
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_i16x32<const OFFSET: usize>(
         self,
         a: i16x32<Self>,
@@ -2665,17 +2665,17 @@ pub trait Simd:
         a: u16x32<Self>,
         b: u16x32<Self>,
     ) -> u16x32<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_u16x32<const OFFSET: usize>(
         self,
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_u16x32<const OFFSET: usize>(
         self,
         a: u16x32<Self>,
@@ -2814,17 +2814,17 @@ pub trait Simd:
         a: i32x16<Self>,
         b: i32x16<Self>,
     ) -> i32x16<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_i32x16<const OFFSET: usize>(
         self,
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_i32x16<const OFFSET: usize>(
         self,
         a: i32x16<Self>,
@@ -2922,17 +2922,17 @@ pub trait Simd:
         a: u32x16<Self>,
         b: u32x16<Self>,
     ) -> u32x16<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_u32x16<const OFFSET: usize>(
         self,
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_u32x16<const OFFSET: usize>(
         self,
         a: u32x16<Self>,
@@ -3069,17 +3069,17 @@ pub trait Simd:
         a: f64x8<Self>,
         b: f64x8<Self>,
     ) -> f64x8<Self>;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self>;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self>;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left_f64x8<const OFFSET: usize>(
         self,
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self>;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right_f64x8<const OFFSET: usize>(
         self,
         a: f64x8<Self>,
@@ -3297,13 +3297,13 @@ pub trait SimdBase<S: Simd>:
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_left<const OFFSET: usize>(self) -> Self;
-    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
     fn rotate_elements_right<const OFFSET: usize>(self) -> Self;
-    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self;
-    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nIf `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
     fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self;

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -144,6 +144,22 @@ pub trait Simd:
         a: f32x4<Self>,
         b: f32x4<Self>,
     ) -> f32x4<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self>;
     #[doc = "Compute the absolute value of each element."]
@@ -254,6 +270,22 @@ pub trait Simd:
         a: i8x16<Self>,
         b: i8x16<Self>,
     ) -> i8x16<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
@@ -339,6 +371,22 @@ pub trait Simd:
         self,
         a: u8x16<Self>,
         b: u8x16<Self>,
+    ) -> u8x16<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
     ) -> u8x16<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self>;
@@ -463,6 +511,22 @@ pub trait Simd:
         a: i16x8<Self>,
         b: i16x8<Self>,
     ) -> i16x8<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
@@ -548,6 +612,22 @@ pub trait Simd:
         self,
         a: u16x8<Self>,
         b: u16x8<Self>,
+    ) -> u16x8<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
     ) -> u16x8<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self>;
@@ -672,6 +752,22 @@ pub trait Simd:
         a: i32x4<Self>,
         b: i32x4<Self>,
     ) -> i32x4<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
@@ -759,6 +855,22 @@ pub trait Simd:
         self,
         a: u32x4<Self>,
         b: u32x4<Self>,
+    ) -> u32x4<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
     ) -> u32x4<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self>;
@@ -882,6 +994,22 @@ pub trait Simd:
         self,
         a: f64x2<Self>,
         b: f64x2<Self>,
+    ) -> f64x2<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
     ) -> f64x2<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self>;
@@ -1018,6 +1146,22 @@ pub trait Simd:
         a: f32x8<Self>,
         b: f32x8<Self>,
     ) -> f32x8<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self>;
     #[doc = "Compute the absolute value of each element."]
@@ -1130,6 +1274,22 @@ pub trait Simd:
         a: i8x32<Self>,
         b: i8x32<Self>,
     ) -> i8x32<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
@@ -1217,6 +1377,22 @@ pub trait Simd:
         self,
         a: u8x32<Self>,
         b: u8x32<Self>,
+    ) -> u8x32<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
     ) -> u8x32<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self>;
@@ -1345,6 +1521,22 @@ pub trait Simd:
         a: i16x16<Self>,
         b: i16x16<Self>,
     ) -> i16x16<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i16x16(
         self,
@@ -1436,6 +1628,22 @@ pub trait Simd:
         self,
         a: u16x16<Self>,
         b: u16x16<Self>,
+    ) -> u16x16<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
     ) -> u16x16<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u16x16(
@@ -1570,6 +1778,22 @@ pub trait Simd:
         a: i32x8<Self>,
         b: i32x8<Self>,
     ) -> i32x8<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
@@ -1659,6 +1883,22 @@ pub trait Simd:
         self,
         a: u32x8<Self>,
         b: u32x8<Self>,
+    ) -> u32x8<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
     ) -> u32x8<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self>;
@@ -1786,6 +2026,22 @@ pub trait Simd:
         self,
         a: f64x4<Self>,
         b: f64x4<Self>,
+    ) -> f64x4<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
     ) -> f64x4<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self>;
@@ -1926,6 +2182,22 @@ pub trait Simd:
         a: f32x16<Self>,
         b: f32x16<Self>,
     ) -> f32x16<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_f32x16(
         self,
@@ -2044,6 +2316,22 @@ pub trait Simd:
         a: i8x64<Self>,
         b: i8x64<Self>,
     ) -> i8x64<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
@@ -2129,6 +2417,22 @@ pub trait Simd:
         self,
         a: u8x64<Self>,
         b: u8x64<Self>,
+    ) -> u8x64<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
     ) -> u8x64<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self>;
@@ -2255,6 +2559,22 @@ pub trait Simd:
         a: i16x32<Self>,
         b: i16x32<Self>,
     ) -> i16x32<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i16x32(
         self,
@@ -2344,6 +2664,22 @@ pub trait Simd:
         self,
         a: u16x32<Self>,
         b: u16x32<Self>,
+    ) -> u16x32<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
     ) -> u16x32<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u16x32(
@@ -2478,6 +2814,22 @@ pub trait Simd:
         a: i32x16<Self>,
         b: i32x16<Self>,
     ) -> i32x16<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_i32x16(
         self,
@@ -2569,6 +2921,22 @@ pub trait Simd:
         self,
         a: u32x16<Self>,
         b: u32x16<Self>,
+    ) -> u32x16<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
     ) -> u32x16<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_u32x16(
@@ -2700,6 +3068,22 @@ pub trait Simd:
         self,
         a: f64x8<Self>,
         b: f64x8<Self>,
+    ) -> f64x8<Self>;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self>;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self>;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self>;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
     ) -> f64x8<Self>;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self>;
@@ -2913,6 +3297,14 @@ pub trait SimdBase<S: Simd>:
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self;
+    #[doc = "Rotate the vector elements to the left by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self;
+    #[doc = "Rotate the vector elements to the right by `OFFSET`.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self;
+    #[doc = "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self;
+    #[doc = "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\nPanics if `OFFSET` is greater than `Self::N`."]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self;
     #[doc = "Dynamically swizzle this vector's bytes independently within each 128-bit block.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values `0..=15` select the corresponding byte from the same 128-bit input block.\n\nOut-of-range index behavior varies by platform."]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self;
 }

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -131,6 +131,23 @@ impl<S: Simd> SimdBase<S> for f32x4<S> {
             .slide_within_blocks_f32x4::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_f32x4::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_f32x4::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_f32x4::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_f32x4::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_f32x4(self, indices.simd_into(self.simd))
@@ -389,6 +406,23 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
             .slide_within_blocks_i8x16::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_i8x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_i8x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_i8x16::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_i8x16::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i8x16(self, indices.simd_into(self.simd))
@@ -577,6 +611,23 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u8x16::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_u8x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_u8x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_u8x16::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_u8x16::<OFFSET>(self, padding)
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
@@ -860,6 +911,23 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
             .slide_within_blocks_i16x8::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_i16x8::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_i16x8::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_i16x8::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_i16x8::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i16x8(self, indices.simd_into(self.simd))
@@ -1048,6 +1116,23 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u16x8::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_u16x8::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_u16x8::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_u16x8::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_u16x8::<OFFSET>(self, padding)
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
@@ -1331,6 +1416,23 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
             .slide_within_blocks_i32x4::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_i32x4::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_i32x4::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_i32x4::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_i32x4::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i32x4(self, indices.simd_into(self.simd))
@@ -1531,6 +1633,23 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u32x4::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_u32x4::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_u32x4::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_u32x4::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_u32x4::<OFFSET>(self, padding)
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
@@ -1824,6 +1943,23 @@ impl<S: Simd> SimdBase<S> for f64x2<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_f64x2::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_f64x2::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_f64x2::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_f64x2::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_f64x2::<OFFSET>(self, padding)
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
@@ -2161,6 +2297,23 @@ impl<S: Simd> SimdBase<S> for f32x8<S> {
             .slide_within_blocks_f32x8::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_f32x8::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_f32x8::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_f32x8::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_f32x8::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_f32x8(self, indices.simd_into(self.simd))
@@ -2426,6 +2579,23 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
             .slide_within_blocks_i8x32::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_i8x32::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_i8x32::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_i8x32::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_i8x32::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i8x32(self, indices.simd_into(self.simd))
@@ -2621,6 +2791,23 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u8x32::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_u8x32::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_u8x32::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_u8x32::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_u8x32::<OFFSET>(self, padding)
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
@@ -2916,6 +3103,24 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
             .slide_within_blocks_i16x16::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_i16x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_i16x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_left_i16x16::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_i16x16::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i16x16(self, indices.simd_into(self.simd))
@@ -3117,6 +3322,24 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u16x16::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_u16x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_u16x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_left_u16x16::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_u16x16::<OFFSET>(self, padding)
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
@@ -3408,6 +3631,23 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
             .slide_within_blocks_i32x8::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_i32x8::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_i32x8::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_i32x8::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_i32x8::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i32x8(self, indices.simd_into(self.simd))
@@ -3615,6 +3855,23 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u32x8::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_u32x8::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_u32x8::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_u32x8::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_u32x8::<OFFSET>(self, padding)
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
@@ -3915,6 +4172,23 @@ impl<S: Simd> SimdBase<S> for f64x4<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_f64x4::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_f64x4::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_f64x4::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_f64x4::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_f64x4::<OFFSET>(self, padding)
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
@@ -4265,6 +4539,24 @@ impl<S: Simd> SimdBase<S> for f32x16<S> {
             .slide_within_blocks_f32x16::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_f32x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_f32x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_left_f32x16::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_f32x16::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_f32x16(self, indices.simd_into(self.simd))
@@ -4525,6 +4817,23 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
             .slide_within_blocks_i8x64::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_i8x64::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_i8x64::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_i8x64::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_i8x64::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i8x64(self, indices.simd_into(self.simd))
@@ -4714,6 +5023,23 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u8x64::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_u8x64::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_u8x64::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_u8x64::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_u8x64::<OFFSET>(self, padding)
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
@@ -5003,6 +5329,24 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
             .slide_within_blocks_i16x32::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_i16x32::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_i16x32::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_left_i16x32::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_i16x32::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i16x32(self, indices.simd_into(self.simd))
@@ -5198,6 +5542,24 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u16x32::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_u16x32::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_u16x32::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_left_u16x32::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_u16x32::<OFFSET>(self, padding)
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
@@ -5488,6 +5850,24 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
             .slide_within_blocks_i32x16::<SHIFT>(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_i32x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_i32x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_left_i32x16::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_i32x16::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_within_blocks_i32x16(self, indices.simd_into(self.simd))
@@ -5695,6 +6075,24 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_u32x16::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_u32x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_u32x16::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_left_u32x16::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_u32x16::<OFFSET>(self, padding)
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
@@ -5990,6 +6388,23 @@ impl<S: Simd> SimdBase<S> for f64x8<S> {
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .slide_within_blocks_f64x8::<SHIFT>(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_left_f64x8::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+        self.simd.rotate_elements_right_f64x8::<OFFSET>(self)
+    }
+    #[inline(always)]
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd.shift_elements_left_f64x8::<OFFSET>(self, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+        self.simd
+            .shift_elements_right_f64x8::<OFFSET>(self, padding)
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -175,28 +175,21 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_f32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_f32x4::<0>(a, a),
+            1 => self.slide_f32x4::<1>(a, a),
+            2 => self.slide_f32x4::<2>(a, a),
+            3 => self.slide_f32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_f32x4::<4>(a, a),
             1 => self.slide_f32x4::<3>(a, a),
             2 => self.slide_f32x4::<2>(a, a),
             3 => self.slide_f32x4::<1>(a, a),
-            4 => self.slide_f32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -206,14 +199,15 @@ impl Simd for Sse4_2 {
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f32x4(padding);
-        self.slide_f32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x4::<0>(a, padding),
+            1 => self.slide_f32x4::<1>(a, padding),
+            2 => self.slide_f32x4::<2>(a, padding),
+            3 => self.slide_f32x4::<3>(a, padding),
+            4 => self.slide_f32x4::<4>(a, padding),
+            _ => self.slide_f32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x4<const OFFSET: usize>(
@@ -221,12 +215,6 @@ impl Simd for Sse4_2 {
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f32x4(padding);
         match OFFSET {
             0 => self.slide_f32x4::<4>(padding, a),
@@ -234,7 +222,7 @@ impl Simd for Sse4_2 {
             2 => self.slide_f32x4::<2>(padding, a),
             3 => self.slide_f32x4::<1>(padding, a),
             4 => self.slide_f32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -760,23 +748,29 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i8x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i8x16::<0>(a, a),
+            1 => self.slide_i8x16::<1>(a, a),
+            2 => self.slide_i8x16::<2>(a, a),
+            3 => self.slide_i8x16::<3>(a, a),
+            4 => self.slide_i8x16::<4>(a, a),
+            5 => self.slide_i8x16::<5>(a, a),
+            6 => self.slide_i8x16::<6>(a, a),
+            7 => self.slide_i8x16::<7>(a, a),
+            8 => self.slide_i8x16::<8>(a, a),
+            9 => self.slide_i8x16::<9>(a, a),
+            10 => self.slide_i8x16::<10>(a, a),
+            11 => self.slide_i8x16::<11>(a, a),
+            12 => self.slide_i8x16::<12>(a, a),
+            13 => self.slide_i8x16::<13>(a, a),
+            14 => self.slide_i8x16::<14>(a, a),
+            15 => self.slide_i8x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i8x16::<16>(a, a),
             1 => self.slide_i8x16::<15>(a, a),
             2 => self.slide_i8x16::<14>(a, a),
@@ -793,7 +787,6 @@ impl Simd for Sse4_2 {
             13 => self.slide_i8x16::<3>(a, a),
             14 => self.slide_i8x16::<2>(a, a),
             15 => self.slide_i8x16::<1>(a, a),
-            16 => self.slide_i8x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -803,14 +796,27 @@ impl Simd for Sse4_2 {
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i8x16(padding);
-        self.slide_i8x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x16::<0>(a, padding),
+            1 => self.slide_i8x16::<1>(a, padding),
+            2 => self.slide_i8x16::<2>(a, padding),
+            3 => self.slide_i8x16::<3>(a, padding),
+            4 => self.slide_i8x16::<4>(a, padding),
+            5 => self.slide_i8x16::<5>(a, padding),
+            6 => self.slide_i8x16::<6>(a, padding),
+            7 => self.slide_i8x16::<7>(a, padding),
+            8 => self.slide_i8x16::<8>(a, padding),
+            9 => self.slide_i8x16::<9>(a, padding),
+            10 => self.slide_i8x16::<10>(a, padding),
+            11 => self.slide_i8x16::<11>(a, padding),
+            12 => self.slide_i8x16::<12>(a, padding),
+            13 => self.slide_i8x16::<13>(a, padding),
+            14 => self.slide_i8x16::<14>(a, padding),
+            15 => self.slide_i8x16::<15>(a, padding),
+            16 => self.slide_i8x16::<16>(a, padding),
+            _ => self.slide_i8x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x16<const OFFSET: usize>(
@@ -818,12 +824,6 @@ impl Simd for Sse4_2 {
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i8x16(padding);
         match OFFSET {
             0 => self.slide_i8x16::<16>(padding, a),
@@ -843,7 +843,7 @@ impl Simd for Sse4_2 {
             14 => self.slide_i8x16::<2>(padding, a),
             15 => self.slide_i8x16::<1>(padding, a),
             16 => self.slide_i8x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -1227,23 +1227,29 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u8x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u8x16::<0>(a, a),
+            1 => self.slide_u8x16::<1>(a, a),
+            2 => self.slide_u8x16::<2>(a, a),
+            3 => self.slide_u8x16::<3>(a, a),
+            4 => self.slide_u8x16::<4>(a, a),
+            5 => self.slide_u8x16::<5>(a, a),
+            6 => self.slide_u8x16::<6>(a, a),
+            7 => self.slide_u8x16::<7>(a, a),
+            8 => self.slide_u8x16::<8>(a, a),
+            9 => self.slide_u8x16::<9>(a, a),
+            10 => self.slide_u8x16::<10>(a, a),
+            11 => self.slide_u8x16::<11>(a, a),
+            12 => self.slide_u8x16::<12>(a, a),
+            13 => self.slide_u8x16::<13>(a, a),
+            14 => self.slide_u8x16::<14>(a, a),
+            15 => self.slide_u8x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u8x16::<16>(a, a),
             1 => self.slide_u8x16::<15>(a, a),
             2 => self.slide_u8x16::<14>(a, a),
@@ -1260,7 +1266,6 @@ impl Simd for Sse4_2 {
             13 => self.slide_u8x16::<3>(a, a),
             14 => self.slide_u8x16::<2>(a, a),
             15 => self.slide_u8x16::<1>(a, a),
-            16 => self.slide_u8x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -1270,14 +1275,27 @@ impl Simd for Sse4_2 {
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u8x16(padding);
-        self.slide_u8x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x16::<0>(a, padding),
+            1 => self.slide_u8x16::<1>(a, padding),
+            2 => self.slide_u8x16::<2>(a, padding),
+            3 => self.slide_u8x16::<3>(a, padding),
+            4 => self.slide_u8x16::<4>(a, padding),
+            5 => self.slide_u8x16::<5>(a, padding),
+            6 => self.slide_u8x16::<6>(a, padding),
+            7 => self.slide_u8x16::<7>(a, padding),
+            8 => self.slide_u8x16::<8>(a, padding),
+            9 => self.slide_u8x16::<9>(a, padding),
+            10 => self.slide_u8x16::<10>(a, padding),
+            11 => self.slide_u8x16::<11>(a, padding),
+            12 => self.slide_u8x16::<12>(a, padding),
+            13 => self.slide_u8x16::<13>(a, padding),
+            14 => self.slide_u8x16::<14>(a, padding),
+            15 => self.slide_u8x16::<15>(a, padding),
+            16 => self.slide_u8x16::<16>(a, padding),
+            _ => self.slide_u8x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x16<const OFFSET: usize>(
@@ -1285,12 +1303,6 @@ impl Simd for Sse4_2 {
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u8x16(padding);
         match OFFSET {
             0 => self.slide_u8x16::<16>(padding, a),
@@ -1310,7 +1322,7 @@ impl Simd for Sse4_2 {
             14 => self.slide_u8x16::<2>(padding, a),
             15 => self.slide_u8x16::<1>(padding, a),
             16 => self.slide_u8x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -1867,23 +1879,21 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_i16x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_i16x8::<0>(a, a),
+            1 => self.slide_i16x8::<1>(a, a),
+            2 => self.slide_i16x8::<2>(a, a),
+            3 => self.slide_i16x8::<3>(a, a),
+            4 => self.slide_i16x8::<4>(a, a),
+            5 => self.slide_i16x8::<5>(a, a),
+            6 => self.slide_i16x8::<6>(a, a),
+            7 => self.slide_i16x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_i16x8::<8>(a, a),
             1 => self.slide_i16x8::<7>(a, a),
             2 => self.slide_i16x8::<6>(a, a),
@@ -1892,7 +1902,6 @@ impl Simd for Sse4_2 {
             5 => self.slide_i16x8::<3>(a, a),
             6 => self.slide_i16x8::<2>(a, a),
             7 => self.slide_i16x8::<1>(a, a),
-            8 => self.slide_i16x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -1902,14 +1911,19 @@ impl Simd for Sse4_2 {
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i16x8(padding);
-        self.slide_i16x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x8::<0>(a, padding),
+            1 => self.slide_i16x8::<1>(a, padding),
+            2 => self.slide_i16x8::<2>(a, padding),
+            3 => self.slide_i16x8::<3>(a, padding),
+            4 => self.slide_i16x8::<4>(a, padding),
+            5 => self.slide_i16x8::<5>(a, padding),
+            6 => self.slide_i16x8::<6>(a, padding),
+            7 => self.slide_i16x8::<7>(a, padding),
+            8 => self.slide_i16x8::<8>(a, padding),
+            _ => self.slide_i16x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x8<const OFFSET: usize>(
@@ -1917,12 +1931,6 @@ impl Simd for Sse4_2 {
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i16x8(padding);
         match OFFSET {
             0 => self.slide_i16x8::<8>(padding, a),
@@ -1934,7 +1942,7 @@ impl Simd for Sse4_2 {
             6 => self.slide_i16x8::<2>(padding, a),
             7 => self.slide_i16x8::<1>(padding, a),
             8 => self.slide_i16x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -2299,23 +2307,21 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_u16x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_u16x8::<0>(a, a),
+            1 => self.slide_u16x8::<1>(a, a),
+            2 => self.slide_u16x8::<2>(a, a),
+            3 => self.slide_u16x8::<3>(a, a),
+            4 => self.slide_u16x8::<4>(a, a),
+            5 => self.slide_u16x8::<5>(a, a),
+            6 => self.slide_u16x8::<6>(a, a),
+            7 => self.slide_u16x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_u16x8::<8>(a, a),
             1 => self.slide_u16x8::<7>(a, a),
             2 => self.slide_u16x8::<6>(a, a),
@@ -2324,7 +2330,6 @@ impl Simd for Sse4_2 {
             5 => self.slide_u16x8::<3>(a, a),
             6 => self.slide_u16x8::<2>(a, a),
             7 => self.slide_u16x8::<1>(a, a),
-            8 => self.slide_u16x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -2334,14 +2339,19 @@ impl Simd for Sse4_2 {
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u16x8(padding);
-        self.slide_u16x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x8::<0>(a, padding),
+            1 => self.slide_u16x8::<1>(a, padding),
+            2 => self.slide_u16x8::<2>(a, padding),
+            3 => self.slide_u16x8::<3>(a, padding),
+            4 => self.slide_u16x8::<4>(a, padding),
+            5 => self.slide_u16x8::<5>(a, padding),
+            6 => self.slide_u16x8::<6>(a, padding),
+            7 => self.slide_u16x8::<7>(a, padding),
+            8 => self.slide_u16x8::<8>(a, padding),
+            _ => self.slide_u16x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x8<const OFFSET: usize>(
@@ -2349,12 +2359,6 @@ impl Simd for Sse4_2 {
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u16x8(padding);
         match OFFSET {
             0 => self.slide_u16x8::<8>(padding, a),
@@ -2366,7 +2370,7 @@ impl Simd for Sse4_2 {
             6 => self.slide_u16x8::<2>(padding, a),
             7 => self.slide_u16x8::<1>(padding, a),
             8 => self.slide_u16x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -2899,28 +2903,21 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_i32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_i32x4::<0>(a, a),
+            1 => self.slide_i32x4::<1>(a, a),
+            2 => self.slide_i32x4::<2>(a, a),
+            3 => self.slide_i32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_i32x4::<4>(a, a),
             1 => self.slide_i32x4::<3>(a, a),
             2 => self.slide_i32x4::<2>(a, a),
             3 => self.slide_i32x4::<1>(a, a),
-            4 => self.slide_i32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -2930,14 +2927,15 @@ impl Simd for Sse4_2 {
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_i32x4(padding);
-        self.slide_i32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x4::<0>(a, padding),
+            1 => self.slide_i32x4::<1>(a, padding),
+            2 => self.slide_i32x4::<2>(a, padding),
+            3 => self.slide_i32x4::<3>(a, padding),
+            4 => self.slide_i32x4::<4>(a, padding),
+            _ => self.slide_i32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x4<const OFFSET: usize>(
@@ -2945,12 +2943,6 @@ impl Simd for Sse4_2 {
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_i32x4(padding);
         match OFFSET {
             0 => self.slide_i32x4::<4>(padding, a),
@@ -2958,7 +2950,7 @@ impl Simd for Sse4_2 {
             2 => self.slide_i32x4::<2>(padding, a),
             3 => self.slide_i32x4::<1>(padding, a),
             4 => self.slide_i32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -3331,28 +3323,21 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_u32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_u32x4::<0>(a, a),
+            1 => self.slide_u32x4::<1>(a, a),
+            2 => self.slide_u32x4::<2>(a, a),
+            3 => self.slide_u32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_u32x4::<4>(a, a),
             1 => self.slide_u32x4::<3>(a, a),
             2 => self.slide_u32x4::<2>(a, a),
             3 => self.slide_u32x4::<1>(a, a),
-            4 => self.slide_u32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -3362,14 +3347,15 @@ impl Simd for Sse4_2 {
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_u32x4(padding);
-        self.slide_u32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x4::<0>(a, padding),
+            1 => self.slide_u32x4::<1>(a, padding),
+            2 => self.slide_u32x4::<2>(a, padding),
+            3 => self.slide_u32x4::<3>(a, padding),
+            4 => self.slide_u32x4::<4>(a, padding),
+            _ => self.slide_u32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x4<const OFFSET: usize>(
@@ -3377,12 +3363,6 @@ impl Simd for Sse4_2 {
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_u32x4(padding);
         match OFFSET {
             0 => self.slide_u32x4::<4>(padding, a),
@@ -3390,7 +3370,7 @@ impl Simd for Sse4_2 {
             2 => self.slide_u32x4::<2>(padding, a),
             3 => self.slide_u32x4::<1>(padding, a),
             4 => self.slide_u32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -3927,26 +3907,17 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
-        self.slide_f64x2::<OFFSET>(a, a)
+        match OFFSET % 2 {
+            0 => self.slide_f64x2::<0>(a, a),
+            1 => self.slide_f64x2::<1>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
-        match OFFSET {
+        match OFFSET % 2 {
             0 => self.slide_f64x2::<2>(a, a),
             1 => self.slide_f64x2::<1>(a, a),
-            2 => self.slide_f64x2::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -3956,14 +3927,13 @@ impl Simd for Sse4_2 {
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
         let padding = self.splat_f64x2(padding);
-        self.slide_f64x2::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x2::<0>(a, padding),
+            1 => self.slide_f64x2::<1>(a, padding),
+            2 => self.slide_f64x2::<2>(a, padding),
+            _ => self.slide_f64x2::<2>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x2<const OFFSET: usize>(
@@ -3971,18 +3941,12 @@ impl Simd for Sse4_2 {
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
         let padding = self.splat_f64x2(padding);
         match OFFSET {
             0 => self.slide_f64x2::<2>(padding, a),
             1 => self.slide_f64x2::<1>(padding, a),
             2 => self.slide_f64x2::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x2::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -4564,23 +4528,21 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_f32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_f32x8::<0>(a, a),
+            1 => self.slide_f32x8::<1>(a, a),
+            2 => self.slide_f32x8::<2>(a, a),
+            3 => self.slide_f32x8::<3>(a, a),
+            4 => self.slide_f32x8::<4>(a, a),
+            5 => self.slide_f32x8::<5>(a, a),
+            6 => self.slide_f32x8::<6>(a, a),
+            7 => self.slide_f32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_f32x8::<8>(a, a),
             1 => self.slide_f32x8::<7>(a, a),
             2 => self.slide_f32x8::<6>(a, a),
@@ -4589,7 +4551,6 @@ impl Simd for Sse4_2 {
             5 => self.slide_f32x8::<3>(a, a),
             6 => self.slide_f32x8::<2>(a, a),
             7 => self.slide_f32x8::<1>(a, a),
-            8 => self.slide_f32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -4599,14 +4560,19 @@ impl Simd for Sse4_2 {
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f32x8(padding);
-        self.slide_f32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x8::<0>(a, padding),
+            1 => self.slide_f32x8::<1>(a, padding),
+            2 => self.slide_f32x8::<2>(a, padding),
+            3 => self.slide_f32x8::<3>(a, padding),
+            4 => self.slide_f32x8::<4>(a, padding),
+            5 => self.slide_f32x8::<5>(a, padding),
+            6 => self.slide_f32x8::<6>(a, padding),
+            7 => self.slide_f32x8::<7>(a, padding),
+            8 => self.slide_f32x8::<8>(a, padding),
+            _ => self.slide_f32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x8<const OFFSET: usize>(
@@ -4614,12 +4580,6 @@ impl Simd for Sse4_2 {
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f32x8(padding);
         match OFFSET {
             0 => self.slide_f32x8::<8>(padding, a),
@@ -4631,7 +4591,7 @@ impl Simd for Sse4_2 {
             6 => self.slide_f32x8::<2>(padding, a),
             7 => self.slide_f32x8::<1>(padding, a),
             8 => self.slide_f32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -5016,23 +4976,45 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_i8x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_i8x32::<0>(a, a),
+            1 => self.slide_i8x32::<1>(a, a),
+            2 => self.slide_i8x32::<2>(a, a),
+            3 => self.slide_i8x32::<3>(a, a),
+            4 => self.slide_i8x32::<4>(a, a),
+            5 => self.slide_i8x32::<5>(a, a),
+            6 => self.slide_i8x32::<6>(a, a),
+            7 => self.slide_i8x32::<7>(a, a),
+            8 => self.slide_i8x32::<8>(a, a),
+            9 => self.slide_i8x32::<9>(a, a),
+            10 => self.slide_i8x32::<10>(a, a),
+            11 => self.slide_i8x32::<11>(a, a),
+            12 => self.slide_i8x32::<12>(a, a),
+            13 => self.slide_i8x32::<13>(a, a),
+            14 => self.slide_i8x32::<14>(a, a),
+            15 => self.slide_i8x32::<15>(a, a),
+            16 => self.slide_i8x32::<16>(a, a),
+            17 => self.slide_i8x32::<17>(a, a),
+            18 => self.slide_i8x32::<18>(a, a),
+            19 => self.slide_i8x32::<19>(a, a),
+            20 => self.slide_i8x32::<20>(a, a),
+            21 => self.slide_i8x32::<21>(a, a),
+            22 => self.slide_i8x32::<22>(a, a),
+            23 => self.slide_i8x32::<23>(a, a),
+            24 => self.slide_i8x32::<24>(a, a),
+            25 => self.slide_i8x32::<25>(a, a),
+            26 => self.slide_i8x32::<26>(a, a),
+            27 => self.slide_i8x32::<27>(a, a),
+            28 => self.slide_i8x32::<28>(a, a),
+            29 => self.slide_i8x32::<29>(a, a),
+            30 => self.slide_i8x32::<30>(a, a),
+            31 => self.slide_i8x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_i8x32::<32>(a, a),
             1 => self.slide_i8x32::<31>(a, a),
             2 => self.slide_i8x32::<30>(a, a),
@@ -5065,7 +5047,6 @@ impl Simd for Sse4_2 {
             29 => self.slide_i8x32::<3>(a, a),
             30 => self.slide_i8x32::<2>(a, a),
             31 => self.slide_i8x32::<1>(a, a),
-            32 => self.slide_i8x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -5075,14 +5056,43 @@ impl Simd for Sse4_2 {
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i8x32(padding);
-        self.slide_i8x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x32::<0>(a, padding),
+            1 => self.slide_i8x32::<1>(a, padding),
+            2 => self.slide_i8x32::<2>(a, padding),
+            3 => self.slide_i8x32::<3>(a, padding),
+            4 => self.slide_i8x32::<4>(a, padding),
+            5 => self.slide_i8x32::<5>(a, padding),
+            6 => self.slide_i8x32::<6>(a, padding),
+            7 => self.slide_i8x32::<7>(a, padding),
+            8 => self.slide_i8x32::<8>(a, padding),
+            9 => self.slide_i8x32::<9>(a, padding),
+            10 => self.slide_i8x32::<10>(a, padding),
+            11 => self.slide_i8x32::<11>(a, padding),
+            12 => self.slide_i8x32::<12>(a, padding),
+            13 => self.slide_i8x32::<13>(a, padding),
+            14 => self.slide_i8x32::<14>(a, padding),
+            15 => self.slide_i8x32::<15>(a, padding),
+            16 => self.slide_i8x32::<16>(a, padding),
+            17 => self.slide_i8x32::<17>(a, padding),
+            18 => self.slide_i8x32::<18>(a, padding),
+            19 => self.slide_i8x32::<19>(a, padding),
+            20 => self.slide_i8x32::<20>(a, padding),
+            21 => self.slide_i8x32::<21>(a, padding),
+            22 => self.slide_i8x32::<22>(a, padding),
+            23 => self.slide_i8x32::<23>(a, padding),
+            24 => self.slide_i8x32::<24>(a, padding),
+            25 => self.slide_i8x32::<25>(a, padding),
+            26 => self.slide_i8x32::<26>(a, padding),
+            27 => self.slide_i8x32::<27>(a, padding),
+            28 => self.slide_i8x32::<28>(a, padding),
+            29 => self.slide_i8x32::<29>(a, padding),
+            30 => self.slide_i8x32::<30>(a, padding),
+            31 => self.slide_i8x32::<31>(a, padding),
+            32 => self.slide_i8x32::<32>(a, padding),
+            _ => self.slide_i8x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x32<const OFFSET: usize>(
@@ -5090,12 +5100,6 @@ impl Simd for Sse4_2 {
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i8x32(padding);
         match OFFSET {
             0 => self.slide_i8x32::<32>(padding, a),
@@ -5131,7 +5135,7 @@ impl Simd for Sse4_2 {
             30 => self.slide_i8x32::<2>(padding, a),
             31 => self.slide_i8x32::<1>(padding, a),
             32 => self.slide_i8x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -5423,23 +5427,45 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_u8x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_u8x32::<0>(a, a),
+            1 => self.slide_u8x32::<1>(a, a),
+            2 => self.slide_u8x32::<2>(a, a),
+            3 => self.slide_u8x32::<3>(a, a),
+            4 => self.slide_u8x32::<4>(a, a),
+            5 => self.slide_u8x32::<5>(a, a),
+            6 => self.slide_u8x32::<6>(a, a),
+            7 => self.slide_u8x32::<7>(a, a),
+            8 => self.slide_u8x32::<8>(a, a),
+            9 => self.slide_u8x32::<9>(a, a),
+            10 => self.slide_u8x32::<10>(a, a),
+            11 => self.slide_u8x32::<11>(a, a),
+            12 => self.slide_u8x32::<12>(a, a),
+            13 => self.slide_u8x32::<13>(a, a),
+            14 => self.slide_u8x32::<14>(a, a),
+            15 => self.slide_u8x32::<15>(a, a),
+            16 => self.slide_u8x32::<16>(a, a),
+            17 => self.slide_u8x32::<17>(a, a),
+            18 => self.slide_u8x32::<18>(a, a),
+            19 => self.slide_u8x32::<19>(a, a),
+            20 => self.slide_u8x32::<20>(a, a),
+            21 => self.slide_u8x32::<21>(a, a),
+            22 => self.slide_u8x32::<22>(a, a),
+            23 => self.slide_u8x32::<23>(a, a),
+            24 => self.slide_u8x32::<24>(a, a),
+            25 => self.slide_u8x32::<25>(a, a),
+            26 => self.slide_u8x32::<26>(a, a),
+            27 => self.slide_u8x32::<27>(a, a),
+            28 => self.slide_u8x32::<28>(a, a),
+            29 => self.slide_u8x32::<29>(a, a),
+            30 => self.slide_u8x32::<30>(a, a),
+            31 => self.slide_u8x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_u8x32::<32>(a, a),
             1 => self.slide_u8x32::<31>(a, a),
             2 => self.slide_u8x32::<30>(a, a),
@@ -5472,7 +5498,6 @@ impl Simd for Sse4_2 {
             29 => self.slide_u8x32::<3>(a, a),
             30 => self.slide_u8x32::<2>(a, a),
             31 => self.slide_u8x32::<1>(a, a),
-            32 => self.slide_u8x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -5482,14 +5507,43 @@ impl Simd for Sse4_2 {
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u8x32(padding);
-        self.slide_u8x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x32::<0>(a, padding),
+            1 => self.slide_u8x32::<1>(a, padding),
+            2 => self.slide_u8x32::<2>(a, padding),
+            3 => self.slide_u8x32::<3>(a, padding),
+            4 => self.slide_u8x32::<4>(a, padding),
+            5 => self.slide_u8x32::<5>(a, padding),
+            6 => self.slide_u8x32::<6>(a, padding),
+            7 => self.slide_u8x32::<7>(a, padding),
+            8 => self.slide_u8x32::<8>(a, padding),
+            9 => self.slide_u8x32::<9>(a, padding),
+            10 => self.slide_u8x32::<10>(a, padding),
+            11 => self.slide_u8x32::<11>(a, padding),
+            12 => self.slide_u8x32::<12>(a, padding),
+            13 => self.slide_u8x32::<13>(a, padding),
+            14 => self.slide_u8x32::<14>(a, padding),
+            15 => self.slide_u8x32::<15>(a, padding),
+            16 => self.slide_u8x32::<16>(a, padding),
+            17 => self.slide_u8x32::<17>(a, padding),
+            18 => self.slide_u8x32::<18>(a, padding),
+            19 => self.slide_u8x32::<19>(a, padding),
+            20 => self.slide_u8x32::<20>(a, padding),
+            21 => self.slide_u8x32::<21>(a, padding),
+            22 => self.slide_u8x32::<22>(a, padding),
+            23 => self.slide_u8x32::<23>(a, padding),
+            24 => self.slide_u8x32::<24>(a, padding),
+            25 => self.slide_u8x32::<25>(a, padding),
+            26 => self.slide_u8x32::<26>(a, padding),
+            27 => self.slide_u8x32::<27>(a, padding),
+            28 => self.slide_u8x32::<28>(a, padding),
+            29 => self.slide_u8x32::<29>(a, padding),
+            30 => self.slide_u8x32::<30>(a, padding),
+            31 => self.slide_u8x32::<31>(a, padding),
+            32 => self.slide_u8x32::<32>(a, padding),
+            _ => self.slide_u8x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x32<const OFFSET: usize>(
@@ -5497,12 +5551,6 @@ impl Simd for Sse4_2 {
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u8x32(padding);
         match OFFSET {
             0 => self.slide_u8x32::<32>(padding, a),
@@ -5538,7 +5586,7 @@ impl Simd for Sse4_2 {
             30 => self.slide_u8x32::<2>(padding, a),
             31 => self.slide_u8x32::<1>(padding, a),
             32 => self.slide_u8x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -5949,23 +5997,29 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i16x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i16x16::<0>(a, a),
+            1 => self.slide_i16x16::<1>(a, a),
+            2 => self.slide_i16x16::<2>(a, a),
+            3 => self.slide_i16x16::<3>(a, a),
+            4 => self.slide_i16x16::<4>(a, a),
+            5 => self.slide_i16x16::<5>(a, a),
+            6 => self.slide_i16x16::<6>(a, a),
+            7 => self.slide_i16x16::<7>(a, a),
+            8 => self.slide_i16x16::<8>(a, a),
+            9 => self.slide_i16x16::<9>(a, a),
+            10 => self.slide_i16x16::<10>(a, a),
+            11 => self.slide_i16x16::<11>(a, a),
+            12 => self.slide_i16x16::<12>(a, a),
+            13 => self.slide_i16x16::<13>(a, a),
+            14 => self.slide_i16x16::<14>(a, a),
+            15 => self.slide_i16x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i16x16::<16>(a, a),
             1 => self.slide_i16x16::<15>(a, a),
             2 => self.slide_i16x16::<14>(a, a),
@@ -5982,7 +6036,6 @@ impl Simd for Sse4_2 {
             13 => self.slide_i16x16::<3>(a, a),
             14 => self.slide_i16x16::<2>(a, a),
             15 => self.slide_i16x16::<1>(a, a),
-            16 => self.slide_i16x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -5992,14 +6045,27 @@ impl Simd for Sse4_2 {
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i16x16(padding);
-        self.slide_i16x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x16::<0>(a, padding),
+            1 => self.slide_i16x16::<1>(a, padding),
+            2 => self.slide_i16x16::<2>(a, padding),
+            3 => self.slide_i16x16::<3>(a, padding),
+            4 => self.slide_i16x16::<4>(a, padding),
+            5 => self.slide_i16x16::<5>(a, padding),
+            6 => self.slide_i16x16::<6>(a, padding),
+            7 => self.slide_i16x16::<7>(a, padding),
+            8 => self.slide_i16x16::<8>(a, padding),
+            9 => self.slide_i16x16::<9>(a, padding),
+            10 => self.slide_i16x16::<10>(a, padding),
+            11 => self.slide_i16x16::<11>(a, padding),
+            12 => self.slide_i16x16::<12>(a, padding),
+            13 => self.slide_i16x16::<13>(a, padding),
+            14 => self.slide_i16x16::<14>(a, padding),
+            15 => self.slide_i16x16::<15>(a, padding),
+            16 => self.slide_i16x16::<16>(a, padding),
+            _ => self.slide_i16x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x16<const OFFSET: usize>(
@@ -6007,12 +6073,6 @@ impl Simd for Sse4_2 {
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i16x16(padding);
         match OFFSET {
             0 => self.slide_i16x16::<16>(padding, a),
@@ -6032,7 +6092,7 @@ impl Simd for Sse4_2 {
             14 => self.slide_i16x16::<2>(padding, a),
             15 => self.slide_i16x16::<1>(padding, a),
             16 => self.slide_i16x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -6328,23 +6388,29 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u16x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u16x16::<0>(a, a),
+            1 => self.slide_u16x16::<1>(a, a),
+            2 => self.slide_u16x16::<2>(a, a),
+            3 => self.slide_u16x16::<3>(a, a),
+            4 => self.slide_u16x16::<4>(a, a),
+            5 => self.slide_u16x16::<5>(a, a),
+            6 => self.slide_u16x16::<6>(a, a),
+            7 => self.slide_u16x16::<7>(a, a),
+            8 => self.slide_u16x16::<8>(a, a),
+            9 => self.slide_u16x16::<9>(a, a),
+            10 => self.slide_u16x16::<10>(a, a),
+            11 => self.slide_u16x16::<11>(a, a),
+            12 => self.slide_u16x16::<12>(a, a),
+            13 => self.slide_u16x16::<13>(a, a),
+            14 => self.slide_u16x16::<14>(a, a),
+            15 => self.slide_u16x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u16x16::<16>(a, a),
             1 => self.slide_u16x16::<15>(a, a),
             2 => self.slide_u16x16::<14>(a, a),
@@ -6361,7 +6427,6 @@ impl Simd for Sse4_2 {
             13 => self.slide_u16x16::<3>(a, a),
             14 => self.slide_u16x16::<2>(a, a),
             15 => self.slide_u16x16::<1>(a, a),
-            16 => self.slide_u16x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -6371,14 +6436,27 @@ impl Simd for Sse4_2 {
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u16x16(padding);
-        self.slide_u16x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x16::<0>(a, padding),
+            1 => self.slide_u16x16::<1>(a, padding),
+            2 => self.slide_u16x16::<2>(a, padding),
+            3 => self.slide_u16x16::<3>(a, padding),
+            4 => self.slide_u16x16::<4>(a, padding),
+            5 => self.slide_u16x16::<5>(a, padding),
+            6 => self.slide_u16x16::<6>(a, padding),
+            7 => self.slide_u16x16::<7>(a, padding),
+            8 => self.slide_u16x16::<8>(a, padding),
+            9 => self.slide_u16x16::<9>(a, padding),
+            10 => self.slide_u16x16::<10>(a, padding),
+            11 => self.slide_u16x16::<11>(a, padding),
+            12 => self.slide_u16x16::<12>(a, padding),
+            13 => self.slide_u16x16::<13>(a, padding),
+            14 => self.slide_u16x16::<14>(a, padding),
+            15 => self.slide_u16x16::<15>(a, padding),
+            16 => self.slide_u16x16::<16>(a, padding),
+            _ => self.slide_u16x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x16<const OFFSET: usize>(
@@ -6386,12 +6464,6 @@ impl Simd for Sse4_2 {
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u16x16(padding);
         match OFFSET {
             0 => self.slide_u16x16::<16>(padding, a),
@@ -6411,7 +6483,7 @@ impl Simd for Sse4_2 {
             14 => self.slide_u16x16::<2>(padding, a),
             15 => self.slide_u16x16::<1>(padding, a),
             16 => self.slide_u16x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -6847,23 +6919,21 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_i32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_i32x8::<0>(a, a),
+            1 => self.slide_i32x8::<1>(a, a),
+            2 => self.slide_i32x8::<2>(a, a),
+            3 => self.slide_i32x8::<3>(a, a),
+            4 => self.slide_i32x8::<4>(a, a),
+            5 => self.slide_i32x8::<5>(a, a),
+            6 => self.slide_i32x8::<6>(a, a),
+            7 => self.slide_i32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_i32x8::<8>(a, a),
             1 => self.slide_i32x8::<7>(a, a),
             2 => self.slide_i32x8::<6>(a, a),
@@ -6872,7 +6942,6 @@ impl Simd for Sse4_2 {
             5 => self.slide_i32x8::<3>(a, a),
             6 => self.slide_i32x8::<2>(a, a),
             7 => self.slide_i32x8::<1>(a, a),
-            8 => self.slide_i32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -6882,14 +6951,19 @@ impl Simd for Sse4_2 {
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i32x8(padding);
-        self.slide_i32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x8::<0>(a, padding),
+            1 => self.slide_i32x8::<1>(a, padding),
+            2 => self.slide_i32x8::<2>(a, padding),
+            3 => self.slide_i32x8::<3>(a, padding),
+            4 => self.slide_i32x8::<4>(a, padding),
+            5 => self.slide_i32x8::<5>(a, padding),
+            6 => self.slide_i32x8::<6>(a, padding),
+            7 => self.slide_i32x8::<7>(a, padding),
+            8 => self.slide_i32x8::<8>(a, padding),
+            _ => self.slide_i32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x8<const OFFSET: usize>(
@@ -6897,12 +6971,6 @@ impl Simd for Sse4_2 {
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i32x8(padding);
         match OFFSET {
             0 => self.slide_i32x8::<8>(padding, a),
@@ -6914,7 +6982,7 @@ impl Simd for Sse4_2 {
             6 => self.slide_i32x8::<2>(padding, a),
             7 => self.slide_i32x8::<1>(padding, a),
             8 => self.slide_i32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7211,23 +7279,21 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_u32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_u32x8::<0>(a, a),
+            1 => self.slide_u32x8::<1>(a, a),
+            2 => self.slide_u32x8::<2>(a, a),
+            3 => self.slide_u32x8::<3>(a, a),
+            4 => self.slide_u32x8::<4>(a, a),
+            5 => self.slide_u32x8::<5>(a, a),
+            6 => self.slide_u32x8::<6>(a, a),
+            7 => self.slide_u32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_u32x8::<8>(a, a),
             1 => self.slide_u32x8::<7>(a, a),
             2 => self.slide_u32x8::<6>(a, a),
@@ -7236,7 +7302,6 @@ impl Simd for Sse4_2 {
             5 => self.slide_u32x8::<3>(a, a),
             6 => self.slide_u32x8::<2>(a, a),
             7 => self.slide_u32x8::<1>(a, a),
-            8 => self.slide_u32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -7246,14 +7311,19 @@ impl Simd for Sse4_2 {
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u32x8(padding);
-        self.slide_u32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x8::<0>(a, padding),
+            1 => self.slide_u32x8::<1>(a, padding),
+            2 => self.slide_u32x8::<2>(a, padding),
+            3 => self.slide_u32x8::<3>(a, padding),
+            4 => self.slide_u32x8::<4>(a, padding),
+            5 => self.slide_u32x8::<5>(a, padding),
+            6 => self.slide_u32x8::<6>(a, padding),
+            7 => self.slide_u32x8::<7>(a, padding),
+            8 => self.slide_u32x8::<8>(a, padding),
+            _ => self.slide_u32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x8<const OFFSET: usize>(
@@ -7261,12 +7331,6 @@ impl Simd for Sse4_2 {
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u32x8(padding);
         match OFFSET {
             0 => self.slide_u32x8::<8>(padding, a),
@@ -7278,7 +7342,7 @@ impl Simd for Sse4_2 {
             6 => self.slide_u32x8::<2>(padding, a),
             7 => self.slide_u32x8::<1>(padding, a),
             8 => self.slide_u32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7686,28 +7750,21 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_f64x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_f64x4::<0>(a, a),
+            1 => self.slide_f64x4::<1>(a, a),
+            2 => self.slide_f64x4::<2>(a, a),
+            3 => self.slide_f64x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_f64x4::<4>(a, a),
             1 => self.slide_f64x4::<3>(a, a),
             2 => self.slide_f64x4::<2>(a, a),
             3 => self.slide_f64x4::<1>(a, a),
-            4 => self.slide_f64x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -7717,14 +7774,15 @@ impl Simd for Sse4_2 {
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f64x4(padding);
-        self.slide_f64x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x4::<0>(a, padding),
+            1 => self.slide_f64x4::<1>(a, padding),
+            2 => self.slide_f64x4::<2>(a, padding),
+            3 => self.slide_f64x4::<3>(a, padding),
+            4 => self.slide_f64x4::<4>(a, padding),
+            _ => self.slide_f64x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x4<const OFFSET: usize>(
@@ -7732,12 +7790,6 @@ impl Simd for Sse4_2 {
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f64x4(padding);
         match OFFSET {
             0 => self.slide_f64x4::<4>(padding, a),
@@ -7745,7 +7797,7 @@ impl Simd for Sse4_2 {
             2 => self.slide_f64x4::<2>(padding, a),
             3 => self.slide_f64x4::<1>(padding, a),
             4 => self.slide_f64x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -8207,23 +8259,29 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_f32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_f32x16::<0>(a, a),
+            1 => self.slide_f32x16::<1>(a, a),
+            2 => self.slide_f32x16::<2>(a, a),
+            3 => self.slide_f32x16::<3>(a, a),
+            4 => self.slide_f32x16::<4>(a, a),
+            5 => self.slide_f32x16::<5>(a, a),
+            6 => self.slide_f32x16::<6>(a, a),
+            7 => self.slide_f32x16::<7>(a, a),
+            8 => self.slide_f32x16::<8>(a, a),
+            9 => self.slide_f32x16::<9>(a, a),
+            10 => self.slide_f32x16::<10>(a, a),
+            11 => self.slide_f32x16::<11>(a, a),
+            12 => self.slide_f32x16::<12>(a, a),
+            13 => self.slide_f32x16::<13>(a, a),
+            14 => self.slide_f32x16::<14>(a, a),
+            15 => self.slide_f32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_f32x16::<16>(a, a),
             1 => self.slide_f32x16::<15>(a, a),
             2 => self.slide_f32x16::<14>(a, a),
@@ -8240,7 +8298,6 @@ impl Simd for Sse4_2 {
             13 => self.slide_f32x16::<3>(a, a),
             14 => self.slide_f32x16::<2>(a, a),
             15 => self.slide_f32x16::<1>(a, a),
-            16 => self.slide_f32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -8250,14 +8307,27 @@ impl Simd for Sse4_2 {
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_f32x16(padding);
-        self.slide_f32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x16::<0>(a, padding),
+            1 => self.slide_f32x16::<1>(a, padding),
+            2 => self.slide_f32x16::<2>(a, padding),
+            3 => self.slide_f32x16::<3>(a, padding),
+            4 => self.slide_f32x16::<4>(a, padding),
+            5 => self.slide_f32x16::<5>(a, padding),
+            6 => self.slide_f32x16::<6>(a, padding),
+            7 => self.slide_f32x16::<7>(a, padding),
+            8 => self.slide_f32x16::<8>(a, padding),
+            9 => self.slide_f32x16::<9>(a, padding),
+            10 => self.slide_f32x16::<10>(a, padding),
+            11 => self.slide_f32x16::<11>(a, padding),
+            12 => self.slide_f32x16::<12>(a, padding),
+            13 => self.slide_f32x16::<13>(a, padding),
+            14 => self.slide_f32x16::<14>(a, padding),
+            15 => self.slide_f32x16::<15>(a, padding),
+            16 => self.slide_f32x16::<16>(a, padding),
+            _ => self.slide_f32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x16<const OFFSET: usize>(
@@ -8265,12 +8335,6 @@ impl Simd for Sse4_2 {
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_f32x16(padding);
         match OFFSET {
             0 => self.slide_f32x16::<16>(padding, a),
@@ -8290,7 +8354,7 @@ impl Simd for Sse4_2 {
             14 => self.slide_f32x16::<2>(padding, a),
             15 => self.slide_f32x16::<1>(padding, a),
             16 => self.slide_f32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -8747,23 +8811,77 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        self.slide_i8x64::<OFFSET>(a, a)
+        match OFFSET % 64 {
+            0 => self.slide_i8x64::<0>(a, a),
+            1 => self.slide_i8x64::<1>(a, a),
+            2 => self.slide_i8x64::<2>(a, a),
+            3 => self.slide_i8x64::<3>(a, a),
+            4 => self.slide_i8x64::<4>(a, a),
+            5 => self.slide_i8x64::<5>(a, a),
+            6 => self.slide_i8x64::<6>(a, a),
+            7 => self.slide_i8x64::<7>(a, a),
+            8 => self.slide_i8x64::<8>(a, a),
+            9 => self.slide_i8x64::<9>(a, a),
+            10 => self.slide_i8x64::<10>(a, a),
+            11 => self.slide_i8x64::<11>(a, a),
+            12 => self.slide_i8x64::<12>(a, a),
+            13 => self.slide_i8x64::<13>(a, a),
+            14 => self.slide_i8x64::<14>(a, a),
+            15 => self.slide_i8x64::<15>(a, a),
+            16 => self.slide_i8x64::<16>(a, a),
+            17 => self.slide_i8x64::<17>(a, a),
+            18 => self.slide_i8x64::<18>(a, a),
+            19 => self.slide_i8x64::<19>(a, a),
+            20 => self.slide_i8x64::<20>(a, a),
+            21 => self.slide_i8x64::<21>(a, a),
+            22 => self.slide_i8x64::<22>(a, a),
+            23 => self.slide_i8x64::<23>(a, a),
+            24 => self.slide_i8x64::<24>(a, a),
+            25 => self.slide_i8x64::<25>(a, a),
+            26 => self.slide_i8x64::<26>(a, a),
+            27 => self.slide_i8x64::<27>(a, a),
+            28 => self.slide_i8x64::<28>(a, a),
+            29 => self.slide_i8x64::<29>(a, a),
+            30 => self.slide_i8x64::<30>(a, a),
+            31 => self.slide_i8x64::<31>(a, a),
+            32 => self.slide_i8x64::<32>(a, a),
+            33 => self.slide_i8x64::<33>(a, a),
+            34 => self.slide_i8x64::<34>(a, a),
+            35 => self.slide_i8x64::<35>(a, a),
+            36 => self.slide_i8x64::<36>(a, a),
+            37 => self.slide_i8x64::<37>(a, a),
+            38 => self.slide_i8x64::<38>(a, a),
+            39 => self.slide_i8x64::<39>(a, a),
+            40 => self.slide_i8x64::<40>(a, a),
+            41 => self.slide_i8x64::<41>(a, a),
+            42 => self.slide_i8x64::<42>(a, a),
+            43 => self.slide_i8x64::<43>(a, a),
+            44 => self.slide_i8x64::<44>(a, a),
+            45 => self.slide_i8x64::<45>(a, a),
+            46 => self.slide_i8x64::<46>(a, a),
+            47 => self.slide_i8x64::<47>(a, a),
+            48 => self.slide_i8x64::<48>(a, a),
+            49 => self.slide_i8x64::<49>(a, a),
+            50 => self.slide_i8x64::<50>(a, a),
+            51 => self.slide_i8x64::<51>(a, a),
+            52 => self.slide_i8x64::<52>(a, a),
+            53 => self.slide_i8x64::<53>(a, a),
+            54 => self.slide_i8x64::<54>(a, a),
+            55 => self.slide_i8x64::<55>(a, a),
+            56 => self.slide_i8x64::<56>(a, a),
+            57 => self.slide_i8x64::<57>(a, a),
+            58 => self.slide_i8x64::<58>(a, a),
+            59 => self.slide_i8x64::<59>(a, a),
+            60 => self.slide_i8x64::<60>(a, a),
+            61 => self.slide_i8x64::<61>(a, a),
+            62 => self.slide_i8x64::<62>(a, a),
+            63 => self.slide_i8x64::<63>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        match OFFSET {
+        match OFFSET % 64 {
             0 => self.slide_i8x64::<64>(a, a),
             1 => self.slide_i8x64::<63>(a, a),
             2 => self.slide_i8x64::<62>(a, a),
@@ -8828,7 +8946,6 @@ impl Simd for Sse4_2 {
             61 => self.slide_i8x64::<3>(a, a),
             62 => self.slide_i8x64::<2>(a, a),
             63 => self.slide_i8x64::<1>(a, a),
-            64 => self.slide_i8x64::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -8838,14 +8955,75 @@ impl Simd for Sse4_2 {
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_i8x64(padding);
-        self.slide_i8x64::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x64::<0>(a, padding),
+            1 => self.slide_i8x64::<1>(a, padding),
+            2 => self.slide_i8x64::<2>(a, padding),
+            3 => self.slide_i8x64::<3>(a, padding),
+            4 => self.slide_i8x64::<4>(a, padding),
+            5 => self.slide_i8x64::<5>(a, padding),
+            6 => self.slide_i8x64::<6>(a, padding),
+            7 => self.slide_i8x64::<7>(a, padding),
+            8 => self.slide_i8x64::<8>(a, padding),
+            9 => self.slide_i8x64::<9>(a, padding),
+            10 => self.slide_i8x64::<10>(a, padding),
+            11 => self.slide_i8x64::<11>(a, padding),
+            12 => self.slide_i8x64::<12>(a, padding),
+            13 => self.slide_i8x64::<13>(a, padding),
+            14 => self.slide_i8x64::<14>(a, padding),
+            15 => self.slide_i8x64::<15>(a, padding),
+            16 => self.slide_i8x64::<16>(a, padding),
+            17 => self.slide_i8x64::<17>(a, padding),
+            18 => self.slide_i8x64::<18>(a, padding),
+            19 => self.slide_i8x64::<19>(a, padding),
+            20 => self.slide_i8x64::<20>(a, padding),
+            21 => self.slide_i8x64::<21>(a, padding),
+            22 => self.slide_i8x64::<22>(a, padding),
+            23 => self.slide_i8x64::<23>(a, padding),
+            24 => self.slide_i8x64::<24>(a, padding),
+            25 => self.slide_i8x64::<25>(a, padding),
+            26 => self.slide_i8x64::<26>(a, padding),
+            27 => self.slide_i8x64::<27>(a, padding),
+            28 => self.slide_i8x64::<28>(a, padding),
+            29 => self.slide_i8x64::<29>(a, padding),
+            30 => self.slide_i8x64::<30>(a, padding),
+            31 => self.slide_i8x64::<31>(a, padding),
+            32 => self.slide_i8x64::<32>(a, padding),
+            33 => self.slide_i8x64::<33>(a, padding),
+            34 => self.slide_i8x64::<34>(a, padding),
+            35 => self.slide_i8x64::<35>(a, padding),
+            36 => self.slide_i8x64::<36>(a, padding),
+            37 => self.slide_i8x64::<37>(a, padding),
+            38 => self.slide_i8x64::<38>(a, padding),
+            39 => self.slide_i8x64::<39>(a, padding),
+            40 => self.slide_i8x64::<40>(a, padding),
+            41 => self.slide_i8x64::<41>(a, padding),
+            42 => self.slide_i8x64::<42>(a, padding),
+            43 => self.slide_i8x64::<43>(a, padding),
+            44 => self.slide_i8x64::<44>(a, padding),
+            45 => self.slide_i8x64::<45>(a, padding),
+            46 => self.slide_i8x64::<46>(a, padding),
+            47 => self.slide_i8x64::<47>(a, padding),
+            48 => self.slide_i8x64::<48>(a, padding),
+            49 => self.slide_i8x64::<49>(a, padding),
+            50 => self.slide_i8x64::<50>(a, padding),
+            51 => self.slide_i8x64::<51>(a, padding),
+            52 => self.slide_i8x64::<52>(a, padding),
+            53 => self.slide_i8x64::<53>(a, padding),
+            54 => self.slide_i8x64::<54>(a, padding),
+            55 => self.slide_i8x64::<55>(a, padding),
+            56 => self.slide_i8x64::<56>(a, padding),
+            57 => self.slide_i8x64::<57>(a, padding),
+            58 => self.slide_i8x64::<58>(a, padding),
+            59 => self.slide_i8x64::<59>(a, padding),
+            60 => self.slide_i8x64::<60>(a, padding),
+            61 => self.slide_i8x64::<61>(a, padding),
+            62 => self.slide_i8x64::<62>(a, padding),
+            63 => self.slide_i8x64::<63>(a, padding),
+            64 => self.slide_i8x64::<64>(a, padding),
+            _ => self.slide_i8x64::<64>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x64<const OFFSET: usize>(
@@ -8853,12 +9031,6 @@ impl Simd for Sse4_2 {
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_i8x64(padding);
         match OFFSET {
             0 => self.slide_i8x64::<64>(padding, a),
@@ -8926,7 +9098,7 @@ impl Simd for Sse4_2 {
             62 => self.slide_i8x64::<2>(padding, a),
             63 => self.slide_i8x64::<1>(padding, a),
             64 => self.slide_i8x64::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x64::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -9211,23 +9383,77 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        self.slide_u8x64::<OFFSET>(a, a)
+        match OFFSET % 64 {
+            0 => self.slide_u8x64::<0>(a, a),
+            1 => self.slide_u8x64::<1>(a, a),
+            2 => self.slide_u8x64::<2>(a, a),
+            3 => self.slide_u8x64::<3>(a, a),
+            4 => self.slide_u8x64::<4>(a, a),
+            5 => self.slide_u8x64::<5>(a, a),
+            6 => self.slide_u8x64::<6>(a, a),
+            7 => self.slide_u8x64::<7>(a, a),
+            8 => self.slide_u8x64::<8>(a, a),
+            9 => self.slide_u8x64::<9>(a, a),
+            10 => self.slide_u8x64::<10>(a, a),
+            11 => self.slide_u8x64::<11>(a, a),
+            12 => self.slide_u8x64::<12>(a, a),
+            13 => self.slide_u8x64::<13>(a, a),
+            14 => self.slide_u8x64::<14>(a, a),
+            15 => self.slide_u8x64::<15>(a, a),
+            16 => self.slide_u8x64::<16>(a, a),
+            17 => self.slide_u8x64::<17>(a, a),
+            18 => self.slide_u8x64::<18>(a, a),
+            19 => self.slide_u8x64::<19>(a, a),
+            20 => self.slide_u8x64::<20>(a, a),
+            21 => self.slide_u8x64::<21>(a, a),
+            22 => self.slide_u8x64::<22>(a, a),
+            23 => self.slide_u8x64::<23>(a, a),
+            24 => self.slide_u8x64::<24>(a, a),
+            25 => self.slide_u8x64::<25>(a, a),
+            26 => self.slide_u8x64::<26>(a, a),
+            27 => self.slide_u8x64::<27>(a, a),
+            28 => self.slide_u8x64::<28>(a, a),
+            29 => self.slide_u8x64::<29>(a, a),
+            30 => self.slide_u8x64::<30>(a, a),
+            31 => self.slide_u8x64::<31>(a, a),
+            32 => self.slide_u8x64::<32>(a, a),
+            33 => self.slide_u8x64::<33>(a, a),
+            34 => self.slide_u8x64::<34>(a, a),
+            35 => self.slide_u8x64::<35>(a, a),
+            36 => self.slide_u8x64::<36>(a, a),
+            37 => self.slide_u8x64::<37>(a, a),
+            38 => self.slide_u8x64::<38>(a, a),
+            39 => self.slide_u8x64::<39>(a, a),
+            40 => self.slide_u8x64::<40>(a, a),
+            41 => self.slide_u8x64::<41>(a, a),
+            42 => self.slide_u8x64::<42>(a, a),
+            43 => self.slide_u8x64::<43>(a, a),
+            44 => self.slide_u8x64::<44>(a, a),
+            45 => self.slide_u8x64::<45>(a, a),
+            46 => self.slide_u8x64::<46>(a, a),
+            47 => self.slide_u8x64::<47>(a, a),
+            48 => self.slide_u8x64::<48>(a, a),
+            49 => self.slide_u8x64::<49>(a, a),
+            50 => self.slide_u8x64::<50>(a, a),
+            51 => self.slide_u8x64::<51>(a, a),
+            52 => self.slide_u8x64::<52>(a, a),
+            53 => self.slide_u8x64::<53>(a, a),
+            54 => self.slide_u8x64::<54>(a, a),
+            55 => self.slide_u8x64::<55>(a, a),
+            56 => self.slide_u8x64::<56>(a, a),
+            57 => self.slide_u8x64::<57>(a, a),
+            58 => self.slide_u8x64::<58>(a, a),
+            59 => self.slide_u8x64::<59>(a, a),
+            60 => self.slide_u8x64::<60>(a, a),
+            61 => self.slide_u8x64::<61>(a, a),
+            62 => self.slide_u8x64::<62>(a, a),
+            63 => self.slide_u8x64::<63>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        match OFFSET {
+        match OFFSET % 64 {
             0 => self.slide_u8x64::<64>(a, a),
             1 => self.slide_u8x64::<63>(a, a),
             2 => self.slide_u8x64::<62>(a, a),
@@ -9292,7 +9518,6 @@ impl Simd for Sse4_2 {
             61 => self.slide_u8x64::<3>(a, a),
             62 => self.slide_u8x64::<2>(a, a),
             63 => self.slide_u8x64::<1>(a, a),
-            64 => self.slide_u8x64::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -9302,14 +9527,75 @@ impl Simd for Sse4_2 {
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_u8x64(padding);
-        self.slide_u8x64::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x64::<0>(a, padding),
+            1 => self.slide_u8x64::<1>(a, padding),
+            2 => self.slide_u8x64::<2>(a, padding),
+            3 => self.slide_u8x64::<3>(a, padding),
+            4 => self.slide_u8x64::<4>(a, padding),
+            5 => self.slide_u8x64::<5>(a, padding),
+            6 => self.slide_u8x64::<6>(a, padding),
+            7 => self.slide_u8x64::<7>(a, padding),
+            8 => self.slide_u8x64::<8>(a, padding),
+            9 => self.slide_u8x64::<9>(a, padding),
+            10 => self.slide_u8x64::<10>(a, padding),
+            11 => self.slide_u8x64::<11>(a, padding),
+            12 => self.slide_u8x64::<12>(a, padding),
+            13 => self.slide_u8x64::<13>(a, padding),
+            14 => self.slide_u8x64::<14>(a, padding),
+            15 => self.slide_u8x64::<15>(a, padding),
+            16 => self.slide_u8x64::<16>(a, padding),
+            17 => self.slide_u8x64::<17>(a, padding),
+            18 => self.slide_u8x64::<18>(a, padding),
+            19 => self.slide_u8x64::<19>(a, padding),
+            20 => self.slide_u8x64::<20>(a, padding),
+            21 => self.slide_u8x64::<21>(a, padding),
+            22 => self.slide_u8x64::<22>(a, padding),
+            23 => self.slide_u8x64::<23>(a, padding),
+            24 => self.slide_u8x64::<24>(a, padding),
+            25 => self.slide_u8x64::<25>(a, padding),
+            26 => self.slide_u8x64::<26>(a, padding),
+            27 => self.slide_u8x64::<27>(a, padding),
+            28 => self.slide_u8x64::<28>(a, padding),
+            29 => self.slide_u8x64::<29>(a, padding),
+            30 => self.slide_u8x64::<30>(a, padding),
+            31 => self.slide_u8x64::<31>(a, padding),
+            32 => self.slide_u8x64::<32>(a, padding),
+            33 => self.slide_u8x64::<33>(a, padding),
+            34 => self.slide_u8x64::<34>(a, padding),
+            35 => self.slide_u8x64::<35>(a, padding),
+            36 => self.slide_u8x64::<36>(a, padding),
+            37 => self.slide_u8x64::<37>(a, padding),
+            38 => self.slide_u8x64::<38>(a, padding),
+            39 => self.slide_u8x64::<39>(a, padding),
+            40 => self.slide_u8x64::<40>(a, padding),
+            41 => self.slide_u8x64::<41>(a, padding),
+            42 => self.slide_u8x64::<42>(a, padding),
+            43 => self.slide_u8x64::<43>(a, padding),
+            44 => self.slide_u8x64::<44>(a, padding),
+            45 => self.slide_u8x64::<45>(a, padding),
+            46 => self.slide_u8x64::<46>(a, padding),
+            47 => self.slide_u8x64::<47>(a, padding),
+            48 => self.slide_u8x64::<48>(a, padding),
+            49 => self.slide_u8x64::<49>(a, padding),
+            50 => self.slide_u8x64::<50>(a, padding),
+            51 => self.slide_u8x64::<51>(a, padding),
+            52 => self.slide_u8x64::<52>(a, padding),
+            53 => self.slide_u8x64::<53>(a, padding),
+            54 => self.slide_u8x64::<54>(a, padding),
+            55 => self.slide_u8x64::<55>(a, padding),
+            56 => self.slide_u8x64::<56>(a, padding),
+            57 => self.slide_u8x64::<57>(a, padding),
+            58 => self.slide_u8x64::<58>(a, padding),
+            59 => self.slide_u8x64::<59>(a, padding),
+            60 => self.slide_u8x64::<60>(a, padding),
+            61 => self.slide_u8x64::<61>(a, padding),
+            62 => self.slide_u8x64::<62>(a, padding),
+            63 => self.slide_u8x64::<63>(a, padding),
+            64 => self.slide_u8x64::<64>(a, padding),
+            _ => self.slide_u8x64::<64>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x64<const OFFSET: usize>(
@@ -9317,12 +9603,6 @@ impl Simd for Sse4_2 {
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_u8x64(padding);
         match OFFSET {
             0 => self.slide_u8x64::<64>(padding, a),
@@ -9390,7 +9670,7 @@ impl Simd for Sse4_2 {
             62 => self.slide_u8x64::<2>(padding, a),
             63 => self.slide_u8x64::<1>(padding, a),
             64 => self.slide_u8x64::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x64::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -9908,23 +10188,45 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_i16x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_i16x32::<0>(a, a),
+            1 => self.slide_i16x32::<1>(a, a),
+            2 => self.slide_i16x32::<2>(a, a),
+            3 => self.slide_i16x32::<3>(a, a),
+            4 => self.slide_i16x32::<4>(a, a),
+            5 => self.slide_i16x32::<5>(a, a),
+            6 => self.slide_i16x32::<6>(a, a),
+            7 => self.slide_i16x32::<7>(a, a),
+            8 => self.slide_i16x32::<8>(a, a),
+            9 => self.slide_i16x32::<9>(a, a),
+            10 => self.slide_i16x32::<10>(a, a),
+            11 => self.slide_i16x32::<11>(a, a),
+            12 => self.slide_i16x32::<12>(a, a),
+            13 => self.slide_i16x32::<13>(a, a),
+            14 => self.slide_i16x32::<14>(a, a),
+            15 => self.slide_i16x32::<15>(a, a),
+            16 => self.slide_i16x32::<16>(a, a),
+            17 => self.slide_i16x32::<17>(a, a),
+            18 => self.slide_i16x32::<18>(a, a),
+            19 => self.slide_i16x32::<19>(a, a),
+            20 => self.slide_i16x32::<20>(a, a),
+            21 => self.slide_i16x32::<21>(a, a),
+            22 => self.slide_i16x32::<22>(a, a),
+            23 => self.slide_i16x32::<23>(a, a),
+            24 => self.slide_i16x32::<24>(a, a),
+            25 => self.slide_i16x32::<25>(a, a),
+            26 => self.slide_i16x32::<26>(a, a),
+            27 => self.slide_i16x32::<27>(a, a),
+            28 => self.slide_i16x32::<28>(a, a),
+            29 => self.slide_i16x32::<29>(a, a),
+            30 => self.slide_i16x32::<30>(a, a),
+            31 => self.slide_i16x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_i16x32::<32>(a, a),
             1 => self.slide_i16x32::<31>(a, a),
             2 => self.slide_i16x32::<30>(a, a),
@@ -9957,7 +10259,6 @@ impl Simd for Sse4_2 {
             29 => self.slide_i16x32::<3>(a, a),
             30 => self.slide_i16x32::<2>(a, a),
             31 => self.slide_i16x32::<1>(a, a),
-            32 => self.slide_i16x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -9967,14 +10268,43 @@ impl Simd for Sse4_2 {
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i16x32(padding);
-        self.slide_i16x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x32::<0>(a, padding),
+            1 => self.slide_i16x32::<1>(a, padding),
+            2 => self.slide_i16x32::<2>(a, padding),
+            3 => self.slide_i16x32::<3>(a, padding),
+            4 => self.slide_i16x32::<4>(a, padding),
+            5 => self.slide_i16x32::<5>(a, padding),
+            6 => self.slide_i16x32::<6>(a, padding),
+            7 => self.slide_i16x32::<7>(a, padding),
+            8 => self.slide_i16x32::<8>(a, padding),
+            9 => self.slide_i16x32::<9>(a, padding),
+            10 => self.slide_i16x32::<10>(a, padding),
+            11 => self.slide_i16x32::<11>(a, padding),
+            12 => self.slide_i16x32::<12>(a, padding),
+            13 => self.slide_i16x32::<13>(a, padding),
+            14 => self.slide_i16x32::<14>(a, padding),
+            15 => self.slide_i16x32::<15>(a, padding),
+            16 => self.slide_i16x32::<16>(a, padding),
+            17 => self.slide_i16x32::<17>(a, padding),
+            18 => self.slide_i16x32::<18>(a, padding),
+            19 => self.slide_i16x32::<19>(a, padding),
+            20 => self.slide_i16x32::<20>(a, padding),
+            21 => self.slide_i16x32::<21>(a, padding),
+            22 => self.slide_i16x32::<22>(a, padding),
+            23 => self.slide_i16x32::<23>(a, padding),
+            24 => self.slide_i16x32::<24>(a, padding),
+            25 => self.slide_i16x32::<25>(a, padding),
+            26 => self.slide_i16x32::<26>(a, padding),
+            27 => self.slide_i16x32::<27>(a, padding),
+            28 => self.slide_i16x32::<28>(a, padding),
+            29 => self.slide_i16x32::<29>(a, padding),
+            30 => self.slide_i16x32::<30>(a, padding),
+            31 => self.slide_i16x32::<31>(a, padding),
+            32 => self.slide_i16x32::<32>(a, padding),
+            _ => self.slide_i16x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x32<const OFFSET: usize>(
@@ -9982,12 +10312,6 @@ impl Simd for Sse4_2 {
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i16x32(padding);
         match OFFSET {
             0 => self.slide_i16x32::<32>(padding, a),
@@ -10023,7 +10347,7 @@ impl Simd for Sse4_2 {
             30 => self.slide_i16x32::<2>(padding, a),
             31 => self.slide_i16x32::<1>(padding, a),
             32 => self.slide_i16x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -10321,23 +10645,45 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_u16x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_u16x32::<0>(a, a),
+            1 => self.slide_u16x32::<1>(a, a),
+            2 => self.slide_u16x32::<2>(a, a),
+            3 => self.slide_u16x32::<3>(a, a),
+            4 => self.slide_u16x32::<4>(a, a),
+            5 => self.slide_u16x32::<5>(a, a),
+            6 => self.slide_u16x32::<6>(a, a),
+            7 => self.slide_u16x32::<7>(a, a),
+            8 => self.slide_u16x32::<8>(a, a),
+            9 => self.slide_u16x32::<9>(a, a),
+            10 => self.slide_u16x32::<10>(a, a),
+            11 => self.slide_u16x32::<11>(a, a),
+            12 => self.slide_u16x32::<12>(a, a),
+            13 => self.slide_u16x32::<13>(a, a),
+            14 => self.slide_u16x32::<14>(a, a),
+            15 => self.slide_u16x32::<15>(a, a),
+            16 => self.slide_u16x32::<16>(a, a),
+            17 => self.slide_u16x32::<17>(a, a),
+            18 => self.slide_u16x32::<18>(a, a),
+            19 => self.slide_u16x32::<19>(a, a),
+            20 => self.slide_u16x32::<20>(a, a),
+            21 => self.slide_u16x32::<21>(a, a),
+            22 => self.slide_u16x32::<22>(a, a),
+            23 => self.slide_u16x32::<23>(a, a),
+            24 => self.slide_u16x32::<24>(a, a),
+            25 => self.slide_u16x32::<25>(a, a),
+            26 => self.slide_u16x32::<26>(a, a),
+            27 => self.slide_u16x32::<27>(a, a),
+            28 => self.slide_u16x32::<28>(a, a),
+            29 => self.slide_u16x32::<29>(a, a),
+            30 => self.slide_u16x32::<30>(a, a),
+            31 => self.slide_u16x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_u16x32::<32>(a, a),
             1 => self.slide_u16x32::<31>(a, a),
             2 => self.slide_u16x32::<30>(a, a),
@@ -10370,7 +10716,6 @@ impl Simd for Sse4_2 {
             29 => self.slide_u16x32::<3>(a, a),
             30 => self.slide_u16x32::<2>(a, a),
             31 => self.slide_u16x32::<1>(a, a),
-            32 => self.slide_u16x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -10380,14 +10725,43 @@ impl Simd for Sse4_2 {
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u16x32(padding);
-        self.slide_u16x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x32::<0>(a, padding),
+            1 => self.slide_u16x32::<1>(a, padding),
+            2 => self.slide_u16x32::<2>(a, padding),
+            3 => self.slide_u16x32::<3>(a, padding),
+            4 => self.slide_u16x32::<4>(a, padding),
+            5 => self.slide_u16x32::<5>(a, padding),
+            6 => self.slide_u16x32::<6>(a, padding),
+            7 => self.slide_u16x32::<7>(a, padding),
+            8 => self.slide_u16x32::<8>(a, padding),
+            9 => self.slide_u16x32::<9>(a, padding),
+            10 => self.slide_u16x32::<10>(a, padding),
+            11 => self.slide_u16x32::<11>(a, padding),
+            12 => self.slide_u16x32::<12>(a, padding),
+            13 => self.slide_u16x32::<13>(a, padding),
+            14 => self.slide_u16x32::<14>(a, padding),
+            15 => self.slide_u16x32::<15>(a, padding),
+            16 => self.slide_u16x32::<16>(a, padding),
+            17 => self.slide_u16x32::<17>(a, padding),
+            18 => self.slide_u16x32::<18>(a, padding),
+            19 => self.slide_u16x32::<19>(a, padding),
+            20 => self.slide_u16x32::<20>(a, padding),
+            21 => self.slide_u16x32::<21>(a, padding),
+            22 => self.slide_u16x32::<22>(a, padding),
+            23 => self.slide_u16x32::<23>(a, padding),
+            24 => self.slide_u16x32::<24>(a, padding),
+            25 => self.slide_u16x32::<25>(a, padding),
+            26 => self.slide_u16x32::<26>(a, padding),
+            27 => self.slide_u16x32::<27>(a, padding),
+            28 => self.slide_u16x32::<28>(a, padding),
+            29 => self.slide_u16x32::<29>(a, padding),
+            30 => self.slide_u16x32::<30>(a, padding),
+            31 => self.slide_u16x32::<31>(a, padding),
+            32 => self.slide_u16x32::<32>(a, padding),
+            _ => self.slide_u16x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x32<const OFFSET: usize>(
@@ -10395,12 +10769,6 @@ impl Simd for Sse4_2 {
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u16x32(padding);
         match OFFSET {
             0 => self.slide_u16x32::<32>(padding, a),
@@ -10436,7 +10804,7 @@ impl Simd for Sse4_2 {
             30 => self.slide_u16x32::<2>(padding, a),
             31 => self.slide_u16x32::<1>(padding, a),
             32 => self.slide_u16x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -10948,23 +11316,29 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i32x16::<0>(a, a),
+            1 => self.slide_i32x16::<1>(a, a),
+            2 => self.slide_i32x16::<2>(a, a),
+            3 => self.slide_i32x16::<3>(a, a),
+            4 => self.slide_i32x16::<4>(a, a),
+            5 => self.slide_i32x16::<5>(a, a),
+            6 => self.slide_i32x16::<6>(a, a),
+            7 => self.slide_i32x16::<7>(a, a),
+            8 => self.slide_i32x16::<8>(a, a),
+            9 => self.slide_i32x16::<9>(a, a),
+            10 => self.slide_i32x16::<10>(a, a),
+            11 => self.slide_i32x16::<11>(a, a),
+            12 => self.slide_i32x16::<12>(a, a),
+            13 => self.slide_i32x16::<13>(a, a),
+            14 => self.slide_i32x16::<14>(a, a),
+            15 => self.slide_i32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i32x16::<16>(a, a),
             1 => self.slide_i32x16::<15>(a, a),
             2 => self.slide_i32x16::<14>(a, a),
@@ -10981,7 +11355,6 @@ impl Simd for Sse4_2 {
             13 => self.slide_i32x16::<3>(a, a),
             14 => self.slide_i32x16::<2>(a, a),
             15 => self.slide_i32x16::<1>(a, a),
-            16 => self.slide_i32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -10991,14 +11364,27 @@ impl Simd for Sse4_2 {
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i32x16(padding);
-        self.slide_i32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x16::<0>(a, padding),
+            1 => self.slide_i32x16::<1>(a, padding),
+            2 => self.slide_i32x16::<2>(a, padding),
+            3 => self.slide_i32x16::<3>(a, padding),
+            4 => self.slide_i32x16::<4>(a, padding),
+            5 => self.slide_i32x16::<5>(a, padding),
+            6 => self.slide_i32x16::<6>(a, padding),
+            7 => self.slide_i32x16::<7>(a, padding),
+            8 => self.slide_i32x16::<8>(a, padding),
+            9 => self.slide_i32x16::<9>(a, padding),
+            10 => self.slide_i32x16::<10>(a, padding),
+            11 => self.slide_i32x16::<11>(a, padding),
+            12 => self.slide_i32x16::<12>(a, padding),
+            13 => self.slide_i32x16::<13>(a, padding),
+            14 => self.slide_i32x16::<14>(a, padding),
+            15 => self.slide_i32x16::<15>(a, padding),
+            16 => self.slide_i32x16::<16>(a, padding),
+            _ => self.slide_i32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x16<const OFFSET: usize>(
@@ -11006,12 +11392,6 @@ impl Simd for Sse4_2 {
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i32x16(padding);
         match OFFSET {
             0 => self.slide_i32x16::<16>(padding, a),
@@ -11031,7 +11411,7 @@ impl Simd for Sse4_2 {
             14 => self.slide_i32x16::<2>(padding, a),
             15 => self.slide_i32x16::<1>(padding, a),
             16 => self.slide_i32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -11325,23 +11705,29 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u32x16::<0>(a, a),
+            1 => self.slide_u32x16::<1>(a, a),
+            2 => self.slide_u32x16::<2>(a, a),
+            3 => self.slide_u32x16::<3>(a, a),
+            4 => self.slide_u32x16::<4>(a, a),
+            5 => self.slide_u32x16::<5>(a, a),
+            6 => self.slide_u32x16::<6>(a, a),
+            7 => self.slide_u32x16::<7>(a, a),
+            8 => self.slide_u32x16::<8>(a, a),
+            9 => self.slide_u32x16::<9>(a, a),
+            10 => self.slide_u32x16::<10>(a, a),
+            11 => self.slide_u32x16::<11>(a, a),
+            12 => self.slide_u32x16::<12>(a, a),
+            13 => self.slide_u32x16::<13>(a, a),
+            14 => self.slide_u32x16::<14>(a, a),
+            15 => self.slide_u32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u32x16::<16>(a, a),
             1 => self.slide_u32x16::<15>(a, a),
             2 => self.slide_u32x16::<14>(a, a),
@@ -11358,7 +11744,6 @@ impl Simd for Sse4_2 {
             13 => self.slide_u32x16::<3>(a, a),
             14 => self.slide_u32x16::<2>(a, a),
             15 => self.slide_u32x16::<1>(a, a),
-            16 => self.slide_u32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -11368,14 +11753,27 @@ impl Simd for Sse4_2 {
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u32x16(padding);
-        self.slide_u32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x16::<0>(a, padding),
+            1 => self.slide_u32x16::<1>(a, padding),
+            2 => self.slide_u32x16::<2>(a, padding),
+            3 => self.slide_u32x16::<3>(a, padding),
+            4 => self.slide_u32x16::<4>(a, padding),
+            5 => self.slide_u32x16::<5>(a, padding),
+            6 => self.slide_u32x16::<6>(a, padding),
+            7 => self.slide_u32x16::<7>(a, padding),
+            8 => self.slide_u32x16::<8>(a, padding),
+            9 => self.slide_u32x16::<9>(a, padding),
+            10 => self.slide_u32x16::<10>(a, padding),
+            11 => self.slide_u32x16::<11>(a, padding),
+            12 => self.slide_u32x16::<12>(a, padding),
+            13 => self.slide_u32x16::<13>(a, padding),
+            14 => self.slide_u32x16::<14>(a, padding),
+            15 => self.slide_u32x16::<15>(a, padding),
+            16 => self.slide_u32x16::<16>(a, padding),
+            _ => self.slide_u32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x16<const OFFSET: usize>(
@@ -11383,12 +11781,6 @@ impl Simd for Sse4_2 {
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u32x16(padding);
         match OFFSET {
             0 => self.slide_u32x16::<16>(padding, a),
@@ -11408,7 +11800,7 @@ impl Simd for Sse4_2 {
             14 => self.slide_u32x16::<2>(padding, a),
             15 => self.slide_u32x16::<1>(padding, a),
             16 => self.slide_u32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -11881,23 +12273,21 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_f64x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_f64x8::<0>(a, a),
+            1 => self.slide_f64x8::<1>(a, a),
+            2 => self.slide_f64x8::<2>(a, a),
+            3 => self.slide_f64x8::<3>(a, a),
+            4 => self.slide_f64x8::<4>(a, a),
+            5 => self.slide_f64x8::<5>(a, a),
+            6 => self.slide_f64x8::<6>(a, a),
+            7 => self.slide_f64x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_f64x8::<8>(a, a),
             1 => self.slide_f64x8::<7>(a, a),
             2 => self.slide_f64x8::<6>(a, a),
@@ -11906,7 +12296,6 @@ impl Simd for Sse4_2 {
             5 => self.slide_f64x8::<3>(a, a),
             6 => self.slide_f64x8::<2>(a, a),
             7 => self.slide_f64x8::<1>(a, a),
-            8 => self.slide_f64x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -11916,14 +12305,19 @@ impl Simd for Sse4_2 {
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f64x8(padding);
-        self.slide_f64x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x8::<0>(a, padding),
+            1 => self.slide_f64x8::<1>(a, padding),
+            2 => self.slide_f64x8::<2>(a, padding),
+            3 => self.slide_f64x8::<3>(a, padding),
+            4 => self.slide_f64x8::<4>(a, padding),
+            5 => self.slide_f64x8::<5>(a, padding),
+            6 => self.slide_f64x8::<6>(a, padding),
+            7 => self.slide_f64x8::<7>(a, padding),
+            8 => self.slide_f64x8::<8>(a, padding),
+            _ => self.slide_f64x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x8<const OFFSET: usize>(
@@ -11931,12 +12325,6 @@ impl Simd for Sse4_2 {
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f64x8(padding);
         match OFFSET {
             0 => self.slide_f64x8::<8>(padding, a),
@@ -11948,7 +12336,7 @@ impl Simd for Sse4_2 {
             6 => self.slide_f64x8::<2>(padding, a),
             7 => self.slide_f64x8::<1>(padding, a),
             8 => self.slide_f64x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x8::<0>(padding, a),
         }
     }
     #[inline(always)]

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -174,6 +174,70 @@ impl Simd for Sse4_2 {
         self.slide_f32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_f32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_f32x4::<4>(a, a),
+            1 => self.slide_f32x4::<3>(a, a),
+            2 => self.slide_f32x4::<2>(a, a),
+            3 => self.slide_f32x4::<1>(a, a),
+            4 => self.slide_f32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f32x4(padding);
+        self.slide_f32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f32x4(padding);
+        match OFFSET {
+            0 => self.slide_f32x4::<4>(padding, a),
+            1 => self.slide_f32x4::<3>(padding, a),
+            2 => self.slide_f32x4::<2>(padding, a),
+            3 => self.slide_f32x4::<1>(padding, a),
+            4 => self.slide_f32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -695,6 +759,94 @@ impl Simd for Sse4_2 {
         self.slide_i8x16::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i8x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i8x16::<16>(a, a),
+            1 => self.slide_i8x16::<15>(a, a),
+            2 => self.slide_i8x16::<14>(a, a),
+            3 => self.slide_i8x16::<13>(a, a),
+            4 => self.slide_i8x16::<12>(a, a),
+            5 => self.slide_i8x16::<11>(a, a),
+            6 => self.slide_i8x16::<10>(a, a),
+            7 => self.slide_i8x16::<9>(a, a),
+            8 => self.slide_i8x16::<8>(a, a),
+            9 => self.slide_i8x16::<7>(a, a),
+            10 => self.slide_i8x16::<6>(a, a),
+            11 => self.slide_i8x16::<5>(a, a),
+            12 => self.slide_i8x16::<4>(a, a),
+            13 => self.slide_i8x16::<3>(a, a),
+            14 => self.slide_i8x16::<2>(a, a),
+            15 => self.slide_i8x16::<1>(a, a),
+            16 => self.slide_i8x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i8x16(padding);
+        self.slide_i8x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i8x16(padding);
+        match OFFSET {
+            0 => self.slide_i8x16::<16>(padding, a),
+            1 => self.slide_i8x16::<15>(padding, a),
+            2 => self.slide_i8x16::<14>(padding, a),
+            3 => self.slide_i8x16::<13>(padding, a),
+            4 => self.slide_i8x16::<12>(padding, a),
+            5 => self.slide_i8x16::<11>(padding, a),
+            6 => self.slide_i8x16::<10>(padding, a),
+            7 => self.slide_i8x16::<9>(padding, a),
+            8 => self.slide_i8x16::<8>(padding, a),
+            9 => self.slide_i8x16::<7>(padding, a),
+            10 => self.slide_i8x16::<6>(padding, a),
+            11 => self.slide_i8x16::<5>(padding, a),
+            12 => self.slide_i8x16::<4>(padding, a),
+            13 => self.slide_i8x16::<3>(padding, a),
+            14 => self.slide_i8x16::<2>(padding, a),
+            15 => self.slide_i8x16::<1>(padding, a),
+            16 => self.slide_i8x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1072,6 +1224,94 @@ impl Simd for Sse4_2 {
         b: u8x16<Self>,
     ) -> u8x16<Self> {
         self.slide_u8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u8x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u8x16::<16>(a, a),
+            1 => self.slide_u8x16::<15>(a, a),
+            2 => self.slide_u8x16::<14>(a, a),
+            3 => self.slide_u8x16::<13>(a, a),
+            4 => self.slide_u8x16::<12>(a, a),
+            5 => self.slide_u8x16::<11>(a, a),
+            6 => self.slide_u8x16::<10>(a, a),
+            7 => self.slide_u8x16::<9>(a, a),
+            8 => self.slide_u8x16::<8>(a, a),
+            9 => self.slide_u8x16::<7>(a, a),
+            10 => self.slide_u8x16::<6>(a, a),
+            11 => self.slide_u8x16::<5>(a, a),
+            12 => self.slide_u8x16::<4>(a, a),
+            13 => self.slide_u8x16::<3>(a, a),
+            14 => self.slide_u8x16::<2>(a, a),
+            15 => self.slide_u8x16::<1>(a, a),
+            16 => self.slide_u8x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u8x16(padding);
+        self.slide_u8x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u8x16(padding);
+        match OFFSET {
+            0 => self.slide_u8x16::<16>(padding, a),
+            1 => self.slide_u8x16::<15>(padding, a),
+            2 => self.slide_u8x16::<14>(padding, a),
+            3 => self.slide_u8x16::<13>(padding, a),
+            4 => self.slide_u8x16::<12>(padding, a),
+            5 => self.slide_u8x16::<11>(padding, a),
+            6 => self.slide_u8x16::<10>(padding, a),
+            7 => self.slide_u8x16::<9>(padding, a),
+            8 => self.slide_u8x16::<8>(padding, a),
+            9 => self.slide_u8x16::<7>(padding, a),
+            10 => self.slide_u8x16::<6>(padding, a),
+            11 => self.slide_u8x16::<5>(padding, a),
+            12 => self.slide_u8x16::<4>(padding, a),
+            13 => self.slide_u8x16::<3>(padding, a),
+            14 => self.slide_u8x16::<2>(padding, a),
+            15 => self.slide_u8x16::<1>(padding, a),
+            16 => self.slide_u8x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
@@ -1626,6 +1866,78 @@ impl Simd for Sse4_2 {
         self.slide_i16x8::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_i16x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_i16x8::<8>(a, a),
+            1 => self.slide_i16x8::<7>(a, a),
+            2 => self.slide_i16x8::<6>(a, a),
+            3 => self.slide_i16x8::<5>(a, a),
+            4 => self.slide_i16x8::<4>(a, a),
+            5 => self.slide_i16x8::<3>(a, a),
+            6 => self.slide_i16x8::<2>(a, a),
+            7 => self.slide_i16x8::<1>(a, a),
+            8 => self.slide_i16x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i16x8(padding);
+        self.slide_i16x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i16x8(padding);
+        match OFFSET {
+            0 => self.slide_i16x8::<8>(padding, a),
+            1 => self.slide_i16x8::<7>(padding, a),
+            2 => self.slide_i16x8::<6>(padding, a),
+            3 => self.slide_i16x8::<5>(padding, a),
+            4 => self.slide_i16x8::<4>(padding, a),
+            5 => self.slide_i16x8::<3>(padding, a),
+            6 => self.slide_i16x8::<2>(padding, a),
+            7 => self.slide_i16x8::<1>(padding, a),
+            8 => self.slide_i16x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1984,6 +2296,78 @@ impl Simd for Sse4_2 {
         b: u16x8<Self>,
     ) -> u16x8<Self> {
         self.slide_u16x8::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_u16x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_u16x8::<8>(a, a),
+            1 => self.slide_u16x8::<7>(a, a),
+            2 => self.slide_u16x8::<6>(a, a),
+            3 => self.slide_u16x8::<5>(a, a),
+            4 => self.slide_u16x8::<4>(a, a),
+            5 => self.slide_u16x8::<3>(a, a),
+            6 => self.slide_u16x8::<2>(a, a),
+            7 => self.slide_u16x8::<1>(a, a),
+            8 => self.slide_u16x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u16x8(padding);
+        self.slide_u16x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u16x8(padding);
+        match OFFSET {
+            0 => self.slide_u16x8::<8>(padding, a),
+            1 => self.slide_u16x8::<7>(padding, a),
+            2 => self.slide_u16x8::<6>(padding, a),
+            3 => self.slide_u16x8::<5>(padding, a),
+            4 => self.slide_u16x8::<4>(padding, a),
+            5 => self.slide_u16x8::<3>(padding, a),
+            6 => self.slide_u16x8::<2>(padding, a),
+            7 => self.slide_u16x8::<1>(padding, a),
+            8 => self.slide_u16x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
@@ -2514,6 +2898,70 @@ impl Simd for Sse4_2 {
         self.slide_i32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_i32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_i32x4::<4>(a, a),
+            1 => self.slide_i32x4::<3>(a, a),
+            2 => self.slide_i32x4::<2>(a, a),
+            3 => self.slide_i32x4::<1>(a, a),
+            4 => self.slide_i32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_i32x4(padding);
+        self.slide_i32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_i32x4(padding);
+        match OFFSET {
+            0 => self.slide_i32x4::<4>(padding, a),
+            1 => self.slide_i32x4::<3>(padding, a),
+            2 => self.slide_i32x4::<2>(padding, a),
+            3 => self.slide_i32x4::<1>(padding, a),
+            4 => self.slide_i32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2880,6 +3328,70 @@ impl Simd for Sse4_2 {
         b: u32x4<Self>,
     ) -> u32x4<Self> {
         self.slide_u32x4::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_u32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_u32x4::<4>(a, a),
+            1 => self.slide_u32x4::<3>(a, a),
+            2 => self.slide_u32x4::<2>(a, a),
+            3 => self.slide_u32x4::<1>(a, a),
+            4 => self.slide_u32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_u32x4(padding);
+        self.slide_u32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_u32x4(padding);
+        match OFFSET {
+            0 => self.slide_u32x4::<4>(padding, a),
+            1 => self.slide_u32x4::<3>(padding, a),
+            2 => self.slide_u32x4::<2>(padding, a),
+            3 => self.slide_u32x4::<1>(padding, a),
+            4 => self.slide_u32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
@@ -3412,6 +3924,66 @@ impl Simd for Sse4_2 {
         b: f64x2<Self>,
     ) -> f64x2<Self> {
         self.slide_f64x2::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        self.slide_f64x2::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        match OFFSET {
+            0 => self.slide_f64x2::<2>(a, a),
+            1 => self.slide_f64x2::<1>(a, a),
+            2 => self.slide_f64x2::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        let padding = self.splat_f64x2(padding);
+        self.slide_f64x2::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        let padding = self.splat_f64x2(padding);
+        match OFFSET {
+            0 => self.slide_f64x2::<2>(padding, a),
+            1 => self.slide_f64x2::<1>(padding, a),
+            2 => self.slide_f64x2::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
@@ -3991,6 +4563,78 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_f32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_f32x8::<8>(a, a),
+            1 => self.slide_f32x8::<7>(a, a),
+            2 => self.slide_f32x8::<6>(a, a),
+            3 => self.slide_f32x8::<5>(a, a),
+            4 => self.slide_f32x8::<4>(a, a),
+            5 => self.slide_f32x8::<3>(a, a),
+            6 => self.slide_f32x8::<2>(a, a),
+            7 => self.slide_f32x8::<1>(a, a),
+            8 => self.slide_f32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f32x8(padding);
+        self.slide_f32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f32x8(padding);
+        match OFFSET {
+            0 => self.slide_f32x8::<8>(padding, a),
+            1 => self.slide_f32x8::<7>(padding, a),
+            2 => self.slide_f32x8::<6>(padding, a),
+            3 => self.slide_f32x8::<5>(padding, a),
+            4 => self.slide_f32x8::<4>(padding, a),
+            5 => self.slide_f32x8::<3>(padding, a),
+            6 => self.slide_f32x8::<2>(padding, a),
+            7 => self.slide_f32x8::<1>(padding, a),
+            8 => self.slide_f32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
         let (indices0, indices1) = self.split_u8x32(indices);
@@ -4371,6 +5015,126 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_i8x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_i8x32::<32>(a, a),
+            1 => self.slide_i8x32::<31>(a, a),
+            2 => self.slide_i8x32::<30>(a, a),
+            3 => self.slide_i8x32::<29>(a, a),
+            4 => self.slide_i8x32::<28>(a, a),
+            5 => self.slide_i8x32::<27>(a, a),
+            6 => self.slide_i8x32::<26>(a, a),
+            7 => self.slide_i8x32::<25>(a, a),
+            8 => self.slide_i8x32::<24>(a, a),
+            9 => self.slide_i8x32::<23>(a, a),
+            10 => self.slide_i8x32::<22>(a, a),
+            11 => self.slide_i8x32::<21>(a, a),
+            12 => self.slide_i8x32::<20>(a, a),
+            13 => self.slide_i8x32::<19>(a, a),
+            14 => self.slide_i8x32::<18>(a, a),
+            15 => self.slide_i8x32::<17>(a, a),
+            16 => self.slide_i8x32::<16>(a, a),
+            17 => self.slide_i8x32::<15>(a, a),
+            18 => self.slide_i8x32::<14>(a, a),
+            19 => self.slide_i8x32::<13>(a, a),
+            20 => self.slide_i8x32::<12>(a, a),
+            21 => self.slide_i8x32::<11>(a, a),
+            22 => self.slide_i8x32::<10>(a, a),
+            23 => self.slide_i8x32::<9>(a, a),
+            24 => self.slide_i8x32::<8>(a, a),
+            25 => self.slide_i8x32::<7>(a, a),
+            26 => self.slide_i8x32::<6>(a, a),
+            27 => self.slide_i8x32::<5>(a, a),
+            28 => self.slide_i8x32::<4>(a, a),
+            29 => self.slide_i8x32::<3>(a, a),
+            30 => self.slide_i8x32::<2>(a, a),
+            31 => self.slide_i8x32::<1>(a, a),
+            32 => self.slide_i8x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i8x32(padding);
+        self.slide_i8x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i8x32(padding);
+        match OFFSET {
+            0 => self.slide_i8x32::<32>(padding, a),
+            1 => self.slide_i8x32::<31>(padding, a),
+            2 => self.slide_i8x32::<30>(padding, a),
+            3 => self.slide_i8x32::<29>(padding, a),
+            4 => self.slide_i8x32::<28>(padding, a),
+            5 => self.slide_i8x32::<27>(padding, a),
+            6 => self.slide_i8x32::<26>(padding, a),
+            7 => self.slide_i8x32::<25>(padding, a),
+            8 => self.slide_i8x32::<24>(padding, a),
+            9 => self.slide_i8x32::<23>(padding, a),
+            10 => self.slide_i8x32::<22>(padding, a),
+            11 => self.slide_i8x32::<21>(padding, a),
+            12 => self.slide_i8x32::<20>(padding, a),
+            13 => self.slide_i8x32::<19>(padding, a),
+            14 => self.slide_i8x32::<18>(padding, a),
+            15 => self.slide_i8x32::<17>(padding, a),
+            16 => self.slide_i8x32::<16>(padding, a),
+            17 => self.slide_i8x32::<15>(padding, a),
+            18 => self.slide_i8x32::<14>(padding, a),
+            19 => self.slide_i8x32::<13>(padding, a),
+            20 => self.slide_i8x32::<12>(padding, a),
+            21 => self.slide_i8x32::<11>(padding, a),
+            22 => self.slide_i8x32::<10>(padding, a),
+            23 => self.slide_i8x32::<9>(padding, a),
+            24 => self.slide_i8x32::<8>(padding, a),
+            25 => self.slide_i8x32::<7>(padding, a),
+            26 => self.slide_i8x32::<6>(padding, a),
+            27 => self.slide_i8x32::<5>(padding, a),
+            28 => self.slide_i8x32::<4>(padding, a),
+            29 => self.slide_i8x32::<3>(padding, a),
+            30 => self.slide_i8x32::<2>(padding, a),
+            31 => self.slide_i8x32::<1>(padding, a),
+            32 => self.slide_i8x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
         let (indices0, indices1) = self.split_u8x32(indices);
@@ -4656,6 +5420,126 @@ impl Simd for Sse4_2 {
             self.slide_within_blocks_u8x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x16::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_u8x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_u8x32::<32>(a, a),
+            1 => self.slide_u8x32::<31>(a, a),
+            2 => self.slide_u8x32::<30>(a, a),
+            3 => self.slide_u8x32::<29>(a, a),
+            4 => self.slide_u8x32::<28>(a, a),
+            5 => self.slide_u8x32::<27>(a, a),
+            6 => self.slide_u8x32::<26>(a, a),
+            7 => self.slide_u8x32::<25>(a, a),
+            8 => self.slide_u8x32::<24>(a, a),
+            9 => self.slide_u8x32::<23>(a, a),
+            10 => self.slide_u8x32::<22>(a, a),
+            11 => self.slide_u8x32::<21>(a, a),
+            12 => self.slide_u8x32::<20>(a, a),
+            13 => self.slide_u8x32::<19>(a, a),
+            14 => self.slide_u8x32::<18>(a, a),
+            15 => self.slide_u8x32::<17>(a, a),
+            16 => self.slide_u8x32::<16>(a, a),
+            17 => self.slide_u8x32::<15>(a, a),
+            18 => self.slide_u8x32::<14>(a, a),
+            19 => self.slide_u8x32::<13>(a, a),
+            20 => self.slide_u8x32::<12>(a, a),
+            21 => self.slide_u8x32::<11>(a, a),
+            22 => self.slide_u8x32::<10>(a, a),
+            23 => self.slide_u8x32::<9>(a, a),
+            24 => self.slide_u8x32::<8>(a, a),
+            25 => self.slide_u8x32::<7>(a, a),
+            26 => self.slide_u8x32::<6>(a, a),
+            27 => self.slide_u8x32::<5>(a, a),
+            28 => self.slide_u8x32::<4>(a, a),
+            29 => self.slide_u8x32::<3>(a, a),
+            30 => self.slide_u8x32::<2>(a, a),
+            31 => self.slide_u8x32::<1>(a, a),
+            32 => self.slide_u8x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u8x32(padding);
+        self.slide_u8x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u8x32(padding);
+        match OFFSET {
+            0 => self.slide_u8x32::<32>(padding, a),
+            1 => self.slide_u8x32::<31>(padding, a),
+            2 => self.slide_u8x32::<30>(padding, a),
+            3 => self.slide_u8x32::<29>(padding, a),
+            4 => self.slide_u8x32::<28>(padding, a),
+            5 => self.slide_u8x32::<27>(padding, a),
+            6 => self.slide_u8x32::<26>(padding, a),
+            7 => self.slide_u8x32::<25>(padding, a),
+            8 => self.slide_u8x32::<24>(padding, a),
+            9 => self.slide_u8x32::<23>(padding, a),
+            10 => self.slide_u8x32::<22>(padding, a),
+            11 => self.slide_u8x32::<21>(padding, a),
+            12 => self.slide_u8x32::<20>(padding, a),
+            13 => self.slide_u8x32::<19>(padding, a),
+            14 => self.slide_u8x32::<18>(padding, a),
+            15 => self.slide_u8x32::<17>(padding, a),
+            16 => self.slide_u8x32::<16>(padding, a),
+            17 => self.slide_u8x32::<15>(padding, a),
+            18 => self.slide_u8x32::<14>(padding, a),
+            19 => self.slide_u8x32::<13>(padding, a),
+            20 => self.slide_u8x32::<12>(padding, a),
+            21 => self.slide_u8x32::<11>(padding, a),
+            22 => self.slide_u8x32::<10>(padding, a),
+            23 => self.slide_u8x32::<9>(padding, a),
+            24 => self.slide_u8x32::<8>(padding, a),
+            25 => self.slide_u8x32::<7>(padding, a),
+            26 => self.slide_u8x32::<6>(padding, a),
+            27 => self.slide_u8x32::<5>(padding, a),
+            28 => self.slide_u8x32::<4>(padding, a),
+            29 => self.slide_u8x32::<3>(padding, a),
+            30 => self.slide_u8x32::<2>(padding, a),
+            31 => self.slide_u8x32::<1>(padding, a),
+            32 => self.slide_u8x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self> {
@@ -5064,6 +5948,94 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i16x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i16x16::<16>(a, a),
+            1 => self.slide_i16x16::<15>(a, a),
+            2 => self.slide_i16x16::<14>(a, a),
+            3 => self.slide_i16x16::<13>(a, a),
+            4 => self.slide_i16x16::<12>(a, a),
+            5 => self.slide_i16x16::<11>(a, a),
+            6 => self.slide_i16x16::<10>(a, a),
+            7 => self.slide_i16x16::<9>(a, a),
+            8 => self.slide_i16x16::<8>(a, a),
+            9 => self.slide_i16x16::<7>(a, a),
+            10 => self.slide_i16x16::<6>(a, a),
+            11 => self.slide_i16x16::<5>(a, a),
+            12 => self.slide_i16x16::<4>(a, a),
+            13 => self.slide_i16x16::<3>(a, a),
+            14 => self.slide_i16x16::<2>(a, a),
+            15 => self.slide_i16x16::<1>(a, a),
+            16 => self.slide_i16x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i16x16(padding);
+        self.slide_i16x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i16x16(padding);
+        match OFFSET {
+            0 => self.slide_i16x16::<16>(padding, a),
+            1 => self.slide_i16x16::<15>(padding, a),
+            2 => self.slide_i16x16::<14>(padding, a),
+            3 => self.slide_i16x16::<13>(padding, a),
+            4 => self.slide_i16x16::<12>(padding, a),
+            5 => self.slide_i16x16::<11>(padding, a),
+            6 => self.slide_i16x16::<10>(padding, a),
+            7 => self.slide_i16x16::<9>(padding, a),
+            8 => self.slide_i16x16::<8>(padding, a),
+            9 => self.slide_i16x16::<7>(padding, a),
+            10 => self.slide_i16x16::<6>(padding, a),
+            11 => self.slide_i16x16::<5>(padding, a),
+            12 => self.slide_i16x16::<4>(padding, a),
+            13 => self.slide_i16x16::<3>(padding, a),
+            14 => self.slide_i16x16::<2>(padding, a),
+            15 => self.slide_i16x16::<1>(padding, a),
+            16 => self.slide_i16x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x16(
         self,
         a: i16x16<Self>,
@@ -5353,6 +6325,94 @@ impl Simd for Sse4_2 {
             self.slide_within_blocks_u16x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x8::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u16x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u16x16::<16>(a, a),
+            1 => self.slide_u16x16::<15>(a, a),
+            2 => self.slide_u16x16::<14>(a, a),
+            3 => self.slide_u16x16::<13>(a, a),
+            4 => self.slide_u16x16::<12>(a, a),
+            5 => self.slide_u16x16::<11>(a, a),
+            6 => self.slide_u16x16::<10>(a, a),
+            7 => self.slide_u16x16::<9>(a, a),
+            8 => self.slide_u16x16::<8>(a, a),
+            9 => self.slide_u16x16::<7>(a, a),
+            10 => self.slide_u16x16::<6>(a, a),
+            11 => self.slide_u16x16::<5>(a, a),
+            12 => self.slide_u16x16::<4>(a, a),
+            13 => self.slide_u16x16::<3>(a, a),
+            14 => self.slide_u16x16::<2>(a, a),
+            15 => self.slide_u16x16::<1>(a, a),
+            16 => self.slide_u16x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u16x16(padding);
+        self.slide_u16x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u16x16(padding);
+        match OFFSET {
+            0 => self.slide_u16x16::<16>(padding, a),
+            1 => self.slide_u16x16::<15>(padding, a),
+            2 => self.slide_u16x16::<14>(padding, a),
+            3 => self.slide_u16x16::<13>(padding, a),
+            4 => self.slide_u16x16::<12>(padding, a),
+            5 => self.slide_u16x16::<11>(padding, a),
+            6 => self.slide_u16x16::<10>(padding, a),
+            7 => self.slide_u16x16::<9>(padding, a),
+            8 => self.slide_u16x16::<8>(padding, a),
+            9 => self.slide_u16x16::<7>(padding, a),
+            10 => self.slide_u16x16::<6>(padding, a),
+            11 => self.slide_u16x16::<5>(padding, a),
+            12 => self.slide_u16x16::<4>(padding, a),
+            13 => self.slide_u16x16::<3>(padding, a),
+            14 => self.slide_u16x16::<2>(padding, a),
+            15 => self.slide_u16x16::<1>(padding, a),
+            16 => self.slide_u16x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x16(
@@ -5786,6 +6846,78 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_i32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_i32x8::<8>(a, a),
+            1 => self.slide_i32x8::<7>(a, a),
+            2 => self.slide_i32x8::<6>(a, a),
+            3 => self.slide_i32x8::<5>(a, a),
+            4 => self.slide_i32x8::<4>(a, a),
+            5 => self.slide_i32x8::<3>(a, a),
+            6 => self.slide_i32x8::<2>(a, a),
+            7 => self.slide_i32x8::<1>(a, a),
+            8 => self.slide_i32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i32x8(padding);
+        self.slide_i32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i32x8(padding);
+        match OFFSET {
+            0 => self.slide_i32x8::<8>(padding, a),
+            1 => self.slide_i32x8::<7>(padding, a),
+            2 => self.slide_i32x8::<6>(padding, a),
+            3 => self.slide_i32x8::<5>(padding, a),
+            4 => self.slide_i32x8::<4>(padding, a),
+            5 => self.slide_i32x8::<3>(padding, a),
+            6 => self.slide_i32x8::<2>(padding, a),
+            7 => self.slide_i32x8::<1>(padding, a),
+            8 => self.slide_i32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
         let (indices0, indices1) = self.split_u8x32(indices);
@@ -6076,6 +7208,78 @@ impl Simd for Sse4_2 {
             self.slide_within_blocks_u32x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x4::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_u32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_u32x8::<8>(a, a),
+            1 => self.slide_u32x8::<7>(a, a),
+            2 => self.slide_u32x8::<6>(a, a),
+            3 => self.slide_u32x8::<5>(a, a),
+            4 => self.slide_u32x8::<4>(a, a),
+            5 => self.slide_u32x8::<3>(a, a),
+            6 => self.slide_u32x8::<2>(a, a),
+            7 => self.slide_u32x8::<1>(a, a),
+            8 => self.slide_u32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u32x8(padding);
+        self.slide_u32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u32x8(padding);
+        match OFFSET {
+            0 => self.slide_u32x8::<8>(padding, a),
+            1 => self.slide_u32x8::<7>(padding, a),
+            2 => self.slide_u32x8::<6>(padding, a),
+            3 => self.slide_u32x8::<5>(padding, a),
+            4 => self.slide_u32x8::<4>(padding, a),
+            5 => self.slide_u32x8::<3>(padding, a),
+            6 => self.slide_u32x8::<2>(padding, a),
+            7 => self.slide_u32x8::<1>(padding, a),
+            8 => self.slide_u32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
@@ -6479,6 +7683,70 @@ impl Simd for Sse4_2 {
             self.slide_within_blocks_f64x2::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x2::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_f64x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_f64x4::<4>(a, a),
+            1 => self.slide_f64x4::<3>(a, a),
+            2 => self.slide_f64x4::<2>(a, a),
+            3 => self.slide_f64x4::<1>(a, a),
+            4 => self.slide_f64x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f64x4(padding);
+        self.slide_f64x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f64x4(padding);
+        match OFFSET {
+            0 => self.slide_f64x4::<4>(padding, a),
+            1 => self.slide_f64x4::<3>(padding, a),
+            2 => self.slide_f64x4::<2>(padding, a),
+            3 => self.slide_f64x4::<1>(padding, a),
+            4 => self.slide_f64x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
@@ -6938,6 +8206,94 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_f32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_f32x16::<16>(a, a),
+            1 => self.slide_f32x16::<15>(a, a),
+            2 => self.slide_f32x16::<14>(a, a),
+            3 => self.slide_f32x16::<13>(a, a),
+            4 => self.slide_f32x16::<12>(a, a),
+            5 => self.slide_f32x16::<11>(a, a),
+            6 => self.slide_f32x16::<10>(a, a),
+            7 => self.slide_f32x16::<9>(a, a),
+            8 => self.slide_f32x16::<8>(a, a),
+            9 => self.slide_f32x16::<7>(a, a),
+            10 => self.slide_f32x16::<6>(a, a),
+            11 => self.slide_f32x16::<5>(a, a),
+            12 => self.slide_f32x16::<4>(a, a),
+            13 => self.slide_f32x16::<3>(a, a),
+            14 => self.slide_f32x16::<2>(a, a),
+            15 => self.slide_f32x16::<1>(a, a),
+            16 => self.slide_f32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_f32x16(padding);
+        self.slide_f32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_f32x16(padding);
+        match OFFSET {
+            0 => self.slide_f32x16::<16>(padding, a),
+            1 => self.slide_f32x16::<15>(padding, a),
+            2 => self.slide_f32x16::<14>(padding, a),
+            3 => self.slide_f32x16::<13>(padding, a),
+            4 => self.slide_f32x16::<12>(padding, a),
+            5 => self.slide_f32x16::<11>(padding, a),
+            6 => self.slide_f32x16::<10>(padding, a),
+            7 => self.slide_f32x16::<9>(padding, a),
+            8 => self.slide_f32x16::<8>(padding, a),
+            9 => self.slide_f32x16::<7>(padding, a),
+            10 => self.slide_f32x16::<6>(padding, a),
+            11 => self.slide_f32x16::<5>(padding, a),
+            12 => self.slide_f32x16::<4>(padding, a),
+            13 => self.slide_f32x16::<3>(padding, a),
+            14 => self.slide_f32x16::<2>(padding, a),
+            15 => self.slide_f32x16::<1>(padding, a),
+            16 => self.slide_f32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x16(
         self,
         a: f32x16<Self>,
@@ -7390,6 +8746,190 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        self.slide_i8x64::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        match OFFSET {
+            0 => self.slide_i8x64::<64>(a, a),
+            1 => self.slide_i8x64::<63>(a, a),
+            2 => self.slide_i8x64::<62>(a, a),
+            3 => self.slide_i8x64::<61>(a, a),
+            4 => self.slide_i8x64::<60>(a, a),
+            5 => self.slide_i8x64::<59>(a, a),
+            6 => self.slide_i8x64::<58>(a, a),
+            7 => self.slide_i8x64::<57>(a, a),
+            8 => self.slide_i8x64::<56>(a, a),
+            9 => self.slide_i8x64::<55>(a, a),
+            10 => self.slide_i8x64::<54>(a, a),
+            11 => self.slide_i8x64::<53>(a, a),
+            12 => self.slide_i8x64::<52>(a, a),
+            13 => self.slide_i8x64::<51>(a, a),
+            14 => self.slide_i8x64::<50>(a, a),
+            15 => self.slide_i8x64::<49>(a, a),
+            16 => self.slide_i8x64::<48>(a, a),
+            17 => self.slide_i8x64::<47>(a, a),
+            18 => self.slide_i8x64::<46>(a, a),
+            19 => self.slide_i8x64::<45>(a, a),
+            20 => self.slide_i8x64::<44>(a, a),
+            21 => self.slide_i8x64::<43>(a, a),
+            22 => self.slide_i8x64::<42>(a, a),
+            23 => self.slide_i8x64::<41>(a, a),
+            24 => self.slide_i8x64::<40>(a, a),
+            25 => self.slide_i8x64::<39>(a, a),
+            26 => self.slide_i8x64::<38>(a, a),
+            27 => self.slide_i8x64::<37>(a, a),
+            28 => self.slide_i8x64::<36>(a, a),
+            29 => self.slide_i8x64::<35>(a, a),
+            30 => self.slide_i8x64::<34>(a, a),
+            31 => self.slide_i8x64::<33>(a, a),
+            32 => self.slide_i8x64::<32>(a, a),
+            33 => self.slide_i8x64::<31>(a, a),
+            34 => self.slide_i8x64::<30>(a, a),
+            35 => self.slide_i8x64::<29>(a, a),
+            36 => self.slide_i8x64::<28>(a, a),
+            37 => self.slide_i8x64::<27>(a, a),
+            38 => self.slide_i8x64::<26>(a, a),
+            39 => self.slide_i8x64::<25>(a, a),
+            40 => self.slide_i8x64::<24>(a, a),
+            41 => self.slide_i8x64::<23>(a, a),
+            42 => self.slide_i8x64::<22>(a, a),
+            43 => self.slide_i8x64::<21>(a, a),
+            44 => self.slide_i8x64::<20>(a, a),
+            45 => self.slide_i8x64::<19>(a, a),
+            46 => self.slide_i8x64::<18>(a, a),
+            47 => self.slide_i8x64::<17>(a, a),
+            48 => self.slide_i8x64::<16>(a, a),
+            49 => self.slide_i8x64::<15>(a, a),
+            50 => self.slide_i8x64::<14>(a, a),
+            51 => self.slide_i8x64::<13>(a, a),
+            52 => self.slide_i8x64::<12>(a, a),
+            53 => self.slide_i8x64::<11>(a, a),
+            54 => self.slide_i8x64::<10>(a, a),
+            55 => self.slide_i8x64::<9>(a, a),
+            56 => self.slide_i8x64::<8>(a, a),
+            57 => self.slide_i8x64::<7>(a, a),
+            58 => self.slide_i8x64::<6>(a, a),
+            59 => self.slide_i8x64::<5>(a, a),
+            60 => self.slide_i8x64::<4>(a, a),
+            61 => self.slide_i8x64::<3>(a, a),
+            62 => self.slide_i8x64::<2>(a, a),
+            63 => self.slide_i8x64::<1>(a, a),
+            64 => self.slide_i8x64::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_i8x64(padding);
+        self.slide_i8x64::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_i8x64(padding);
+        match OFFSET {
+            0 => self.slide_i8x64::<64>(padding, a),
+            1 => self.slide_i8x64::<63>(padding, a),
+            2 => self.slide_i8x64::<62>(padding, a),
+            3 => self.slide_i8x64::<61>(padding, a),
+            4 => self.slide_i8x64::<60>(padding, a),
+            5 => self.slide_i8x64::<59>(padding, a),
+            6 => self.slide_i8x64::<58>(padding, a),
+            7 => self.slide_i8x64::<57>(padding, a),
+            8 => self.slide_i8x64::<56>(padding, a),
+            9 => self.slide_i8x64::<55>(padding, a),
+            10 => self.slide_i8x64::<54>(padding, a),
+            11 => self.slide_i8x64::<53>(padding, a),
+            12 => self.slide_i8x64::<52>(padding, a),
+            13 => self.slide_i8x64::<51>(padding, a),
+            14 => self.slide_i8x64::<50>(padding, a),
+            15 => self.slide_i8x64::<49>(padding, a),
+            16 => self.slide_i8x64::<48>(padding, a),
+            17 => self.slide_i8x64::<47>(padding, a),
+            18 => self.slide_i8x64::<46>(padding, a),
+            19 => self.slide_i8x64::<45>(padding, a),
+            20 => self.slide_i8x64::<44>(padding, a),
+            21 => self.slide_i8x64::<43>(padding, a),
+            22 => self.slide_i8x64::<42>(padding, a),
+            23 => self.slide_i8x64::<41>(padding, a),
+            24 => self.slide_i8x64::<40>(padding, a),
+            25 => self.slide_i8x64::<39>(padding, a),
+            26 => self.slide_i8x64::<38>(padding, a),
+            27 => self.slide_i8x64::<37>(padding, a),
+            28 => self.slide_i8x64::<36>(padding, a),
+            29 => self.slide_i8x64::<35>(padding, a),
+            30 => self.slide_i8x64::<34>(padding, a),
+            31 => self.slide_i8x64::<33>(padding, a),
+            32 => self.slide_i8x64::<32>(padding, a),
+            33 => self.slide_i8x64::<31>(padding, a),
+            34 => self.slide_i8x64::<30>(padding, a),
+            35 => self.slide_i8x64::<29>(padding, a),
+            36 => self.slide_i8x64::<28>(padding, a),
+            37 => self.slide_i8x64::<27>(padding, a),
+            38 => self.slide_i8x64::<26>(padding, a),
+            39 => self.slide_i8x64::<25>(padding, a),
+            40 => self.slide_i8x64::<24>(padding, a),
+            41 => self.slide_i8x64::<23>(padding, a),
+            42 => self.slide_i8x64::<22>(padding, a),
+            43 => self.slide_i8x64::<21>(padding, a),
+            44 => self.slide_i8x64::<20>(padding, a),
+            45 => self.slide_i8x64::<19>(padding, a),
+            46 => self.slide_i8x64::<18>(padding, a),
+            47 => self.slide_i8x64::<17>(padding, a),
+            48 => self.slide_i8x64::<16>(padding, a),
+            49 => self.slide_i8x64::<15>(padding, a),
+            50 => self.slide_i8x64::<14>(padding, a),
+            51 => self.slide_i8x64::<13>(padding, a),
+            52 => self.slide_i8x64::<12>(padding, a),
+            53 => self.slide_i8x64::<11>(padding, a),
+            54 => self.slide_i8x64::<10>(padding, a),
+            55 => self.slide_i8x64::<9>(padding, a),
+            56 => self.slide_i8x64::<8>(padding, a),
+            57 => self.slide_i8x64::<7>(padding, a),
+            58 => self.slide_i8x64::<6>(padding, a),
+            59 => self.slide_i8x64::<5>(padding, a),
+            60 => self.slide_i8x64::<4>(padding, a),
+            61 => self.slide_i8x64::<3>(padding, a),
+            62 => self.slide_i8x64::<2>(padding, a),
+            63 => self.slide_i8x64::<1>(padding, a),
+            64 => self.slide_i8x64::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
         let (indices0, indices1) = self.split_u8x64(indices);
@@ -7668,6 +9208,190 @@ impl Simd for Sse4_2 {
             self.slide_within_blocks_u8x32::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x32::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        self.slide_u8x64::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        match OFFSET {
+            0 => self.slide_u8x64::<64>(a, a),
+            1 => self.slide_u8x64::<63>(a, a),
+            2 => self.slide_u8x64::<62>(a, a),
+            3 => self.slide_u8x64::<61>(a, a),
+            4 => self.slide_u8x64::<60>(a, a),
+            5 => self.slide_u8x64::<59>(a, a),
+            6 => self.slide_u8x64::<58>(a, a),
+            7 => self.slide_u8x64::<57>(a, a),
+            8 => self.slide_u8x64::<56>(a, a),
+            9 => self.slide_u8x64::<55>(a, a),
+            10 => self.slide_u8x64::<54>(a, a),
+            11 => self.slide_u8x64::<53>(a, a),
+            12 => self.slide_u8x64::<52>(a, a),
+            13 => self.slide_u8x64::<51>(a, a),
+            14 => self.slide_u8x64::<50>(a, a),
+            15 => self.slide_u8x64::<49>(a, a),
+            16 => self.slide_u8x64::<48>(a, a),
+            17 => self.slide_u8x64::<47>(a, a),
+            18 => self.slide_u8x64::<46>(a, a),
+            19 => self.slide_u8x64::<45>(a, a),
+            20 => self.slide_u8x64::<44>(a, a),
+            21 => self.slide_u8x64::<43>(a, a),
+            22 => self.slide_u8x64::<42>(a, a),
+            23 => self.slide_u8x64::<41>(a, a),
+            24 => self.slide_u8x64::<40>(a, a),
+            25 => self.slide_u8x64::<39>(a, a),
+            26 => self.slide_u8x64::<38>(a, a),
+            27 => self.slide_u8x64::<37>(a, a),
+            28 => self.slide_u8x64::<36>(a, a),
+            29 => self.slide_u8x64::<35>(a, a),
+            30 => self.slide_u8x64::<34>(a, a),
+            31 => self.slide_u8x64::<33>(a, a),
+            32 => self.slide_u8x64::<32>(a, a),
+            33 => self.slide_u8x64::<31>(a, a),
+            34 => self.slide_u8x64::<30>(a, a),
+            35 => self.slide_u8x64::<29>(a, a),
+            36 => self.slide_u8x64::<28>(a, a),
+            37 => self.slide_u8x64::<27>(a, a),
+            38 => self.slide_u8x64::<26>(a, a),
+            39 => self.slide_u8x64::<25>(a, a),
+            40 => self.slide_u8x64::<24>(a, a),
+            41 => self.slide_u8x64::<23>(a, a),
+            42 => self.slide_u8x64::<22>(a, a),
+            43 => self.slide_u8x64::<21>(a, a),
+            44 => self.slide_u8x64::<20>(a, a),
+            45 => self.slide_u8x64::<19>(a, a),
+            46 => self.slide_u8x64::<18>(a, a),
+            47 => self.slide_u8x64::<17>(a, a),
+            48 => self.slide_u8x64::<16>(a, a),
+            49 => self.slide_u8x64::<15>(a, a),
+            50 => self.slide_u8x64::<14>(a, a),
+            51 => self.slide_u8x64::<13>(a, a),
+            52 => self.slide_u8x64::<12>(a, a),
+            53 => self.slide_u8x64::<11>(a, a),
+            54 => self.slide_u8x64::<10>(a, a),
+            55 => self.slide_u8x64::<9>(a, a),
+            56 => self.slide_u8x64::<8>(a, a),
+            57 => self.slide_u8x64::<7>(a, a),
+            58 => self.slide_u8x64::<6>(a, a),
+            59 => self.slide_u8x64::<5>(a, a),
+            60 => self.slide_u8x64::<4>(a, a),
+            61 => self.slide_u8x64::<3>(a, a),
+            62 => self.slide_u8x64::<2>(a, a),
+            63 => self.slide_u8x64::<1>(a, a),
+            64 => self.slide_u8x64::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_u8x64(padding);
+        self.slide_u8x64::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_u8x64(padding);
+        match OFFSET {
+            0 => self.slide_u8x64::<64>(padding, a),
+            1 => self.slide_u8x64::<63>(padding, a),
+            2 => self.slide_u8x64::<62>(padding, a),
+            3 => self.slide_u8x64::<61>(padding, a),
+            4 => self.slide_u8x64::<60>(padding, a),
+            5 => self.slide_u8x64::<59>(padding, a),
+            6 => self.slide_u8x64::<58>(padding, a),
+            7 => self.slide_u8x64::<57>(padding, a),
+            8 => self.slide_u8x64::<56>(padding, a),
+            9 => self.slide_u8x64::<55>(padding, a),
+            10 => self.slide_u8x64::<54>(padding, a),
+            11 => self.slide_u8x64::<53>(padding, a),
+            12 => self.slide_u8x64::<52>(padding, a),
+            13 => self.slide_u8x64::<51>(padding, a),
+            14 => self.slide_u8x64::<50>(padding, a),
+            15 => self.slide_u8x64::<49>(padding, a),
+            16 => self.slide_u8x64::<48>(padding, a),
+            17 => self.slide_u8x64::<47>(padding, a),
+            18 => self.slide_u8x64::<46>(padding, a),
+            19 => self.slide_u8x64::<45>(padding, a),
+            20 => self.slide_u8x64::<44>(padding, a),
+            21 => self.slide_u8x64::<43>(padding, a),
+            22 => self.slide_u8x64::<42>(padding, a),
+            23 => self.slide_u8x64::<41>(padding, a),
+            24 => self.slide_u8x64::<40>(padding, a),
+            25 => self.slide_u8x64::<39>(padding, a),
+            26 => self.slide_u8x64::<38>(padding, a),
+            27 => self.slide_u8x64::<37>(padding, a),
+            28 => self.slide_u8x64::<36>(padding, a),
+            29 => self.slide_u8x64::<35>(padding, a),
+            30 => self.slide_u8x64::<34>(padding, a),
+            31 => self.slide_u8x64::<33>(padding, a),
+            32 => self.slide_u8x64::<32>(padding, a),
+            33 => self.slide_u8x64::<31>(padding, a),
+            34 => self.slide_u8x64::<30>(padding, a),
+            35 => self.slide_u8x64::<29>(padding, a),
+            36 => self.slide_u8x64::<28>(padding, a),
+            37 => self.slide_u8x64::<27>(padding, a),
+            38 => self.slide_u8x64::<26>(padding, a),
+            39 => self.slide_u8x64::<25>(padding, a),
+            40 => self.slide_u8x64::<24>(padding, a),
+            41 => self.slide_u8x64::<23>(padding, a),
+            42 => self.slide_u8x64::<22>(padding, a),
+            43 => self.slide_u8x64::<21>(padding, a),
+            44 => self.slide_u8x64::<20>(padding, a),
+            45 => self.slide_u8x64::<19>(padding, a),
+            46 => self.slide_u8x64::<18>(padding, a),
+            47 => self.slide_u8x64::<17>(padding, a),
+            48 => self.slide_u8x64::<16>(padding, a),
+            49 => self.slide_u8x64::<15>(padding, a),
+            50 => self.slide_u8x64::<14>(padding, a),
+            51 => self.slide_u8x64::<13>(padding, a),
+            52 => self.slide_u8x64::<12>(padding, a),
+            53 => self.slide_u8x64::<11>(padding, a),
+            54 => self.slide_u8x64::<10>(padding, a),
+            55 => self.slide_u8x64::<9>(padding, a),
+            56 => self.slide_u8x64::<8>(padding, a),
+            57 => self.slide_u8x64::<7>(padding, a),
+            58 => self.slide_u8x64::<6>(padding, a),
+            59 => self.slide_u8x64::<5>(padding, a),
+            60 => self.slide_u8x64::<4>(padding, a),
+            61 => self.slide_u8x64::<3>(padding, a),
+            62 => self.slide_u8x64::<2>(padding, a),
+            63 => self.slide_u8x64::<1>(padding, a),
+            64 => self.slide_u8x64::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self> {
@@ -8183,6 +9907,126 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_i16x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_i16x32::<32>(a, a),
+            1 => self.slide_i16x32::<31>(a, a),
+            2 => self.slide_i16x32::<30>(a, a),
+            3 => self.slide_i16x32::<29>(a, a),
+            4 => self.slide_i16x32::<28>(a, a),
+            5 => self.slide_i16x32::<27>(a, a),
+            6 => self.slide_i16x32::<26>(a, a),
+            7 => self.slide_i16x32::<25>(a, a),
+            8 => self.slide_i16x32::<24>(a, a),
+            9 => self.slide_i16x32::<23>(a, a),
+            10 => self.slide_i16x32::<22>(a, a),
+            11 => self.slide_i16x32::<21>(a, a),
+            12 => self.slide_i16x32::<20>(a, a),
+            13 => self.slide_i16x32::<19>(a, a),
+            14 => self.slide_i16x32::<18>(a, a),
+            15 => self.slide_i16x32::<17>(a, a),
+            16 => self.slide_i16x32::<16>(a, a),
+            17 => self.slide_i16x32::<15>(a, a),
+            18 => self.slide_i16x32::<14>(a, a),
+            19 => self.slide_i16x32::<13>(a, a),
+            20 => self.slide_i16x32::<12>(a, a),
+            21 => self.slide_i16x32::<11>(a, a),
+            22 => self.slide_i16x32::<10>(a, a),
+            23 => self.slide_i16x32::<9>(a, a),
+            24 => self.slide_i16x32::<8>(a, a),
+            25 => self.slide_i16x32::<7>(a, a),
+            26 => self.slide_i16x32::<6>(a, a),
+            27 => self.slide_i16x32::<5>(a, a),
+            28 => self.slide_i16x32::<4>(a, a),
+            29 => self.slide_i16x32::<3>(a, a),
+            30 => self.slide_i16x32::<2>(a, a),
+            31 => self.slide_i16x32::<1>(a, a),
+            32 => self.slide_i16x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i16x32(padding);
+        self.slide_i16x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i16x32(padding);
+        match OFFSET {
+            0 => self.slide_i16x32::<32>(padding, a),
+            1 => self.slide_i16x32::<31>(padding, a),
+            2 => self.slide_i16x32::<30>(padding, a),
+            3 => self.slide_i16x32::<29>(padding, a),
+            4 => self.slide_i16x32::<28>(padding, a),
+            5 => self.slide_i16x32::<27>(padding, a),
+            6 => self.slide_i16x32::<26>(padding, a),
+            7 => self.slide_i16x32::<25>(padding, a),
+            8 => self.slide_i16x32::<24>(padding, a),
+            9 => self.slide_i16x32::<23>(padding, a),
+            10 => self.slide_i16x32::<22>(padding, a),
+            11 => self.slide_i16x32::<21>(padding, a),
+            12 => self.slide_i16x32::<20>(padding, a),
+            13 => self.slide_i16x32::<19>(padding, a),
+            14 => self.slide_i16x32::<18>(padding, a),
+            15 => self.slide_i16x32::<17>(padding, a),
+            16 => self.slide_i16x32::<16>(padding, a),
+            17 => self.slide_i16x32::<15>(padding, a),
+            18 => self.slide_i16x32::<14>(padding, a),
+            19 => self.slide_i16x32::<13>(padding, a),
+            20 => self.slide_i16x32::<12>(padding, a),
+            21 => self.slide_i16x32::<11>(padding, a),
+            22 => self.slide_i16x32::<10>(padding, a),
+            23 => self.slide_i16x32::<9>(padding, a),
+            24 => self.slide_i16x32::<8>(padding, a),
+            25 => self.slide_i16x32::<7>(padding, a),
+            26 => self.slide_i16x32::<6>(padding, a),
+            27 => self.slide_i16x32::<5>(padding, a),
+            28 => self.slide_i16x32::<4>(padding, a),
+            29 => self.slide_i16x32::<3>(padding, a),
+            30 => self.slide_i16x32::<2>(padding, a),
+            31 => self.slide_i16x32::<1>(padding, a),
+            32 => self.slide_i16x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x32(
         self,
         a: i16x32<Self>,
@@ -8474,6 +10318,126 @@ impl Simd for Sse4_2 {
             self.slide_within_blocks_u16x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x16::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_u16x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_u16x32::<32>(a, a),
+            1 => self.slide_u16x32::<31>(a, a),
+            2 => self.slide_u16x32::<30>(a, a),
+            3 => self.slide_u16x32::<29>(a, a),
+            4 => self.slide_u16x32::<28>(a, a),
+            5 => self.slide_u16x32::<27>(a, a),
+            6 => self.slide_u16x32::<26>(a, a),
+            7 => self.slide_u16x32::<25>(a, a),
+            8 => self.slide_u16x32::<24>(a, a),
+            9 => self.slide_u16x32::<23>(a, a),
+            10 => self.slide_u16x32::<22>(a, a),
+            11 => self.slide_u16x32::<21>(a, a),
+            12 => self.slide_u16x32::<20>(a, a),
+            13 => self.slide_u16x32::<19>(a, a),
+            14 => self.slide_u16x32::<18>(a, a),
+            15 => self.slide_u16x32::<17>(a, a),
+            16 => self.slide_u16x32::<16>(a, a),
+            17 => self.slide_u16x32::<15>(a, a),
+            18 => self.slide_u16x32::<14>(a, a),
+            19 => self.slide_u16x32::<13>(a, a),
+            20 => self.slide_u16x32::<12>(a, a),
+            21 => self.slide_u16x32::<11>(a, a),
+            22 => self.slide_u16x32::<10>(a, a),
+            23 => self.slide_u16x32::<9>(a, a),
+            24 => self.slide_u16x32::<8>(a, a),
+            25 => self.slide_u16x32::<7>(a, a),
+            26 => self.slide_u16x32::<6>(a, a),
+            27 => self.slide_u16x32::<5>(a, a),
+            28 => self.slide_u16x32::<4>(a, a),
+            29 => self.slide_u16x32::<3>(a, a),
+            30 => self.slide_u16x32::<2>(a, a),
+            31 => self.slide_u16x32::<1>(a, a),
+            32 => self.slide_u16x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u16x32(padding);
+        self.slide_u16x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u16x32(padding);
+        match OFFSET {
+            0 => self.slide_u16x32::<32>(padding, a),
+            1 => self.slide_u16x32::<31>(padding, a),
+            2 => self.slide_u16x32::<30>(padding, a),
+            3 => self.slide_u16x32::<29>(padding, a),
+            4 => self.slide_u16x32::<28>(padding, a),
+            5 => self.slide_u16x32::<27>(padding, a),
+            6 => self.slide_u16x32::<26>(padding, a),
+            7 => self.slide_u16x32::<25>(padding, a),
+            8 => self.slide_u16x32::<24>(padding, a),
+            9 => self.slide_u16x32::<23>(padding, a),
+            10 => self.slide_u16x32::<22>(padding, a),
+            11 => self.slide_u16x32::<21>(padding, a),
+            12 => self.slide_u16x32::<20>(padding, a),
+            13 => self.slide_u16x32::<19>(padding, a),
+            14 => self.slide_u16x32::<18>(padding, a),
+            15 => self.slide_u16x32::<17>(padding, a),
+            16 => self.slide_u16x32::<16>(padding, a),
+            17 => self.slide_u16x32::<15>(padding, a),
+            18 => self.slide_u16x32::<14>(padding, a),
+            19 => self.slide_u16x32::<13>(padding, a),
+            20 => self.slide_u16x32::<12>(padding, a),
+            21 => self.slide_u16x32::<11>(padding, a),
+            22 => self.slide_u16x32::<10>(padding, a),
+            23 => self.slide_u16x32::<9>(padding, a),
+            24 => self.slide_u16x32::<8>(padding, a),
+            25 => self.slide_u16x32::<7>(padding, a),
+            26 => self.slide_u16x32::<6>(padding, a),
+            27 => self.slide_u16x32::<5>(padding, a),
+            28 => self.slide_u16x32::<4>(padding, a),
+            29 => self.slide_u16x32::<3>(padding, a),
+            30 => self.slide_u16x32::<2>(padding, a),
+            31 => self.slide_u16x32::<1>(padding, a),
+            32 => self.slide_u16x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x32(
@@ -8983,6 +10947,94 @@ impl Simd for Sse4_2 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i32x16::<16>(a, a),
+            1 => self.slide_i32x16::<15>(a, a),
+            2 => self.slide_i32x16::<14>(a, a),
+            3 => self.slide_i32x16::<13>(a, a),
+            4 => self.slide_i32x16::<12>(a, a),
+            5 => self.slide_i32x16::<11>(a, a),
+            6 => self.slide_i32x16::<10>(a, a),
+            7 => self.slide_i32x16::<9>(a, a),
+            8 => self.slide_i32x16::<8>(a, a),
+            9 => self.slide_i32x16::<7>(a, a),
+            10 => self.slide_i32x16::<6>(a, a),
+            11 => self.slide_i32x16::<5>(a, a),
+            12 => self.slide_i32x16::<4>(a, a),
+            13 => self.slide_i32x16::<3>(a, a),
+            14 => self.slide_i32x16::<2>(a, a),
+            15 => self.slide_i32x16::<1>(a, a),
+            16 => self.slide_i32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i32x16(padding);
+        self.slide_i32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i32x16(padding);
+        match OFFSET {
+            0 => self.slide_i32x16::<16>(padding, a),
+            1 => self.slide_i32x16::<15>(padding, a),
+            2 => self.slide_i32x16::<14>(padding, a),
+            3 => self.slide_i32x16::<13>(padding, a),
+            4 => self.slide_i32x16::<12>(padding, a),
+            5 => self.slide_i32x16::<11>(padding, a),
+            6 => self.slide_i32x16::<10>(padding, a),
+            7 => self.slide_i32x16::<9>(padding, a),
+            8 => self.slide_i32x16::<8>(padding, a),
+            9 => self.slide_i32x16::<7>(padding, a),
+            10 => self.slide_i32x16::<6>(padding, a),
+            11 => self.slide_i32x16::<5>(padding, a),
+            12 => self.slide_i32x16::<4>(padding, a),
+            13 => self.slide_i32x16::<3>(padding, a),
+            14 => self.slide_i32x16::<2>(padding, a),
+            15 => self.slide_i32x16::<1>(padding, a),
+            16 => self.slide_i32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x16(
         self,
         a: i32x16<Self>,
@@ -9270,6 +11322,94 @@ impl Simd for Sse4_2 {
             self.slide_within_blocks_u32x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x8::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u32x16::<16>(a, a),
+            1 => self.slide_u32x16::<15>(a, a),
+            2 => self.slide_u32x16::<14>(a, a),
+            3 => self.slide_u32x16::<13>(a, a),
+            4 => self.slide_u32x16::<12>(a, a),
+            5 => self.slide_u32x16::<11>(a, a),
+            6 => self.slide_u32x16::<10>(a, a),
+            7 => self.slide_u32x16::<9>(a, a),
+            8 => self.slide_u32x16::<8>(a, a),
+            9 => self.slide_u32x16::<7>(a, a),
+            10 => self.slide_u32x16::<6>(a, a),
+            11 => self.slide_u32x16::<5>(a, a),
+            12 => self.slide_u32x16::<4>(a, a),
+            13 => self.slide_u32x16::<3>(a, a),
+            14 => self.slide_u32x16::<2>(a, a),
+            15 => self.slide_u32x16::<1>(a, a),
+            16 => self.slide_u32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u32x16(padding);
+        self.slide_u32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u32x16(padding);
+        match OFFSET {
+            0 => self.slide_u32x16::<16>(padding, a),
+            1 => self.slide_u32x16::<15>(padding, a),
+            2 => self.slide_u32x16::<14>(padding, a),
+            3 => self.slide_u32x16::<13>(padding, a),
+            4 => self.slide_u32x16::<12>(padding, a),
+            5 => self.slide_u32x16::<11>(padding, a),
+            6 => self.slide_u32x16::<10>(padding, a),
+            7 => self.slide_u32x16::<9>(padding, a),
+            8 => self.slide_u32x16::<8>(padding, a),
+            9 => self.slide_u32x16::<7>(padding, a),
+            10 => self.slide_u32x16::<6>(padding, a),
+            11 => self.slide_u32x16::<5>(padding, a),
+            12 => self.slide_u32x16::<4>(padding, a),
+            13 => self.slide_u32x16::<3>(padding, a),
+            14 => self.slide_u32x16::<2>(padding, a),
+            15 => self.slide_u32x16::<1>(padding, a),
+            16 => self.slide_u32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x16(
@@ -9738,6 +11878,78 @@ impl Simd for Sse4_2 {
             self.slide_within_blocks_f64x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x4::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_f64x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_f64x8::<8>(a, a),
+            1 => self.slide_f64x8::<7>(a, a),
+            2 => self.slide_f64x8::<6>(a, a),
+            3 => self.slide_f64x8::<5>(a, a),
+            4 => self.slide_f64x8::<4>(a, a),
+            5 => self.slide_f64x8::<3>(a, a),
+            6 => self.slide_f64x8::<2>(a, a),
+            7 => self.slide_f64x8::<1>(a, a),
+            8 => self.slide_f64x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f64x8(padding);
+        self.slide_f64x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f64x8(padding);
+        match OFFSET {
+            0 => self.slide_f64x8::<8>(padding, a),
+            1 => self.slide_f64x8::<7>(padding, a),
+            2 => self.slide_f64x8::<6>(padding, a),
+            3 => self.slide_f64x8::<5>(padding, a),
+            4 => self.slide_f64x8::<4>(padding, a),
+            5 => self.slide_f64x8::<3>(padding, a),
+            6 => self.slide_f64x8::<2>(padding, a),
+            7 => self.slide_f64x8::<1>(padding, a),
+            8 => self.slide_f64x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -157,6 +157,70 @@ impl Simd for WasmSimd128 {
         self.slide_f32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_f32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_f32x4::<4>(a, a),
+            1 => self.slide_f32x4::<3>(a, a),
+            2 => self.slide_f32x4::<2>(a, a),
+            3 => self.slide_f32x4::<1>(a, a),
+            4 => self.slide_f32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f32x4(padding);
+        self.slide_f32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x4<const OFFSET: usize>(
+        self,
+        a: f32x4<Self>,
+        padding: f32,
+    ) -> f32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f32x4(padding);
+        match OFFSET {
+            0 => self.slide_f32x4::<4>(padding, a),
+            1 => self.slide_f32x4::<3>(padding, a),
+            2 => self.slide_f32x4::<2>(padding, a),
+            3 => self.slide_f32x4::<1>(padding, a),
+            4 => self.slide_f32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
         let result = u8x16_swizzle(self.cvt_to_bytes_f32x4(a).val.0, indices.into());
         self.cvt_from_bytes_f32x4(u8x16 {
@@ -459,6 +523,94 @@ impl Simd for WasmSimd128 {
         self.slide_i8x16::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i8x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i8x16::<16>(a, a),
+            1 => self.slide_i8x16::<15>(a, a),
+            2 => self.slide_i8x16::<14>(a, a),
+            3 => self.slide_i8x16::<13>(a, a),
+            4 => self.slide_i8x16::<12>(a, a),
+            5 => self.slide_i8x16::<11>(a, a),
+            6 => self.slide_i8x16::<10>(a, a),
+            7 => self.slide_i8x16::<9>(a, a),
+            8 => self.slide_i8x16::<8>(a, a),
+            9 => self.slide_i8x16::<7>(a, a),
+            10 => self.slide_i8x16::<6>(a, a),
+            11 => self.slide_i8x16::<5>(a, a),
+            12 => self.slide_i8x16::<4>(a, a),
+            13 => self.slide_i8x16::<3>(a, a),
+            14 => self.slide_i8x16::<2>(a, a),
+            15 => self.slide_i8x16::<1>(a, a),
+            16 => self.slide_i8x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i8x16(padding);
+        self.slide_i8x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x16<const OFFSET: usize>(
+        self,
+        a: i8x16<Self>,
+        padding: i8,
+    ) -> i8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i8x16(padding);
+        match OFFSET {
+            0 => self.slide_i8x16::<16>(padding, a),
+            1 => self.slide_i8x16::<15>(padding, a),
+            2 => self.slide_i8x16::<14>(padding, a),
+            3 => self.slide_i8x16::<13>(padding, a),
+            4 => self.slide_i8x16::<12>(padding, a),
+            5 => self.slide_i8x16::<11>(padding, a),
+            6 => self.slide_i8x16::<10>(padding, a),
+            7 => self.slide_i8x16::<9>(padding, a),
+            8 => self.slide_i8x16::<8>(padding, a),
+            9 => self.slide_i8x16::<7>(padding, a),
+            10 => self.slide_i8x16::<6>(padding, a),
+            11 => self.slide_i8x16::<5>(padding, a),
+            12 => self.slide_i8x16::<4>(padding, a),
+            13 => self.slide_i8x16::<3>(padding, a),
+            14 => self.slide_i8x16::<2>(padding, a),
+            15 => self.slide_i8x16::<1>(padding, a),
+            16 => self.slide_i8x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
         let result = u8x16_swizzle(self.cvt_to_bytes_i8x16(a).val.0, indices.into());
         self.cvt_from_bytes_i8x16(u8x16 {
@@ -678,6 +830,94 @@ impl Simd for WasmSimd128 {
         b: u8x16<Self>,
     ) -> u8x16<Self> {
         self.slide_u8x16::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u8x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u8x16::<16>(a, a),
+            1 => self.slide_u8x16::<15>(a, a),
+            2 => self.slide_u8x16::<14>(a, a),
+            3 => self.slide_u8x16::<13>(a, a),
+            4 => self.slide_u8x16::<12>(a, a),
+            5 => self.slide_u8x16::<11>(a, a),
+            6 => self.slide_u8x16::<10>(a, a),
+            7 => self.slide_u8x16::<9>(a, a),
+            8 => self.slide_u8x16::<8>(a, a),
+            9 => self.slide_u8x16::<7>(a, a),
+            10 => self.slide_u8x16::<6>(a, a),
+            11 => self.slide_u8x16::<5>(a, a),
+            12 => self.slide_u8x16::<4>(a, a),
+            13 => self.slide_u8x16::<3>(a, a),
+            14 => self.slide_u8x16::<2>(a, a),
+            15 => self.slide_u8x16::<1>(a, a),
+            16 => self.slide_u8x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u8x16(padding);
+        self.slide_u8x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x16<const OFFSET: usize>(
+        self,
+        a: u8x16<Self>,
+        padding: u8,
+    ) -> u8x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u8x16(padding);
+        match OFFSET {
+            0 => self.slide_u8x16::<16>(padding, a),
+            1 => self.slide_u8x16::<15>(padding, a),
+            2 => self.slide_u8x16::<14>(padding, a),
+            3 => self.slide_u8x16::<13>(padding, a),
+            4 => self.slide_u8x16::<12>(padding, a),
+            5 => self.slide_u8x16::<11>(padding, a),
+            6 => self.slide_u8x16::<10>(padding, a),
+            7 => self.slide_u8x16::<9>(padding, a),
+            8 => self.slide_u8x16::<8>(padding, a),
+            9 => self.slide_u8x16::<7>(padding, a),
+            10 => self.slide_u8x16::<6>(padding, a),
+            11 => self.slide_u8x16::<5>(padding, a),
+            12 => self.slide_u8x16::<4>(padding, a),
+            13 => self.slide_u8x16::<3>(padding, a),
+            14 => self.slide_u8x16::<2>(padding, a),
+            15 => self.slide_u8x16::<1>(padding, a),
+            16 => self.slide_u8x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
@@ -998,6 +1238,78 @@ impl Simd for WasmSimd128 {
         self.slide_i16x8::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_i16x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_i16x8::<8>(a, a),
+            1 => self.slide_i16x8::<7>(a, a),
+            2 => self.slide_i16x8::<6>(a, a),
+            3 => self.slide_i16x8::<5>(a, a),
+            4 => self.slide_i16x8::<4>(a, a),
+            5 => self.slide_i16x8::<3>(a, a),
+            6 => self.slide_i16x8::<2>(a, a),
+            7 => self.slide_i16x8::<1>(a, a),
+            8 => self.slide_i16x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i16x8(padding);
+        self.slide_i16x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x8<const OFFSET: usize>(
+        self,
+        a: i16x8<Self>,
+        padding: i16,
+    ) -> i16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i16x8(padding);
+        match OFFSET {
+            0 => self.slide_i16x8::<8>(padding, a),
+            1 => self.slide_i16x8::<7>(padding, a),
+            2 => self.slide_i16x8::<6>(padding, a),
+            3 => self.slide_i16x8::<5>(padding, a),
+            4 => self.slide_i16x8::<4>(padding, a),
+            5 => self.slide_i16x8::<3>(padding, a),
+            6 => self.slide_i16x8::<2>(padding, a),
+            7 => self.slide_i16x8::<1>(padding, a),
+            8 => self.slide_i16x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
         let result = u8x16_swizzle(self.cvt_to_bytes_i16x8(a).val.0, indices.into());
         self.cvt_from_bytes_i16x8(u8x16 {
@@ -1201,6 +1513,78 @@ impl Simd for WasmSimd128 {
         b: u16x8<Self>,
     ) -> u16x8<Self> {
         self.slide_u16x8::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_u16x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_u16x8::<8>(a, a),
+            1 => self.slide_u16x8::<7>(a, a),
+            2 => self.slide_u16x8::<6>(a, a),
+            3 => self.slide_u16x8::<5>(a, a),
+            4 => self.slide_u16x8::<4>(a, a),
+            5 => self.slide_u16x8::<3>(a, a),
+            6 => self.slide_u16x8::<2>(a, a),
+            7 => self.slide_u16x8::<1>(a, a),
+            8 => self.slide_u16x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u16x8(padding);
+        self.slide_u16x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x8<const OFFSET: usize>(
+        self,
+        a: u16x8<Self>,
+        padding: u16,
+    ) -> u16x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u16x8(padding);
+        match OFFSET {
+            0 => self.slide_u16x8::<8>(padding, a),
+            1 => self.slide_u16x8::<7>(padding, a),
+            2 => self.slide_u16x8::<6>(padding, a),
+            3 => self.slide_u16x8::<5>(padding, a),
+            4 => self.slide_u16x8::<4>(padding, a),
+            5 => self.slide_u16x8::<3>(padding, a),
+            6 => self.slide_u16x8::<2>(padding, a),
+            7 => self.slide_u16x8::<1>(padding, a),
+            8 => self.slide_u16x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
@@ -1501,6 +1885,70 @@ impl Simd for WasmSimd128 {
         self.slide_i32x4::<SHIFT>(a, b)
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_i32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_i32x4::<4>(a, a),
+            1 => self.slide_i32x4::<3>(a, a),
+            2 => self.slide_i32x4::<2>(a, a),
+            3 => self.slide_i32x4::<1>(a, a),
+            4 => self.slide_i32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_i32x4(padding);
+        self.slide_i32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x4<const OFFSET: usize>(
+        self,
+        a: i32x4<Self>,
+        padding: i32,
+    ) -> i32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_i32x4(padding);
+        match OFFSET {
+            0 => self.slide_i32x4::<4>(padding, a),
+            1 => self.slide_i32x4::<3>(padding, a),
+            2 => self.slide_i32x4::<2>(padding, a),
+            3 => self.slide_i32x4::<1>(padding, a),
+            4 => self.slide_i32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
         let result = u8x16_swizzle(self.cvt_to_bytes_i32x4(a).val.0, indices.into());
         self.cvt_from_bytes_i32x4(u8x16 {
@@ -1708,6 +2156,70 @@ impl Simd for WasmSimd128 {
         b: u32x4<Self>,
     ) -> u32x4<Self> {
         self.slide_u32x4::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_u32x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_u32x4::<4>(a, a),
+            1 => self.slide_u32x4::<3>(a, a),
+            2 => self.slide_u32x4::<2>(a, a),
+            3 => self.slide_u32x4::<1>(a, a),
+            4 => self.slide_u32x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_u32x4(padding);
+        self.slide_u32x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x4<const OFFSET: usize>(
+        self,
+        a: u32x4<Self>,
+        padding: u32,
+    ) -> u32x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_u32x4(padding);
+        match OFFSET {
+            0 => self.slide_u32x4::<4>(padding, a),
+            1 => self.slide_u32x4::<3>(padding, a),
+            2 => self.slide_u32x4::<2>(padding, a),
+            3 => self.slide_u32x4::<1>(padding, a),
+            4 => self.slide_u32x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
@@ -2006,6 +2518,66 @@ impl Simd for WasmSimd128 {
         b: f64x2<Self>,
     ) -> f64x2<Self> {
         self.slide_f64x2::<SHIFT>(a, b)
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        self.slide_f64x2::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        match OFFSET {
+            0 => self.slide_f64x2::<2>(a, a),
+            1 => self.slide_f64x2::<1>(a, a),
+            2 => self.slide_f64x2::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        let padding = self.splat_f64x2(padding);
+        self.slide_f64x2::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x2<const OFFSET: usize>(
+        self,
+        a: f64x2<Self>,
+        padding: f64,
+    ) -> f64x2<Self> {
+        assert!(
+            OFFSET <= 2,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            2,
+        );
+        let padding = self.splat_f64x2(padding);
+        match OFFSET {
+            0 => self.slide_f64x2::<2>(padding, a),
+            1 => self.slide_f64x2::<1>(padding, a),
+            2 => self.slide_f64x2::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
@@ -2369,6 +2941,78 @@ impl Simd for WasmSimd128 {
             self.slide_within_blocks_f32x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_f32x4::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_f32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_f32x8::<8>(a, a),
+            1 => self.slide_f32x8::<7>(a, a),
+            2 => self.slide_f32x8::<6>(a, a),
+            3 => self.slide_f32x8::<5>(a, a),
+            4 => self.slide_f32x8::<4>(a, a),
+            5 => self.slide_f32x8::<3>(a, a),
+            6 => self.slide_f32x8::<2>(a, a),
+            7 => self.slide_f32x8::<1>(a, a),
+            8 => self.slide_f32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f32x8(padding);
+        self.slide_f32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x8<const OFFSET: usize>(
+        self,
+        a: f32x8<Self>,
+        padding: f32,
+    ) -> f32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f32x8(padding);
+        match OFFSET {
+            0 => self.slide_f32x8::<8>(padding, a),
+            1 => self.slide_f32x8::<7>(padding, a),
+            2 => self.slide_f32x8::<6>(padding, a),
+            3 => self.slide_f32x8::<5>(padding, a),
+            4 => self.slide_f32x8::<4>(padding, a),
+            5 => self.slide_f32x8::<3>(padding, a),
+            6 => self.slide_f32x8::<2>(padding, a),
+            7 => self.slide_f32x8::<1>(padding, a),
+            8 => self.slide_f32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
@@ -2750,6 +3394,126 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_i8x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_i8x32::<32>(a, a),
+            1 => self.slide_i8x32::<31>(a, a),
+            2 => self.slide_i8x32::<30>(a, a),
+            3 => self.slide_i8x32::<29>(a, a),
+            4 => self.slide_i8x32::<28>(a, a),
+            5 => self.slide_i8x32::<27>(a, a),
+            6 => self.slide_i8x32::<26>(a, a),
+            7 => self.slide_i8x32::<25>(a, a),
+            8 => self.slide_i8x32::<24>(a, a),
+            9 => self.slide_i8x32::<23>(a, a),
+            10 => self.slide_i8x32::<22>(a, a),
+            11 => self.slide_i8x32::<21>(a, a),
+            12 => self.slide_i8x32::<20>(a, a),
+            13 => self.slide_i8x32::<19>(a, a),
+            14 => self.slide_i8x32::<18>(a, a),
+            15 => self.slide_i8x32::<17>(a, a),
+            16 => self.slide_i8x32::<16>(a, a),
+            17 => self.slide_i8x32::<15>(a, a),
+            18 => self.slide_i8x32::<14>(a, a),
+            19 => self.slide_i8x32::<13>(a, a),
+            20 => self.slide_i8x32::<12>(a, a),
+            21 => self.slide_i8x32::<11>(a, a),
+            22 => self.slide_i8x32::<10>(a, a),
+            23 => self.slide_i8x32::<9>(a, a),
+            24 => self.slide_i8x32::<8>(a, a),
+            25 => self.slide_i8x32::<7>(a, a),
+            26 => self.slide_i8x32::<6>(a, a),
+            27 => self.slide_i8x32::<5>(a, a),
+            28 => self.slide_i8x32::<4>(a, a),
+            29 => self.slide_i8x32::<3>(a, a),
+            30 => self.slide_i8x32::<2>(a, a),
+            31 => self.slide_i8x32::<1>(a, a),
+            32 => self.slide_i8x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i8x32(padding);
+        self.slide_i8x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x32<const OFFSET: usize>(
+        self,
+        a: i8x32<Self>,
+        padding: i8,
+    ) -> i8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i8x32(padding);
+        match OFFSET {
+            0 => self.slide_i8x32::<32>(padding, a),
+            1 => self.slide_i8x32::<31>(padding, a),
+            2 => self.slide_i8x32::<30>(padding, a),
+            3 => self.slide_i8x32::<29>(padding, a),
+            4 => self.slide_i8x32::<28>(padding, a),
+            5 => self.slide_i8x32::<27>(padding, a),
+            6 => self.slide_i8x32::<26>(padding, a),
+            7 => self.slide_i8x32::<25>(padding, a),
+            8 => self.slide_i8x32::<24>(padding, a),
+            9 => self.slide_i8x32::<23>(padding, a),
+            10 => self.slide_i8x32::<22>(padding, a),
+            11 => self.slide_i8x32::<21>(padding, a),
+            12 => self.slide_i8x32::<20>(padding, a),
+            13 => self.slide_i8x32::<19>(padding, a),
+            14 => self.slide_i8x32::<18>(padding, a),
+            15 => self.slide_i8x32::<17>(padding, a),
+            16 => self.slide_i8x32::<16>(padding, a),
+            17 => self.slide_i8x32::<15>(padding, a),
+            18 => self.slide_i8x32::<14>(padding, a),
+            19 => self.slide_i8x32::<13>(padding, a),
+            20 => self.slide_i8x32::<12>(padding, a),
+            21 => self.slide_i8x32::<11>(padding, a),
+            22 => self.slide_i8x32::<10>(padding, a),
+            23 => self.slide_i8x32::<9>(padding, a),
+            24 => self.slide_i8x32::<8>(padding, a),
+            25 => self.slide_i8x32::<7>(padding, a),
+            26 => self.slide_i8x32::<6>(padding, a),
+            27 => self.slide_i8x32::<5>(padding, a),
+            28 => self.slide_i8x32::<4>(padding, a),
+            29 => self.slide_i8x32::<3>(padding, a),
+            30 => self.slide_i8x32::<2>(padding, a),
+            31 => self.slide_i8x32::<1>(padding, a),
+            32 => self.slide_i8x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
         let (indices0, indices1) = self.split_u8x32(indices);
@@ -3034,6 +3798,126 @@ impl Simd for WasmSimd128 {
             self.slide_within_blocks_u8x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x16::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_u8x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_u8x32::<32>(a, a),
+            1 => self.slide_u8x32::<31>(a, a),
+            2 => self.slide_u8x32::<30>(a, a),
+            3 => self.slide_u8x32::<29>(a, a),
+            4 => self.slide_u8x32::<28>(a, a),
+            5 => self.slide_u8x32::<27>(a, a),
+            6 => self.slide_u8x32::<26>(a, a),
+            7 => self.slide_u8x32::<25>(a, a),
+            8 => self.slide_u8x32::<24>(a, a),
+            9 => self.slide_u8x32::<23>(a, a),
+            10 => self.slide_u8x32::<22>(a, a),
+            11 => self.slide_u8x32::<21>(a, a),
+            12 => self.slide_u8x32::<20>(a, a),
+            13 => self.slide_u8x32::<19>(a, a),
+            14 => self.slide_u8x32::<18>(a, a),
+            15 => self.slide_u8x32::<17>(a, a),
+            16 => self.slide_u8x32::<16>(a, a),
+            17 => self.slide_u8x32::<15>(a, a),
+            18 => self.slide_u8x32::<14>(a, a),
+            19 => self.slide_u8x32::<13>(a, a),
+            20 => self.slide_u8x32::<12>(a, a),
+            21 => self.slide_u8x32::<11>(a, a),
+            22 => self.slide_u8x32::<10>(a, a),
+            23 => self.slide_u8x32::<9>(a, a),
+            24 => self.slide_u8x32::<8>(a, a),
+            25 => self.slide_u8x32::<7>(a, a),
+            26 => self.slide_u8x32::<6>(a, a),
+            27 => self.slide_u8x32::<5>(a, a),
+            28 => self.slide_u8x32::<4>(a, a),
+            29 => self.slide_u8x32::<3>(a, a),
+            30 => self.slide_u8x32::<2>(a, a),
+            31 => self.slide_u8x32::<1>(a, a),
+            32 => self.slide_u8x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u8x32(padding);
+        self.slide_u8x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x32<const OFFSET: usize>(
+        self,
+        a: u8x32<Self>,
+        padding: u8,
+    ) -> u8x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u8x32(padding);
+        match OFFSET {
+            0 => self.slide_u8x32::<32>(padding, a),
+            1 => self.slide_u8x32::<31>(padding, a),
+            2 => self.slide_u8x32::<30>(padding, a),
+            3 => self.slide_u8x32::<29>(padding, a),
+            4 => self.slide_u8x32::<28>(padding, a),
+            5 => self.slide_u8x32::<27>(padding, a),
+            6 => self.slide_u8x32::<26>(padding, a),
+            7 => self.slide_u8x32::<25>(padding, a),
+            8 => self.slide_u8x32::<24>(padding, a),
+            9 => self.slide_u8x32::<23>(padding, a),
+            10 => self.slide_u8x32::<22>(padding, a),
+            11 => self.slide_u8x32::<21>(padding, a),
+            12 => self.slide_u8x32::<20>(padding, a),
+            13 => self.slide_u8x32::<19>(padding, a),
+            14 => self.slide_u8x32::<18>(padding, a),
+            15 => self.slide_u8x32::<17>(padding, a),
+            16 => self.slide_u8x32::<16>(padding, a),
+            17 => self.slide_u8x32::<15>(padding, a),
+            18 => self.slide_u8x32::<14>(padding, a),
+            19 => self.slide_u8x32::<13>(padding, a),
+            20 => self.slide_u8x32::<12>(padding, a),
+            21 => self.slide_u8x32::<11>(padding, a),
+            22 => self.slide_u8x32::<10>(padding, a),
+            23 => self.slide_u8x32::<9>(padding, a),
+            24 => self.slide_u8x32::<8>(padding, a),
+            25 => self.slide_u8x32::<7>(padding, a),
+            26 => self.slide_u8x32::<6>(padding, a),
+            27 => self.slide_u8x32::<5>(padding, a),
+            28 => self.slide_u8x32::<4>(padding, a),
+            29 => self.slide_u8x32::<3>(padding, a),
+            30 => self.slide_u8x32::<2>(padding, a),
+            31 => self.slide_u8x32::<1>(padding, a),
+            32 => self.slide_u8x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self> {
@@ -3441,6 +4325,94 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i16x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i16x16::<16>(a, a),
+            1 => self.slide_i16x16::<15>(a, a),
+            2 => self.slide_i16x16::<14>(a, a),
+            3 => self.slide_i16x16::<13>(a, a),
+            4 => self.slide_i16x16::<12>(a, a),
+            5 => self.slide_i16x16::<11>(a, a),
+            6 => self.slide_i16x16::<10>(a, a),
+            7 => self.slide_i16x16::<9>(a, a),
+            8 => self.slide_i16x16::<8>(a, a),
+            9 => self.slide_i16x16::<7>(a, a),
+            10 => self.slide_i16x16::<6>(a, a),
+            11 => self.slide_i16x16::<5>(a, a),
+            12 => self.slide_i16x16::<4>(a, a),
+            13 => self.slide_i16x16::<3>(a, a),
+            14 => self.slide_i16x16::<2>(a, a),
+            15 => self.slide_i16x16::<1>(a, a),
+            16 => self.slide_i16x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i16x16(padding);
+        self.slide_i16x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x16<const OFFSET: usize>(
+        self,
+        a: i16x16<Self>,
+        padding: i16,
+    ) -> i16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i16x16(padding);
+        match OFFSET {
+            0 => self.slide_i16x16::<16>(padding, a),
+            1 => self.slide_i16x16::<15>(padding, a),
+            2 => self.slide_i16x16::<14>(padding, a),
+            3 => self.slide_i16x16::<13>(padding, a),
+            4 => self.slide_i16x16::<12>(padding, a),
+            5 => self.slide_i16x16::<11>(padding, a),
+            6 => self.slide_i16x16::<10>(padding, a),
+            7 => self.slide_i16x16::<9>(padding, a),
+            8 => self.slide_i16x16::<8>(padding, a),
+            9 => self.slide_i16x16::<7>(padding, a),
+            10 => self.slide_i16x16::<6>(padding, a),
+            11 => self.slide_i16x16::<5>(padding, a),
+            12 => self.slide_i16x16::<4>(padding, a),
+            13 => self.slide_i16x16::<3>(padding, a),
+            14 => self.slide_i16x16::<2>(padding, a),
+            15 => self.slide_i16x16::<1>(padding, a),
+            16 => self.slide_i16x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x16(
         self,
         a: i16x16<Self>,
@@ -3729,6 +4701,94 @@ impl Simd for WasmSimd128 {
             self.slide_within_blocks_u16x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x8::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u16x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u16x16::<16>(a, a),
+            1 => self.slide_u16x16::<15>(a, a),
+            2 => self.slide_u16x16::<14>(a, a),
+            3 => self.slide_u16x16::<13>(a, a),
+            4 => self.slide_u16x16::<12>(a, a),
+            5 => self.slide_u16x16::<11>(a, a),
+            6 => self.slide_u16x16::<10>(a, a),
+            7 => self.slide_u16x16::<9>(a, a),
+            8 => self.slide_u16x16::<8>(a, a),
+            9 => self.slide_u16x16::<7>(a, a),
+            10 => self.slide_u16x16::<6>(a, a),
+            11 => self.slide_u16x16::<5>(a, a),
+            12 => self.slide_u16x16::<4>(a, a),
+            13 => self.slide_u16x16::<3>(a, a),
+            14 => self.slide_u16x16::<2>(a, a),
+            15 => self.slide_u16x16::<1>(a, a),
+            16 => self.slide_u16x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u16x16(padding);
+        self.slide_u16x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x16<const OFFSET: usize>(
+        self,
+        a: u16x16<Self>,
+        padding: u16,
+    ) -> u16x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u16x16(padding);
+        match OFFSET {
+            0 => self.slide_u16x16::<16>(padding, a),
+            1 => self.slide_u16x16::<15>(padding, a),
+            2 => self.slide_u16x16::<14>(padding, a),
+            3 => self.slide_u16x16::<13>(padding, a),
+            4 => self.slide_u16x16::<12>(padding, a),
+            5 => self.slide_u16x16::<11>(padding, a),
+            6 => self.slide_u16x16::<10>(padding, a),
+            7 => self.slide_u16x16::<9>(padding, a),
+            8 => self.slide_u16x16::<8>(padding, a),
+            9 => self.slide_u16x16::<7>(padding, a),
+            10 => self.slide_u16x16::<6>(padding, a),
+            11 => self.slide_u16x16::<5>(padding, a),
+            12 => self.slide_u16x16::<4>(padding, a),
+            13 => self.slide_u16x16::<3>(padding, a),
+            14 => self.slide_u16x16::<2>(padding, a),
+            15 => self.slide_u16x16::<1>(padding, a),
+            16 => self.slide_u16x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x16(
@@ -4149,6 +5209,78 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_i32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_i32x8::<8>(a, a),
+            1 => self.slide_i32x8::<7>(a, a),
+            2 => self.slide_i32x8::<6>(a, a),
+            3 => self.slide_i32x8::<5>(a, a),
+            4 => self.slide_i32x8::<4>(a, a),
+            5 => self.slide_i32x8::<3>(a, a),
+            6 => self.slide_i32x8::<2>(a, a),
+            7 => self.slide_i32x8::<1>(a, a),
+            8 => self.slide_i32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i32x8(padding);
+        self.slide_i32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x8<const OFFSET: usize>(
+        self,
+        a: i32x8<Self>,
+        padding: i32,
+    ) -> i32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_i32x8(padding);
+        match OFFSET {
+            0 => self.slide_i32x8::<8>(padding, a),
+            1 => self.slide_i32x8::<7>(padding, a),
+            2 => self.slide_i32x8::<6>(padding, a),
+            3 => self.slide_i32x8::<5>(padding, a),
+            4 => self.slide_i32x8::<4>(padding, a),
+            5 => self.slide_i32x8::<3>(padding, a),
+            6 => self.slide_i32x8::<2>(padding, a),
+            7 => self.slide_i32x8::<1>(padding, a),
+            8 => self.slide_i32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
         let (indices0, indices1) = self.split_u8x32(indices);
@@ -4438,6 +5570,78 @@ impl Simd for WasmSimd128 {
             self.slide_within_blocks_u32x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x4::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_u32x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_u32x8::<8>(a, a),
+            1 => self.slide_u32x8::<7>(a, a),
+            2 => self.slide_u32x8::<6>(a, a),
+            3 => self.slide_u32x8::<5>(a, a),
+            4 => self.slide_u32x8::<4>(a, a),
+            5 => self.slide_u32x8::<3>(a, a),
+            6 => self.slide_u32x8::<2>(a, a),
+            7 => self.slide_u32x8::<1>(a, a),
+            8 => self.slide_u32x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u32x8(padding);
+        self.slide_u32x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x8<const OFFSET: usize>(
+        self,
+        a: u32x8<Self>,
+        padding: u32,
+    ) -> u32x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_u32x8(padding);
+        match OFFSET {
+            0 => self.slide_u32x8::<8>(padding, a),
+            1 => self.slide_u32x8::<7>(padding, a),
+            2 => self.slide_u32x8::<6>(padding, a),
+            3 => self.slide_u32x8::<5>(padding, a),
+            4 => self.slide_u32x8::<4>(padding, a),
+            5 => self.slide_u32x8::<3>(padding, a),
+            6 => self.slide_u32x8::<2>(padding, a),
+            7 => self.slide_u32x8::<1>(padding, a),
+            8 => self.slide_u32x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
@@ -4840,6 +6044,70 @@ impl Simd for WasmSimd128 {
             self.slide_within_blocks_f64x2::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x2::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        self.slide_f64x4::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        match OFFSET {
+            0 => self.slide_f64x4::<4>(a, a),
+            1 => self.slide_f64x4::<3>(a, a),
+            2 => self.slide_f64x4::<2>(a, a),
+            3 => self.slide_f64x4::<1>(a, a),
+            4 => self.slide_f64x4::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f64x4(padding);
+        self.slide_f64x4::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x4<const OFFSET: usize>(
+        self,
+        a: f64x4<Self>,
+        padding: f64,
+    ) -> f64x4<Self> {
+        assert!(
+            OFFSET <= 4,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            4,
+        );
+        let padding = self.splat_f64x4(padding);
+        match OFFSET {
+            0 => self.slide_f64x4::<4>(padding, a),
+            1 => self.slide_f64x4::<3>(padding, a),
+            2 => self.slide_f64x4::<2>(padding, a),
+            3 => self.slide_f64x4::<1>(padding, a),
+            4 => self.slide_f64x4::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
@@ -5298,6 +6566,94 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_f32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_f32x16::<16>(a, a),
+            1 => self.slide_f32x16::<15>(a, a),
+            2 => self.slide_f32x16::<14>(a, a),
+            3 => self.slide_f32x16::<13>(a, a),
+            4 => self.slide_f32x16::<12>(a, a),
+            5 => self.slide_f32x16::<11>(a, a),
+            6 => self.slide_f32x16::<10>(a, a),
+            7 => self.slide_f32x16::<9>(a, a),
+            8 => self.slide_f32x16::<8>(a, a),
+            9 => self.slide_f32x16::<7>(a, a),
+            10 => self.slide_f32x16::<6>(a, a),
+            11 => self.slide_f32x16::<5>(a, a),
+            12 => self.slide_f32x16::<4>(a, a),
+            13 => self.slide_f32x16::<3>(a, a),
+            14 => self.slide_f32x16::<2>(a, a),
+            15 => self.slide_f32x16::<1>(a, a),
+            16 => self.slide_f32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_f32x16(padding);
+        self.slide_f32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f32x16<const OFFSET: usize>(
+        self,
+        a: f32x16<Self>,
+        padding: f32,
+    ) -> f32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_f32x16(padding);
+        match OFFSET {
+            0 => self.slide_f32x16::<16>(padding, a),
+            1 => self.slide_f32x16::<15>(padding, a),
+            2 => self.slide_f32x16::<14>(padding, a),
+            3 => self.slide_f32x16::<13>(padding, a),
+            4 => self.slide_f32x16::<12>(padding, a),
+            5 => self.slide_f32x16::<11>(padding, a),
+            6 => self.slide_f32x16::<10>(padding, a),
+            7 => self.slide_f32x16::<9>(padding, a),
+            8 => self.slide_f32x16::<8>(padding, a),
+            9 => self.slide_f32x16::<7>(padding, a),
+            10 => self.slide_f32x16::<6>(padding, a),
+            11 => self.slide_f32x16::<5>(padding, a),
+            12 => self.slide_f32x16::<4>(padding, a),
+            13 => self.slide_f32x16::<3>(padding, a),
+            14 => self.slide_f32x16::<2>(padding, a),
+            15 => self.slide_f32x16::<1>(padding, a),
+            16 => self.slide_f32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_f32x16(
         self,
         a: f32x16<Self>,
@@ -5720,6 +7076,190 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        self.slide_i8x64::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        match OFFSET {
+            0 => self.slide_i8x64::<64>(a, a),
+            1 => self.slide_i8x64::<63>(a, a),
+            2 => self.slide_i8x64::<62>(a, a),
+            3 => self.slide_i8x64::<61>(a, a),
+            4 => self.slide_i8x64::<60>(a, a),
+            5 => self.slide_i8x64::<59>(a, a),
+            6 => self.slide_i8x64::<58>(a, a),
+            7 => self.slide_i8x64::<57>(a, a),
+            8 => self.slide_i8x64::<56>(a, a),
+            9 => self.slide_i8x64::<55>(a, a),
+            10 => self.slide_i8x64::<54>(a, a),
+            11 => self.slide_i8x64::<53>(a, a),
+            12 => self.slide_i8x64::<52>(a, a),
+            13 => self.slide_i8x64::<51>(a, a),
+            14 => self.slide_i8x64::<50>(a, a),
+            15 => self.slide_i8x64::<49>(a, a),
+            16 => self.slide_i8x64::<48>(a, a),
+            17 => self.slide_i8x64::<47>(a, a),
+            18 => self.slide_i8x64::<46>(a, a),
+            19 => self.slide_i8x64::<45>(a, a),
+            20 => self.slide_i8x64::<44>(a, a),
+            21 => self.slide_i8x64::<43>(a, a),
+            22 => self.slide_i8x64::<42>(a, a),
+            23 => self.slide_i8x64::<41>(a, a),
+            24 => self.slide_i8x64::<40>(a, a),
+            25 => self.slide_i8x64::<39>(a, a),
+            26 => self.slide_i8x64::<38>(a, a),
+            27 => self.slide_i8x64::<37>(a, a),
+            28 => self.slide_i8x64::<36>(a, a),
+            29 => self.slide_i8x64::<35>(a, a),
+            30 => self.slide_i8x64::<34>(a, a),
+            31 => self.slide_i8x64::<33>(a, a),
+            32 => self.slide_i8x64::<32>(a, a),
+            33 => self.slide_i8x64::<31>(a, a),
+            34 => self.slide_i8x64::<30>(a, a),
+            35 => self.slide_i8x64::<29>(a, a),
+            36 => self.slide_i8x64::<28>(a, a),
+            37 => self.slide_i8x64::<27>(a, a),
+            38 => self.slide_i8x64::<26>(a, a),
+            39 => self.slide_i8x64::<25>(a, a),
+            40 => self.slide_i8x64::<24>(a, a),
+            41 => self.slide_i8x64::<23>(a, a),
+            42 => self.slide_i8x64::<22>(a, a),
+            43 => self.slide_i8x64::<21>(a, a),
+            44 => self.slide_i8x64::<20>(a, a),
+            45 => self.slide_i8x64::<19>(a, a),
+            46 => self.slide_i8x64::<18>(a, a),
+            47 => self.slide_i8x64::<17>(a, a),
+            48 => self.slide_i8x64::<16>(a, a),
+            49 => self.slide_i8x64::<15>(a, a),
+            50 => self.slide_i8x64::<14>(a, a),
+            51 => self.slide_i8x64::<13>(a, a),
+            52 => self.slide_i8x64::<12>(a, a),
+            53 => self.slide_i8x64::<11>(a, a),
+            54 => self.slide_i8x64::<10>(a, a),
+            55 => self.slide_i8x64::<9>(a, a),
+            56 => self.slide_i8x64::<8>(a, a),
+            57 => self.slide_i8x64::<7>(a, a),
+            58 => self.slide_i8x64::<6>(a, a),
+            59 => self.slide_i8x64::<5>(a, a),
+            60 => self.slide_i8x64::<4>(a, a),
+            61 => self.slide_i8x64::<3>(a, a),
+            62 => self.slide_i8x64::<2>(a, a),
+            63 => self.slide_i8x64::<1>(a, a),
+            64 => self.slide_i8x64::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_i8x64(padding);
+        self.slide_i8x64::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i8x64<const OFFSET: usize>(
+        self,
+        a: i8x64<Self>,
+        padding: i8,
+    ) -> i8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_i8x64(padding);
+        match OFFSET {
+            0 => self.slide_i8x64::<64>(padding, a),
+            1 => self.slide_i8x64::<63>(padding, a),
+            2 => self.slide_i8x64::<62>(padding, a),
+            3 => self.slide_i8x64::<61>(padding, a),
+            4 => self.slide_i8x64::<60>(padding, a),
+            5 => self.slide_i8x64::<59>(padding, a),
+            6 => self.slide_i8x64::<58>(padding, a),
+            7 => self.slide_i8x64::<57>(padding, a),
+            8 => self.slide_i8x64::<56>(padding, a),
+            9 => self.slide_i8x64::<55>(padding, a),
+            10 => self.slide_i8x64::<54>(padding, a),
+            11 => self.slide_i8x64::<53>(padding, a),
+            12 => self.slide_i8x64::<52>(padding, a),
+            13 => self.slide_i8x64::<51>(padding, a),
+            14 => self.slide_i8x64::<50>(padding, a),
+            15 => self.slide_i8x64::<49>(padding, a),
+            16 => self.slide_i8x64::<48>(padding, a),
+            17 => self.slide_i8x64::<47>(padding, a),
+            18 => self.slide_i8x64::<46>(padding, a),
+            19 => self.slide_i8x64::<45>(padding, a),
+            20 => self.slide_i8x64::<44>(padding, a),
+            21 => self.slide_i8x64::<43>(padding, a),
+            22 => self.slide_i8x64::<42>(padding, a),
+            23 => self.slide_i8x64::<41>(padding, a),
+            24 => self.slide_i8x64::<40>(padding, a),
+            25 => self.slide_i8x64::<39>(padding, a),
+            26 => self.slide_i8x64::<38>(padding, a),
+            27 => self.slide_i8x64::<37>(padding, a),
+            28 => self.slide_i8x64::<36>(padding, a),
+            29 => self.slide_i8x64::<35>(padding, a),
+            30 => self.slide_i8x64::<34>(padding, a),
+            31 => self.slide_i8x64::<33>(padding, a),
+            32 => self.slide_i8x64::<32>(padding, a),
+            33 => self.slide_i8x64::<31>(padding, a),
+            34 => self.slide_i8x64::<30>(padding, a),
+            35 => self.slide_i8x64::<29>(padding, a),
+            36 => self.slide_i8x64::<28>(padding, a),
+            37 => self.slide_i8x64::<27>(padding, a),
+            38 => self.slide_i8x64::<26>(padding, a),
+            39 => self.slide_i8x64::<25>(padding, a),
+            40 => self.slide_i8x64::<24>(padding, a),
+            41 => self.slide_i8x64::<23>(padding, a),
+            42 => self.slide_i8x64::<22>(padding, a),
+            43 => self.slide_i8x64::<21>(padding, a),
+            44 => self.slide_i8x64::<20>(padding, a),
+            45 => self.slide_i8x64::<19>(padding, a),
+            46 => self.slide_i8x64::<18>(padding, a),
+            47 => self.slide_i8x64::<17>(padding, a),
+            48 => self.slide_i8x64::<16>(padding, a),
+            49 => self.slide_i8x64::<15>(padding, a),
+            50 => self.slide_i8x64::<14>(padding, a),
+            51 => self.slide_i8x64::<13>(padding, a),
+            52 => self.slide_i8x64::<12>(padding, a),
+            53 => self.slide_i8x64::<11>(padding, a),
+            54 => self.slide_i8x64::<10>(padding, a),
+            55 => self.slide_i8x64::<9>(padding, a),
+            56 => self.slide_i8x64::<8>(padding, a),
+            57 => self.slide_i8x64::<7>(padding, a),
+            58 => self.slide_i8x64::<6>(padding, a),
+            59 => self.slide_i8x64::<5>(padding, a),
+            60 => self.slide_i8x64::<4>(padding, a),
+            61 => self.slide_i8x64::<3>(padding, a),
+            62 => self.slide_i8x64::<2>(padding, a),
+            63 => self.slide_i8x64::<1>(padding, a),
+            64 => self.slide_i8x64::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
         let (indices0, indices1) = self.split_u8x64(indices);
@@ -5997,6 +7537,190 @@ impl Simd for WasmSimd128 {
             self.slide_within_blocks_u8x32::<SHIFT>(a0, b0),
             self.slide_within_blocks_u8x32::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        self.slide_u8x64::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        match OFFSET {
+            0 => self.slide_u8x64::<64>(a, a),
+            1 => self.slide_u8x64::<63>(a, a),
+            2 => self.slide_u8x64::<62>(a, a),
+            3 => self.slide_u8x64::<61>(a, a),
+            4 => self.slide_u8x64::<60>(a, a),
+            5 => self.slide_u8x64::<59>(a, a),
+            6 => self.slide_u8x64::<58>(a, a),
+            7 => self.slide_u8x64::<57>(a, a),
+            8 => self.slide_u8x64::<56>(a, a),
+            9 => self.slide_u8x64::<55>(a, a),
+            10 => self.slide_u8x64::<54>(a, a),
+            11 => self.slide_u8x64::<53>(a, a),
+            12 => self.slide_u8x64::<52>(a, a),
+            13 => self.slide_u8x64::<51>(a, a),
+            14 => self.slide_u8x64::<50>(a, a),
+            15 => self.slide_u8x64::<49>(a, a),
+            16 => self.slide_u8x64::<48>(a, a),
+            17 => self.slide_u8x64::<47>(a, a),
+            18 => self.slide_u8x64::<46>(a, a),
+            19 => self.slide_u8x64::<45>(a, a),
+            20 => self.slide_u8x64::<44>(a, a),
+            21 => self.slide_u8x64::<43>(a, a),
+            22 => self.slide_u8x64::<42>(a, a),
+            23 => self.slide_u8x64::<41>(a, a),
+            24 => self.slide_u8x64::<40>(a, a),
+            25 => self.slide_u8x64::<39>(a, a),
+            26 => self.slide_u8x64::<38>(a, a),
+            27 => self.slide_u8x64::<37>(a, a),
+            28 => self.slide_u8x64::<36>(a, a),
+            29 => self.slide_u8x64::<35>(a, a),
+            30 => self.slide_u8x64::<34>(a, a),
+            31 => self.slide_u8x64::<33>(a, a),
+            32 => self.slide_u8x64::<32>(a, a),
+            33 => self.slide_u8x64::<31>(a, a),
+            34 => self.slide_u8x64::<30>(a, a),
+            35 => self.slide_u8x64::<29>(a, a),
+            36 => self.slide_u8x64::<28>(a, a),
+            37 => self.slide_u8x64::<27>(a, a),
+            38 => self.slide_u8x64::<26>(a, a),
+            39 => self.slide_u8x64::<25>(a, a),
+            40 => self.slide_u8x64::<24>(a, a),
+            41 => self.slide_u8x64::<23>(a, a),
+            42 => self.slide_u8x64::<22>(a, a),
+            43 => self.slide_u8x64::<21>(a, a),
+            44 => self.slide_u8x64::<20>(a, a),
+            45 => self.slide_u8x64::<19>(a, a),
+            46 => self.slide_u8x64::<18>(a, a),
+            47 => self.slide_u8x64::<17>(a, a),
+            48 => self.slide_u8x64::<16>(a, a),
+            49 => self.slide_u8x64::<15>(a, a),
+            50 => self.slide_u8x64::<14>(a, a),
+            51 => self.slide_u8x64::<13>(a, a),
+            52 => self.slide_u8x64::<12>(a, a),
+            53 => self.slide_u8x64::<11>(a, a),
+            54 => self.slide_u8x64::<10>(a, a),
+            55 => self.slide_u8x64::<9>(a, a),
+            56 => self.slide_u8x64::<8>(a, a),
+            57 => self.slide_u8x64::<7>(a, a),
+            58 => self.slide_u8x64::<6>(a, a),
+            59 => self.slide_u8x64::<5>(a, a),
+            60 => self.slide_u8x64::<4>(a, a),
+            61 => self.slide_u8x64::<3>(a, a),
+            62 => self.slide_u8x64::<2>(a, a),
+            63 => self.slide_u8x64::<1>(a, a),
+            64 => self.slide_u8x64::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_u8x64(padding);
+        self.slide_u8x64::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u8x64<const OFFSET: usize>(
+        self,
+        a: u8x64<Self>,
+        padding: u8,
+    ) -> u8x64<Self> {
+        assert!(
+            OFFSET <= 64,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            64,
+        );
+        let padding = self.splat_u8x64(padding);
+        match OFFSET {
+            0 => self.slide_u8x64::<64>(padding, a),
+            1 => self.slide_u8x64::<63>(padding, a),
+            2 => self.slide_u8x64::<62>(padding, a),
+            3 => self.slide_u8x64::<61>(padding, a),
+            4 => self.slide_u8x64::<60>(padding, a),
+            5 => self.slide_u8x64::<59>(padding, a),
+            6 => self.slide_u8x64::<58>(padding, a),
+            7 => self.slide_u8x64::<57>(padding, a),
+            8 => self.slide_u8x64::<56>(padding, a),
+            9 => self.slide_u8x64::<55>(padding, a),
+            10 => self.slide_u8x64::<54>(padding, a),
+            11 => self.slide_u8x64::<53>(padding, a),
+            12 => self.slide_u8x64::<52>(padding, a),
+            13 => self.slide_u8x64::<51>(padding, a),
+            14 => self.slide_u8x64::<50>(padding, a),
+            15 => self.slide_u8x64::<49>(padding, a),
+            16 => self.slide_u8x64::<48>(padding, a),
+            17 => self.slide_u8x64::<47>(padding, a),
+            18 => self.slide_u8x64::<46>(padding, a),
+            19 => self.slide_u8x64::<45>(padding, a),
+            20 => self.slide_u8x64::<44>(padding, a),
+            21 => self.slide_u8x64::<43>(padding, a),
+            22 => self.slide_u8x64::<42>(padding, a),
+            23 => self.slide_u8x64::<41>(padding, a),
+            24 => self.slide_u8x64::<40>(padding, a),
+            25 => self.slide_u8x64::<39>(padding, a),
+            26 => self.slide_u8x64::<38>(padding, a),
+            27 => self.slide_u8x64::<37>(padding, a),
+            28 => self.slide_u8x64::<36>(padding, a),
+            29 => self.slide_u8x64::<35>(padding, a),
+            30 => self.slide_u8x64::<34>(padding, a),
+            31 => self.slide_u8x64::<33>(padding, a),
+            32 => self.slide_u8x64::<32>(padding, a),
+            33 => self.slide_u8x64::<31>(padding, a),
+            34 => self.slide_u8x64::<30>(padding, a),
+            35 => self.slide_u8x64::<29>(padding, a),
+            36 => self.slide_u8x64::<28>(padding, a),
+            37 => self.slide_u8x64::<27>(padding, a),
+            38 => self.slide_u8x64::<26>(padding, a),
+            39 => self.slide_u8x64::<25>(padding, a),
+            40 => self.slide_u8x64::<24>(padding, a),
+            41 => self.slide_u8x64::<23>(padding, a),
+            42 => self.slide_u8x64::<22>(padding, a),
+            43 => self.slide_u8x64::<21>(padding, a),
+            44 => self.slide_u8x64::<20>(padding, a),
+            45 => self.slide_u8x64::<19>(padding, a),
+            46 => self.slide_u8x64::<18>(padding, a),
+            47 => self.slide_u8x64::<17>(padding, a),
+            48 => self.slide_u8x64::<16>(padding, a),
+            49 => self.slide_u8x64::<15>(padding, a),
+            50 => self.slide_u8x64::<14>(padding, a),
+            51 => self.slide_u8x64::<13>(padding, a),
+            52 => self.slide_u8x64::<12>(padding, a),
+            53 => self.slide_u8x64::<11>(padding, a),
+            54 => self.slide_u8x64::<10>(padding, a),
+            55 => self.slide_u8x64::<9>(padding, a),
+            56 => self.slide_u8x64::<8>(padding, a),
+            57 => self.slide_u8x64::<7>(padding, a),
+            58 => self.slide_u8x64::<6>(padding, a),
+            59 => self.slide_u8x64::<5>(padding, a),
+            60 => self.slide_u8x64::<4>(padding, a),
+            61 => self.slide_u8x64::<3>(padding, a),
+            62 => self.slide_u8x64::<2>(padding, a),
+            63 => self.slide_u8x64::<1>(padding, a),
+            64 => self.slide_u8x64::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self> {
@@ -6455,6 +8179,126 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_i16x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_i16x32::<32>(a, a),
+            1 => self.slide_i16x32::<31>(a, a),
+            2 => self.slide_i16x32::<30>(a, a),
+            3 => self.slide_i16x32::<29>(a, a),
+            4 => self.slide_i16x32::<28>(a, a),
+            5 => self.slide_i16x32::<27>(a, a),
+            6 => self.slide_i16x32::<26>(a, a),
+            7 => self.slide_i16x32::<25>(a, a),
+            8 => self.slide_i16x32::<24>(a, a),
+            9 => self.slide_i16x32::<23>(a, a),
+            10 => self.slide_i16x32::<22>(a, a),
+            11 => self.slide_i16x32::<21>(a, a),
+            12 => self.slide_i16x32::<20>(a, a),
+            13 => self.slide_i16x32::<19>(a, a),
+            14 => self.slide_i16x32::<18>(a, a),
+            15 => self.slide_i16x32::<17>(a, a),
+            16 => self.slide_i16x32::<16>(a, a),
+            17 => self.slide_i16x32::<15>(a, a),
+            18 => self.slide_i16x32::<14>(a, a),
+            19 => self.slide_i16x32::<13>(a, a),
+            20 => self.slide_i16x32::<12>(a, a),
+            21 => self.slide_i16x32::<11>(a, a),
+            22 => self.slide_i16x32::<10>(a, a),
+            23 => self.slide_i16x32::<9>(a, a),
+            24 => self.slide_i16x32::<8>(a, a),
+            25 => self.slide_i16x32::<7>(a, a),
+            26 => self.slide_i16x32::<6>(a, a),
+            27 => self.slide_i16x32::<5>(a, a),
+            28 => self.slide_i16x32::<4>(a, a),
+            29 => self.slide_i16x32::<3>(a, a),
+            30 => self.slide_i16x32::<2>(a, a),
+            31 => self.slide_i16x32::<1>(a, a),
+            32 => self.slide_i16x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i16x32(padding);
+        self.slide_i16x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i16x32<const OFFSET: usize>(
+        self,
+        a: i16x32<Self>,
+        padding: i16,
+    ) -> i16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_i16x32(padding);
+        match OFFSET {
+            0 => self.slide_i16x32::<32>(padding, a),
+            1 => self.slide_i16x32::<31>(padding, a),
+            2 => self.slide_i16x32::<30>(padding, a),
+            3 => self.slide_i16x32::<29>(padding, a),
+            4 => self.slide_i16x32::<28>(padding, a),
+            5 => self.slide_i16x32::<27>(padding, a),
+            6 => self.slide_i16x32::<26>(padding, a),
+            7 => self.slide_i16x32::<25>(padding, a),
+            8 => self.slide_i16x32::<24>(padding, a),
+            9 => self.slide_i16x32::<23>(padding, a),
+            10 => self.slide_i16x32::<22>(padding, a),
+            11 => self.slide_i16x32::<21>(padding, a),
+            12 => self.slide_i16x32::<20>(padding, a),
+            13 => self.slide_i16x32::<19>(padding, a),
+            14 => self.slide_i16x32::<18>(padding, a),
+            15 => self.slide_i16x32::<17>(padding, a),
+            16 => self.slide_i16x32::<16>(padding, a),
+            17 => self.slide_i16x32::<15>(padding, a),
+            18 => self.slide_i16x32::<14>(padding, a),
+            19 => self.slide_i16x32::<13>(padding, a),
+            20 => self.slide_i16x32::<12>(padding, a),
+            21 => self.slide_i16x32::<11>(padding, a),
+            22 => self.slide_i16x32::<10>(padding, a),
+            23 => self.slide_i16x32::<9>(padding, a),
+            24 => self.slide_i16x32::<8>(padding, a),
+            25 => self.slide_i16x32::<7>(padding, a),
+            26 => self.slide_i16x32::<6>(padding, a),
+            27 => self.slide_i16x32::<5>(padding, a),
+            28 => self.slide_i16x32::<4>(padding, a),
+            29 => self.slide_i16x32::<3>(padding, a),
+            30 => self.slide_i16x32::<2>(padding, a),
+            31 => self.slide_i16x32::<1>(padding, a),
+            32 => self.slide_i16x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i16x32(
         self,
         a: i16x32<Self>,
@@ -6745,6 +8589,126 @@ impl Simd for WasmSimd128 {
             self.slide_within_blocks_u16x16::<SHIFT>(a0, b0),
             self.slide_within_blocks_u16x16::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        self.slide_u16x32::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        match OFFSET {
+            0 => self.slide_u16x32::<32>(a, a),
+            1 => self.slide_u16x32::<31>(a, a),
+            2 => self.slide_u16x32::<30>(a, a),
+            3 => self.slide_u16x32::<29>(a, a),
+            4 => self.slide_u16x32::<28>(a, a),
+            5 => self.slide_u16x32::<27>(a, a),
+            6 => self.slide_u16x32::<26>(a, a),
+            7 => self.slide_u16x32::<25>(a, a),
+            8 => self.slide_u16x32::<24>(a, a),
+            9 => self.slide_u16x32::<23>(a, a),
+            10 => self.slide_u16x32::<22>(a, a),
+            11 => self.slide_u16x32::<21>(a, a),
+            12 => self.slide_u16x32::<20>(a, a),
+            13 => self.slide_u16x32::<19>(a, a),
+            14 => self.slide_u16x32::<18>(a, a),
+            15 => self.slide_u16x32::<17>(a, a),
+            16 => self.slide_u16x32::<16>(a, a),
+            17 => self.slide_u16x32::<15>(a, a),
+            18 => self.slide_u16x32::<14>(a, a),
+            19 => self.slide_u16x32::<13>(a, a),
+            20 => self.slide_u16x32::<12>(a, a),
+            21 => self.slide_u16x32::<11>(a, a),
+            22 => self.slide_u16x32::<10>(a, a),
+            23 => self.slide_u16x32::<9>(a, a),
+            24 => self.slide_u16x32::<8>(a, a),
+            25 => self.slide_u16x32::<7>(a, a),
+            26 => self.slide_u16x32::<6>(a, a),
+            27 => self.slide_u16x32::<5>(a, a),
+            28 => self.slide_u16x32::<4>(a, a),
+            29 => self.slide_u16x32::<3>(a, a),
+            30 => self.slide_u16x32::<2>(a, a),
+            31 => self.slide_u16x32::<1>(a, a),
+            32 => self.slide_u16x32::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u16x32(padding);
+        self.slide_u16x32::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u16x32<const OFFSET: usize>(
+        self,
+        a: u16x32<Self>,
+        padding: u16,
+    ) -> u16x32<Self> {
+        assert!(
+            OFFSET <= 32,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            32,
+        );
+        let padding = self.splat_u16x32(padding);
+        match OFFSET {
+            0 => self.slide_u16x32::<32>(padding, a),
+            1 => self.slide_u16x32::<31>(padding, a),
+            2 => self.slide_u16x32::<30>(padding, a),
+            3 => self.slide_u16x32::<29>(padding, a),
+            4 => self.slide_u16x32::<28>(padding, a),
+            5 => self.slide_u16x32::<27>(padding, a),
+            6 => self.slide_u16x32::<26>(padding, a),
+            7 => self.slide_u16x32::<25>(padding, a),
+            8 => self.slide_u16x32::<24>(padding, a),
+            9 => self.slide_u16x32::<23>(padding, a),
+            10 => self.slide_u16x32::<22>(padding, a),
+            11 => self.slide_u16x32::<21>(padding, a),
+            12 => self.slide_u16x32::<20>(padding, a),
+            13 => self.slide_u16x32::<19>(padding, a),
+            14 => self.slide_u16x32::<18>(padding, a),
+            15 => self.slide_u16x32::<17>(padding, a),
+            16 => self.slide_u16x32::<16>(padding, a),
+            17 => self.slide_u16x32::<15>(padding, a),
+            18 => self.slide_u16x32::<14>(padding, a),
+            19 => self.slide_u16x32::<13>(padding, a),
+            20 => self.slide_u16x32::<12>(padding, a),
+            21 => self.slide_u16x32::<11>(padding, a),
+            22 => self.slide_u16x32::<10>(padding, a),
+            23 => self.slide_u16x32::<9>(padding, a),
+            24 => self.slide_u16x32::<8>(padding, a),
+            25 => self.slide_u16x32::<7>(padding, a),
+            26 => self.slide_u16x32::<6>(padding, a),
+            27 => self.slide_u16x32::<5>(padding, a),
+            28 => self.slide_u16x32::<4>(padding, a),
+            29 => self.slide_u16x32::<3>(padding, a),
+            30 => self.slide_u16x32::<2>(padding, a),
+            31 => self.slide_u16x32::<1>(padding, a),
+            32 => self.slide_u16x32::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u16x32(
@@ -7205,6 +9169,94 @@ impl Simd for WasmSimd128 {
         )
     }
     #[inline(always)]
+    fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_i32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_i32x16::<16>(a, a),
+            1 => self.slide_i32x16::<15>(a, a),
+            2 => self.slide_i32x16::<14>(a, a),
+            3 => self.slide_i32x16::<13>(a, a),
+            4 => self.slide_i32x16::<12>(a, a),
+            5 => self.slide_i32x16::<11>(a, a),
+            6 => self.slide_i32x16::<10>(a, a),
+            7 => self.slide_i32x16::<9>(a, a),
+            8 => self.slide_i32x16::<8>(a, a),
+            9 => self.slide_i32x16::<7>(a, a),
+            10 => self.slide_i32x16::<6>(a, a),
+            11 => self.slide_i32x16::<5>(a, a),
+            12 => self.slide_i32x16::<4>(a, a),
+            13 => self.slide_i32x16::<3>(a, a),
+            14 => self.slide_i32x16::<2>(a, a),
+            15 => self.slide_i32x16::<1>(a, a),
+            16 => self.slide_i32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i32x16(padding);
+        self.slide_i32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_i32x16<const OFFSET: usize>(
+        self,
+        a: i32x16<Self>,
+        padding: i32,
+    ) -> i32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_i32x16(padding);
+        match OFFSET {
+            0 => self.slide_i32x16::<16>(padding, a),
+            1 => self.slide_i32x16::<15>(padding, a),
+            2 => self.slide_i32x16::<14>(padding, a),
+            3 => self.slide_i32x16::<13>(padding, a),
+            4 => self.slide_i32x16::<12>(padding, a),
+            5 => self.slide_i32x16::<11>(padding, a),
+            6 => self.slide_i32x16::<10>(padding, a),
+            7 => self.slide_i32x16::<9>(padding, a),
+            8 => self.slide_i32x16::<8>(padding, a),
+            9 => self.slide_i32x16::<7>(padding, a),
+            10 => self.slide_i32x16::<6>(padding, a),
+            11 => self.slide_i32x16::<5>(padding, a),
+            12 => self.slide_i32x16::<4>(padding, a),
+            13 => self.slide_i32x16::<3>(padding, a),
+            14 => self.slide_i32x16::<2>(padding, a),
+            15 => self.slide_i32x16::<1>(padding, a),
+            16 => self.slide_i32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
     fn swizzle_dyn_within_blocks_i32x16(
         self,
         a: i32x16<Self>,
@@ -7491,6 +9543,94 @@ impl Simd for WasmSimd128 {
             self.slide_within_blocks_u32x8::<SHIFT>(a0, b0),
             self.slide_within_blocks_u32x8::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        self.slide_u32x16::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        match OFFSET {
+            0 => self.slide_u32x16::<16>(a, a),
+            1 => self.slide_u32x16::<15>(a, a),
+            2 => self.slide_u32x16::<14>(a, a),
+            3 => self.slide_u32x16::<13>(a, a),
+            4 => self.slide_u32x16::<12>(a, a),
+            5 => self.slide_u32x16::<11>(a, a),
+            6 => self.slide_u32x16::<10>(a, a),
+            7 => self.slide_u32x16::<9>(a, a),
+            8 => self.slide_u32x16::<8>(a, a),
+            9 => self.slide_u32x16::<7>(a, a),
+            10 => self.slide_u32x16::<6>(a, a),
+            11 => self.slide_u32x16::<5>(a, a),
+            12 => self.slide_u32x16::<4>(a, a),
+            13 => self.slide_u32x16::<3>(a, a),
+            14 => self.slide_u32x16::<2>(a, a),
+            15 => self.slide_u32x16::<1>(a, a),
+            16 => self.slide_u32x16::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u32x16(padding);
+        self.slide_u32x16::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_u32x16<const OFFSET: usize>(
+        self,
+        a: u32x16<Self>,
+        padding: u32,
+    ) -> u32x16<Self> {
+        assert!(
+            OFFSET <= 16,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            16,
+        );
+        let padding = self.splat_u32x16(padding);
+        match OFFSET {
+            0 => self.slide_u32x16::<16>(padding, a),
+            1 => self.slide_u32x16::<15>(padding, a),
+            2 => self.slide_u32x16::<14>(padding, a),
+            3 => self.slide_u32x16::<13>(padding, a),
+            4 => self.slide_u32x16::<12>(padding, a),
+            5 => self.slide_u32x16::<11>(padding, a),
+            6 => self.slide_u32x16::<10>(padding, a),
+            7 => self.slide_u32x16::<9>(padding, a),
+            8 => self.slide_u32x16::<8>(padding, a),
+            9 => self.slide_u32x16::<7>(padding, a),
+            10 => self.slide_u32x16::<6>(padding, a),
+            11 => self.slide_u32x16::<5>(padding, a),
+            12 => self.slide_u32x16::<4>(padding, a),
+            13 => self.slide_u32x16::<3>(padding, a),
+            14 => self.slide_u32x16::<2>(padding, a),
+            15 => self.slide_u32x16::<1>(padding, a),
+            16 => self.slide_u32x16::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_u32x16(
@@ -7929,6 +10069,78 @@ impl Simd for WasmSimd128 {
             self.slide_within_blocks_f64x4::<SHIFT>(a0, b0),
             self.slide_within_blocks_f64x4::<SHIFT>(a1, b1),
         )
+    }
+    #[inline(always)]
+    fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        self.slide_f64x8::<OFFSET>(a, a)
+    }
+    #[inline(always)]
+    fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        match OFFSET {
+            0 => self.slide_f64x8::<8>(a, a),
+            1 => self.slide_f64x8::<7>(a, a),
+            2 => self.slide_f64x8::<6>(a, a),
+            3 => self.slide_f64x8::<5>(a, a),
+            4 => self.slide_f64x8::<4>(a, a),
+            5 => self.slide_f64x8::<3>(a, a),
+            6 => self.slide_f64x8::<2>(a, a),
+            7 => self.slide_f64x8::<1>(a, a),
+            8 => self.slide_f64x8::<0>(a, a),
+            _ => unreachable!(),
+        }
+    }
+    #[inline(always)]
+    fn shift_elements_left_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f64x8(padding);
+        self.slide_f64x8::<OFFSET>(a, padding)
+    }
+    #[inline(always)]
+    fn shift_elements_right_f64x8<const OFFSET: usize>(
+        self,
+        a: f64x8<Self>,
+        padding: f64,
+    ) -> f64x8<Self> {
+        assert!(
+            OFFSET <= 8,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            8,
+        );
+        let padding = self.splat_f64x8(padding);
+        match OFFSET {
+            0 => self.slide_f64x8::<8>(padding, a),
+            1 => self.slide_f64x8::<7>(padding, a),
+            2 => self.slide_f64x8::<6>(padding, a),
+            3 => self.slide_f64x8::<5>(padding, a),
+            4 => self.slide_f64x8::<4>(padding, a),
+            5 => self.slide_f64x8::<3>(padding, a),
+            6 => self.slide_f64x8::<2>(padding, a),
+            7 => self.slide_f64x8::<1>(padding, a),
+            8 => self.slide_f64x8::<0>(padding, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_within_blocks_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -158,28 +158,21 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_f32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_f32x4::<0>(a, a),
+            1 => self.slide_f32x4::<1>(a, a),
+            2 => self.slide_f32x4::<2>(a, a),
+            3 => self.slide_f32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x4<const OFFSET: usize>(self, a: f32x4<Self>) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_f32x4::<4>(a, a),
             1 => self.slide_f32x4::<3>(a, a),
             2 => self.slide_f32x4::<2>(a, a),
             3 => self.slide_f32x4::<1>(a, a),
-            4 => self.slide_f32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -189,14 +182,15 @@ impl Simd for WasmSimd128 {
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f32x4(padding);
-        self.slide_f32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x4::<0>(a, padding),
+            1 => self.slide_f32x4::<1>(a, padding),
+            2 => self.slide_f32x4::<2>(a, padding),
+            3 => self.slide_f32x4::<3>(a, padding),
+            4 => self.slide_f32x4::<4>(a, padding),
+            _ => self.slide_f32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x4<const OFFSET: usize>(
@@ -204,12 +198,6 @@ impl Simd for WasmSimd128 {
         a: f32x4<Self>,
         padding: f32,
     ) -> f32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f32x4(padding);
         match OFFSET {
             0 => self.slide_f32x4::<4>(padding, a),
@@ -217,7 +205,7 @@ impl Simd for WasmSimd128 {
             2 => self.slide_f32x4::<2>(padding, a),
             3 => self.slide_f32x4::<1>(padding, a),
             4 => self.slide_f32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -524,23 +512,29 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i8x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i8x16::<0>(a, a),
+            1 => self.slide_i8x16::<1>(a, a),
+            2 => self.slide_i8x16::<2>(a, a),
+            3 => self.slide_i8x16::<3>(a, a),
+            4 => self.slide_i8x16::<4>(a, a),
+            5 => self.slide_i8x16::<5>(a, a),
+            6 => self.slide_i8x16::<6>(a, a),
+            7 => self.slide_i8x16::<7>(a, a),
+            8 => self.slide_i8x16::<8>(a, a),
+            9 => self.slide_i8x16::<9>(a, a),
+            10 => self.slide_i8x16::<10>(a, a),
+            11 => self.slide_i8x16::<11>(a, a),
+            12 => self.slide_i8x16::<12>(a, a),
+            13 => self.slide_i8x16::<13>(a, a),
+            14 => self.slide_i8x16::<14>(a, a),
+            15 => self.slide_i8x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x16<const OFFSET: usize>(self, a: i8x16<Self>) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i8x16::<16>(a, a),
             1 => self.slide_i8x16::<15>(a, a),
             2 => self.slide_i8x16::<14>(a, a),
@@ -557,7 +551,6 @@ impl Simd for WasmSimd128 {
             13 => self.slide_i8x16::<3>(a, a),
             14 => self.slide_i8x16::<2>(a, a),
             15 => self.slide_i8x16::<1>(a, a),
-            16 => self.slide_i8x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -567,14 +560,27 @@ impl Simd for WasmSimd128 {
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i8x16(padding);
-        self.slide_i8x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x16::<0>(a, padding),
+            1 => self.slide_i8x16::<1>(a, padding),
+            2 => self.slide_i8x16::<2>(a, padding),
+            3 => self.slide_i8x16::<3>(a, padding),
+            4 => self.slide_i8x16::<4>(a, padding),
+            5 => self.slide_i8x16::<5>(a, padding),
+            6 => self.slide_i8x16::<6>(a, padding),
+            7 => self.slide_i8x16::<7>(a, padding),
+            8 => self.slide_i8x16::<8>(a, padding),
+            9 => self.slide_i8x16::<9>(a, padding),
+            10 => self.slide_i8x16::<10>(a, padding),
+            11 => self.slide_i8x16::<11>(a, padding),
+            12 => self.slide_i8x16::<12>(a, padding),
+            13 => self.slide_i8x16::<13>(a, padding),
+            14 => self.slide_i8x16::<14>(a, padding),
+            15 => self.slide_i8x16::<15>(a, padding),
+            16 => self.slide_i8x16::<16>(a, padding),
+            _ => self.slide_i8x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x16<const OFFSET: usize>(
@@ -582,12 +588,6 @@ impl Simd for WasmSimd128 {
         a: i8x16<Self>,
         padding: i8,
     ) -> i8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i8x16(padding);
         match OFFSET {
             0 => self.slide_i8x16::<16>(padding, a),
@@ -607,7 +607,7 @@ impl Simd for WasmSimd128 {
             14 => self.slide_i8x16::<2>(padding, a),
             15 => self.slide_i8x16::<1>(padding, a),
             16 => self.slide_i8x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -833,23 +833,29 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u8x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u8x16::<0>(a, a),
+            1 => self.slide_u8x16::<1>(a, a),
+            2 => self.slide_u8x16::<2>(a, a),
+            3 => self.slide_u8x16::<3>(a, a),
+            4 => self.slide_u8x16::<4>(a, a),
+            5 => self.slide_u8x16::<5>(a, a),
+            6 => self.slide_u8x16::<6>(a, a),
+            7 => self.slide_u8x16::<7>(a, a),
+            8 => self.slide_u8x16::<8>(a, a),
+            9 => self.slide_u8x16::<9>(a, a),
+            10 => self.slide_u8x16::<10>(a, a),
+            11 => self.slide_u8x16::<11>(a, a),
+            12 => self.slide_u8x16::<12>(a, a),
+            13 => self.slide_u8x16::<13>(a, a),
+            14 => self.slide_u8x16::<14>(a, a),
+            15 => self.slide_u8x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x16<const OFFSET: usize>(self, a: u8x16<Self>) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u8x16::<16>(a, a),
             1 => self.slide_u8x16::<15>(a, a),
             2 => self.slide_u8x16::<14>(a, a),
@@ -866,7 +872,6 @@ impl Simd for WasmSimd128 {
             13 => self.slide_u8x16::<3>(a, a),
             14 => self.slide_u8x16::<2>(a, a),
             15 => self.slide_u8x16::<1>(a, a),
-            16 => self.slide_u8x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -876,14 +881,27 @@ impl Simd for WasmSimd128 {
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u8x16(padding);
-        self.slide_u8x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x16::<0>(a, padding),
+            1 => self.slide_u8x16::<1>(a, padding),
+            2 => self.slide_u8x16::<2>(a, padding),
+            3 => self.slide_u8x16::<3>(a, padding),
+            4 => self.slide_u8x16::<4>(a, padding),
+            5 => self.slide_u8x16::<5>(a, padding),
+            6 => self.slide_u8x16::<6>(a, padding),
+            7 => self.slide_u8x16::<7>(a, padding),
+            8 => self.slide_u8x16::<8>(a, padding),
+            9 => self.slide_u8x16::<9>(a, padding),
+            10 => self.slide_u8x16::<10>(a, padding),
+            11 => self.slide_u8x16::<11>(a, padding),
+            12 => self.slide_u8x16::<12>(a, padding),
+            13 => self.slide_u8x16::<13>(a, padding),
+            14 => self.slide_u8x16::<14>(a, padding),
+            15 => self.slide_u8x16::<15>(a, padding),
+            16 => self.slide_u8x16::<16>(a, padding),
+            _ => self.slide_u8x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x16<const OFFSET: usize>(
@@ -891,12 +909,6 @@ impl Simd for WasmSimd128 {
         a: u8x16<Self>,
         padding: u8,
     ) -> u8x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u8x16(padding);
         match OFFSET {
             0 => self.slide_u8x16::<16>(padding, a),
@@ -916,7 +928,7 @@ impl Simd for WasmSimd128 {
             14 => self.slide_u8x16::<2>(padding, a),
             15 => self.slide_u8x16::<1>(padding, a),
             16 => self.slide_u8x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -1239,23 +1251,21 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_i16x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_i16x8::<0>(a, a),
+            1 => self.slide_i16x8::<1>(a, a),
+            2 => self.slide_i16x8::<2>(a, a),
+            3 => self.slide_i16x8::<3>(a, a),
+            4 => self.slide_i16x8::<4>(a, a),
+            5 => self.slide_i16x8::<5>(a, a),
+            6 => self.slide_i16x8::<6>(a, a),
+            7 => self.slide_i16x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x8<const OFFSET: usize>(self, a: i16x8<Self>) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_i16x8::<8>(a, a),
             1 => self.slide_i16x8::<7>(a, a),
             2 => self.slide_i16x8::<6>(a, a),
@@ -1264,7 +1274,6 @@ impl Simd for WasmSimd128 {
             5 => self.slide_i16x8::<3>(a, a),
             6 => self.slide_i16x8::<2>(a, a),
             7 => self.slide_i16x8::<1>(a, a),
-            8 => self.slide_i16x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -1274,14 +1283,19 @@ impl Simd for WasmSimd128 {
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i16x8(padding);
-        self.slide_i16x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x8::<0>(a, padding),
+            1 => self.slide_i16x8::<1>(a, padding),
+            2 => self.slide_i16x8::<2>(a, padding),
+            3 => self.slide_i16x8::<3>(a, padding),
+            4 => self.slide_i16x8::<4>(a, padding),
+            5 => self.slide_i16x8::<5>(a, padding),
+            6 => self.slide_i16x8::<6>(a, padding),
+            7 => self.slide_i16x8::<7>(a, padding),
+            8 => self.slide_i16x8::<8>(a, padding),
+            _ => self.slide_i16x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x8<const OFFSET: usize>(
@@ -1289,12 +1303,6 @@ impl Simd for WasmSimd128 {
         a: i16x8<Self>,
         padding: i16,
     ) -> i16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i16x8(padding);
         match OFFSET {
             0 => self.slide_i16x8::<8>(padding, a),
@@ -1306,7 +1314,7 @@ impl Simd for WasmSimd128 {
             6 => self.slide_i16x8::<2>(padding, a),
             7 => self.slide_i16x8::<1>(padding, a),
             8 => self.slide_i16x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -1516,23 +1524,21 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_u16x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_u16x8::<0>(a, a),
+            1 => self.slide_u16x8::<1>(a, a),
+            2 => self.slide_u16x8::<2>(a, a),
+            3 => self.slide_u16x8::<3>(a, a),
+            4 => self.slide_u16x8::<4>(a, a),
+            5 => self.slide_u16x8::<5>(a, a),
+            6 => self.slide_u16x8::<6>(a, a),
+            7 => self.slide_u16x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x8<const OFFSET: usize>(self, a: u16x8<Self>) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_u16x8::<8>(a, a),
             1 => self.slide_u16x8::<7>(a, a),
             2 => self.slide_u16x8::<6>(a, a),
@@ -1541,7 +1547,6 @@ impl Simd for WasmSimd128 {
             5 => self.slide_u16x8::<3>(a, a),
             6 => self.slide_u16x8::<2>(a, a),
             7 => self.slide_u16x8::<1>(a, a),
-            8 => self.slide_u16x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -1551,14 +1556,19 @@ impl Simd for WasmSimd128 {
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u16x8(padding);
-        self.slide_u16x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x8::<0>(a, padding),
+            1 => self.slide_u16x8::<1>(a, padding),
+            2 => self.slide_u16x8::<2>(a, padding),
+            3 => self.slide_u16x8::<3>(a, padding),
+            4 => self.slide_u16x8::<4>(a, padding),
+            5 => self.slide_u16x8::<5>(a, padding),
+            6 => self.slide_u16x8::<6>(a, padding),
+            7 => self.slide_u16x8::<7>(a, padding),
+            8 => self.slide_u16x8::<8>(a, padding),
+            _ => self.slide_u16x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x8<const OFFSET: usize>(
@@ -1566,12 +1576,6 @@ impl Simd for WasmSimd128 {
         a: u16x8<Self>,
         padding: u16,
     ) -> u16x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u16x8(padding);
         match OFFSET {
             0 => self.slide_u16x8::<8>(padding, a),
@@ -1583,7 +1587,7 @@ impl Simd for WasmSimd128 {
             6 => self.slide_u16x8::<2>(padding, a),
             7 => self.slide_u16x8::<1>(padding, a),
             8 => self.slide_u16x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -1886,28 +1890,21 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_i32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_i32x4::<0>(a, a),
+            1 => self.slide_i32x4::<1>(a, a),
+            2 => self.slide_i32x4::<2>(a, a),
+            3 => self.slide_i32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x4<const OFFSET: usize>(self, a: i32x4<Self>) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_i32x4::<4>(a, a),
             1 => self.slide_i32x4::<3>(a, a),
             2 => self.slide_i32x4::<2>(a, a),
             3 => self.slide_i32x4::<1>(a, a),
-            4 => self.slide_i32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -1917,14 +1914,15 @@ impl Simd for WasmSimd128 {
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_i32x4(padding);
-        self.slide_i32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x4::<0>(a, padding),
+            1 => self.slide_i32x4::<1>(a, padding),
+            2 => self.slide_i32x4::<2>(a, padding),
+            3 => self.slide_i32x4::<3>(a, padding),
+            4 => self.slide_i32x4::<4>(a, padding),
+            _ => self.slide_i32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x4<const OFFSET: usize>(
@@ -1932,12 +1930,6 @@ impl Simd for WasmSimd128 {
         a: i32x4<Self>,
         padding: i32,
     ) -> i32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_i32x4(padding);
         match OFFSET {
             0 => self.slide_i32x4::<4>(padding, a),
@@ -1945,7 +1937,7 @@ impl Simd for WasmSimd128 {
             2 => self.slide_i32x4::<2>(padding, a),
             3 => self.slide_i32x4::<1>(padding, a),
             4 => self.slide_i32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -2159,28 +2151,21 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_u32x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_u32x4::<0>(a, a),
+            1 => self.slide_u32x4::<1>(a, a),
+            2 => self.slide_u32x4::<2>(a, a),
+            3 => self.slide_u32x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x4<const OFFSET: usize>(self, a: u32x4<Self>) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_u32x4::<4>(a, a),
             1 => self.slide_u32x4::<3>(a, a),
             2 => self.slide_u32x4::<2>(a, a),
             3 => self.slide_u32x4::<1>(a, a),
-            4 => self.slide_u32x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -2190,14 +2175,15 @@ impl Simd for WasmSimd128 {
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_u32x4(padding);
-        self.slide_u32x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x4::<0>(a, padding),
+            1 => self.slide_u32x4::<1>(a, padding),
+            2 => self.slide_u32x4::<2>(a, padding),
+            3 => self.slide_u32x4::<3>(a, padding),
+            4 => self.slide_u32x4::<4>(a, padding),
+            _ => self.slide_u32x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x4<const OFFSET: usize>(
@@ -2205,12 +2191,6 @@ impl Simd for WasmSimd128 {
         a: u32x4<Self>,
         padding: u32,
     ) -> u32x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_u32x4(padding);
         match OFFSET {
             0 => self.slide_u32x4::<4>(padding, a),
@@ -2218,7 +2198,7 @@ impl Simd for WasmSimd128 {
             2 => self.slide_u32x4::<2>(padding, a),
             3 => self.slide_u32x4::<1>(padding, a),
             4 => self.slide_u32x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -2521,26 +2501,17 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
-        self.slide_f64x2::<OFFSET>(a, a)
+        match OFFSET % 2 {
+            0 => self.slide_f64x2::<0>(a, a),
+            1 => self.slide_f64x2::<1>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x2<const OFFSET: usize>(self, a: f64x2<Self>) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
-        match OFFSET {
+        match OFFSET % 2 {
             0 => self.slide_f64x2::<2>(a, a),
             1 => self.slide_f64x2::<1>(a, a),
-            2 => self.slide_f64x2::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -2550,14 +2521,13 @@ impl Simd for WasmSimd128 {
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
         let padding = self.splat_f64x2(padding);
-        self.slide_f64x2::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x2::<0>(a, padding),
+            1 => self.slide_f64x2::<1>(a, padding),
+            2 => self.slide_f64x2::<2>(a, padding),
+            _ => self.slide_f64x2::<2>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x2<const OFFSET: usize>(
@@ -2565,18 +2535,12 @@ impl Simd for WasmSimd128 {
         a: f64x2<Self>,
         padding: f64,
     ) -> f64x2<Self> {
-        assert!(
-            OFFSET <= 2,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            2,
-        );
         let padding = self.splat_f64x2(padding);
         match OFFSET {
             0 => self.slide_f64x2::<2>(padding, a),
             1 => self.slide_f64x2::<1>(padding, a),
             2 => self.slide_f64x2::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x2::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -2944,23 +2908,21 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_f32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_f32x8::<0>(a, a),
+            1 => self.slide_f32x8::<1>(a, a),
+            2 => self.slide_f32x8::<2>(a, a),
+            3 => self.slide_f32x8::<3>(a, a),
+            4 => self.slide_f32x8::<4>(a, a),
+            5 => self.slide_f32x8::<5>(a, a),
+            6 => self.slide_f32x8::<6>(a, a),
+            7 => self.slide_f32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x8<const OFFSET: usize>(self, a: f32x8<Self>) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_f32x8::<8>(a, a),
             1 => self.slide_f32x8::<7>(a, a),
             2 => self.slide_f32x8::<6>(a, a),
@@ -2969,7 +2931,6 @@ impl Simd for WasmSimd128 {
             5 => self.slide_f32x8::<3>(a, a),
             6 => self.slide_f32x8::<2>(a, a),
             7 => self.slide_f32x8::<1>(a, a),
-            8 => self.slide_f32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -2979,14 +2940,19 @@ impl Simd for WasmSimd128 {
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f32x8(padding);
-        self.slide_f32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x8::<0>(a, padding),
+            1 => self.slide_f32x8::<1>(a, padding),
+            2 => self.slide_f32x8::<2>(a, padding),
+            3 => self.slide_f32x8::<3>(a, padding),
+            4 => self.slide_f32x8::<4>(a, padding),
+            5 => self.slide_f32x8::<5>(a, padding),
+            6 => self.slide_f32x8::<6>(a, padding),
+            7 => self.slide_f32x8::<7>(a, padding),
+            8 => self.slide_f32x8::<8>(a, padding),
+            _ => self.slide_f32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x8<const OFFSET: usize>(
@@ -2994,12 +2960,6 @@ impl Simd for WasmSimd128 {
         a: f32x8<Self>,
         padding: f32,
     ) -> f32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f32x8(padding);
         match OFFSET {
             0 => self.slide_f32x8::<8>(padding, a),
@@ -3011,7 +2971,7 @@ impl Simd for WasmSimd128 {
             6 => self.slide_f32x8::<2>(padding, a),
             7 => self.slide_f32x8::<1>(padding, a),
             8 => self.slide_f32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -3395,23 +3355,45 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_i8x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_i8x32::<0>(a, a),
+            1 => self.slide_i8x32::<1>(a, a),
+            2 => self.slide_i8x32::<2>(a, a),
+            3 => self.slide_i8x32::<3>(a, a),
+            4 => self.slide_i8x32::<4>(a, a),
+            5 => self.slide_i8x32::<5>(a, a),
+            6 => self.slide_i8x32::<6>(a, a),
+            7 => self.slide_i8x32::<7>(a, a),
+            8 => self.slide_i8x32::<8>(a, a),
+            9 => self.slide_i8x32::<9>(a, a),
+            10 => self.slide_i8x32::<10>(a, a),
+            11 => self.slide_i8x32::<11>(a, a),
+            12 => self.slide_i8x32::<12>(a, a),
+            13 => self.slide_i8x32::<13>(a, a),
+            14 => self.slide_i8x32::<14>(a, a),
+            15 => self.slide_i8x32::<15>(a, a),
+            16 => self.slide_i8x32::<16>(a, a),
+            17 => self.slide_i8x32::<17>(a, a),
+            18 => self.slide_i8x32::<18>(a, a),
+            19 => self.slide_i8x32::<19>(a, a),
+            20 => self.slide_i8x32::<20>(a, a),
+            21 => self.slide_i8x32::<21>(a, a),
+            22 => self.slide_i8x32::<22>(a, a),
+            23 => self.slide_i8x32::<23>(a, a),
+            24 => self.slide_i8x32::<24>(a, a),
+            25 => self.slide_i8x32::<25>(a, a),
+            26 => self.slide_i8x32::<26>(a, a),
+            27 => self.slide_i8x32::<27>(a, a),
+            28 => self.slide_i8x32::<28>(a, a),
+            29 => self.slide_i8x32::<29>(a, a),
+            30 => self.slide_i8x32::<30>(a, a),
+            31 => self.slide_i8x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x32<const OFFSET: usize>(self, a: i8x32<Self>) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_i8x32::<32>(a, a),
             1 => self.slide_i8x32::<31>(a, a),
             2 => self.slide_i8x32::<30>(a, a),
@@ -3444,7 +3426,6 @@ impl Simd for WasmSimd128 {
             29 => self.slide_i8x32::<3>(a, a),
             30 => self.slide_i8x32::<2>(a, a),
             31 => self.slide_i8x32::<1>(a, a),
-            32 => self.slide_i8x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -3454,14 +3435,43 @@ impl Simd for WasmSimd128 {
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i8x32(padding);
-        self.slide_i8x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x32::<0>(a, padding),
+            1 => self.slide_i8x32::<1>(a, padding),
+            2 => self.slide_i8x32::<2>(a, padding),
+            3 => self.slide_i8x32::<3>(a, padding),
+            4 => self.slide_i8x32::<4>(a, padding),
+            5 => self.slide_i8x32::<5>(a, padding),
+            6 => self.slide_i8x32::<6>(a, padding),
+            7 => self.slide_i8x32::<7>(a, padding),
+            8 => self.slide_i8x32::<8>(a, padding),
+            9 => self.slide_i8x32::<9>(a, padding),
+            10 => self.slide_i8x32::<10>(a, padding),
+            11 => self.slide_i8x32::<11>(a, padding),
+            12 => self.slide_i8x32::<12>(a, padding),
+            13 => self.slide_i8x32::<13>(a, padding),
+            14 => self.slide_i8x32::<14>(a, padding),
+            15 => self.slide_i8x32::<15>(a, padding),
+            16 => self.slide_i8x32::<16>(a, padding),
+            17 => self.slide_i8x32::<17>(a, padding),
+            18 => self.slide_i8x32::<18>(a, padding),
+            19 => self.slide_i8x32::<19>(a, padding),
+            20 => self.slide_i8x32::<20>(a, padding),
+            21 => self.slide_i8x32::<21>(a, padding),
+            22 => self.slide_i8x32::<22>(a, padding),
+            23 => self.slide_i8x32::<23>(a, padding),
+            24 => self.slide_i8x32::<24>(a, padding),
+            25 => self.slide_i8x32::<25>(a, padding),
+            26 => self.slide_i8x32::<26>(a, padding),
+            27 => self.slide_i8x32::<27>(a, padding),
+            28 => self.slide_i8x32::<28>(a, padding),
+            29 => self.slide_i8x32::<29>(a, padding),
+            30 => self.slide_i8x32::<30>(a, padding),
+            31 => self.slide_i8x32::<31>(a, padding),
+            32 => self.slide_i8x32::<32>(a, padding),
+            _ => self.slide_i8x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x32<const OFFSET: usize>(
@@ -3469,12 +3479,6 @@ impl Simd for WasmSimd128 {
         a: i8x32<Self>,
         padding: i8,
     ) -> i8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i8x32(padding);
         match OFFSET {
             0 => self.slide_i8x32::<32>(padding, a),
@@ -3510,7 +3514,7 @@ impl Simd for WasmSimd128 {
             30 => self.slide_i8x32::<2>(padding, a),
             31 => self.slide_i8x32::<1>(padding, a),
             32 => self.slide_i8x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -3801,23 +3805,45 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_u8x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_u8x32::<0>(a, a),
+            1 => self.slide_u8x32::<1>(a, a),
+            2 => self.slide_u8x32::<2>(a, a),
+            3 => self.slide_u8x32::<3>(a, a),
+            4 => self.slide_u8x32::<4>(a, a),
+            5 => self.slide_u8x32::<5>(a, a),
+            6 => self.slide_u8x32::<6>(a, a),
+            7 => self.slide_u8x32::<7>(a, a),
+            8 => self.slide_u8x32::<8>(a, a),
+            9 => self.slide_u8x32::<9>(a, a),
+            10 => self.slide_u8x32::<10>(a, a),
+            11 => self.slide_u8x32::<11>(a, a),
+            12 => self.slide_u8x32::<12>(a, a),
+            13 => self.slide_u8x32::<13>(a, a),
+            14 => self.slide_u8x32::<14>(a, a),
+            15 => self.slide_u8x32::<15>(a, a),
+            16 => self.slide_u8x32::<16>(a, a),
+            17 => self.slide_u8x32::<17>(a, a),
+            18 => self.slide_u8x32::<18>(a, a),
+            19 => self.slide_u8x32::<19>(a, a),
+            20 => self.slide_u8x32::<20>(a, a),
+            21 => self.slide_u8x32::<21>(a, a),
+            22 => self.slide_u8x32::<22>(a, a),
+            23 => self.slide_u8x32::<23>(a, a),
+            24 => self.slide_u8x32::<24>(a, a),
+            25 => self.slide_u8x32::<25>(a, a),
+            26 => self.slide_u8x32::<26>(a, a),
+            27 => self.slide_u8x32::<27>(a, a),
+            28 => self.slide_u8x32::<28>(a, a),
+            29 => self.slide_u8x32::<29>(a, a),
+            30 => self.slide_u8x32::<30>(a, a),
+            31 => self.slide_u8x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x32<const OFFSET: usize>(self, a: u8x32<Self>) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_u8x32::<32>(a, a),
             1 => self.slide_u8x32::<31>(a, a),
             2 => self.slide_u8x32::<30>(a, a),
@@ -3850,7 +3876,6 @@ impl Simd for WasmSimd128 {
             29 => self.slide_u8x32::<3>(a, a),
             30 => self.slide_u8x32::<2>(a, a),
             31 => self.slide_u8x32::<1>(a, a),
-            32 => self.slide_u8x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -3860,14 +3885,43 @@ impl Simd for WasmSimd128 {
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u8x32(padding);
-        self.slide_u8x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x32::<0>(a, padding),
+            1 => self.slide_u8x32::<1>(a, padding),
+            2 => self.slide_u8x32::<2>(a, padding),
+            3 => self.slide_u8x32::<3>(a, padding),
+            4 => self.slide_u8x32::<4>(a, padding),
+            5 => self.slide_u8x32::<5>(a, padding),
+            6 => self.slide_u8x32::<6>(a, padding),
+            7 => self.slide_u8x32::<7>(a, padding),
+            8 => self.slide_u8x32::<8>(a, padding),
+            9 => self.slide_u8x32::<9>(a, padding),
+            10 => self.slide_u8x32::<10>(a, padding),
+            11 => self.slide_u8x32::<11>(a, padding),
+            12 => self.slide_u8x32::<12>(a, padding),
+            13 => self.slide_u8x32::<13>(a, padding),
+            14 => self.slide_u8x32::<14>(a, padding),
+            15 => self.slide_u8x32::<15>(a, padding),
+            16 => self.slide_u8x32::<16>(a, padding),
+            17 => self.slide_u8x32::<17>(a, padding),
+            18 => self.slide_u8x32::<18>(a, padding),
+            19 => self.slide_u8x32::<19>(a, padding),
+            20 => self.slide_u8x32::<20>(a, padding),
+            21 => self.slide_u8x32::<21>(a, padding),
+            22 => self.slide_u8x32::<22>(a, padding),
+            23 => self.slide_u8x32::<23>(a, padding),
+            24 => self.slide_u8x32::<24>(a, padding),
+            25 => self.slide_u8x32::<25>(a, padding),
+            26 => self.slide_u8x32::<26>(a, padding),
+            27 => self.slide_u8x32::<27>(a, padding),
+            28 => self.slide_u8x32::<28>(a, padding),
+            29 => self.slide_u8x32::<29>(a, padding),
+            30 => self.slide_u8x32::<30>(a, padding),
+            31 => self.slide_u8x32::<31>(a, padding),
+            32 => self.slide_u8x32::<32>(a, padding),
+            _ => self.slide_u8x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x32<const OFFSET: usize>(
@@ -3875,12 +3929,6 @@ impl Simd for WasmSimd128 {
         a: u8x32<Self>,
         padding: u8,
     ) -> u8x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u8x32(padding);
         match OFFSET {
             0 => self.slide_u8x32::<32>(padding, a),
@@ -3916,7 +3964,7 @@ impl Simd for WasmSimd128 {
             30 => self.slide_u8x32::<2>(padding, a),
             31 => self.slide_u8x32::<1>(padding, a),
             32 => self.slide_u8x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -4326,23 +4374,29 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i16x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i16x16::<0>(a, a),
+            1 => self.slide_i16x16::<1>(a, a),
+            2 => self.slide_i16x16::<2>(a, a),
+            3 => self.slide_i16x16::<3>(a, a),
+            4 => self.slide_i16x16::<4>(a, a),
+            5 => self.slide_i16x16::<5>(a, a),
+            6 => self.slide_i16x16::<6>(a, a),
+            7 => self.slide_i16x16::<7>(a, a),
+            8 => self.slide_i16x16::<8>(a, a),
+            9 => self.slide_i16x16::<9>(a, a),
+            10 => self.slide_i16x16::<10>(a, a),
+            11 => self.slide_i16x16::<11>(a, a),
+            12 => self.slide_i16x16::<12>(a, a),
+            13 => self.slide_i16x16::<13>(a, a),
+            14 => self.slide_i16x16::<14>(a, a),
+            15 => self.slide_i16x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x16<const OFFSET: usize>(self, a: i16x16<Self>) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i16x16::<16>(a, a),
             1 => self.slide_i16x16::<15>(a, a),
             2 => self.slide_i16x16::<14>(a, a),
@@ -4359,7 +4413,6 @@ impl Simd for WasmSimd128 {
             13 => self.slide_i16x16::<3>(a, a),
             14 => self.slide_i16x16::<2>(a, a),
             15 => self.slide_i16x16::<1>(a, a),
-            16 => self.slide_i16x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -4369,14 +4422,27 @@ impl Simd for WasmSimd128 {
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i16x16(padding);
-        self.slide_i16x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x16::<0>(a, padding),
+            1 => self.slide_i16x16::<1>(a, padding),
+            2 => self.slide_i16x16::<2>(a, padding),
+            3 => self.slide_i16x16::<3>(a, padding),
+            4 => self.slide_i16x16::<4>(a, padding),
+            5 => self.slide_i16x16::<5>(a, padding),
+            6 => self.slide_i16x16::<6>(a, padding),
+            7 => self.slide_i16x16::<7>(a, padding),
+            8 => self.slide_i16x16::<8>(a, padding),
+            9 => self.slide_i16x16::<9>(a, padding),
+            10 => self.slide_i16x16::<10>(a, padding),
+            11 => self.slide_i16x16::<11>(a, padding),
+            12 => self.slide_i16x16::<12>(a, padding),
+            13 => self.slide_i16x16::<13>(a, padding),
+            14 => self.slide_i16x16::<14>(a, padding),
+            15 => self.slide_i16x16::<15>(a, padding),
+            16 => self.slide_i16x16::<16>(a, padding),
+            _ => self.slide_i16x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x16<const OFFSET: usize>(
@@ -4384,12 +4450,6 @@ impl Simd for WasmSimd128 {
         a: i16x16<Self>,
         padding: i16,
     ) -> i16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i16x16(padding);
         match OFFSET {
             0 => self.slide_i16x16::<16>(padding, a),
@@ -4409,7 +4469,7 @@ impl Simd for WasmSimd128 {
             14 => self.slide_i16x16::<2>(padding, a),
             15 => self.slide_i16x16::<1>(padding, a),
             16 => self.slide_i16x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -4704,23 +4764,29 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u16x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u16x16::<0>(a, a),
+            1 => self.slide_u16x16::<1>(a, a),
+            2 => self.slide_u16x16::<2>(a, a),
+            3 => self.slide_u16x16::<3>(a, a),
+            4 => self.slide_u16x16::<4>(a, a),
+            5 => self.slide_u16x16::<5>(a, a),
+            6 => self.slide_u16x16::<6>(a, a),
+            7 => self.slide_u16x16::<7>(a, a),
+            8 => self.slide_u16x16::<8>(a, a),
+            9 => self.slide_u16x16::<9>(a, a),
+            10 => self.slide_u16x16::<10>(a, a),
+            11 => self.slide_u16x16::<11>(a, a),
+            12 => self.slide_u16x16::<12>(a, a),
+            13 => self.slide_u16x16::<13>(a, a),
+            14 => self.slide_u16x16::<14>(a, a),
+            15 => self.slide_u16x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x16<const OFFSET: usize>(self, a: u16x16<Self>) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u16x16::<16>(a, a),
             1 => self.slide_u16x16::<15>(a, a),
             2 => self.slide_u16x16::<14>(a, a),
@@ -4737,7 +4803,6 @@ impl Simd for WasmSimd128 {
             13 => self.slide_u16x16::<3>(a, a),
             14 => self.slide_u16x16::<2>(a, a),
             15 => self.slide_u16x16::<1>(a, a),
-            16 => self.slide_u16x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -4747,14 +4812,27 @@ impl Simd for WasmSimd128 {
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u16x16(padding);
-        self.slide_u16x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x16::<0>(a, padding),
+            1 => self.slide_u16x16::<1>(a, padding),
+            2 => self.slide_u16x16::<2>(a, padding),
+            3 => self.slide_u16x16::<3>(a, padding),
+            4 => self.slide_u16x16::<4>(a, padding),
+            5 => self.slide_u16x16::<5>(a, padding),
+            6 => self.slide_u16x16::<6>(a, padding),
+            7 => self.slide_u16x16::<7>(a, padding),
+            8 => self.slide_u16x16::<8>(a, padding),
+            9 => self.slide_u16x16::<9>(a, padding),
+            10 => self.slide_u16x16::<10>(a, padding),
+            11 => self.slide_u16x16::<11>(a, padding),
+            12 => self.slide_u16x16::<12>(a, padding),
+            13 => self.slide_u16x16::<13>(a, padding),
+            14 => self.slide_u16x16::<14>(a, padding),
+            15 => self.slide_u16x16::<15>(a, padding),
+            16 => self.slide_u16x16::<16>(a, padding),
+            _ => self.slide_u16x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x16<const OFFSET: usize>(
@@ -4762,12 +4840,6 @@ impl Simd for WasmSimd128 {
         a: u16x16<Self>,
         padding: u16,
     ) -> u16x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u16x16(padding);
         match OFFSET {
             0 => self.slide_u16x16::<16>(padding, a),
@@ -4787,7 +4859,7 @@ impl Simd for WasmSimd128 {
             14 => self.slide_u16x16::<2>(padding, a),
             15 => self.slide_u16x16::<1>(padding, a),
             16 => self.slide_u16x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -5210,23 +5282,21 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_i32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_i32x8::<0>(a, a),
+            1 => self.slide_i32x8::<1>(a, a),
+            2 => self.slide_i32x8::<2>(a, a),
+            3 => self.slide_i32x8::<3>(a, a),
+            4 => self.slide_i32x8::<4>(a, a),
+            5 => self.slide_i32x8::<5>(a, a),
+            6 => self.slide_i32x8::<6>(a, a),
+            7 => self.slide_i32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x8<const OFFSET: usize>(self, a: i32x8<Self>) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_i32x8::<8>(a, a),
             1 => self.slide_i32x8::<7>(a, a),
             2 => self.slide_i32x8::<6>(a, a),
@@ -5235,7 +5305,6 @@ impl Simd for WasmSimd128 {
             5 => self.slide_i32x8::<3>(a, a),
             6 => self.slide_i32x8::<2>(a, a),
             7 => self.slide_i32x8::<1>(a, a),
-            8 => self.slide_i32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -5245,14 +5314,19 @@ impl Simd for WasmSimd128 {
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i32x8(padding);
-        self.slide_i32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x8::<0>(a, padding),
+            1 => self.slide_i32x8::<1>(a, padding),
+            2 => self.slide_i32x8::<2>(a, padding),
+            3 => self.slide_i32x8::<3>(a, padding),
+            4 => self.slide_i32x8::<4>(a, padding),
+            5 => self.slide_i32x8::<5>(a, padding),
+            6 => self.slide_i32x8::<6>(a, padding),
+            7 => self.slide_i32x8::<7>(a, padding),
+            8 => self.slide_i32x8::<8>(a, padding),
+            _ => self.slide_i32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x8<const OFFSET: usize>(
@@ -5260,12 +5334,6 @@ impl Simd for WasmSimd128 {
         a: i32x8<Self>,
         padding: i32,
     ) -> i32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_i32x8(padding);
         match OFFSET {
             0 => self.slide_i32x8::<8>(padding, a),
@@ -5277,7 +5345,7 @@ impl Simd for WasmSimd128 {
             6 => self.slide_i32x8::<2>(padding, a),
             7 => self.slide_i32x8::<1>(padding, a),
             8 => self.slide_i32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -5573,23 +5641,21 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_u32x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_u32x8::<0>(a, a),
+            1 => self.slide_u32x8::<1>(a, a),
+            2 => self.slide_u32x8::<2>(a, a),
+            3 => self.slide_u32x8::<3>(a, a),
+            4 => self.slide_u32x8::<4>(a, a),
+            5 => self.slide_u32x8::<5>(a, a),
+            6 => self.slide_u32x8::<6>(a, a),
+            7 => self.slide_u32x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x8<const OFFSET: usize>(self, a: u32x8<Self>) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_u32x8::<8>(a, a),
             1 => self.slide_u32x8::<7>(a, a),
             2 => self.slide_u32x8::<6>(a, a),
@@ -5598,7 +5664,6 @@ impl Simd for WasmSimd128 {
             5 => self.slide_u32x8::<3>(a, a),
             6 => self.slide_u32x8::<2>(a, a),
             7 => self.slide_u32x8::<1>(a, a),
-            8 => self.slide_u32x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -5608,14 +5673,19 @@ impl Simd for WasmSimd128 {
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u32x8(padding);
-        self.slide_u32x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x8::<0>(a, padding),
+            1 => self.slide_u32x8::<1>(a, padding),
+            2 => self.slide_u32x8::<2>(a, padding),
+            3 => self.slide_u32x8::<3>(a, padding),
+            4 => self.slide_u32x8::<4>(a, padding),
+            5 => self.slide_u32x8::<5>(a, padding),
+            6 => self.slide_u32x8::<6>(a, padding),
+            7 => self.slide_u32x8::<7>(a, padding),
+            8 => self.slide_u32x8::<8>(a, padding),
+            _ => self.slide_u32x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x8<const OFFSET: usize>(
@@ -5623,12 +5693,6 @@ impl Simd for WasmSimd128 {
         a: u32x8<Self>,
         padding: u32,
     ) -> u32x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_u32x8(padding);
         match OFFSET {
             0 => self.slide_u32x8::<8>(padding, a),
@@ -5640,7 +5704,7 @@ impl Simd for WasmSimd128 {
             6 => self.slide_u32x8::<2>(padding, a),
             7 => self.slide_u32x8::<1>(padding, a),
             8 => self.slide_u32x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x8::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -6047,28 +6111,21 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        self.slide_f64x4::<OFFSET>(a, a)
+        match OFFSET % 4 {
+            0 => self.slide_f64x4::<0>(a, a),
+            1 => self.slide_f64x4::<1>(a, a),
+            2 => self.slide_f64x4::<2>(a, a),
+            3 => self.slide_f64x4::<3>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x4<const OFFSET: usize>(self, a: f64x4<Self>) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
-        match OFFSET {
+        match OFFSET % 4 {
             0 => self.slide_f64x4::<4>(a, a),
             1 => self.slide_f64x4::<3>(a, a),
             2 => self.slide_f64x4::<2>(a, a),
             3 => self.slide_f64x4::<1>(a, a),
-            4 => self.slide_f64x4::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -6078,14 +6135,15 @@ impl Simd for WasmSimd128 {
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f64x4(padding);
-        self.slide_f64x4::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x4::<0>(a, padding),
+            1 => self.slide_f64x4::<1>(a, padding),
+            2 => self.slide_f64x4::<2>(a, padding),
+            3 => self.slide_f64x4::<3>(a, padding),
+            4 => self.slide_f64x4::<4>(a, padding),
+            _ => self.slide_f64x4::<4>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x4<const OFFSET: usize>(
@@ -6093,12 +6151,6 @@ impl Simd for WasmSimd128 {
         a: f64x4<Self>,
         padding: f64,
     ) -> f64x4<Self> {
-        assert!(
-            OFFSET <= 4,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            4,
-        );
         let padding = self.splat_f64x4(padding);
         match OFFSET {
             0 => self.slide_f64x4::<4>(padding, a),
@@ -6106,7 +6158,7 @@ impl Simd for WasmSimd128 {
             2 => self.slide_f64x4::<2>(padding, a),
             3 => self.slide_f64x4::<1>(padding, a),
             4 => self.slide_f64x4::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x4::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -6567,23 +6619,29 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_f32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_f32x16::<0>(a, a),
+            1 => self.slide_f32x16::<1>(a, a),
+            2 => self.slide_f32x16::<2>(a, a),
+            3 => self.slide_f32x16::<3>(a, a),
+            4 => self.slide_f32x16::<4>(a, a),
+            5 => self.slide_f32x16::<5>(a, a),
+            6 => self.slide_f32x16::<6>(a, a),
+            7 => self.slide_f32x16::<7>(a, a),
+            8 => self.slide_f32x16::<8>(a, a),
+            9 => self.slide_f32x16::<9>(a, a),
+            10 => self.slide_f32x16::<10>(a, a),
+            11 => self.slide_f32x16::<11>(a, a),
+            12 => self.slide_f32x16::<12>(a, a),
+            13 => self.slide_f32x16::<13>(a, a),
+            14 => self.slide_f32x16::<14>(a, a),
+            15 => self.slide_f32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f32x16<const OFFSET: usize>(self, a: f32x16<Self>) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_f32x16::<16>(a, a),
             1 => self.slide_f32x16::<15>(a, a),
             2 => self.slide_f32x16::<14>(a, a),
@@ -6600,7 +6658,6 @@ impl Simd for WasmSimd128 {
             13 => self.slide_f32x16::<3>(a, a),
             14 => self.slide_f32x16::<2>(a, a),
             15 => self.slide_f32x16::<1>(a, a),
-            16 => self.slide_f32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -6610,14 +6667,27 @@ impl Simd for WasmSimd128 {
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_f32x16(padding);
-        self.slide_f32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f32x16::<0>(a, padding),
+            1 => self.slide_f32x16::<1>(a, padding),
+            2 => self.slide_f32x16::<2>(a, padding),
+            3 => self.slide_f32x16::<3>(a, padding),
+            4 => self.slide_f32x16::<4>(a, padding),
+            5 => self.slide_f32x16::<5>(a, padding),
+            6 => self.slide_f32x16::<6>(a, padding),
+            7 => self.slide_f32x16::<7>(a, padding),
+            8 => self.slide_f32x16::<8>(a, padding),
+            9 => self.slide_f32x16::<9>(a, padding),
+            10 => self.slide_f32x16::<10>(a, padding),
+            11 => self.slide_f32x16::<11>(a, padding),
+            12 => self.slide_f32x16::<12>(a, padding),
+            13 => self.slide_f32x16::<13>(a, padding),
+            14 => self.slide_f32x16::<14>(a, padding),
+            15 => self.slide_f32x16::<15>(a, padding),
+            16 => self.slide_f32x16::<16>(a, padding),
+            _ => self.slide_f32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f32x16<const OFFSET: usize>(
@@ -6625,12 +6695,6 @@ impl Simd for WasmSimd128 {
         a: f32x16<Self>,
         padding: f32,
     ) -> f32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_f32x16(padding);
         match OFFSET {
             0 => self.slide_f32x16::<16>(padding, a),
@@ -6650,7 +6714,7 @@ impl Simd for WasmSimd128 {
             14 => self.slide_f32x16::<2>(padding, a),
             15 => self.slide_f32x16::<1>(padding, a),
             16 => self.slide_f32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7077,23 +7141,77 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        self.slide_i8x64::<OFFSET>(a, a)
+        match OFFSET % 64 {
+            0 => self.slide_i8x64::<0>(a, a),
+            1 => self.slide_i8x64::<1>(a, a),
+            2 => self.slide_i8x64::<2>(a, a),
+            3 => self.slide_i8x64::<3>(a, a),
+            4 => self.slide_i8x64::<4>(a, a),
+            5 => self.slide_i8x64::<5>(a, a),
+            6 => self.slide_i8x64::<6>(a, a),
+            7 => self.slide_i8x64::<7>(a, a),
+            8 => self.slide_i8x64::<8>(a, a),
+            9 => self.slide_i8x64::<9>(a, a),
+            10 => self.slide_i8x64::<10>(a, a),
+            11 => self.slide_i8x64::<11>(a, a),
+            12 => self.slide_i8x64::<12>(a, a),
+            13 => self.slide_i8x64::<13>(a, a),
+            14 => self.slide_i8x64::<14>(a, a),
+            15 => self.slide_i8x64::<15>(a, a),
+            16 => self.slide_i8x64::<16>(a, a),
+            17 => self.slide_i8x64::<17>(a, a),
+            18 => self.slide_i8x64::<18>(a, a),
+            19 => self.slide_i8x64::<19>(a, a),
+            20 => self.slide_i8x64::<20>(a, a),
+            21 => self.slide_i8x64::<21>(a, a),
+            22 => self.slide_i8x64::<22>(a, a),
+            23 => self.slide_i8x64::<23>(a, a),
+            24 => self.slide_i8x64::<24>(a, a),
+            25 => self.slide_i8x64::<25>(a, a),
+            26 => self.slide_i8x64::<26>(a, a),
+            27 => self.slide_i8x64::<27>(a, a),
+            28 => self.slide_i8x64::<28>(a, a),
+            29 => self.slide_i8x64::<29>(a, a),
+            30 => self.slide_i8x64::<30>(a, a),
+            31 => self.slide_i8x64::<31>(a, a),
+            32 => self.slide_i8x64::<32>(a, a),
+            33 => self.slide_i8x64::<33>(a, a),
+            34 => self.slide_i8x64::<34>(a, a),
+            35 => self.slide_i8x64::<35>(a, a),
+            36 => self.slide_i8x64::<36>(a, a),
+            37 => self.slide_i8x64::<37>(a, a),
+            38 => self.slide_i8x64::<38>(a, a),
+            39 => self.slide_i8x64::<39>(a, a),
+            40 => self.slide_i8x64::<40>(a, a),
+            41 => self.slide_i8x64::<41>(a, a),
+            42 => self.slide_i8x64::<42>(a, a),
+            43 => self.slide_i8x64::<43>(a, a),
+            44 => self.slide_i8x64::<44>(a, a),
+            45 => self.slide_i8x64::<45>(a, a),
+            46 => self.slide_i8x64::<46>(a, a),
+            47 => self.slide_i8x64::<47>(a, a),
+            48 => self.slide_i8x64::<48>(a, a),
+            49 => self.slide_i8x64::<49>(a, a),
+            50 => self.slide_i8x64::<50>(a, a),
+            51 => self.slide_i8x64::<51>(a, a),
+            52 => self.slide_i8x64::<52>(a, a),
+            53 => self.slide_i8x64::<53>(a, a),
+            54 => self.slide_i8x64::<54>(a, a),
+            55 => self.slide_i8x64::<55>(a, a),
+            56 => self.slide_i8x64::<56>(a, a),
+            57 => self.slide_i8x64::<57>(a, a),
+            58 => self.slide_i8x64::<58>(a, a),
+            59 => self.slide_i8x64::<59>(a, a),
+            60 => self.slide_i8x64::<60>(a, a),
+            61 => self.slide_i8x64::<61>(a, a),
+            62 => self.slide_i8x64::<62>(a, a),
+            63 => self.slide_i8x64::<63>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i8x64<const OFFSET: usize>(self, a: i8x64<Self>) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        match OFFSET {
+        match OFFSET % 64 {
             0 => self.slide_i8x64::<64>(a, a),
             1 => self.slide_i8x64::<63>(a, a),
             2 => self.slide_i8x64::<62>(a, a),
@@ -7158,7 +7276,6 @@ impl Simd for WasmSimd128 {
             61 => self.slide_i8x64::<3>(a, a),
             62 => self.slide_i8x64::<2>(a, a),
             63 => self.slide_i8x64::<1>(a, a),
-            64 => self.slide_i8x64::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -7168,14 +7285,75 @@ impl Simd for WasmSimd128 {
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_i8x64(padding);
-        self.slide_i8x64::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i8x64::<0>(a, padding),
+            1 => self.slide_i8x64::<1>(a, padding),
+            2 => self.slide_i8x64::<2>(a, padding),
+            3 => self.slide_i8x64::<3>(a, padding),
+            4 => self.slide_i8x64::<4>(a, padding),
+            5 => self.slide_i8x64::<5>(a, padding),
+            6 => self.slide_i8x64::<6>(a, padding),
+            7 => self.slide_i8x64::<7>(a, padding),
+            8 => self.slide_i8x64::<8>(a, padding),
+            9 => self.slide_i8x64::<9>(a, padding),
+            10 => self.slide_i8x64::<10>(a, padding),
+            11 => self.slide_i8x64::<11>(a, padding),
+            12 => self.slide_i8x64::<12>(a, padding),
+            13 => self.slide_i8x64::<13>(a, padding),
+            14 => self.slide_i8x64::<14>(a, padding),
+            15 => self.slide_i8x64::<15>(a, padding),
+            16 => self.slide_i8x64::<16>(a, padding),
+            17 => self.slide_i8x64::<17>(a, padding),
+            18 => self.slide_i8x64::<18>(a, padding),
+            19 => self.slide_i8x64::<19>(a, padding),
+            20 => self.slide_i8x64::<20>(a, padding),
+            21 => self.slide_i8x64::<21>(a, padding),
+            22 => self.slide_i8x64::<22>(a, padding),
+            23 => self.slide_i8x64::<23>(a, padding),
+            24 => self.slide_i8x64::<24>(a, padding),
+            25 => self.slide_i8x64::<25>(a, padding),
+            26 => self.slide_i8x64::<26>(a, padding),
+            27 => self.slide_i8x64::<27>(a, padding),
+            28 => self.slide_i8x64::<28>(a, padding),
+            29 => self.slide_i8x64::<29>(a, padding),
+            30 => self.slide_i8x64::<30>(a, padding),
+            31 => self.slide_i8x64::<31>(a, padding),
+            32 => self.slide_i8x64::<32>(a, padding),
+            33 => self.slide_i8x64::<33>(a, padding),
+            34 => self.slide_i8x64::<34>(a, padding),
+            35 => self.slide_i8x64::<35>(a, padding),
+            36 => self.slide_i8x64::<36>(a, padding),
+            37 => self.slide_i8x64::<37>(a, padding),
+            38 => self.slide_i8x64::<38>(a, padding),
+            39 => self.slide_i8x64::<39>(a, padding),
+            40 => self.slide_i8x64::<40>(a, padding),
+            41 => self.slide_i8x64::<41>(a, padding),
+            42 => self.slide_i8x64::<42>(a, padding),
+            43 => self.slide_i8x64::<43>(a, padding),
+            44 => self.slide_i8x64::<44>(a, padding),
+            45 => self.slide_i8x64::<45>(a, padding),
+            46 => self.slide_i8x64::<46>(a, padding),
+            47 => self.slide_i8x64::<47>(a, padding),
+            48 => self.slide_i8x64::<48>(a, padding),
+            49 => self.slide_i8x64::<49>(a, padding),
+            50 => self.slide_i8x64::<50>(a, padding),
+            51 => self.slide_i8x64::<51>(a, padding),
+            52 => self.slide_i8x64::<52>(a, padding),
+            53 => self.slide_i8x64::<53>(a, padding),
+            54 => self.slide_i8x64::<54>(a, padding),
+            55 => self.slide_i8x64::<55>(a, padding),
+            56 => self.slide_i8x64::<56>(a, padding),
+            57 => self.slide_i8x64::<57>(a, padding),
+            58 => self.slide_i8x64::<58>(a, padding),
+            59 => self.slide_i8x64::<59>(a, padding),
+            60 => self.slide_i8x64::<60>(a, padding),
+            61 => self.slide_i8x64::<61>(a, padding),
+            62 => self.slide_i8x64::<62>(a, padding),
+            63 => self.slide_i8x64::<63>(a, padding),
+            64 => self.slide_i8x64::<64>(a, padding),
+            _ => self.slide_i8x64::<64>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i8x64<const OFFSET: usize>(
@@ -7183,12 +7361,6 @@ impl Simd for WasmSimd128 {
         a: i8x64<Self>,
         padding: i8,
     ) -> i8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_i8x64(padding);
         match OFFSET {
             0 => self.slide_i8x64::<64>(padding, a),
@@ -7256,7 +7428,7 @@ impl Simd for WasmSimd128 {
             62 => self.slide_i8x64::<2>(padding, a),
             63 => self.slide_i8x64::<1>(padding, a),
             64 => self.slide_i8x64::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i8x64::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -7540,23 +7712,77 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        self.slide_u8x64::<OFFSET>(a, a)
+        match OFFSET % 64 {
+            0 => self.slide_u8x64::<0>(a, a),
+            1 => self.slide_u8x64::<1>(a, a),
+            2 => self.slide_u8x64::<2>(a, a),
+            3 => self.slide_u8x64::<3>(a, a),
+            4 => self.slide_u8x64::<4>(a, a),
+            5 => self.slide_u8x64::<5>(a, a),
+            6 => self.slide_u8x64::<6>(a, a),
+            7 => self.slide_u8x64::<7>(a, a),
+            8 => self.slide_u8x64::<8>(a, a),
+            9 => self.slide_u8x64::<9>(a, a),
+            10 => self.slide_u8x64::<10>(a, a),
+            11 => self.slide_u8x64::<11>(a, a),
+            12 => self.slide_u8x64::<12>(a, a),
+            13 => self.slide_u8x64::<13>(a, a),
+            14 => self.slide_u8x64::<14>(a, a),
+            15 => self.slide_u8x64::<15>(a, a),
+            16 => self.slide_u8x64::<16>(a, a),
+            17 => self.slide_u8x64::<17>(a, a),
+            18 => self.slide_u8x64::<18>(a, a),
+            19 => self.slide_u8x64::<19>(a, a),
+            20 => self.slide_u8x64::<20>(a, a),
+            21 => self.slide_u8x64::<21>(a, a),
+            22 => self.slide_u8x64::<22>(a, a),
+            23 => self.slide_u8x64::<23>(a, a),
+            24 => self.slide_u8x64::<24>(a, a),
+            25 => self.slide_u8x64::<25>(a, a),
+            26 => self.slide_u8x64::<26>(a, a),
+            27 => self.slide_u8x64::<27>(a, a),
+            28 => self.slide_u8x64::<28>(a, a),
+            29 => self.slide_u8x64::<29>(a, a),
+            30 => self.slide_u8x64::<30>(a, a),
+            31 => self.slide_u8x64::<31>(a, a),
+            32 => self.slide_u8x64::<32>(a, a),
+            33 => self.slide_u8x64::<33>(a, a),
+            34 => self.slide_u8x64::<34>(a, a),
+            35 => self.slide_u8x64::<35>(a, a),
+            36 => self.slide_u8x64::<36>(a, a),
+            37 => self.slide_u8x64::<37>(a, a),
+            38 => self.slide_u8x64::<38>(a, a),
+            39 => self.slide_u8x64::<39>(a, a),
+            40 => self.slide_u8x64::<40>(a, a),
+            41 => self.slide_u8x64::<41>(a, a),
+            42 => self.slide_u8x64::<42>(a, a),
+            43 => self.slide_u8x64::<43>(a, a),
+            44 => self.slide_u8x64::<44>(a, a),
+            45 => self.slide_u8x64::<45>(a, a),
+            46 => self.slide_u8x64::<46>(a, a),
+            47 => self.slide_u8x64::<47>(a, a),
+            48 => self.slide_u8x64::<48>(a, a),
+            49 => self.slide_u8x64::<49>(a, a),
+            50 => self.slide_u8x64::<50>(a, a),
+            51 => self.slide_u8x64::<51>(a, a),
+            52 => self.slide_u8x64::<52>(a, a),
+            53 => self.slide_u8x64::<53>(a, a),
+            54 => self.slide_u8x64::<54>(a, a),
+            55 => self.slide_u8x64::<55>(a, a),
+            56 => self.slide_u8x64::<56>(a, a),
+            57 => self.slide_u8x64::<57>(a, a),
+            58 => self.slide_u8x64::<58>(a, a),
+            59 => self.slide_u8x64::<59>(a, a),
+            60 => self.slide_u8x64::<60>(a, a),
+            61 => self.slide_u8x64::<61>(a, a),
+            62 => self.slide_u8x64::<62>(a, a),
+            63 => self.slide_u8x64::<63>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u8x64<const OFFSET: usize>(self, a: u8x64<Self>) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
-        match OFFSET {
+        match OFFSET % 64 {
             0 => self.slide_u8x64::<64>(a, a),
             1 => self.slide_u8x64::<63>(a, a),
             2 => self.slide_u8x64::<62>(a, a),
@@ -7621,7 +7847,6 @@ impl Simd for WasmSimd128 {
             61 => self.slide_u8x64::<3>(a, a),
             62 => self.slide_u8x64::<2>(a, a),
             63 => self.slide_u8x64::<1>(a, a),
-            64 => self.slide_u8x64::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -7631,14 +7856,75 @@ impl Simd for WasmSimd128 {
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_u8x64(padding);
-        self.slide_u8x64::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u8x64::<0>(a, padding),
+            1 => self.slide_u8x64::<1>(a, padding),
+            2 => self.slide_u8x64::<2>(a, padding),
+            3 => self.slide_u8x64::<3>(a, padding),
+            4 => self.slide_u8x64::<4>(a, padding),
+            5 => self.slide_u8x64::<5>(a, padding),
+            6 => self.slide_u8x64::<6>(a, padding),
+            7 => self.slide_u8x64::<7>(a, padding),
+            8 => self.slide_u8x64::<8>(a, padding),
+            9 => self.slide_u8x64::<9>(a, padding),
+            10 => self.slide_u8x64::<10>(a, padding),
+            11 => self.slide_u8x64::<11>(a, padding),
+            12 => self.slide_u8x64::<12>(a, padding),
+            13 => self.slide_u8x64::<13>(a, padding),
+            14 => self.slide_u8x64::<14>(a, padding),
+            15 => self.slide_u8x64::<15>(a, padding),
+            16 => self.slide_u8x64::<16>(a, padding),
+            17 => self.slide_u8x64::<17>(a, padding),
+            18 => self.slide_u8x64::<18>(a, padding),
+            19 => self.slide_u8x64::<19>(a, padding),
+            20 => self.slide_u8x64::<20>(a, padding),
+            21 => self.slide_u8x64::<21>(a, padding),
+            22 => self.slide_u8x64::<22>(a, padding),
+            23 => self.slide_u8x64::<23>(a, padding),
+            24 => self.slide_u8x64::<24>(a, padding),
+            25 => self.slide_u8x64::<25>(a, padding),
+            26 => self.slide_u8x64::<26>(a, padding),
+            27 => self.slide_u8x64::<27>(a, padding),
+            28 => self.slide_u8x64::<28>(a, padding),
+            29 => self.slide_u8x64::<29>(a, padding),
+            30 => self.slide_u8x64::<30>(a, padding),
+            31 => self.slide_u8x64::<31>(a, padding),
+            32 => self.slide_u8x64::<32>(a, padding),
+            33 => self.slide_u8x64::<33>(a, padding),
+            34 => self.slide_u8x64::<34>(a, padding),
+            35 => self.slide_u8x64::<35>(a, padding),
+            36 => self.slide_u8x64::<36>(a, padding),
+            37 => self.slide_u8x64::<37>(a, padding),
+            38 => self.slide_u8x64::<38>(a, padding),
+            39 => self.slide_u8x64::<39>(a, padding),
+            40 => self.slide_u8x64::<40>(a, padding),
+            41 => self.slide_u8x64::<41>(a, padding),
+            42 => self.slide_u8x64::<42>(a, padding),
+            43 => self.slide_u8x64::<43>(a, padding),
+            44 => self.slide_u8x64::<44>(a, padding),
+            45 => self.slide_u8x64::<45>(a, padding),
+            46 => self.slide_u8x64::<46>(a, padding),
+            47 => self.slide_u8x64::<47>(a, padding),
+            48 => self.slide_u8x64::<48>(a, padding),
+            49 => self.slide_u8x64::<49>(a, padding),
+            50 => self.slide_u8x64::<50>(a, padding),
+            51 => self.slide_u8x64::<51>(a, padding),
+            52 => self.slide_u8x64::<52>(a, padding),
+            53 => self.slide_u8x64::<53>(a, padding),
+            54 => self.slide_u8x64::<54>(a, padding),
+            55 => self.slide_u8x64::<55>(a, padding),
+            56 => self.slide_u8x64::<56>(a, padding),
+            57 => self.slide_u8x64::<57>(a, padding),
+            58 => self.slide_u8x64::<58>(a, padding),
+            59 => self.slide_u8x64::<59>(a, padding),
+            60 => self.slide_u8x64::<60>(a, padding),
+            61 => self.slide_u8x64::<61>(a, padding),
+            62 => self.slide_u8x64::<62>(a, padding),
+            63 => self.slide_u8x64::<63>(a, padding),
+            64 => self.slide_u8x64::<64>(a, padding),
+            _ => self.slide_u8x64::<64>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u8x64<const OFFSET: usize>(
@@ -7646,12 +7932,6 @@ impl Simd for WasmSimd128 {
         a: u8x64<Self>,
         padding: u8,
     ) -> u8x64<Self> {
-        assert!(
-            OFFSET <= 64,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            64,
-        );
         let padding = self.splat_u8x64(padding);
         match OFFSET {
             0 => self.slide_u8x64::<64>(padding, a),
@@ -7719,7 +7999,7 @@ impl Simd for WasmSimd128 {
             62 => self.slide_u8x64::<2>(padding, a),
             63 => self.slide_u8x64::<1>(padding, a),
             64 => self.slide_u8x64::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u8x64::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -8180,23 +8460,45 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_i16x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_i16x32::<0>(a, a),
+            1 => self.slide_i16x32::<1>(a, a),
+            2 => self.slide_i16x32::<2>(a, a),
+            3 => self.slide_i16x32::<3>(a, a),
+            4 => self.slide_i16x32::<4>(a, a),
+            5 => self.slide_i16x32::<5>(a, a),
+            6 => self.slide_i16x32::<6>(a, a),
+            7 => self.slide_i16x32::<7>(a, a),
+            8 => self.slide_i16x32::<8>(a, a),
+            9 => self.slide_i16x32::<9>(a, a),
+            10 => self.slide_i16x32::<10>(a, a),
+            11 => self.slide_i16x32::<11>(a, a),
+            12 => self.slide_i16x32::<12>(a, a),
+            13 => self.slide_i16x32::<13>(a, a),
+            14 => self.slide_i16x32::<14>(a, a),
+            15 => self.slide_i16x32::<15>(a, a),
+            16 => self.slide_i16x32::<16>(a, a),
+            17 => self.slide_i16x32::<17>(a, a),
+            18 => self.slide_i16x32::<18>(a, a),
+            19 => self.slide_i16x32::<19>(a, a),
+            20 => self.slide_i16x32::<20>(a, a),
+            21 => self.slide_i16x32::<21>(a, a),
+            22 => self.slide_i16x32::<22>(a, a),
+            23 => self.slide_i16x32::<23>(a, a),
+            24 => self.slide_i16x32::<24>(a, a),
+            25 => self.slide_i16x32::<25>(a, a),
+            26 => self.slide_i16x32::<26>(a, a),
+            27 => self.slide_i16x32::<27>(a, a),
+            28 => self.slide_i16x32::<28>(a, a),
+            29 => self.slide_i16x32::<29>(a, a),
+            30 => self.slide_i16x32::<30>(a, a),
+            31 => self.slide_i16x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i16x32<const OFFSET: usize>(self, a: i16x32<Self>) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_i16x32::<32>(a, a),
             1 => self.slide_i16x32::<31>(a, a),
             2 => self.slide_i16x32::<30>(a, a),
@@ -8229,7 +8531,6 @@ impl Simd for WasmSimd128 {
             29 => self.slide_i16x32::<3>(a, a),
             30 => self.slide_i16x32::<2>(a, a),
             31 => self.slide_i16x32::<1>(a, a),
-            32 => self.slide_i16x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -8239,14 +8540,43 @@ impl Simd for WasmSimd128 {
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i16x32(padding);
-        self.slide_i16x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i16x32::<0>(a, padding),
+            1 => self.slide_i16x32::<1>(a, padding),
+            2 => self.slide_i16x32::<2>(a, padding),
+            3 => self.slide_i16x32::<3>(a, padding),
+            4 => self.slide_i16x32::<4>(a, padding),
+            5 => self.slide_i16x32::<5>(a, padding),
+            6 => self.slide_i16x32::<6>(a, padding),
+            7 => self.slide_i16x32::<7>(a, padding),
+            8 => self.slide_i16x32::<8>(a, padding),
+            9 => self.slide_i16x32::<9>(a, padding),
+            10 => self.slide_i16x32::<10>(a, padding),
+            11 => self.slide_i16x32::<11>(a, padding),
+            12 => self.slide_i16x32::<12>(a, padding),
+            13 => self.slide_i16x32::<13>(a, padding),
+            14 => self.slide_i16x32::<14>(a, padding),
+            15 => self.slide_i16x32::<15>(a, padding),
+            16 => self.slide_i16x32::<16>(a, padding),
+            17 => self.slide_i16x32::<17>(a, padding),
+            18 => self.slide_i16x32::<18>(a, padding),
+            19 => self.slide_i16x32::<19>(a, padding),
+            20 => self.slide_i16x32::<20>(a, padding),
+            21 => self.slide_i16x32::<21>(a, padding),
+            22 => self.slide_i16x32::<22>(a, padding),
+            23 => self.slide_i16x32::<23>(a, padding),
+            24 => self.slide_i16x32::<24>(a, padding),
+            25 => self.slide_i16x32::<25>(a, padding),
+            26 => self.slide_i16x32::<26>(a, padding),
+            27 => self.slide_i16x32::<27>(a, padding),
+            28 => self.slide_i16x32::<28>(a, padding),
+            29 => self.slide_i16x32::<29>(a, padding),
+            30 => self.slide_i16x32::<30>(a, padding),
+            31 => self.slide_i16x32::<31>(a, padding),
+            32 => self.slide_i16x32::<32>(a, padding),
+            _ => self.slide_i16x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i16x32<const OFFSET: usize>(
@@ -8254,12 +8584,6 @@ impl Simd for WasmSimd128 {
         a: i16x32<Self>,
         padding: i16,
     ) -> i16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_i16x32(padding);
         match OFFSET {
             0 => self.slide_i16x32::<32>(padding, a),
@@ -8295,7 +8619,7 @@ impl Simd for WasmSimd128 {
             30 => self.slide_i16x32::<2>(padding, a),
             31 => self.slide_i16x32::<1>(padding, a),
             32 => self.slide_i16x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i16x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -8592,23 +8916,45 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        self.slide_u16x32::<OFFSET>(a, a)
+        match OFFSET % 32 {
+            0 => self.slide_u16x32::<0>(a, a),
+            1 => self.slide_u16x32::<1>(a, a),
+            2 => self.slide_u16x32::<2>(a, a),
+            3 => self.slide_u16x32::<3>(a, a),
+            4 => self.slide_u16x32::<4>(a, a),
+            5 => self.slide_u16x32::<5>(a, a),
+            6 => self.slide_u16x32::<6>(a, a),
+            7 => self.slide_u16x32::<7>(a, a),
+            8 => self.slide_u16x32::<8>(a, a),
+            9 => self.slide_u16x32::<9>(a, a),
+            10 => self.slide_u16x32::<10>(a, a),
+            11 => self.slide_u16x32::<11>(a, a),
+            12 => self.slide_u16x32::<12>(a, a),
+            13 => self.slide_u16x32::<13>(a, a),
+            14 => self.slide_u16x32::<14>(a, a),
+            15 => self.slide_u16x32::<15>(a, a),
+            16 => self.slide_u16x32::<16>(a, a),
+            17 => self.slide_u16x32::<17>(a, a),
+            18 => self.slide_u16x32::<18>(a, a),
+            19 => self.slide_u16x32::<19>(a, a),
+            20 => self.slide_u16x32::<20>(a, a),
+            21 => self.slide_u16x32::<21>(a, a),
+            22 => self.slide_u16x32::<22>(a, a),
+            23 => self.slide_u16x32::<23>(a, a),
+            24 => self.slide_u16x32::<24>(a, a),
+            25 => self.slide_u16x32::<25>(a, a),
+            26 => self.slide_u16x32::<26>(a, a),
+            27 => self.slide_u16x32::<27>(a, a),
+            28 => self.slide_u16x32::<28>(a, a),
+            29 => self.slide_u16x32::<29>(a, a),
+            30 => self.slide_u16x32::<30>(a, a),
+            31 => self.slide_u16x32::<31>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u16x32<const OFFSET: usize>(self, a: u16x32<Self>) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
-        match OFFSET {
+        match OFFSET % 32 {
             0 => self.slide_u16x32::<32>(a, a),
             1 => self.slide_u16x32::<31>(a, a),
             2 => self.slide_u16x32::<30>(a, a),
@@ -8641,7 +8987,6 @@ impl Simd for WasmSimd128 {
             29 => self.slide_u16x32::<3>(a, a),
             30 => self.slide_u16x32::<2>(a, a),
             31 => self.slide_u16x32::<1>(a, a),
-            32 => self.slide_u16x32::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -8651,14 +8996,43 @@ impl Simd for WasmSimd128 {
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u16x32(padding);
-        self.slide_u16x32::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u16x32::<0>(a, padding),
+            1 => self.slide_u16x32::<1>(a, padding),
+            2 => self.slide_u16x32::<2>(a, padding),
+            3 => self.slide_u16x32::<3>(a, padding),
+            4 => self.slide_u16x32::<4>(a, padding),
+            5 => self.slide_u16x32::<5>(a, padding),
+            6 => self.slide_u16x32::<6>(a, padding),
+            7 => self.slide_u16x32::<7>(a, padding),
+            8 => self.slide_u16x32::<8>(a, padding),
+            9 => self.slide_u16x32::<9>(a, padding),
+            10 => self.slide_u16x32::<10>(a, padding),
+            11 => self.slide_u16x32::<11>(a, padding),
+            12 => self.slide_u16x32::<12>(a, padding),
+            13 => self.slide_u16x32::<13>(a, padding),
+            14 => self.slide_u16x32::<14>(a, padding),
+            15 => self.slide_u16x32::<15>(a, padding),
+            16 => self.slide_u16x32::<16>(a, padding),
+            17 => self.slide_u16x32::<17>(a, padding),
+            18 => self.slide_u16x32::<18>(a, padding),
+            19 => self.slide_u16x32::<19>(a, padding),
+            20 => self.slide_u16x32::<20>(a, padding),
+            21 => self.slide_u16x32::<21>(a, padding),
+            22 => self.slide_u16x32::<22>(a, padding),
+            23 => self.slide_u16x32::<23>(a, padding),
+            24 => self.slide_u16x32::<24>(a, padding),
+            25 => self.slide_u16x32::<25>(a, padding),
+            26 => self.slide_u16x32::<26>(a, padding),
+            27 => self.slide_u16x32::<27>(a, padding),
+            28 => self.slide_u16x32::<28>(a, padding),
+            29 => self.slide_u16x32::<29>(a, padding),
+            30 => self.slide_u16x32::<30>(a, padding),
+            31 => self.slide_u16x32::<31>(a, padding),
+            32 => self.slide_u16x32::<32>(a, padding),
+            _ => self.slide_u16x32::<32>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u16x32<const OFFSET: usize>(
@@ -8666,12 +9040,6 @@ impl Simd for WasmSimd128 {
         a: u16x32<Self>,
         padding: u16,
     ) -> u16x32<Self> {
-        assert!(
-            OFFSET <= 32,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            32,
-        );
         let padding = self.splat_u16x32(padding);
         match OFFSET {
             0 => self.slide_u16x32::<32>(padding, a),
@@ -8707,7 +9075,7 @@ impl Simd for WasmSimd128 {
             30 => self.slide_u16x32::<2>(padding, a),
             31 => self.slide_u16x32::<1>(padding, a),
             32 => self.slide_u16x32::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u16x32::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -9170,23 +9538,29 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_i32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_i32x16::<0>(a, a),
+            1 => self.slide_i32x16::<1>(a, a),
+            2 => self.slide_i32x16::<2>(a, a),
+            3 => self.slide_i32x16::<3>(a, a),
+            4 => self.slide_i32x16::<4>(a, a),
+            5 => self.slide_i32x16::<5>(a, a),
+            6 => self.slide_i32x16::<6>(a, a),
+            7 => self.slide_i32x16::<7>(a, a),
+            8 => self.slide_i32x16::<8>(a, a),
+            9 => self.slide_i32x16::<9>(a, a),
+            10 => self.slide_i32x16::<10>(a, a),
+            11 => self.slide_i32x16::<11>(a, a),
+            12 => self.slide_i32x16::<12>(a, a),
+            13 => self.slide_i32x16::<13>(a, a),
+            14 => self.slide_i32x16::<14>(a, a),
+            15 => self.slide_i32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_i32x16<const OFFSET: usize>(self, a: i32x16<Self>) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_i32x16::<16>(a, a),
             1 => self.slide_i32x16::<15>(a, a),
             2 => self.slide_i32x16::<14>(a, a),
@@ -9203,7 +9577,6 @@ impl Simd for WasmSimd128 {
             13 => self.slide_i32x16::<3>(a, a),
             14 => self.slide_i32x16::<2>(a, a),
             15 => self.slide_i32x16::<1>(a, a),
-            16 => self.slide_i32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -9213,14 +9586,27 @@ impl Simd for WasmSimd128 {
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i32x16(padding);
-        self.slide_i32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_i32x16::<0>(a, padding),
+            1 => self.slide_i32x16::<1>(a, padding),
+            2 => self.slide_i32x16::<2>(a, padding),
+            3 => self.slide_i32x16::<3>(a, padding),
+            4 => self.slide_i32x16::<4>(a, padding),
+            5 => self.slide_i32x16::<5>(a, padding),
+            6 => self.slide_i32x16::<6>(a, padding),
+            7 => self.slide_i32x16::<7>(a, padding),
+            8 => self.slide_i32x16::<8>(a, padding),
+            9 => self.slide_i32x16::<9>(a, padding),
+            10 => self.slide_i32x16::<10>(a, padding),
+            11 => self.slide_i32x16::<11>(a, padding),
+            12 => self.slide_i32x16::<12>(a, padding),
+            13 => self.slide_i32x16::<13>(a, padding),
+            14 => self.slide_i32x16::<14>(a, padding),
+            15 => self.slide_i32x16::<15>(a, padding),
+            16 => self.slide_i32x16::<16>(a, padding),
+            _ => self.slide_i32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_i32x16<const OFFSET: usize>(
@@ -9228,12 +9614,6 @@ impl Simd for WasmSimd128 {
         a: i32x16<Self>,
         padding: i32,
     ) -> i32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_i32x16(padding);
         match OFFSET {
             0 => self.slide_i32x16::<16>(padding, a),
@@ -9253,7 +9633,7 @@ impl Simd for WasmSimd128 {
             14 => self.slide_i32x16::<2>(padding, a),
             15 => self.slide_i32x16::<1>(padding, a),
             16 => self.slide_i32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_i32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -9546,23 +9926,29 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        self.slide_u32x16::<OFFSET>(a, a)
+        match OFFSET % 16 {
+            0 => self.slide_u32x16::<0>(a, a),
+            1 => self.slide_u32x16::<1>(a, a),
+            2 => self.slide_u32x16::<2>(a, a),
+            3 => self.slide_u32x16::<3>(a, a),
+            4 => self.slide_u32x16::<4>(a, a),
+            5 => self.slide_u32x16::<5>(a, a),
+            6 => self.slide_u32x16::<6>(a, a),
+            7 => self.slide_u32x16::<7>(a, a),
+            8 => self.slide_u32x16::<8>(a, a),
+            9 => self.slide_u32x16::<9>(a, a),
+            10 => self.slide_u32x16::<10>(a, a),
+            11 => self.slide_u32x16::<11>(a, a),
+            12 => self.slide_u32x16::<12>(a, a),
+            13 => self.slide_u32x16::<13>(a, a),
+            14 => self.slide_u32x16::<14>(a, a),
+            15 => self.slide_u32x16::<15>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_u32x16<const OFFSET: usize>(self, a: u32x16<Self>) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
-        match OFFSET {
+        match OFFSET % 16 {
             0 => self.slide_u32x16::<16>(a, a),
             1 => self.slide_u32x16::<15>(a, a),
             2 => self.slide_u32x16::<14>(a, a),
@@ -9579,7 +9965,6 @@ impl Simd for WasmSimd128 {
             13 => self.slide_u32x16::<3>(a, a),
             14 => self.slide_u32x16::<2>(a, a),
             15 => self.slide_u32x16::<1>(a, a),
-            16 => self.slide_u32x16::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -9589,14 +9974,27 @@ impl Simd for WasmSimd128 {
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u32x16(padding);
-        self.slide_u32x16::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_u32x16::<0>(a, padding),
+            1 => self.slide_u32x16::<1>(a, padding),
+            2 => self.slide_u32x16::<2>(a, padding),
+            3 => self.slide_u32x16::<3>(a, padding),
+            4 => self.slide_u32x16::<4>(a, padding),
+            5 => self.slide_u32x16::<5>(a, padding),
+            6 => self.slide_u32x16::<6>(a, padding),
+            7 => self.slide_u32x16::<7>(a, padding),
+            8 => self.slide_u32x16::<8>(a, padding),
+            9 => self.slide_u32x16::<9>(a, padding),
+            10 => self.slide_u32x16::<10>(a, padding),
+            11 => self.slide_u32x16::<11>(a, padding),
+            12 => self.slide_u32x16::<12>(a, padding),
+            13 => self.slide_u32x16::<13>(a, padding),
+            14 => self.slide_u32x16::<14>(a, padding),
+            15 => self.slide_u32x16::<15>(a, padding),
+            16 => self.slide_u32x16::<16>(a, padding),
+            _ => self.slide_u32x16::<16>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_u32x16<const OFFSET: usize>(
@@ -9604,12 +10002,6 @@ impl Simd for WasmSimd128 {
         a: u32x16<Self>,
         padding: u32,
     ) -> u32x16<Self> {
-        assert!(
-            OFFSET <= 16,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            16,
-        );
         let padding = self.splat_u32x16(padding);
         match OFFSET {
             0 => self.slide_u32x16::<16>(padding, a),
@@ -9629,7 +10021,7 @@ impl Simd for WasmSimd128 {
             14 => self.slide_u32x16::<2>(padding, a),
             15 => self.slide_u32x16::<1>(padding, a),
             16 => self.slide_u32x16::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_u32x16::<0>(padding, a),
         }
     }
     #[inline(always)]
@@ -10072,23 +10464,21 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn rotate_elements_left_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        self.slide_f64x8::<OFFSET>(a, a)
+        match OFFSET % 8 {
+            0 => self.slide_f64x8::<0>(a, a),
+            1 => self.slide_f64x8::<1>(a, a),
+            2 => self.slide_f64x8::<2>(a, a),
+            3 => self.slide_f64x8::<3>(a, a),
+            4 => self.slide_f64x8::<4>(a, a),
+            5 => self.slide_f64x8::<5>(a, a),
+            6 => self.slide_f64x8::<6>(a, a),
+            7 => self.slide_f64x8::<7>(a, a),
+            _ => unreachable!(),
+        }
     }
     #[inline(always)]
     fn rotate_elements_right_f64x8<const OFFSET: usize>(self, a: f64x8<Self>) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
-        match OFFSET {
+        match OFFSET % 8 {
             0 => self.slide_f64x8::<8>(a, a),
             1 => self.slide_f64x8::<7>(a, a),
             2 => self.slide_f64x8::<6>(a, a),
@@ -10097,7 +10487,6 @@ impl Simd for WasmSimd128 {
             5 => self.slide_f64x8::<3>(a, a),
             6 => self.slide_f64x8::<2>(a, a),
             7 => self.slide_f64x8::<1>(a, a),
-            8 => self.slide_f64x8::<0>(a, a),
             _ => unreachable!(),
         }
     }
@@ -10107,14 +10496,19 @@ impl Simd for WasmSimd128 {
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f64x8(padding);
-        self.slide_f64x8::<OFFSET>(a, padding)
+        match OFFSET {
+            0 => self.slide_f64x8::<0>(a, padding),
+            1 => self.slide_f64x8::<1>(a, padding),
+            2 => self.slide_f64x8::<2>(a, padding),
+            3 => self.slide_f64x8::<3>(a, padding),
+            4 => self.slide_f64x8::<4>(a, padding),
+            5 => self.slide_f64x8::<5>(a, padding),
+            6 => self.slide_f64x8::<6>(a, padding),
+            7 => self.slide_f64x8::<7>(a, padding),
+            8 => self.slide_f64x8::<8>(a, padding),
+            _ => self.slide_f64x8::<8>(a, padding),
+        }
     }
     #[inline(always)]
     fn shift_elements_right_f64x8<const OFFSET: usize>(
@@ -10122,12 +10516,6 @@ impl Simd for WasmSimd128 {
         a: f64x8<Self>,
         padding: f64,
     ) -> f64x8<Self> {
-        assert!(
-            OFFSET <= 8,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            8,
-        );
         let padding = self.splat_f64x8(padding);
         match OFFSET {
             0 => self.slide_f64x8::<8>(padding, a),
@@ -10139,7 +10527,7 @@ impl Simd for WasmSimd128 {
             6 => self.slide_f64x8::<2>(padding, a),
             7 => self.slide_f64x8::<1>(padding, a),
             8 => self.slide_f64x8::<0>(padding, a),
-            _ => unreachable!(),
+            _ => self.slide_f64x8::<0>(padding, a),
         }
     }
     #[inline(always)]

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -299,23 +299,31 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
         }
         OpSig::ElementRotate { direction } => {
             let slide = generic_op_name("slide", ty);
-            let offset_check = offset_check(ty);
+            let len = Literal::usize_unsuffixed(ty.len);
             match direction {
                 ElementDirection::Left => {
+                    let arms = modulo_offset_arms(ty, |offset| {
+                        let offset = Literal::usize_unsuffixed(offset);
+                        quote! { self.#slide::<#offset>(a, a) }
+                    });
                     quote! {
                         #method_sig {
-                            #offset_check
-                            self.#slide::<OFFSET>(a, a)
+                            match OFFSET % #len {
+                                #(#arms,)*
+                                _ => unreachable!(),
+                            }
                         }
                     }
                 }
                 ElementDirection::Right => {
-                    let arms =
-                        right_offset_arms(ty, |shift| quote! { self.#slide::<#shift>(a, a) });
+                    let arms = modulo_offset_arms(ty, |offset| {
+                        let shift = if offset == 0 { ty.len } else { ty.len - offset };
+                        let shift = Literal::usize_unsuffixed(shift);
+                        quote! { self.#slide::<#shift>(a, a) }
+                    });
                     quote! {
                         #method_sig {
-                            #offset_check
-                            match OFFSET {
+                            match OFFSET % #len {
                                 #(#arms,)*
                                 _ => unreachable!(),
                             }
@@ -327,14 +335,18 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
         OpSig::ElementShift { direction } => {
             let splat = generic_op_name("splat", ty);
             let slide = generic_op_name("slide", ty);
-            let offset_check = offset_check(ty);
             match direction {
                 ElementDirection::Left => {
+                    let arms =
+                        offset_arms(ty, |shift| quote! { self.#slide::<#shift>(a, padding) });
+                    let all_padding = Literal::usize_unsuffixed(ty.len);
                     quote! {
                         #method_sig {
-                            #offset_check
                             let padding = self.#splat(padding);
-                            self.#slide::<OFFSET>(a, padding)
+                            match OFFSET {
+                                #(#arms,)*
+                                _ => self.#slide::<#all_padding>(a, padding),
+                            }
                         }
                     }
                 }
@@ -343,11 +355,10 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
                         right_offset_arms(ty, |shift| quote! { self.#slide::<#shift>(padding, a) });
                     quote! {
                         #method_sig {
-                            #offset_check
                             let padding = self.#splat(padding);
                             match OFFSET {
                                 #(#arms,)*
-                                _ => unreachable!(),
+                                _ => self.#slide::<0>(padding, a),
                             }
                         }
                     }
@@ -383,16 +394,27 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
     }
 }
 
-fn offset_check(ty: &VecType) -> TokenStream {
-    let len = Literal::usize_unsuffixed(ty.len);
-    quote! {
-        assert!(
-            OFFSET <= #len,
-            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
-            OFFSET,
-            #len,
-        );
-    }
+fn modulo_offset_arms(
+    ty: &VecType,
+    mut body: impl FnMut(usize) -> TokenStream,
+) -> Vec<TokenStream> {
+    (0..ty.len)
+        .map(|offset| {
+            let offset_lit = Literal::usize_unsuffixed(offset);
+            let body = body(offset);
+            quote! { #offset_lit => #body }
+        })
+        .collect()
+}
+
+fn offset_arms(ty: &VecType, mut body: impl FnMut(Literal) -> TokenStream) -> Vec<TokenStream> {
+    (0..=ty.len)
+        .map(|offset| {
+            let offset_lit = Literal::usize_unsuffixed(offset);
+            let body = body(offset_lit.clone());
+            quote! { #offset_lit => #body }
+        })
+        .collect()
 }
 
 fn right_offset_arms(

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -1,11 +1,11 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{ToTokens, quote};
 
 use crate::{
-    ops::{Op, OpSig, RefKind, SlideGranularity},
+    ops::{ElementDirection, Op, OpSig, RefKind, SlideGranularity},
     types::{ScalarType, VecType},
 };
 
@@ -297,6 +297,63 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
                 }
             }
         }
+        OpSig::ElementRotate { direction } => {
+            let slide = generic_op_name("slide", ty);
+            let offset_check = offset_check(ty);
+            match direction {
+                ElementDirection::Left => {
+                    quote! {
+                        #method_sig {
+                            #offset_check
+                            self.#slide::<OFFSET>(a, a)
+                        }
+                    }
+                }
+                ElementDirection::Right => {
+                    let arms =
+                        right_offset_arms(ty, |shift| quote! { self.#slide::<#shift>(a, a) });
+                    quote! {
+                        #method_sig {
+                            #offset_check
+                            match OFFSET {
+                                #(#arms,)*
+                                _ => unreachable!(),
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        OpSig::ElementShift { direction } => {
+            let splat = generic_op_name("splat", ty);
+            let slide = generic_op_name("slide", ty);
+            let offset_check = offset_check(ty);
+            match direction {
+                ElementDirection::Left => {
+                    quote! {
+                        #method_sig {
+                            #offset_check
+                            let padding = self.#splat(padding);
+                            self.#slide::<OFFSET>(a, padding)
+                        }
+                    }
+                }
+                ElementDirection::Right => {
+                    let arms =
+                        right_offset_arms(ty, |shift| quote! { self.#slide::<#shift>(padding, a) });
+                    quote! {
+                        #method_sig {
+                            #offset_check
+                            let padding = self.#splat(padding);
+                            match OFFSET {
+                                #(#arms,)*
+                                _ => unreachable!(),
+                            }
+                        }
+                    }
+                }
+            }
+        }
         OpSig::Slide { granularity, .. } => {
             match (granularity, ty.n_bits()) {
                 (SlideGranularity::WithinBlocks, 128) => {
@@ -324,6 +381,32 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
             }
         }
     }
+}
+
+fn offset_check(ty: &VecType) -> TokenStream {
+    let len = Literal::usize_unsuffixed(ty.len);
+    quote! {
+        assert!(
+            OFFSET <= #len,
+            "OFFSET ({}) must be less than or equal to the number of lanes ({})",
+            OFFSET,
+            #len,
+        );
+    }
+}
+
+fn right_offset_arms(
+    ty: &VecType,
+    mut body: impl FnMut(Literal) -> TokenStream,
+) -> Vec<TokenStream> {
+    (0..=ty.len)
+        .map(|offset| {
+            let offset_lit = Literal::usize_unsuffixed(offset);
+            let shift = Literal::usize_unsuffixed(ty.len - offset);
+            let body = body(shift);
+            quote! { #offset_lit => #body }
+        })
+        .collect()
 }
 
 pub(crate) fn scalar_binary(f: TokenStream) -> TokenStream {

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -392,6 +392,9 @@ impl Level for Fallback {
                     }
                 }
             }
+            OpSig::ElementRotate { .. } | OpSig::ElementShift { .. } => {
+                unreachable!("element moves use generic lowering")
+            }
             OpSig::SwizzleDynWithinBlocks => {
                 assert_eq!(
                     vec_ty.n_bits(),

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -424,6 +424,9 @@ impl Level for Neon {
                     }
                 }
             }
+            OpSig::ElementRotate { .. } | OpSig::ElementShift { .. } => {
+                unreachable!("element moves use generic lowering")
+            }
             OpSig::SwizzleDynWithinBlocks => {
                 assert_eq!(
                     vec_ty.n_bits(),

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -429,6 +429,10 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
     let as_array_mut_op = generic_op_name("as_array_mut", ty);
     let slide_op = generic_op_name("slide", ty);
     let slide_blockwise_op = generic_op_name("slide_within_blocks", ty);
+    let rotate_elements_left_op = generic_op_name("rotate_elements_left", ty);
+    let rotate_elements_right_op = generic_op_name("rotate_elements_right", ty);
+    let shift_elements_left_op = generic_op_name("shift_elements_left", ty);
+    let shift_elements_right_op = generic_op_name("shift_elements_right", ty);
     let swizzle_dyn_within_blocks_op = generic_op_name("swizzle_dyn_within_blocks", ty);
     quote! {
         impl<S: Simd> SimdBase<S> for #name<S> {
@@ -486,6 +490,26 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
             #[inline(always)]
             fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
                 self.simd.#slide_blockwise_op::<SHIFT>(self, rhs.simd_into(self.simd))
+            }
+
+            #[inline(always)]
+            fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
+                self.simd.#rotate_elements_left_op::<OFFSET>(self)
+            }
+
+            #[inline(always)]
+            fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
+                self.simd.#rotate_elements_right_op::<OFFSET>(self)
+            }
+
+            #[inline(always)]
+            fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+                self.simd.#shift_elements_left_op::<OFFSET>(self, padding)
+            }
+
+            #[inline(always)]
+            fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
+                self.simd.#shift_elements_right_op::<OFFSET>(self, padding)
             }
 
             #[inline(always)]

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -483,6 +483,9 @@ impl Level for WasmSimd128 {
                     }
                 }
             }
+            OpSig::ElementRotate { .. } | OpSig::ElementShift { .. } => {
+                unreachable!("element moves use generic lowering")
+            }
             OpSig::SwizzleDynWithinBlocks => {
                 assert_eq!(
                     vec_ty.n_bits(),

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -272,6 +272,9 @@ impl Level for X86 {
             OpSig::Zip { select_low } => self.handle_zip(op, vec_ty, select_low),
             OpSig::Unzip { select_even } => self.handle_unzip(op, vec_ty, select_even),
             OpSig::Slide { granularity } => self.handle_slide(method_sig, vec_ty, granularity),
+            OpSig::ElementRotate { .. } | OpSig::ElementShift { .. } => {
+                unreachable!("element moves use generic lowering")
+            }
             OpSig::SwizzleDynWithinBlocks => self.handle_swizzle_dyn_within_blocks(op, vec_ty),
             OpSig::Cvt {
                 target_ty,

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -49,6 +49,12 @@ pub(crate) enum SlideGranularity {
     AcrossBlocks,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ElementDirection {
+    Left,
+    Right,
+}
+
 #[derive(Clone, Copy)]
 pub(crate) enum OpSig {
     /// Takes a single scalar argument, and returns the corresponding vector type.
@@ -80,6 +86,11 @@ pub(crate) enum OpSig {
     /// This is equivalent to calling `unzip_low` and `unzip_high` and returning both results.
     /// This is the inverse of `Interleave`.
     Deinterleave,
+    /// Takes a vector plus a const-generic offset, and returns that same vector type with elements rotated.
+    ElementRotate { direction: ElementDirection },
+    /// Takes a vector, a scalar padding value, plus a const-generic offset, and returns that same vector type with
+    /// elements shifted.
+    ElementShift { direction: ElementDirection },
     /// Takes two arguments of a vector type, plus a const generic shift amount, and returns that same vector type.
     Slide { granularity: SlideGranularity },
     /// Takes a vector and a same-width byte-index vector, and returns the original vector type with its bytes
@@ -262,10 +273,12 @@ impl Op {
             .map(|n| Ident::new(n, Span::call_site()))
             .collect::<Vec<_>>();
         let vec = quote! { #ty<#simd_ty> };
-        let const_params = if matches!(self.sig, OpSig::Slide { .. }) {
-            quote! { <const SHIFT: usize> }
-        } else {
-            TokenStream::new()
+        let const_params = match self.sig {
+            OpSig::Slide { .. } => quote! { <const SHIFT: usize> },
+            OpSig::ElementRotate { .. } | OpSig::ElementShift { .. } => {
+                quote! { <const OFFSET: usize> }
+            }
+            _ => TokenStream::new(),
         };
 
         let (arg_tys, ret) = match &self.sig {
@@ -306,6 +319,8 @@ impl Op {
             OpSig::Interleave | OpSig::Deinterleave => {
                 (vec![vec.clone(), vec.clone()], quote! { (#vec, #vec) })
             }
+            OpSig::ElementRotate { .. } => (vec![vec.clone()], vec),
+            OpSig::ElementShift { .. } => (vec![vec.clone(), splat_arg_ty(vec_ty)], vec),
             OpSig::Slide { .. } => (vec![vec.clone(), vec.clone()], vec),
             OpSig::SwizzleDynWithinBlocks => {
                 let bytes_ty = vec_ty.bytes_ty().rust();
@@ -422,6 +437,15 @@ impl Op {
                 let arg0 = &arg_names[0];
                 let arg1 = &arg_names[1];
                 quote! { (#arg0, #arg1: impl SimdInto<Self, S>) -> (Self, Self) }
+            }
+            OpSig::ElementRotate { .. } => {
+                let arg0 = &arg_names[0];
+                quote! { <const OFFSET: usize>(#arg0) -> Self }
+            }
+            OpSig::ElementShift { .. } => {
+                let arg0 = &arg_names[0];
+                let arg1 = &arg_names[1];
+                quote! { <const OFFSET: usize>(#arg0, #arg1: Self::Element) -> Self }
             }
             OpSig::Slide { .. } => {
                 let arg0 = &arg_names[0];
@@ -598,6 +622,42 @@ const BASE_OPS: &[Op] = &[
             granularity: SlideGranularity::WithinBlocks,
         },
         "Like `slide`, but operates independently on each 128-bit block.",
+    ),
+    Op::new(
+        "rotate_elements_left",
+        OpKind::BaseTraitMethod,
+        OpSig::ElementRotate {
+            direction: ElementDirection::Left,
+        },
+        "Rotate the vector elements to the left by `OFFSET`.\n\n\
+        Panics if `OFFSET` is greater than `Self::N`.",
+    ),
+    Op::new(
+        "rotate_elements_right",
+        OpKind::BaseTraitMethod,
+        OpSig::ElementRotate {
+            direction: ElementDirection::Right,
+        },
+        "Rotate the vector elements to the right by `OFFSET`.\n\n\
+        Panics if `OFFSET` is greater than `Self::N`.",
+    ),
+    Op::new(
+        "shift_elements_left",
+        OpKind::BaseTraitMethod,
+        OpSig::ElementShift {
+            direction: ElementDirection::Left,
+        },
+        "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\n\
+        Panics if `OFFSET` is greater than `Self::N`.",
+    ),
+    Op::new(
+        "shift_elements_right",
+        OpKind::BaseTraitMethod,
+        OpSig::ElementShift {
+            direction: ElementDirection::Right,
+        },
+        "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\n\
+        Panics if `OFFSET` is greater than `Self::N`.",
     ),
     Op::new(
         "swizzle_dyn_within_blocks",
@@ -1580,6 +1640,10 @@ impl OpSig {
             return false;
         }
 
+        if matches!(self, Self::ElementRotate { .. } | Self::ElementShift { .. }) {
+            return true;
+        }
+
         // These operations need to work on the full vector type.
         if matches!(
             self,
@@ -1640,6 +1704,8 @@ impl OpSig {
             | Self::Interleave
             | Self::Deinterleave
             | Self::Slide { .. } => &["a", "b"],
+            Self::ElementRotate { .. } => &["a"],
+            Self::ElementShift { .. } => &["a", "padding"],
             Self::Ternary | Self::Select => &["a", "b", "c"],
             Self::Shift => &["a", "shift"],
             Self::LoadInterleaved { .. } => &["src"],
@@ -1672,6 +1738,8 @@ impl OpSig {
             | Self::Interleave
             | Self::Deinterleave
             | Self::Slide { .. } => &["self", "rhs"],
+            Self::ElementRotate { .. } => &["self"],
+            Self::ElementShift { .. } => &["self", "padding"],
             Self::Shift => &["self", "shift"],
             Self::Ternary => &["self", "op1", "op2"],
             Self::Select | Self::Split { .. } | Self::Combine { .. } => &[],
@@ -1716,6 +1784,8 @@ impl OpSig {
             | Self::Reinterpret { .. }
             | Self::WidenNarrow { .. }
             | Self::Shift
+            | Self::ElementRotate { .. }
+            | Self::ElementShift { .. }
             | Self::MaskFromBitmask
             | Self::MaskToBitmask
             | Self::MaskSet

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -630,7 +630,7 @@ const BASE_OPS: &[Op] = &[
             direction: ElementDirection::Left,
         },
         "Rotate the vector elements to the left by `OFFSET`.\n\n\
-        Panics if `OFFSET` is greater than `Self::N`.",
+        If `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`.",
     ),
     Op::new(
         "rotate_elements_right",
@@ -639,7 +639,7 @@ const BASE_OPS: &[Op] = &[
             direction: ElementDirection::Right,
         },
         "Rotate the vector elements to the right by `OFFSET`.\n\n\
-        Panics if `OFFSET` is greater than `Self::N`.",
+        If `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`.",
     ),
     Op::new(
         "shift_elements_left",
@@ -648,7 +648,7 @@ const BASE_OPS: &[Op] = &[
             direction: ElementDirection::Left,
         },
         "Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.\n\n\
-        Panics if `OFFSET` is greater than `Self::N`.",
+        If `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`.",
     ),
     Op::new(
         "shift_elements_right",
@@ -657,7 +657,7 @@ const BASE_OPS: &[Op] = &[
             direction: ElementDirection::Right,
         },
         "Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.\n\n\
-        Panics if `OFFSET` is greater than `Self::N`.",
+        If `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`.",
     ),
     Op::new(
         "swizzle_dyn_within_blocks",

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -4438,6 +4438,777 @@ fn slide_f32x4<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn rotate_elements_f32x4<S: Simd>(simd: S) {
+    let a = f32x4::from_slice(simd, &[0.0, 1.0, 2.0, 3.0]);
+    assert_eq!(*a.rotate_elements_left::<3>(), [3.0, 0.0, 1.0, 2.0]);
+    assert_eq!(*a.rotate_elements_right::<3>(), [1.0, 2.0, 3.0, 0.0]);
+}
+
+#[simd_test]
+fn shift_elements_f32x4<S: Simd>(simd: S) {
+    let a = f32x4::from_slice(simd, &[0.0, 1.0, 2.0, 3.0]);
+    assert_eq!(*a.shift_elements_left::<3>(99.0), [3.0, 99.0, 99.0, 99.0]);
+    assert_eq!(*a.shift_elements_right::<3>(99.0), [99.0, 99.0, 99.0, 0.0]);
+}
+
+#[simd_test]
+fn rotate_elements_i8x16<S: Simd>(simd: S) {
+    let a = i8x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<9>(),
+        [9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<9>(),
+        [7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6]
+    );
+}
+
+#[simd_test]
+fn shift_elements_i8x16<S: Simd>(simd: S) {
+    let a = i8x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<9>(-1),
+        [
+            9, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<9>(-1),
+        [-1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3, 4, 5, 6]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_u8x16<S: Simd>(simd: S) {
+    let a = u8x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<9>(),
+        [9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<9>(),
+        [7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6]
+    );
+}
+
+#[simd_test]
+fn shift_elements_u8x16<S: Simd>(simd: S) {
+    let a = u8x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<9>(255),
+        [
+            9, 10, 11, 12, 13, 14, 15, 255, 255, 255, 255, 255, 255, 255, 255, 255
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<9>(255),
+        [
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 1, 2, 3, 4, 5, 6
+        ]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_i16x8<S: Simd>(simd: S) {
+    let a = i16x8::from_slice(simd, &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(*a.rotate_elements_left::<5>(), [5, 6, 7, 0, 1, 2, 3, 4]);
+    assert_eq!(*a.rotate_elements_right::<5>(), [3, 4, 5, 6, 7, 0, 1, 2]);
+}
+
+#[simd_test]
+fn shift_elements_i16x8<S: Simd>(simd: S) {
+    let a = i16x8::from_slice(simd, &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(
+        *a.shift_elements_left::<5>(-1),
+        [5, 6, 7, -1, -1, -1, -1, -1]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<5>(-1),
+        [-1, -1, -1, -1, -1, 0, 1, 2]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_u16x8<S: Simd>(simd: S) {
+    let a = u16x8::from_slice(simd, &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(*a.rotate_elements_left::<5>(), [5, 6, 7, 0, 1, 2, 3, 4]);
+    assert_eq!(*a.rotate_elements_right::<5>(), [3, 4, 5, 6, 7, 0, 1, 2]);
+}
+
+#[simd_test]
+fn shift_elements_u16x8<S: Simd>(simd: S) {
+    let a = u16x8::from_slice(simd, &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(
+        *a.shift_elements_left::<5>(255),
+        [5, 6, 7, 255, 255, 255, 255, 255]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<5>(255),
+        [255, 255, 255, 255, 255, 0, 1, 2]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_i32x4<S: Simd>(simd: S) {
+    let a = i32x4::from_slice(simd, &[0, 1, 2, 3]);
+    assert_eq!(*a.rotate_elements_left::<3>(), [3, 0, 1, 2]);
+    assert_eq!(*a.rotate_elements_right::<3>(), [1, 2, 3, 0]);
+}
+
+#[simd_test]
+fn shift_elements_i32x4<S: Simd>(simd: S) {
+    let a = i32x4::from_slice(simd, &[0, 1, 2, 3]);
+    assert_eq!(*a.shift_elements_left::<3>(-1), [3, -1, -1, -1]);
+    assert_eq!(*a.shift_elements_right::<3>(-1), [-1, -1, -1, 0]);
+}
+
+#[simd_test]
+fn rotate_elements_u32x4<S: Simd>(simd: S) {
+    let a = u32x4::from_slice(simd, &[0, 1, 2, 3]);
+    assert_eq!(*a.rotate_elements_left::<3>(), [3, 0, 1, 2]);
+    assert_eq!(*a.rotate_elements_right::<3>(), [1, 2, 3, 0]);
+}
+
+#[simd_test]
+fn shift_elements_u32x4<S: Simd>(simd: S) {
+    let a = u32x4::from_slice(simd, &[0, 1, 2, 3]);
+    assert_eq!(*a.shift_elements_left::<3>(255), [3, 255, 255, 255]);
+    assert_eq!(*a.shift_elements_right::<3>(255), [255, 255, 255, 0]);
+}
+
+#[simd_test]
+fn rotate_elements_f64x2<S: Simd>(simd: S) {
+    let a = f64x2::from_slice(simd, &[0.0, 1.0]);
+    assert_eq!(*a.rotate_elements_left::<1>(), [1.0, 0.0]);
+    assert_eq!(*a.rotate_elements_right::<1>(), [1.0, 0.0]);
+}
+
+#[simd_test]
+fn shift_elements_f64x2<S: Simd>(simd: S) {
+    let a = f64x2::from_slice(simd, &[0.0, 1.0]);
+    assert_eq!(*a.shift_elements_left::<1>(99.0), [1.0, 99.0]);
+    assert_eq!(*a.shift_elements_right::<1>(99.0), [99.0, 0.0]);
+}
+
+#[simd_test]
+fn rotate_elements_f32x8<S: Simd>(simd: S) {
+    let a = f32x8::from_slice(simd, &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
+    assert_eq!(
+        *a.rotate_elements_left::<5>(),
+        [5.0, 6.0, 7.0, 0.0, 1.0, 2.0, 3.0, 4.0]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<5>(),
+        [3.0, 4.0, 5.0, 6.0, 7.0, 0.0, 1.0, 2.0]
+    );
+}
+
+#[simd_test]
+fn shift_elements_f32x8<S: Simd>(simd: S) {
+    let a = f32x8::from_slice(simd, &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
+    assert_eq!(
+        *a.shift_elements_left::<5>(99.0),
+        [5.0, 6.0, 7.0, 99.0, 99.0, 99.0, 99.0, 99.0]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<5>(99.0),
+        [99.0, 99.0, 99.0, 99.0, 99.0, 0.0, 1.0, 2.0]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_i8x32<S: Simd>(simd: S) {
+    let a = i8x32::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<17>(),
+        [
+            17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8,
+            9, 10, 11, 12, 13, 14, 15, 16
+        ]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<17>(),
+        [
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5,
+            6, 7, 8, 9, 10, 11, 12, 13, 14
+        ]
+    );
+}
+
+#[simd_test]
+fn shift_elements_i8x32<S: Simd>(simd: S) {
+    let a = i8x32::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<17>(-1),
+        [
+            17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<17>(-1),
+        [
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3, 4, 5,
+            6, 7, 8, 9, 10, 11, 12, 13, 14
+        ]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_u8x32<S: Simd>(simd: S) {
+    let a = u8x32::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<17>(),
+        [
+            17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8,
+            9, 10, 11, 12, 13, 14, 15, 16
+        ]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<17>(),
+        [
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5,
+            6, 7, 8, 9, 10, 11, 12, 13, 14
+        ]
+    );
+}
+
+#[simd_test]
+fn shift_elements_u8x32<S: Simd>(simd: S) {
+    let a = u8x32::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<17>(255),
+        [
+            17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<17>(255),
+        [
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0,
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
+        ]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_i16x16<S: Simd>(simd: S) {
+    let a = i16x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<9>(),
+        [9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<9>(),
+        [7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6]
+    );
+}
+
+#[simd_test]
+fn shift_elements_i16x16<S: Simd>(simd: S) {
+    let a = i16x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<9>(-1),
+        [
+            9, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<9>(-1),
+        [-1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3, 4, 5, 6]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_u16x16<S: Simd>(simd: S) {
+    let a = u16x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<9>(),
+        [9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<9>(),
+        [7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6]
+    );
+}
+
+#[simd_test]
+fn shift_elements_u16x16<S: Simd>(simd: S) {
+    let a = u16x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<9>(255),
+        [
+            9, 10, 11, 12, 13, 14, 15, 255, 255, 255, 255, 255, 255, 255, 255, 255
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<9>(255),
+        [
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 1, 2, 3, 4, 5, 6
+        ]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_i32x8<S: Simd>(simd: S) {
+    let a = i32x8::from_slice(simd, &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(*a.rotate_elements_left::<5>(), [5, 6, 7, 0, 1, 2, 3, 4]);
+    assert_eq!(*a.rotate_elements_right::<5>(), [3, 4, 5, 6, 7, 0, 1, 2]);
+}
+
+#[simd_test]
+fn shift_elements_i32x8<S: Simd>(simd: S) {
+    let a = i32x8::from_slice(simd, &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(
+        *a.shift_elements_left::<5>(-1),
+        [5, 6, 7, -1, -1, -1, -1, -1]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<5>(-1),
+        [-1, -1, -1, -1, -1, 0, 1, 2]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_u32x8<S: Simd>(simd: S) {
+    let a = u32x8::from_slice(simd, &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(*a.rotate_elements_left::<5>(), [5, 6, 7, 0, 1, 2, 3, 4]);
+    assert_eq!(*a.rotate_elements_right::<5>(), [3, 4, 5, 6, 7, 0, 1, 2]);
+}
+
+#[simd_test]
+fn shift_elements_u32x8<S: Simd>(simd: S) {
+    let a = u32x8::from_slice(simd, &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(
+        *a.shift_elements_left::<5>(255),
+        [5, 6, 7, 255, 255, 255, 255, 255]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<5>(255),
+        [255, 255, 255, 255, 255, 0, 1, 2]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_f64x4<S: Simd>(simd: S) {
+    let a = f64x4::from_slice(simd, &[0.0, 1.0, 2.0, 3.0]);
+    assert_eq!(*a.rotate_elements_left::<3>(), [3.0, 0.0, 1.0, 2.0]);
+    assert_eq!(*a.rotate_elements_right::<3>(), [1.0, 2.0, 3.0, 0.0]);
+}
+
+#[simd_test]
+fn shift_elements_f64x4<S: Simd>(simd: S) {
+    let a = f64x4::from_slice(simd, &[0.0, 1.0, 2.0, 3.0]);
+    assert_eq!(*a.shift_elements_left::<3>(99.0), [3.0, 99.0, 99.0, 99.0]);
+    assert_eq!(*a.shift_elements_right::<3>(99.0), [99.0, 99.0, 99.0, 0.0]);
+}
+
+#[simd_test]
+fn rotate_elements_f32x16<S: Simd>(simd: S) {
+    let a = f32x16::from_slice(
+        simd,
+        &[
+            0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+        ],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<9>(),
+        [
+            9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0
+        ]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<9>(),
+        [
+            7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0
+        ]
+    );
+}
+
+#[simd_test]
+fn shift_elements_f32x16<S: Simd>(simd: S) {
+    let a = f32x16::from_slice(
+        simd,
+        &[
+            0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+        ],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<9>(99.0),
+        [
+            9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0,
+            99.0, 99.0
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<9>(99.0),
+        [
+            99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0
+        ]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_i8x64<S: Simd>(simd: S) {
+    let a = i8x64::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+            46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+        ],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<33>(),
+        [
+            33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+            55, 56, 57, 58, 59, 60, 61, 62, 63, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
+        ]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<33>(),
+        [
+            31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52,
+            53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+            13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30
+        ]
+    );
+}
+
+#[simd_test]
+fn shift_elements_i8x64<S: Simd>(simd: S) {
+    let a = i8x64::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+            46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+        ],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<33>(-1),
+        [
+            33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+            55, 56, 57, 58, 59, 60, 61, 62, 63, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<33>(-1),
+        [
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+            13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30
+        ]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_u8x64<S: Simd>(simd: S) {
+    let a = u8x64::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+            46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+        ],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<33>(),
+        [
+            33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+            55, 56, 57, 58, 59, 60, 61, 62, 63, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
+        ]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<33>(),
+        [
+            31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52,
+            53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+            13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30
+        ]
+    );
+}
+
+#[simd_test]
+fn shift_elements_u8x64<S: Simd>(simd: S) {
+    let a = u8x64::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+            46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+        ],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<33>(255),
+        [
+            33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+            55, 56, 57, 58, 59, 60, 61, 62, 63, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<33>(255),
+        [
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 1,
+            2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+            26, 27, 28, 29, 30
+        ]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_i16x32<S: Simd>(simd: S) {
+    let a = i16x32::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<17>(),
+        [
+            17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8,
+            9, 10, 11, 12, 13, 14, 15, 16
+        ]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<17>(),
+        [
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5,
+            6, 7, 8, 9, 10, 11, 12, 13, 14
+        ]
+    );
+}
+
+#[simd_test]
+fn shift_elements_i16x32<S: Simd>(simd: S) {
+    let a = i16x32::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<17>(-1),
+        [
+            17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<17>(-1),
+        [
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3, 4, 5,
+            6, 7, 8, 9, 10, 11, 12, 13, 14
+        ]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_u16x32<S: Simd>(simd: S) {
+    let a = u16x32::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<17>(),
+        [
+            17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8,
+            9, 10, 11, 12, 13, 14, 15, 16
+        ]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<17>(),
+        [
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5,
+            6, 7, 8, 9, 10, 11, 12, 13, 14
+        ]
+    );
+}
+
+#[simd_test]
+fn shift_elements_u16x32<S: Simd>(simd: S) {
+    let a = u16x32::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<17>(255),
+        [
+            17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<17>(255),
+        [
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0,
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
+        ]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_i32x16<S: Simd>(simd: S) {
+    let a = i32x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<9>(),
+        [9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<9>(),
+        [7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6]
+    );
+}
+
+#[simd_test]
+fn shift_elements_i32x16<S: Simd>(simd: S) {
+    let a = i32x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<9>(-1),
+        [
+            9, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<9>(-1),
+        [-1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3, 4, 5, 6]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_u32x16<S: Simd>(simd: S) {
+    let a = u32x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.rotate_elements_left::<9>(),
+        [9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<9>(),
+        [7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6]
+    );
+}
+
+#[simd_test]
+fn shift_elements_u32x16<S: Simd>(simd: S) {
+    let a = u32x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.shift_elements_left::<9>(255),
+        [
+            9, 10, 11, 12, 13, 14, 15, 255, 255, 255, 255, 255, 255, 255, 255, 255
+        ]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<9>(255),
+        [
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 1, 2, 3, 4, 5, 6
+        ]
+    );
+}
+
+#[simd_test]
+fn rotate_elements_f64x8<S: Simd>(simd: S) {
+    let a = f64x8::from_slice(simd, &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
+    assert_eq!(
+        *a.rotate_elements_left::<5>(),
+        [5.0, 6.0, 7.0, 0.0, 1.0, 2.0, 3.0, 4.0]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<5>(),
+        [3.0, 4.0, 5.0, 6.0, 7.0, 0.0, 1.0, 2.0]
+    );
+}
+
+#[simd_test]
+fn shift_elements_f64x8<S: Simd>(simd: S) {
+    let a = f64x8::from_slice(simd, &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
+    assert_eq!(
+        *a.shift_elements_left::<5>(99.0),
+        [5.0, 6.0, 7.0, 99.0, 99.0, 99.0, 99.0, 99.0]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<5>(99.0),
+        [99.0, 99.0, 99.0, 99.0, 99.0, 0.0, 1.0, 2.0]
+    );
+}
+
+#[simd_test]
 fn slide_within_blocks_f32x4<S: Simd>(simd: S) {
     let a = f32x4::from_slice(simd, &[1.0, 2.0, 3.0, 4.0]);
     let b = f32x4::from_slice(simd, &[5.0, 6.0, 7.0, 8.0]);

--- a/fearless_simd_tests/tests/harness/mod.rs
+++ b/fearless_simd_tests/tests/harness/mod.rs
@@ -4441,14 +4441,34 @@ fn slide_f32x4<S: Simd>(simd: S) {
 fn rotate_elements_f32x4<S: Simd>(simd: S) {
     let a = f32x4::from_slice(simd, &[0.0, 1.0, 2.0, 3.0]);
     assert_eq!(*a.rotate_elements_left::<3>(), [3.0, 0.0, 1.0, 2.0]);
+    assert_eq!(*a.rotate_elements_left::<7>(), [3.0, 0.0, 1.0, 2.0]);
+    assert_eq!(
+        *a.rotate_elements_left::<{ usize::MAX }>(),
+        [3.0, 0.0, 1.0, 2.0]
+    );
     assert_eq!(*a.rotate_elements_right::<3>(), [1.0, 2.0, 3.0, 0.0]);
+    assert_eq!(*a.rotate_elements_right::<7>(), [1.0, 2.0, 3.0, 0.0]);
+    assert_eq!(
+        *a.rotate_elements_right::<{ usize::MAX }>(),
+        [1.0, 2.0, 3.0, 0.0]
+    );
 }
 
 #[simd_test]
 fn shift_elements_f32x4<S: Simd>(simd: S) {
     let a = f32x4::from_slice(simd, &[0.0, 1.0, 2.0, 3.0]);
     assert_eq!(*a.shift_elements_left::<3>(99.0), [3.0, 99.0, 99.0, 99.0]);
+    assert_eq!(*a.shift_elements_left::<7>(99.0), [99.0, 99.0, 99.0, 99.0]);
+    assert_eq!(
+        *a.shift_elements_left::<{ usize::MAX }>(99.0),
+        [99.0, 99.0, 99.0, 99.0]
+    );
     assert_eq!(*a.shift_elements_right::<3>(99.0), [99.0, 99.0, 99.0, 0.0]);
+    assert_eq!(*a.shift_elements_right::<7>(99.0), [99.0, 99.0, 99.0, 99.0]);
+    assert_eq!(
+        *a.shift_elements_right::<{ usize::MAX }>(99.0),
+        [99.0, 99.0, 99.0, 99.0]
+    );
 }
 
 #[simd_test]
@@ -4614,6 +4634,14 @@ fn rotate_elements_f32x8<S: Simd>(simd: S) {
         *a.rotate_elements_right::<5>(),
         [3.0, 4.0, 5.0, 6.0, 7.0, 0.0, 1.0, 2.0]
     );
+    assert_eq!(
+        *a.rotate_elements_left::<{ usize::MAX }>(),
+        [7.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    );
+    assert_eq!(
+        *a.rotate_elements_right::<{ usize::MAX }>(),
+        [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 0.0]
+    );
 }
 
 #[simd_test]
@@ -4626,6 +4654,14 @@ fn shift_elements_f32x8<S: Simd>(simd: S) {
     assert_eq!(
         *a.shift_elements_right::<5>(99.0),
         [99.0, 99.0, 99.0, 99.0, 99.0, 0.0, 1.0, 2.0]
+    );
+    assert_eq!(
+        *a.shift_elements_left::<{ usize::MAX }>(99.0),
+        [99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0]
+    );
+    assert_eq!(
+        *a.shift_elements_right::<{ usize::MAX }>(99.0),
+        [99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0]
     );
 }
 

--- a/fearless_simd_tests/tests/soundness.rs
+++ b/fearless_simd_tests/tests/soundness.rs
@@ -138,21 +138,3 @@ fn mask_test_rejects_out_of_bounds<S: Simd>(simd: S) {
 fn mask_set_rejects_out_of_bounds<S: Simd>(simd: S) {
     for_each_mask_type!(check_mask_set_oob, simd);
 }
-
-#[simd_test]
-fn element_moves_reject_out_of_bounds_offset<S: Simd>(simd: S) {
-    let a = f32x4::from_slice(simd, &[0.0, 1.0, 2.0, 3.0]);
-
-    assert_panics("f32x4::rotate_elements_left", || {
-        let _ = a.rotate_elements_left::<5>();
-    });
-    assert_panics("f32x4::rotate_elements_right", || {
-        let _ = a.rotate_elements_right::<5>();
-    });
-    assert_panics("f32x4::shift_elements_left", || {
-        let _ = a.shift_elements_left::<5>(99.0);
-    });
-    assert_panics("f32x4::shift_elements_right", || {
-        let _ = a.shift_elements_right::<5>(99.0);
-    });
-}

--- a/fearless_simd_tests/tests/soundness.rs
+++ b/fearless_simd_tests/tests/soundness.rs
@@ -138,3 +138,21 @@ fn mask_test_rejects_out_of_bounds<S: Simd>(simd: S) {
 fn mask_set_rejects_out_of_bounds<S: Simd>(simd: S) {
     for_each_mask_type!(check_mask_set_oob, simd);
 }
+
+#[simd_test]
+fn element_moves_reject_out_of_bounds_offset<S: Simd>(simd: S) {
+    let a = f32x4::from_slice(simd, &[0.0, 1.0, 2.0, 3.0]);
+
+    assert_panics("f32x4::rotate_elements_left", || {
+        let _ = a.rotate_elements_left::<5>();
+    });
+    assert_panics("f32x4::rotate_elements_right", || {
+        let _ = a.rotate_elements_right::<5>();
+    });
+    assert_panics("f32x4::shift_elements_left", || {
+        let _ = a.shift_elements_left::<5>(99.0);
+    });
+    assert_panics("f32x4::shift_elements_right", || {
+        let _ = a.shift_elements_right::<5>(99.0);
+    });
+}


### PR DESCRIPTION
Adds convenience functions that lower into `slide` behind the scenes, matching the `std::simd` API and improving discoverability.

No new intrinsic/platform-specific code is added, since this simply lowers into calls to the existing slide() op.

Closes https://github.com/linebender/fearless_simd/issues/269