### PR TITLE
Fix byte-wise shl on i8 to match rust semantics

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -965,14 +965,12 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: i8x16<Avx2>, shift: u32) -> i8x16<Avx2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm_set1_epi16(0x00ff);
-                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
-                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
-                _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask = _mm_set1_epi16(0x00ff);
+                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
+                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
+                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
+                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -1486,13 +1484,11 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: u8x16<Avx2>, shift: u32) -> u8x16<Avx2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
+                let mask = _mm_set1_epi16(0x00ff);
                 let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
                 let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm_set1_epi16(0x00ff);
-                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
-                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
+                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
                 _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -6483,16 +6479,12 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: i8x32<Avx2>, shift: u32) -> i8x32<Avx2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 =
-                    _mm256_unpacklo_epi8(val, _mm256_cmpgt_epi8(_mm256_setzero_si256(), val));
-                let hi_16 =
-                    _mm256_unpackhi_epi8(val, _mm256_cmpgt_epi8(_mm256_setzero_si256(), val));
-                let lo_shifted = _mm256_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm256_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm256_set1_epi16(0x00ff);
-                let lo_shifted = _mm256_and_si256(lo_shifted, byte_mask);
-                let hi_shifted = _mm256_and_si256(hi_shifted, byte_mask);
-                _mm256_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask = _mm256_set1_epi16(0x00ff);
+                let lo_16 = _mm256_unpacklo_epi8(val, _mm256_setzero_si256());
+                let hi_16 = _mm256_unpackhi_epi8(val, _mm256_setzero_si256());
+                let lo_shifted = _mm256_and_si256(_mm256_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm256_and_si256(_mm256_sll_epi16(hi_16, shift_count), mask);
+                _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -7188,13 +7180,11 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: u8x32<Avx2>, shift: u32) -> u8x32<Avx2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
+                let mask = _mm256_set1_epi16(0x00ff);
                 let lo_16 = _mm256_unpacklo_epi8(val, _mm256_setzero_si256());
                 let hi_16 = _mm256_unpackhi_epi8(val, _mm256_setzero_si256());
-                let lo_shifted = _mm256_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm256_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm256_set1_epi16(0x00ff);
-                let lo_shifted = _mm256_and_si256(lo_shifted, byte_mask);
-                let hi_shifted = _mm256_and_si256(hi_shifted, byte_mask);
+                let lo_shifted = _mm256_and_si256(_mm256_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm256_and_si256(_mm256_sll_epi16(hi_16, shift_count), mask);
                 _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -971,14 +971,12 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i8x16<Avx512>, shift: u32) -> i8x16<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm_set1_epi16(0x00ff);
-                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
-                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
-                _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask = _mm_set1_epi16(0x00ff);
+                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
+                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
+                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
+                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -1535,13 +1533,11 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u8x16<Avx512>, shift: u32) -> u8x16<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
+                let mask = _mm_set1_epi16(0x00ff);
                 let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
                 let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm_set1_epi16(0x00ff);
-                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
-                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
+                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
                 _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -6659,16 +6655,12 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i8x32<Avx512>, shift: u32) -> i8x32<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 =
-                    _mm256_unpacklo_epi8(val, _mm256_cmpgt_epi8(_mm256_setzero_si256(), val));
-                let hi_16 =
-                    _mm256_unpackhi_epi8(val, _mm256_cmpgt_epi8(_mm256_setzero_si256(), val));
-                let lo_shifted = _mm256_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm256_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm256_set1_epi16(0x00ff);
-                let lo_shifted = _mm256_and_si256(lo_shifted, byte_mask);
-                let hi_shifted = _mm256_and_si256(hi_shifted, byte_mask);
-                _mm256_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask = _mm256_set1_epi16(0x00ff);
+                let lo_16 = _mm256_unpacklo_epi8(val, _mm256_setzero_si256());
+                let hi_16 = _mm256_unpackhi_epi8(val, _mm256_setzero_si256());
+                let lo_shifted = _mm256_and_si256(_mm256_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm256_and_si256(_mm256_sll_epi16(hi_16, shift_count), mask);
+                _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -7398,13 +7390,11 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u8x32<Avx512>, shift: u32) -> u8x32<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
+                let mask = _mm256_set1_epi16(0x00ff);
                 let lo_16 = _mm256_unpacklo_epi8(val, _mm256_setzero_si256());
                 let hi_16 = _mm256_unpackhi_epi8(val, _mm256_setzero_si256());
