### PR TITLE
Optimize shrv_i64 for AVX2

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -4723,11 +4723,18 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn shrv_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
-        [
-            i64::shr(a[0usize], &b[0usize]),
-            i64::shr(a[1usize], &b[1usize]),
-        ]
-        .simd_into(self)
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i64x2<Avx2>, b: i64x2<Avx2>) -> i64x2<Avx2> {
+                let value = a.into();
+                let counts = b.into();
+                let bias = _mm_set1_epi64x(i64::MIN);
+                let shifted_bias = _mm_srlv_epi64(bias, counts);
+                let shifted = _mm_srlv_epi64(value, counts);
+                _mm_sub_epi64(_mm_xor_si128(shifted, shifted_bias), shifted_bias).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
     }
     #[inline(always)]
     fn simd_eq_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> mask64x2<Self> {
@@ -11112,13 +11119,19 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn shrv_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
-        [
-            i64::shr(a[0usize], &b[0usize]),
-            i64::shr(a[1usize], &b[1usize]),
-            i64::shr(a[2usize], &b[2usize]),
-            i64::shr(a[3usize], &b[3usize]),
-        ]
-        .simd_into(self)
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i64x4<Avx2>, b: i64x4<Avx2>) -> i64x4<Avx2> {
+                let value = a.into();
+                let counts = b.into();
+                let bias = _mm256_set1_epi64x(i64::MIN);
+                let shifted_bias = _mm256_srlv_epi64(bias, counts);
+                let shifted = _mm256_srlv_epi64(value, counts);
+                _mm256_sub_epi64(_mm256_xor_si256(shifted, shifted_bias), shifted_bias)
+                    .simd_into(token)
+            }
+        );
+        kernel(self, a, b)
     }
     #[inline(always)]
     fn simd_eq_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> mask64x4<Self> {

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -1779,6 +1779,29 @@ impl X86 {
 
         match method {
             "shrv"
+                if *self == Self::Avx2
+                    && vec_ty.scalar == ScalarType::Int
+                    && vec_ty.scalar_bits == 64 =>
+            {
+                // AVX2 has no packed arithmetic right shift for 64-bit lanes. For shift counts in
+                // 0..=63, biasing the logical result reconstructs the sign extension:
+                //     arithmetic = ((value >> count) ^ (MIN >> count)) - (MIN >> count)
+                let set1 = set1_intrinsic(vec_ty);
+                let srlv = intrinsic_ident("srlv", "epi64", vec_ty.n_bits());
+                let xor = intrinsic_ident("xor", coarse_type(vec_ty), vec_ty.n_bits());
+                let sub = intrinsic_ident("sub", "epi64", vec_ty.n_bits());
+                self.kernel_method(op, vec_ty, |token| {
+                    quote! {
+                        let value = a.into();
+                        let counts = b.into();
+                        let bias = #set1(i64::MIN);
+                        let shifted_bias = #srlv(bias, counts);
+                        let shifted = #srlv(value, counts);
+                        #sub(#xor(shifted, shifted_bias), shifted_bias).simd_into(#token)
+                    }
+                })
+            }
+            "shrv"
                 if *self != Self::Avx512
                     && vec_ty.scalar == ScalarType::Int
                     && vec_ty.scalar_bits == 64 =>

--- a/fearless_simd_tests/tests/harness/ops/shr.rs
+++ b/fearless_simd_tests/tests/harness/ops/shr.rs
@@ -253,11 +253,20 @@ fn shr_u64x8<S: Simd>(simd: S) {
 
 #[simd_test]
 fn shr_i8x32<S: Simd>(simd: S) {
-    let values: [i8; 32] = core::array::from_fn(|i| (i % 31) as i8 + 1_i8);
-    let a = i8x32::from_slice(simd, &values);
-    let expected: [i8; 32] = core::array::from_fn(|i| values[i] >> 1);
-    let result = simd.shr_i8x32(a, 1);
-    assert_eq!(result.as_slice(), expected.as_slice());
+    let a = i8x32::from_slice(
+        simd,
+        &[
+            -128, -64, -33, -1, 127, 64, 33, 1, -2, -4, -8, -16, 0, 2, 4, 8, -128, -64, -33, -1,
+            127, 64, 33, 1, -2, -4, -8, -16, 0, 2, 4, 8,
+        ],
+    );
+    assert_eq!(
+        *simd.shr_i8x32(a, 2),
+        [
+            -32, -16, -9, -1, 31, 16, 8, 0, -1, -1, -2, -4, 0, 0, 1, 2, -32, -16, -9, -1, 31, 16,
+            8, 0, -1, -1, -2, -4, 0, 0, 1, 2,
+        ]
+    );
 }
 
 #[simd_test]
@@ -271,11 +280,19 @@ fn shr_u8x32<S: Simd>(simd: S) {
 
 #[simd_test]
 fn shr_i16x16<S: Simd>(simd: S) {
-    let values: [i16; 16] = core::array::from_fn(|i| (i % 31) as i16 + 1_i16);
-    let a = i16x16::from_slice(simd, &values);
-    let expected: [i16; 16] = core::array::from_fn(|i| values[i] >> 1);
-    let result = simd.shr_i16x16(a, 1);
-    assert_eq!(result.as_slice(), expected.as_slice());
+    let a = i16x16::from_slice(
+        simd,
+        &[
+            -32768, -16384, -1025, -1, 32767, 16384, 1025, 1, -32768, -16384, -1025, -1, 32767,
+            16384, 1025, 1,
+        ],
+    );
+    assert_eq!(
+        *simd.shr_i16x16(a, 3),
+        [
+            -4096, -2048, -129, -1, 4095, 2048, 128, 0, -4096, -2048, -129, -1, 4095, 2048, 128, 0,
+        ]
+    );
 }
 
 #[simd_test]
@@ -289,11 +306,18 @@ fn shr_u16x16<S: Simd>(simd: S) {
 
 #[simd_test]
 fn shr_i32x8<S: Simd>(simd: S) {
-    let values: [i32; 8] = core::array::from_fn(|i| (i % 31) as i32 + 1_i32);
-    let a = i32x8::from_slice(simd, &values);
-    let expected: [i32; 8] = core::array::from_fn(|i| values[i] >> 1);
-    let result = simd.shr_i32x8(a, 1);
-    assert_eq!(result.as_slice(), expected.as_slice());
+    const MIN: i32 = i32::MIN;
+    const MAX: i32 = i32::MAX;
+    let a = i32x8::from_slice(
+        simd,
+        &[MIN, -1073741824, -65537, -1, MAX, 1073741824, 65537, 1],
+    );
+    assert_eq!(
+        *simd.shr_i32x8(a, 4),
+        [
+            -134217728, -67108864, -4097, -1, 134217727, 67108864, 4096, 0,
+        ]
+    );
 }
 
 #[simd_test]

--- a/fearless_simd_tests/tests/harness/ops/shrv.rs
+++ b/fearless_simd_tests/tests/harness/ops/shrv.rs
@@ -270,13 +270,27 @@ fn shrv_u64x8<S: Simd>(simd: S) {
 
 #[simd_test]
 fn shrv_i8x32<S: Simd>(simd: S) {
-    let values: [i8; 32] = core::array::from_fn(|i| (i % 31) as i8 + 1_i8);
-    let shift_values: [i8; 32] = core::array::from_fn(|i| (i % 3) as i8);
-    let a = i8x32::from_slice(simd, &values);
-    let shifts = i8x32::from_slice(simd, &shift_values);
-    let expected: [i8; 32] = core::array::from_fn(|i| values[i] >> shift_values[i]);
-    let result = simd.shrv_i8x32(a, shifts);
-    assert_eq!(result.as_slice(), expected.as_slice());
+    let a = i8x32::from_slice(
+        simd,
+        &[
+            -128, -64, -33, -1, 127, 64, 33, 1, -2, -4, -8, -16, 0, 2, 4, 8, -128, -64, -33, -1,
+            127, 64, 33, 1, -2, -4, -8, -16, 0, 2, 4, 8,
+        ],
+    );
+    let shifts = i8x32::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4,
+            5, 6, 7,
+        ],
+    );
+    assert_eq!(
+        *simd.shrv_i8x32(a, shifts),
+        [
+            -128, -32, -9, -1, 7, 2, 0, 0, -2, -2, -2, -2, 0, 0, 0, 0, -128, -32, -9, -1, 7, 2, 0,
+            0, -2, -2, -2, -2, 0, 0, 0, 0,
+        ]
+    );
 }
 
 #[simd_test]
@@ -292,13 +306,20 @@ fn shrv_u8x32<S: Simd>(simd: S) {
 
 #[simd_test]
 fn shrv_i16x16<S: Simd>(simd: S) {
-    let values: [i16; 16] = core::array::from_fn(|i| (i % 31) as i16 + 1_i16);
-    let shift_values: [i16; 16] = core::array::from_fn(|i| (i % 3) as i16);
-    let a = i16x16::from_slice(simd, &values);
-    let shifts = i16x16::from_slice(simd, &shift_values);
-    let expected: [i16; 16] = core::array::from_fn(|i| values[i] >> shift_values[i]);
-    let result = simd.shrv_i16x16(a, shifts);
-    assert_eq!(result.as_slice(), expected.as_slice());
+    let a = i16x16::from_slice(
+        simd,
+        &[
+            -32768, -16384, -1025, -1, 32767, 16384, 1025, 1, -32768, -16384, -1025, -1, 32767,
+            16384, 1025, 1,
+        ],
+    );
+    let shifts = i16x16::from_slice(simd, &[0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(
+        *simd.shrv_i16x16(a, shifts),
+        [
+            -32768, -8192, -257, -1, 2047, 512, 16, 0, -32768, -8192, -257, -1, 2047, 512, 16, 0,
+        ]
+    );
 }
 
 #[simd_test]
@@ -314,13 +335,17 @@ fn shrv_u16x16<S: Simd>(simd: S) {
 
 #[simd_test]
 fn shrv_i32x8<S: Simd>(simd: S) {
-    let values: [i32; 8] = core::array::from_fn(|i| (i % 31) as i32 + 1_i32);
-    let shift_values: [i32; 8] = core::array::from_fn(|i| (i % 3) as i32);
-    let a = i32x8::from_slice(simd, &values);
-    let shifts = i32x8::from_slice(simd, &shift_values);
-    let expected: [i32; 8] = core::array::from_fn(|i| values[i] >> shift_values[i]);
-    let result = simd.shrv_i32x8(a, shifts);
-    assert_eq!(result.as_slice(), expected.as_slice());
+    const MIN: i32 = i32::MIN;
+    const MAX: i32 = i32::MAX;
+    let a = i32x8::from_slice(
+        simd,
+        &[MIN, -1073741824, -65537, -1, MAX, 1073741824, 65537, 1],
+    );
+    let shifts = i32x8::from_slice(simd, &[0, 1, 2, 31, 4, 5, 16, 31]);
+    assert_eq!(
+        *simd.shrv_i32x8(a, shifts),
+        [MIN, -536870912, -16385, -1, 134217727, 33554432, 1, 0,]
+    );
 }
 
 #[simd_test]


### PR DESCRIPTION
LLVM already autovectorizes this in isolation, but autovec can easily break when inlined into larger functions. 

This enshrines the autovec formulation, but gains some performance by dropping 2 instructions for handling shifts of size 64 or greater (i.e. shifting out of bounds entirely), which are inconsistent across backends today anyway.

Tests used in development but omitted to avoid conflicting with the tests refactor PR #275. Ideally #275 should be merged first to ensure test coverage.

Gains for other sizes are possible but blocked on suboptimal codegen by rustc: https://github.com/linebender/fearless_simd/issues/280