### PR TITLE
Fix byte-wise shl to not saturate when overflowing u8

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -969,6 +969,9 @@ impl Simd for Avx2 {
                 let hi_16 = _mm_unpackhi_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
                 let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm_set1_epi16(0x00ff);
+                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
+                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
                 _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -1487,6 +1490,9 @@ impl Simd for Avx2 {
                 let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
                 let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm_set1_epi16(0x00ff);
+                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
+                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
                 _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -6483,6 +6489,9 @@ impl Simd for Avx2 {
                     _mm256_unpackhi_epi8(val, _mm256_cmpgt_epi8(_mm256_setzero_si256(), val));
                 let lo_shifted = _mm256_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm256_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm256_set1_epi16(0x00ff);
+                let lo_shifted = _mm256_and_si256(lo_shifted, byte_mask);
+                let hi_shifted = _mm256_and_si256(hi_shifted, byte_mask);
                 _mm256_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -7183,6 +7192,9 @@ impl Simd for Avx2 {
                 let hi_16 = _mm256_unpackhi_epi8(val, _mm256_setzero_si256());
                 let lo_shifted = _mm256_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm256_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm256_set1_epi16(0x00ff);
+                let lo_shifted = _mm256_and_si256(lo_shifted, byte_mask);
+                let hi_shifted = _mm256_and_si256(hi_shifted, byte_mask);
                 _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -975,6 +975,9 @@ impl Simd for Avx512 {
                 let hi_16 = _mm_unpackhi_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
                 let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm_set1_epi16(0x00ff);
+                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
+                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
                 _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -1536,6 +1539,9 @@ impl Simd for Avx512 {
                 let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
                 let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm_set1_epi16(0x00ff);
+                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
+                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
                 _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -6659,6 +6665,9 @@ impl Simd for Avx512 {
                     _mm256_unpackhi_epi8(val, _mm256_cmpgt_epi8(_mm256_setzero_si256(), val));
                 let lo_shifted = _mm256_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm256_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm256_set1_epi16(0x00ff);
+                let lo_shifted = _mm256_and_si256(lo_shifted, byte_mask);
+                let hi_shifted = _mm256_and_si256(hi_shifted, byte_mask);
                 _mm256_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -7393,6 +7402,9 @@ impl Simd for Avx512 {
                 let hi_16 = _mm256_unpackhi_epi8(val, _mm256_setzero_si256());
                 let lo_shifted = _mm256_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm256_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm256_set1_epi16(0x00ff);
+                let lo_shifted = _mm256_and_si256(lo_shifted, byte_mask);
+                let hi_shifted = _mm256_and_si256(hi_shifted, byte_mask);
                 _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -13548,6 +13560,9 @@ impl Simd for Avx512 {
                 );
                 let lo_shifted = _mm512_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm512_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm512_set1_epi16(0x00ff);
+                let lo_shifted = _mm512_and_si512(lo_shifted, byte_mask);
+                let hi_shifted = _mm512_and_si512(hi_shifted, byte_mask);
                 _mm512_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -14421,6 +14436,9 @@ impl Simd for Avx512 {
                 let hi_16 = _mm512_unpackhi_epi8(val, _mm512_setzero_si512());
                 let lo_shifted = _mm512_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm512_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm512_set1_epi16(0x00ff);
+                let lo_shifted = _mm512_and_si512(lo_shifted, byte_mask);
+                let hi_shifted = _mm512_and_si512(hi_shifted, byte_mask);
                 _mm512_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -1108,6 +1108,9 @@ impl Simd for Sse2 {
                 let hi_16 = _mm_unpackhi_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
                 let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm_set1_epi16(0x00ff);
+                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
+                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
                 _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -1697,6 +1700,9 @@ impl Simd for Sse2 {
                 let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
                 let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm_set1_epi16(0x00ff);
+                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
+                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
                 _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -951,6 +951,9 @@ impl Simd for Sse4_2 {
                 let hi_16 = _mm_unpackhi_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
                 let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm_set1_epi16(0x00ff);
+                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
+                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
                 _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -1466,6 +1469,9 @@ impl Simd for Sse4_2 {
                 let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
                 let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
                 let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
+                let byte_mask = _mm_set1_epi16(0x00ff);
+                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
+                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
                 _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -1972,6 +1972,20 @@ impl X86 {
                 _ => unimplemented!(),
             };
 
+            // The conversion from 16-bit back to 8-bit uses saturating arithmetic. We have to
+            // explicitly mask to get the desired truncation semantics.
+            let mask_result = if method == "shl" {
+                let and = intrinsic_ident("and", coarse_type(vec_ty), ty_bits);
+                let set1_epi16 = intrinsic_ident("set1", "epi16", ty_bits);
+                quote! {
+                    let byte_mask = #set1_epi16(0x00ff);
+                    let lo_shifted = #and(lo_shifted, byte_mask);
+                    let hi_shifted = #and(hi_shifted, byte_mask);
+                }
+            } else {
+                TokenStream::new()
+            };
+
             let extend_intrinsic_lo = extend_expr(unpack_lo);
             let extend_intrinsic_hi = extend_expr(unpack_hi);
             let pack_intrinsic = pack_intrinsic(16, vec_ty.scalar == ScalarType::Int, ty_bits);
@@ -1986,6 +2000,8 @@ impl X86 {
 
                     let lo_shifted = #shift_intrinsic(lo_16, shift_count);
                     let hi_shifted = #shift_intrinsic(hi_16, shift_count);
+
+                    #mask_result
 
                     #pack_intrinsic(lo_shifted, hi_shifted).simd_into(#token)
                 }

--- a/fearless_simd_tests/tests/harness/ops/shl.rs
+++ b/fearless_simd_tests/tests/harness/ops/shl.rs
@@ -50,6 +50,10 @@ fn shl_u8x64<S: Simd>(simd: S) {
             56, 60, 64, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64
         ]
     );
+
+    // Shift that overflows u8, regression test for https://github.com/linebender/fearless_simd/issues/287
+    let a = u8x64::splat(simd, 3);
+    assert_eq!(*(a << 7), *u8x64::splat(simd, 128));
 }
 
 #[simd_test]


### PR DESCRIPTION
Fixes #287