-                let lo_shifted = _mm256_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm256_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm256_set1_epi16(0x00ff);
-                let lo_shifted = _mm256_and_si256(lo_shifted, byte_mask);
-                let hi_shifted = _mm256_and_si256(hi_shifted, byte_mask);
+                let lo_shifted = _mm256_and_si256(_mm256_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm256_and_si256(_mm256_sll_epi16(hi_16, shift_count), mask);
                 _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
@@ -13550,20 +13540,12 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i8x64<Avx512>, shift: u32) -> i8x64<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm512_unpacklo_epi8(
-                    val,
-                    _mm512_movm_epi8(_mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), val)),
-                );
-                let hi_16 = _mm512_unpackhi_epi8(
-                    val,
-                    _mm512_movm_epi8(_mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), val)),
-                );
-                let lo_shifted = _mm512_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm512_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm512_set1_epi16(0x00ff);
-                let lo_shifted = _mm512_and_si512(lo_shifted, byte_mask);
-                let hi_shifted = _mm512_and_si512(hi_shifted, byte_mask);
-                _mm512_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask = _mm512_set1_epi16(0x00ff);
+                let lo_16 = _mm512_unpacklo_epi8(val, _mm512_setzero_si512());
+                let hi_16 = _mm512_unpackhi_epi8(val, _mm512_setzero_si512());
+                let lo_shifted = _mm512_and_si512(_mm512_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm512_and_si512(_mm512_sll_epi16(hi_16, shift_count), mask);
+                _mm512_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -14432,13 +14414,11 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u8x64<Avx512>, shift: u32) -> u8x64<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
+                let mask = _mm512_set1_epi16(0x00ff);
                 let lo_16 = _mm512_unpacklo_epi8(val, _mm512_setzero_si512());
                 let hi_16 = _mm512_unpackhi_epi8(val, _mm512_setzero_si512());
