### PR TITLE
Better generic bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ You can find its changes [documented below](#060-2026-07-10).
 - The `fxsr` CPU feature is now required for all x86 SIMD levels. It is present in hardware on all SIMD-capable CPUs, but it is possible to disable it in some emulators combined with a custom Rust target specification. ([#270][] by [@Shnatsel][])
 - `SimdBase::Mask` now guarantees support for selecting vectors of its associated `SimdBase` type, enabling mask selection in generic code without additional bounds.
 - `SimdElement` now requires `Copy`, enabling elements to be read by value from vectors in generic code without additional bounds.
+- `SimdBase::Block` now declares that a 128-bit block is its own block, enabling recursive use in generic code without additional equality bounds.
+- `SimdElement::Mask` now declares that a mask lane type is its own mask lane type, exposing this invariant to generic code.
 - `SimdCombine` and `SimdSplit` now declare their associated vector types as inverse operations, enabling generic code to recover the original vector type without additional equality bounds.
 - `SimdBase::Array` now guarantees `Copy` (and therefore `Clone`), `Debug`, by-value `IntoIterator`, `AsRef`, `AsMut`, and conversion from its vector type, while `SimdBase` guarantees construction from its associated array through `SimdFrom`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ You can find its changes [documented below](#060-2026-07-10).
 - `SimdBase::Mask` now guarantees support for selecting vectors of its associated `SimdBase` type, enabling mask selection in generic code without additional bounds.
 - `SimdElement` now requires `Copy`, enabling elements to be read by value from vectors in generic code without additional bounds.
 - `SimdCombine` and `SimdSplit` now declare their associated vector types as inverse operations, enabling generic code to recover the original vector type without additional equality bounds.
+- `SimdBase::Array` now guarantees `Copy` (and therefore `Clone`), `Debug`, by-value `IntoIterator`, `AsRef`, `AsMut`, and conversion from its vector type, while `SimdBase` guarantees construction from its associated array through `SimdFrom`.
 
 ## [0.6.0][] (2026-07-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ You can find its changes [documented below](#060-2026-07-10).
 - On x86_64 targets with static SSE2 support, `Level::baseline()` now returns `Sse2` instead of `Fallback`. ([#270][] by [@Shnatsel][])
 - The `fxsr` CPU feature is now required for all x86 SIMD levels. It is present in hardware on all SIMD-capable CPUs, but it is possible to disable it in some emulators combined with a custom Rust target specification. ([#270][] by [@Shnatsel][])
 - `SimdBase::Mask` now guarantees support for selecting vectors of its associated `SimdBase` type, enabling mask selection in generic code without additional bounds.
+- `SimdElement` now requires `Copy`, enabling elements to be read by value from vectors in generic code without additional bounds.
 
 ## [0.6.0][] (2026-07-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ You can find its changes [documented below](#060-2026-07-10).
 - The `fxsr` CPU feature is now required for all x86 SIMD levels. It is present in hardware on all SIMD-capable CPUs, but it is possible to disable it in some emulators combined with a custom Rust target specification. ([#270][] by [@Shnatsel][])
 - `SimdBase::Mask` now guarantees support for selecting vectors of its associated `SimdBase` type, enabling mask selection in generic code without additional bounds.
 - `SimdElement` now requires `Copy`, enabling elements to be read by value from vectors in generic code without additional bounds.
+- `SimdCombine` and `SimdSplit` now declare their associated vector types as inverse operations, enabling generic code to recover the original vector type without additional equality bounds.
 
 ## [0.6.0][] (2026-07-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ You can find its changes [documented below](#060-2026-07-10).
 
 - On x86_64 targets with static SSE2 support, `Level::baseline()` now returns `Sse2` instead of `Fallback`. ([#270][] by [@Shnatsel][])
 - The `fxsr` CPU feature is now required for all x86 SIMD levels. It is present in hardware on all SIMD-capable CPUs, but it is possible to disable it in some emulators combined with a custom Rust target specification. ([#270][] by [@Shnatsel][])
+- `SimdBase::Mask` now guarantees support for selecting vectors of its associated `SimdBase` type, enabling mask selection in generic code without additional bounds.
 
 ## [0.6.0][] (2026-07-10)
 

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -3889,6 +3889,7 @@ pub trait SimdBase<S: Simd>:
     + Seal
     + Bytes
     + SimdFrom<Self::Element, S>
+    + SimdFrom<Self::Array, S>
     + core::ops::Index<usize, Output = Self::Element>
     + core::ops::IndexMut<usize, Output = Self::Element>
     + core::ops::Deref<Target = Self::Array>
@@ -3911,7 +3912,12 @@ pub trait SimdBase<S: Simd>:
     #[doc = r" The array type that this vector type corresponds to, which will"]
     #[doc = r" always be `[Self::Element; Self::N]`. It has the same layout as"]
     #[doc = r" this vector type, but likely has a lower alignment."]
-    type Array;
+    type Array: Copy
+        + core::fmt::Debug
+        + IntoIterator<Item = Self::Element>
+        + AsRef<[Self::Element]>
+        + AsMut<[Self::Element]>
+        + From<Self>;
     #[doc = r" Get the [`Simd`] implementation associated with this type."]
     fn witness(&self) -> S;
     fn as_slice(&self) -> &[Self::Element];

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -3905,7 +3905,7 @@ pub trait SimdBase<S: Simd>:
     #[doc = r" Masks intentionally do not implement [`SimdBase`]. SSE, NEON, WASM, and the"]
     #[doc = r" fallback backend currently store masks as all-zero/all-one integer vectors, but"]
     #[doc = r" AVX-512/RVV/SVE-style targets use compact predicate registers instead."]
-    type Mask: SimdMask<S, Element = <Self::Element as SimdElement>::Mask>;
+    type Mask: SimdMask<S, Element = <Self::Element as SimdElement>::Mask> + Select<Self>;
     #[doc = r" A 128-bit SIMD vector of the same scalar type."]
     type Block: SimdBase<S, Element = Self::Element>;
     #[doc = r" The array type that this vector type corresponds to, which will"]

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -3908,7 +3908,7 @@ pub trait SimdBase<S: Simd>:
     #[doc = r" AVX-512/RVV/SVE-style targets use compact predicate registers instead."]
     type Mask: SimdMask<S, Element = <Self::Element as SimdElement>::Mask> + Select<Self>;
     #[doc = r" A 128-bit SIMD vector of the same scalar type."]
-    type Block: SimdBase<S, Element = Self::Element>;
+    type Block: SimdBase<S, Element = Self::Element, Block = Self::Block>;
     #[doc = r" The array type that this vector type corresponds to, which will"]
     #[doc = r" always be `[Self::Element; Self::N]`. It has the same layout as"]
     #[doc = r" this vector type, but likely has a lower alignment."]

--- a/fearless_simd/src/traits.rs
+++ b/fearless_simd/src/traits.rs
@@ -105,7 +105,7 @@ impl<T, S: Simd> SimdFrom<T, S> for T {
 }
 
 /// Types that can be used as elements in SIMD vectors.
-pub trait SimdElement: Seal {
+pub trait SimdElement: Copy + Seal {
     /// The associated mask lane type. This will be a signed integer of the same size as this type.
     type Mask: SimdElement;
 }

--- a/fearless_simd/src/traits.rs
+++ b/fearless_simd/src/traits.rs
@@ -107,7 +107,7 @@ impl<T, S: Simd> SimdFrom<T, S> for T {
 /// Types that can be used as elements in SIMD vectors.
 pub trait SimdElement: Copy + Seal {
     /// The associated mask lane type. This will be a signed integer of the same size as this type.
-    type Mask: SimdElement;
+    type Mask: SimdElement<Mask = Self::Mask>;
 }
 
 impl SimdElement for f32 {

--- a/fearless_simd/src/traits.rs
+++ b/fearless_simd/src/traits.rs
@@ -165,7 +165,8 @@ pub trait SimdCvtFloat<T: Seal>: Seal {
 ///
 /// This is implemented on all vectors 256 bits and lower, producing vectors of up to 512 bits.
 pub trait SimdCombine<S: Simd>: SimdBase<S> + Seal {
-    type Combined: SimdBase<S, Element = Self::Element, Block = Self::Block>;
+    type Combined: SimdBase<S, Element = Self::Element, Block = Self::Block>
+        + SimdSplit<S, Split = Self>;
 
     /// Concatenate two vectors into a new one that's twice as long.
     fn combine(self, rhs: impl SimdInto<Self, S>) -> Self::Combined;
@@ -175,7 +176,8 @@ pub trait SimdCombine<S: Simd>: SimdBase<S> + Seal {
 ///
 /// This is implemented on all vectors 256 bits and higher, producing vectors of down to 128 bits.
 pub trait SimdSplit<S: Simd>: SimdBase<S> + Seal {
-    type Split: SimdBase<S, Element = Self::Element, Block = Self::Block>;
+    type Split: SimdBase<S, Element = Self::Element, Block = Self::Block>
+        + SimdCombine<S, Combined = Self>;
 
     /// Split this vector into left and right halves.
     fn split(self) -> (Self::Split, Self::Split);

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -155,7 +155,7 @@ fn mk_simd_base() -> TokenStream {
         pub trait SimdBase<S: Simd>:
             Copy + Sync + Send + 'static
             + Seal
-            + Bytes + SimdFrom<Self::Element, S>
+            + Bytes + SimdFrom<Self::Element, S> + SimdFrom<Self::Array, S>
             + core::ops::Index<usize, Output = Self::Element> + core::ops::IndexMut<usize, Output = Self::Element>
             + core::ops::Deref<Target = Self::Array>+ core::ops::DerefMut<Target = Self::Array>
         {
@@ -176,7 +176,12 @@ fn mk_simd_base() -> TokenStream {
             /// The array type that this vector type corresponds to, which will
             /// always be `[Self::Element; Self::N]`. It has the same layout as
             /// this vector type, but likely has a lower alignment.
-            type Array;
+            type Array: Copy
+                + core::fmt::Debug
+                + IntoIterator<Item = Self::Element>
+                + AsRef<[Self::Element]>
+                + AsMut<[Self::Element]>
+                + From<Self>;
             /// Get the [`Simd`] implementation associated with this type.
             fn witness(&self) -> S;
             fn as_slice(&self) -> &[Self::Element];

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -170,7 +170,7 @@ fn mk_simd_base() -> TokenStream {
             /// Masks intentionally do not implement [`SimdBase`]. SSE, NEON, WASM, and the
             /// fallback backend currently store masks as all-zero/all-one integer vectors, but
             /// AVX-512/RVV/SVE-style targets use compact predicate registers instead.
-            type Mask: SimdMask<S, Element = <Self::Element as SimdElement>::Mask>;
+            type Mask: SimdMask<S, Element = <Self::Element as SimdElement>::Mask> + Select<Self>;
             /// A 128-bit SIMD vector of the same scalar type.
             type Block: SimdBase<S, Element = Self::Element>;
             /// The array type that this vector type corresponds to, which will

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -172,7 +172,7 @@ fn mk_simd_base() -> TokenStream {
             /// AVX-512/RVV/SVE-style targets use compact predicate registers instead.
             type Mask: SimdMask<S, Element = <Self::Element as SimdElement>::Mask> + Select<Self>;
             /// A 128-bit SIMD vector of the same scalar type.
-            type Block: SimdBase<S, Element = Self::Element>;
+            type Block: SimdBase<S, Element = Self::Element, Block = Self::Block>;
             /// The array type that this vector type corresponds to, which will
             /// always be `[Self::Element; Self::N]`. It has the same layout as
             /// this vector type, but likely has a lower alignment.

--- a/fearless_simd_tests/tests/generics.rs
+++ b/fearless_simd_tests/tests/generics.rs
@@ -21,3 +21,14 @@ fn generic_select<S: Simd, V: SimdBase<S>>(mask: V::Mask, if_true: V, if_false: 
 fn generic_first<S: Simd, V: SimdBase<S>>(vector: V) -> V::Element {
     vector[0]
 }
+
+// Ensure that combining and then splitting generic vectors returns the original type
+fn generic_combine_split<S: Simd, V: SimdCombine<S>>(left: V, right: V) -> (V, V) {
+    left.combine(right).split()
+}
+
+// Ensure that splitting and then combining a generic vector returns the original type
+fn generic_split_combine<S: Simd, V: SimdSplit<S>>(vector: V) -> V {
+    let (left, right) = vector.split();
+    left.combine(right)
+}

--- a/fearless_simd_tests/tests/generics.rs
+++ b/fearless_simd_tests/tests/generics.rs
@@ -1,0 +1,18 @@
+//! Tests enforcing that generic code still compiles
+
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![expect(dead_code, reason = "Compile only tests")]
+
+use fearless_simd::prelude::*;
+
+// Ensure that we can cast between generic native-width vectors
+fn generic_cast<S: Simd>(x: S::f32s) -> S::u32s {
+    x.to_int()
+}
+
+// Ensure that a generic vector's mask can select between vectors of that type
+fn generic_select<S: Simd, V: SimdBase<S>>(mask: V::Mask, if_true: V, if_false: V) -> V {
+    mask.select(if_true, if_false)
+}

--- a/fearless_simd_tests/tests/generics.rs
+++ b/fearless_simd_tests/tests/generics.rs
@@ -32,3 +32,18 @@ fn generic_split_combine<S: Simd, V: SimdSplit<S>>(vector: V) -> V {
     let (left, right) = vector.split();
     left.combine(right)
 }
+
+// Ensure that a generic vector can round-trip through its associated array type
+fn generic_array_roundtrip<S: Simd, V: SimdBase<S>>(vector: V) -> V {
+    fn require_debug<T: core::fmt::Debug>(_: &T) {}
+
+    let simd = vector.witness();
+    let mut array: V::Array = vector.into();
+    let array_copy = array;
+    let array_clone = array.clone();
+    require_debug(&array_clone);
+    let _: Option<V::Element> = array_clone.into_iter().next();
+    let _: &[V::Element] = array.as_ref();
+    let _: &mut [V::Element] = array.as_mut();
+    V::simd_from(simd, array_copy)
+}

--- a/fearless_simd_tests/tests/generics.rs
+++ b/fearless_simd_tests/tests/generics.rs
@@ -22,6 +22,18 @@ fn generic_first<S: Simd, V: SimdBase<S>>(vector: V) -> V::Element {
     vector[0]
 }
 
+// Ensure that a generic vector's 128-bit block is its own block
+fn generic_block_splat<S: Simd, V: SimdBase<S>>(block: V::Block) -> V::Block {
+    V::Block::block_splat(block)
+}
+
+// Ensure that a mask lane's signed integer encoding type is its own mask lane encoding type
+fn generic_mask_lane_encoding_idempotent<E: SimdElement>(
+    lane_encoding: E::Mask,
+) -> <E::Mask as SimdElement>::Mask {
+    lane_encoding
+}
+
 // Ensure that combining and then splitting generic vectors returns the original type
 fn generic_combine_split<S: Simd, V: SimdCombine<S>>(left: V, right: V) -> (V, V) {
     left.combine(right).split()

--- a/fearless_simd_tests/tests/generics.rs
+++ b/fearless_simd_tests/tests/generics.rs
@@ -52,6 +52,7 @@ fn generic_array_roundtrip<S: Simd, V: SimdBase<S>>(vector: V) -> V {
     let simd = vector.witness();
     let mut array: V::Array = vector.into();
     let array_copy = array;
+    #[expect(clippy::clone_on_copy, reason = "Deliberate test")]
     let array_clone = array.clone();
     require_debug(&array_clone);
     let _: Option<V::Element> = array_clone.into_iter().next();

--- a/fearless_simd_tests/tests/generics.rs
+++ b/fearless_simd_tests/tests/generics.rs
@@ -16,3 +16,8 @@ fn generic_cast<S: Simd>(x: S::f32s) -> S::u32s {
 fn generic_select<S: Simd, V: SimdBase<S>>(mask: V::Mask, if_true: V, if_false: V) -> V {
     mask.select(if_true, if_false)
 }
+
+// Ensure that elements can be copied out of a generic vector
+fn generic_first<S: Simd, V: SimdBase<S>>(vector: V) -> V::Element {
+    vector[0]
+}

--- a/fearless_simd_tests/tests/mod.rs
+++ b/fearless_simd_tests/tests/mod.rs
@@ -13,15 +13,10 @@
 use fearless_simd::*;
 use fearless_simd_dev_macros::simd_test;
 
+mod generics;
 mod harness;
 #[cfg(not(miri))] // too slow
 mod soundness;
-
-// Ensure that we can cast between generic native-width vectors
-#[expect(dead_code, reason = "Compile only test")]
-fn generic_cast<S: Simd>(x: S::f32s) -> S::u32s {
-    x.to_int()
-}
 
 #[allow(clippy::allow_attributes, reason = "Only needed in some cfgs.")]
 #[allow(


### PR DESCRIPTION
The relationships that already hold for all types are now encoded in the type system, to allow more things to be expressed in generic code. Adds tests to enforce that this kind of generic code will keep compiling.

Unlike #284 this is not a breaking change because all the relevant traits are sealed (except SimdFrom but the change involving it is non-breaking).