-                let lo_shifted = _mm512_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm512_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm512_set1_epi16(0x00ff);
-                let lo_shifted = _mm512_and_si512(lo_shifted, byte_mask);
-                let hi_shifted = _mm512_and_si512(hi_shifted, byte_mask);
+                let lo_shifted = _mm512_and_si512(_mm512_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm512_and_si512(_mm512_sll_epi16(hi_16, shift_count), mask);
                 _mm512_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -1104,14 +1104,12 @@ impl Simd for Sse2 {
             fn kernel(token: Sse2, a: i8x16<Sse2>, shift: u32) -> i8x16<Sse2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm_set1_epi16(0x00ff);
-                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
-                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
-                _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask = _mm_set1_epi16(0x00ff);
+                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
+                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
+                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
+                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -1696,13 +1694,11 @@ impl Simd for Sse2 {
             fn kernel(token: Sse2, a: u8x16<Sse2>, shift: u32) -> u8x16<Sse2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
+                let mask = _mm_set1_epi16(0x00ff);
                 let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
                 let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm_set1_epi16(0x00ff);
-                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
-                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
+                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
                 _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -947,14 +947,12 @@ impl Simd for Sse4_2 {
             fn kernel(token: Sse4_2, a: i8x16<Sse4_2>, shift: u32) -> i8x16<Sse4_2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm_set1_epi16(0x00ff);
-                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
-                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
-                _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask = _mm_set1_epi16(0x00ff);
+                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
+                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
+                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
+                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -1465,13 +1463,11 @@ impl Simd for Sse4_2 {
             fn kernel(token: Sse4_2, a: u8x16<Sse4_2>, shift: u32) -> u8x16<Sse4_2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
+                let mask = _mm_set1_epi16(0x00ff);
                 let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
                 let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_sll_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_sll_epi16(hi_16, shift_count);
-                let byte_mask = _mm_set1_epi16(0x00ff);
-                let lo_shifted = _mm_and_si128(lo_shifted, byte_mask);
-                let hi_shifted = _mm_and_si128(hi_shifted, byte_mask);
+                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
+                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
                 _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
             }
         );

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -1926,6 +1926,79 @@ impl X86 {
         }
     }
 
+    fn shl_8bit(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+        let ty_bits = vec_ty.n_bits();
+        let suffix = op_suffix(vec_ty.scalar, vec_ty.scalar_bits.max(16), false);
+
+        let unpack_hi = unpack_intrinsic(ScalarType::Int, 8, false, ty_bits);
+        let unpack_lo = unpack_intrinsic(ScalarType::Int, 8, true, ty_bits);
+        let set0 = intrinsic_ident("setzero", coarse_type(vec_ty), ty_bits);
+        let and = intrinsic_ident("and", coarse_type(vec_ty), ty_bits);
+        let set1_epi16 = intrinsic_ident("set1", "epi16", ty_bits);
+        let shift_intrinsic = intrinsic_ident("sll", suffix, ty_bits);
+        let pack_intrinsic = pack_intrinsic(16, false, ty_bits);
+
+        self.kernel_method(op, vec_ty, |token| {
+            quote! {
+                let val = a.into();
+                let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
+                let mask = #set1_epi16(0x00ff);
+
+                let lo_16 = #unpack_lo(val, #set0());
+                let hi_16 = #unpack_hi(val, #set0());
+
+                let lo_shifted = #and(#shift_intrinsic(lo_16, shift_count), mask);
+                let hi_shifted = #and(#shift_intrinsic(hi_16, shift_count), mask);
+
+                #pack_intrinsic(lo_shifted, hi_shifted).simd_into(#token)
+            }
+        })
+    }
+
+    fn shr_8bit(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+        let op_name = match vec_ty.scalar {
+            ScalarType::Unsigned => "srl",
+            ScalarType::Int => "sra",
+            _ => unreachable!(),
+        };
+        let ty_bits = vec_ty.n_bits();
+        let suffix = op_suffix(vec_ty.scalar, vec_ty.scalar_bits.max(16), false);
+
+        let unpack_hi = unpack_intrinsic(ScalarType::Int, 8, false, ty_bits);
+        let unpack_lo = unpack_intrinsic(ScalarType::Int, 8, true, ty_bits);
+        let set0 = intrinsic_ident("setzero", coarse_type(vec_ty), ty_bits);
+        let shift_intrinsic = intrinsic_ident(op_name, suffix, ty_bits);
+        let pack_intrinsic = pack_intrinsic(16, vec_ty.scalar == ScalarType::Int, ty_bits);
+
+        let sign_extend_bits = match vec_ty.scalar {
+            ScalarType::Unsigned => quote!(#set0()),
+            ScalarType::Int => {
+                if *self == Self::Avx512 && ty_bits == 512 {
+                    quote!(_mm512_movm_epi8(_mm512_cmpgt_epi8_mask(#set0(), val)))
+                } else {
+                    let cmp_intrinsic = intrinsic_ident("cmpgt", "epi8", ty_bits);
+                    quote!(#cmp_intrinsic(#set0(), val))
+                }
+            }
+            _ => unreachable!(),
+        };
+
+        self.kernel_method(op, vec_ty, |token| {
+            quote! {
+                let val = a.into();
+                let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
+
+                let lo_16 = #unpack_lo(val, #sign_extend_bits);
+                let hi_16 = #unpack_hi(val, #sign_extend_bits);
+
+                let lo_shifted = #shift_intrinsic(lo_16, shift_count);
+                let hi_shifted = #shift_intrinsic(hi_16, shift_count);
+
+                #pack_intrinsic(lo_shifted, hi_shifted).simd_into(#token)
+            }
+        })
+    }
+
     pub(crate) fn handle_shift(&self, op: Op, method: &str, vec_ty: &VecType) -> TokenStream {
         if *self != Self::Avx512
             && method == "shr"
@@ -1935,78 +2008,23 @@ impl X86 {
             return fallback_method(op, vec_ty);
         }
 
-        let shift_op = match (method, vec_ty.scalar) {
-            ("shr", ScalarType::Unsigned) => "srl",
-            ("shr", ScalarType::Int) => "sra",
-            ("shl", _) => "sll",
-            _ => unreachable!(),
-        };
-        let ty_bits = vec_ty.n_bits();
-        let suffix = op_suffix(vec_ty.scalar, vec_ty.scalar_bits.max(16), false);
-        let shift_intrinsic = intrinsic_ident(shift_op, suffix, ty_bits);
-
         if vec_ty.scalar_bits == 8 {
-            // x86 doesn't have shifting for 8-bit, so we first convert into 16-bit, shift, and then back to 8-bit.
-
-            let unpack_hi = unpack_intrinsic(ScalarType::Int, 8, false, ty_bits);
-            let unpack_lo = unpack_intrinsic(ScalarType::Int, 8, true, ty_bits);
-
-            let set0 = intrinsic_ident("setzero", coarse_type(vec_ty), ty_bits);
-            let extend_expr = |expr| match vec_ty.scalar {
-                ScalarType::Unsigned => quote! {
-                    #expr(val, #set0())
-                },
-                ScalarType::Int => {
-                    let sign_bits = if *self == Self::Avx512 && ty_bits == 512 {
-                        quote! {
-                            _mm512_movm_epi8(_mm512_cmpgt_epi8_mask(#set0(), val))
-                        }
-                    } else {
-                        let cmp_intrinsic = intrinsic_ident("cmpgt", "epi8", ty_bits);
-                        quote! { #cmp_intrinsic(#set0(), val) }
-                    };
-                    quote! {
-                        #expr(val, #sign_bits)
-                    }
-                }
-                _ => unimplemented!(),
-            };
-
-            // The conversion from 16-bit back to 8-bit uses saturating arithmetic. We have to
-            // explicitly mask to get the desired truncation semantics.
-            let mask_result = if method == "shl" {
-                let and = intrinsic_ident("and", coarse_type(vec_ty), ty_bits);
-                let set1_epi16 = intrinsic_ident("set1", "epi16", ty_bits);
-                quote! {
-                    let byte_mask = #set1_epi16(0x00ff);
-                    let lo_shifted = #and(lo_shifted, byte_mask);
-                    let hi_shifted = #and(hi_shifted, byte_mask);
-                }
+            if method == "shl" {
+                self.shl_8bit(op, vec_ty)
             } else {
-                TokenStream::new()
-            };
-
-            let extend_intrinsic_lo = extend_expr(unpack_lo);
-            let extend_intrinsic_hi = extend_expr(unpack_hi);
-            let pack_intrinsic = pack_intrinsic(16, vec_ty.scalar == ScalarType::Int, ty_bits);
-
-            self.kernel_method(op, vec_ty, |token| {
-                quote! {
-                    let val = a.into();
-                    let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-
-                    let lo_16 = #extend_intrinsic_lo;
-                    let hi_16 = #extend_intrinsic_hi;
-
-                    let lo_shifted = #shift_intrinsic(lo_16, shift_count);
-                    let hi_shifted = #shift_intrinsic(hi_16, shift_count);
-
-                    #mask_result
-
-                    #pack_intrinsic(lo_shifted, hi_shifted).simd_into(#token)
-                }
-            })
+                self.shr_8bit(op, vec_ty)
+            }
         } else {
+            let shift_op = match (method, vec_ty.scalar) {
+                ("shr", ScalarType::Unsigned) => "srl",
+                ("shr", ScalarType::Int) => "sra",
+                ("shl", _) => "sll",
+                _ => unreachable!(),
+            };
+            let ty_bits = vec_ty.n_bits();
+            let suffix = op_suffix(vec_ty.scalar, vec_ty.scalar_bits.max(16), false);
+            let shift_intrinsic = intrinsic_ident(shift_op, suffix, ty_bits);
+
             self.kernel_method(
                 op,
                 vec_ty,

--- a/fearless_simd_tests/tests/harness/ops/shl.rs
+++ b/fearless_simd_tests/tests/harness/ops/shl.rs
@@ -30,6 +30,10 @@ fn shl_i8x64<S: Simd>(simd: S) {
             56, 60, 64, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64
         ]
     );
+
+    // Shift that overflows i8, regression test for https://github.com/linebender/fearless_simd/issues/289
+    let a = i8x64::splat(simd, 1);
+    assert_eq!(*(a << 7), *i8x64::splat(simd, -128));
 }
 
 #[simd_test]


### PR DESCRIPTION
And factor out the x86 8-bit shift kernels into helpers, since their logic is diverging between left/right shifts.

Updates #289 

---

The main logic change in generated code is the use of `packus` instead of `packs` for signed shl implementations. The other diffs are just reorganizing of the shift+and chain into a more compact form.