### PR TITLE
Faster 8-bit full-vector shifts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "fearless_simd"
 version = "0.6.0"
 dependencies = [
@@ -134,6 +140,7 @@ dependencies = [
 name = "fearless_simd_tests"
 version = "0.0.0"
 dependencies = [
+ "fastrand",
  "fearless_simd",
  "fearless_simd_dev_macros",
 ]

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -1001,11 +1001,17 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: i8x16<Avx2>, shift: u32) -> i8x16<Avx2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let lo_shifted = _mm_sra_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_sra_epi16(hi_16, shift_count);
-                _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                let shifted = _mm_srl_epi16(val, shift_count);
+                let result = {
+                    let sign = _mm_cmpgt_epi8(_mm_setzero_si128(), val);
+                    _mm_or_si128(
+                        _mm_and_si128(shifted, byte_mask),
+                        _mm_andnot_si128(byte_mask, sign),
+                    )
+                };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -1517,11 +1523,11 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: u8x16<Avx2>, shift: u32) -> u8x16<Avx2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_srl_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_srl_epi16(hi_16, shift_count);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                let shifted = _mm_srl_epi16(val, shift_count);
+                let result = { _mm_and_si128(shifted, byte_mask) };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -6525,13 +6531,17 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: i8x32<Avx2>, shift: u32) -> i8x32<Avx2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 =
-                    _mm256_unpacklo_epi8(val, _mm256_cmpgt_epi8(_mm256_setzero_si256(), val));
-                let hi_16 =
-                    _mm256_unpackhi_epi8(val, _mm256_cmpgt_epi8(_mm256_setzero_si256(), val));
-                let lo_shifted = _mm256_sra_epi16(lo_16, shift_count);
-                let hi_shifted = _mm256_sra_epi16(hi_16, shift_count);
-                _mm256_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm256_set1_epi8(mask_byte);
+                let shifted = _mm256_srl_epi16(val, shift_count);
+                let result = {
+                    let sign = _mm256_cmpgt_epi8(_mm256_setzero_si256(), val);
+                    _mm256_or_si256(
+                        _mm256_and_si256(shifted, byte_mask),
+                        _mm256_andnot_si256(byte_mask, sign),
+                    )
+                };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -7223,11 +7233,11 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: u8x32<Avx2>, shift: u32) -> u8x32<Avx2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm256_unpacklo_epi8(val, _mm256_setzero_si256());
-                let hi_16 = _mm256_unpackhi_epi8(val, _mm256_setzero_si256());
-                let lo_shifted = _mm256_srl_epi16(lo_16, shift_count);
-                let hi_shifted = _mm256_srl_epi16(hi_16, shift_count);
-                _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm256_set1_epi8(mask_byte);
+                let shifted = _mm256_srl_epi16(val, shift_count);
+                let result = { _mm256_and_si256(shifted, byte_mask) };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -965,12 +965,9 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: i8x16<Avx2>, shift: u32) -> i8x16<Avx2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm_set1_epi16(0x00ff);
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                _mm_sll_epi16(_mm_and_si128(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -1484,12 +1481,9 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: u8x16<Avx2>, shift: u32) -> u8x16<Avx2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm_set1_epi16(0x00ff);
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                _mm_sll_epi16(_mm_and_si128(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -6479,12 +6473,9 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: i8x32<Avx2>, shift: u32) -> i8x32<Avx2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm256_set1_epi16(0x00ff);
-                let lo_16 = _mm256_unpacklo_epi8(val, _mm256_setzero_si256());
-                let hi_16 = _mm256_unpackhi_epi8(val, _mm256_setzero_si256());
-                let lo_shifted = _mm256_and_si256(_mm256_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm256_and_si256(_mm256_sll_epi16(hi_16, shift_count), mask);
-                _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm256_set1_epi8(mask_byte);
+                _mm256_sll_epi16(_mm256_and_si256(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -7180,12 +7171,9 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: u8x32<Avx2>, shift: u32) -> u8x32<Avx2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm256_set1_epi16(0x00ff);
-                let lo_16 = _mm256_unpacklo_epi8(val, _mm256_setzero_si256());
-                let hi_16 = _mm256_unpackhi_epi8(val, _mm256_setzero_si256());
-                let lo_shifted = _mm256_and_si256(_mm256_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm256_and_si256(_mm256_sll_epi16(hi_16, shift_count), mask);
-                _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm256_set1_epi8(mask_byte);
+                _mm256_sll_epi16(_mm256_and_si256(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -1006,11 +1006,14 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i8x16<Avx512>, shift: u32) -> i8x16<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let lo_shifted = _mm_sra_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_sra_epi16(hi_16, shift_count);
-                _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                let shifted = _mm_srl_epi16(val, shift_count);
+                let result = {
+                    let sign = _mm_cmpgt_epi8(_mm_setzero_si128(), val);
+                    _mm_ternarylogic_epi32::<0xca>(byte_mask, shifted, sign)
+                };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -1565,11 +1568,11 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u8x16<Avx512>, shift: u32) -> u8x16<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_srl_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_srl_epi16(hi_16, shift_count);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                let shifted = _mm_srl_epi16(val, shift_count);
+                let result = { _mm_and_si128(shifted, byte_mask) };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -6686,13 +6689,14 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i8x32<Avx512>, shift: u32) -> i8x32<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 =
-                    _mm256_unpacklo_epi8(val, _mm256_cmpgt_epi8(_mm256_setzero_si256(), val));
-                let hi_16 =
-                    _mm256_unpackhi_epi8(val, _mm256_cmpgt_epi8(_mm256_setzero_si256(), val));
-                let lo_shifted = _mm256_sra_epi16(lo_16, shift_count);
-                let hi_shifted = _mm256_sra_epi16(hi_16, shift_count);
-                _mm256_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm256_set1_epi8(mask_byte);
+                let shifted = _mm256_srl_epi16(val, shift_count);
+                let result = {
+                    let sign = _mm256_cmpgt_epi8(_mm256_setzero_si256(), val);
+                    _mm256_ternarylogic_epi32::<0xca>(byte_mask, shifted, sign)
+                };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -7418,11 +7422,11 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u8x32<Avx512>, shift: u32) -> u8x32<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm256_unpacklo_epi8(val, _mm256_setzero_si256());
-                let hi_16 = _mm256_unpackhi_epi8(val, _mm256_setzero_si256());
-                let lo_shifted = _mm256_srl_epi16(lo_16, shift_count);
-                let hi_shifted = _mm256_srl_epi16(hi_16, shift_count);
-                _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm256_set1_epi8(mask_byte);
+                let shifted = _mm256_srl_epi16(val, shift_count);
+                let result = { _mm256_and_si256(shifted, byte_mask) };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -13565,17 +13569,15 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i8x64<Avx512>, shift: u32) -> i8x64<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm512_unpacklo_epi8(
-                    val,
-                    _mm512_movm_epi8(_mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), val)),
-                );
-                let hi_16 = _mm512_unpackhi_epi8(
-                    val,
-                    _mm512_movm_epi8(_mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), val)),
-                );
-                let lo_shifted = _mm512_sra_epi16(lo_16, shift_count);
-                let hi_shifted = _mm512_sra_epi16(hi_16, shift_count);
-                _mm512_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm512_set1_epi8(mask_byte);
+                let shifted = _mm512_srl_epi16(val, shift_count);
+                let result = {
+                    let sign =
+                        _mm512_movm_epi8(_mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), val));
+                    _mm512_ternarylogic_epi32::<0xca>(byte_mask, shifted, sign)
+                };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -14436,11 +14438,11 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u8x64<Avx512>, shift: u32) -> u8x64<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm512_unpacklo_epi8(val, _mm512_setzero_si512());
-                let hi_16 = _mm512_unpackhi_epi8(val, _mm512_setzero_si512());
-                let lo_shifted = _mm512_srl_epi16(lo_16, shift_count);
-                let hi_shifted = _mm512_srl_epi16(hi_16, shift_count);
-                _mm512_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm512_set1_epi8(mask_byte);
+                let shifted = _mm512_srl_epi16(val, shift_count);
+                let result = { _mm512_and_si512(shifted, byte_mask) };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -971,12 +971,9 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i8x16<Avx512>, shift: u32) -> i8x16<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm_set1_epi16(0x00ff);
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                _mm_sll_epi16(_mm_and_si128(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -1533,12 +1530,9 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u8x16<Avx512>, shift: u32) -> u8x16<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm_set1_epi16(0x00ff);
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                _mm_sll_epi16(_mm_and_si128(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -6655,12 +6649,9 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i8x32<Avx512>, shift: u32) -> i8x32<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm256_set1_epi16(0x00ff);
-                let lo_16 = _mm256_unpacklo_epi8(val, _mm256_setzero_si256());
-                let hi_16 = _mm256_unpackhi_epi8(val, _mm256_setzero_si256());
-                let lo_shifted = _mm256_and_si256(_mm256_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm256_and_si256(_mm256_sll_epi16(hi_16, shift_count), mask);
-                _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm256_set1_epi8(mask_byte);
+                _mm256_sll_epi16(_mm256_and_si256(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -7390,12 +7381,9 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u8x32<Avx512>, shift: u32) -> u8x32<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm256_set1_epi16(0x00ff);
-                let lo_16 = _mm256_unpacklo_epi8(val, _mm256_setzero_si256());
-                let hi_16 = _mm256_unpackhi_epi8(val, _mm256_setzero_si256());
-                let lo_shifted = _mm256_and_si256(_mm256_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm256_and_si256(_mm256_sll_epi16(hi_16, shift_count), mask);
-                _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm256_set1_epi8(mask_byte);
+                _mm256_sll_epi16(_mm256_and_si256(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -13540,12 +13528,9 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i8x64<Avx512>, shift: u32) -> i8x64<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm512_set1_epi16(0x00ff);
-                let lo_16 = _mm512_unpacklo_epi8(val, _mm512_setzero_si512());
-                let hi_16 = _mm512_unpackhi_epi8(val, _mm512_setzero_si512());
-                let lo_shifted = _mm512_and_si512(_mm512_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm512_and_si512(_mm512_sll_epi16(hi_16, shift_count), mask);
-                _mm512_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm512_set1_epi8(mask_byte);
+                _mm512_sll_epi16(_mm512_and_si512(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -14414,12 +14399,9 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u8x64<Avx512>, shift: u32) -> u8x64<Avx512> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm512_set1_epi16(0x00ff);
-                let lo_16 = _mm512_unpacklo_epi8(val, _mm512_setzero_si512());
-                let hi_16 = _mm512_unpackhi_epi8(val, _mm512_setzero_si512());
-                let lo_shifted = _mm512_and_si512(_mm512_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm512_and_si512(_mm512_sll_epi16(hi_16, shift_count), mask);
-                _mm512_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm512_set1_epi8(mask_byte);
+                _mm512_sll_epi16(_mm512_and_si512(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -1104,12 +1104,9 @@ impl Simd for Sse2 {
             fn kernel(token: Sse2, a: i8x16<Sse2>, shift: u32) -> i8x16<Sse2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm_set1_epi16(0x00ff);
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                _mm_sll_epi16(_mm_and_si128(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -1694,12 +1691,9 @@ impl Simd for Sse2 {
             fn kernel(token: Sse2, a: u8x16<Sse2>, shift: u32) -> u8x16<Sse2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm_set1_epi16(0x00ff);
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                _mm_sll_epi16(_mm_and_si128(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -1140,11 +1140,17 @@ impl Simd for Sse2 {
             fn kernel(token: Sse2, a: i8x16<Sse2>, shift: u32) -> i8x16<Sse2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let lo_shifted = _mm_sra_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_sra_epi16(hi_16, shift_count);
-                _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                let shifted = _mm_srl_epi16(val, shift_count);
+                let result = {
+                    let sign = _mm_cmpgt_epi8(_mm_setzero_si128(), val);
+                    _mm_or_si128(
+                        _mm_and_si128(shifted, byte_mask),
+                        _mm_andnot_si128(byte_mask, sign),
+                    )
+                };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -1727,11 +1733,11 @@ impl Simd for Sse2 {
             fn kernel(token: Sse2, a: u8x16<Sse2>, shift: u32) -> u8x16<Sse2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_srl_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_srl_epi16(hi_16, shift_count);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                let shifted = _mm_srl_epi16(val, shift_count);
+                let result = { _mm_and_si128(shifted, byte_mask) };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -983,11 +983,17 @@ impl Simd for Sse4_2 {
             fn kernel(token: Sse4_2, a: i8x16<Sse4_2>, shift: u32) -> i8x16<Sse4_2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_cmpgt_epi8(_mm_setzero_si128(), val));
-                let lo_shifted = _mm_sra_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_sra_epi16(hi_16, shift_count);
-                _mm_packs_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                let shifted = _mm_srl_epi16(val, shift_count);
+                let result = {
+                    let sign = _mm_cmpgt_epi8(_mm_setzero_si128(), val);
+                    _mm_or_si128(
+                        _mm_and_si128(shifted, byte_mask),
+                        _mm_andnot_si128(byte_mask, sign),
+                    )
+                };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -1496,11 +1502,11 @@ impl Simd for Sse4_2 {
             fn kernel(token: Sse4_2, a: u8x16<Sse4_2>, shift: u32) -> u8x16<Sse4_2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_srl_epi16(lo_16, shift_count);
-                let hi_shifted = _mm_srl_epi16(hi_16, shift_count);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                let shifted = _mm_srl_epi16(val, shift_count);
+                let result = { _mm_and_si128(shifted, byte_mask) };
+                result.simd_into(token)
             }
         );
         kernel(self, a, shift)

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -947,12 +947,9 @@ impl Simd for Sse4_2 {
             fn kernel(token: Sse4_2, a: i8x16<Sse4_2>, shift: u32) -> i8x16<Sse4_2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm_set1_epi16(0x00ff);
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                _mm_sll_epi16(_mm_and_si128(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)
@@ -1463,12 +1460,9 @@ impl Simd for Sse4_2 {
             fn kernel(token: Sse4_2, a: u8x16<Sse4_2>, shift: u32) -> u8x16<Sse4_2> {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = _mm_set1_epi16(0x00ff);
-                let lo_16 = _mm_unpacklo_epi8(val, _mm_setzero_si128());
-                let hi_16 = _mm_unpackhi_epi8(val, _mm_setzero_si128());
-                let lo_shifted = _mm_and_si128(_mm_sll_epi16(lo_16, shift_count), mask);
-                let hi_shifted = _mm_and_si128(_mm_sll_epi16(hi_16, shift_count), mask);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = _mm_set1_epi8(mask_byte);
+                _mm_sll_epi16(_mm_and_si128(val, byte_mask), shift_count).simd_into(token)
             }
         );
         kernel(self, a, shift)

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -1930,27 +1930,17 @@ impl X86 {
         let ty_bits = vec_ty.n_bits();
         let suffix = op_suffix(vec_ty.scalar, vec_ty.scalar_bits.max(16), false);
 
-        let unpack_hi = unpack_intrinsic(ScalarType::Int, 8, false, ty_bits);
-        let unpack_lo = unpack_intrinsic(ScalarType::Int, 8, true, ty_bits);
-        let set0 = intrinsic_ident("setzero", coarse_type(vec_ty), ty_bits);
         let and = intrinsic_ident("and", coarse_type(vec_ty), ty_bits);
-        let set1_epi16 = intrinsic_ident("set1", "epi16", ty_bits);
+        let set1_epi8 = intrinsic_ident("set1", "epi8", ty_bits);
         let shift_intrinsic = intrinsic_ident("sll", suffix, ty_bits);
-        let pack_intrinsic = pack_intrinsic(16, false, ty_bits);
 
         self.kernel_method(op, vec_ty, |token| {
             quote! {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-                let mask = #set1_epi16(0x00ff);
-
-                let lo_16 = #unpack_lo(val, #set0());
-                let hi_16 = #unpack_hi(val, #set0());
-
-                let lo_shifted = #and(#shift_intrinsic(lo_16, shift_count), mask);
-                let hi_shifted = #and(#shift_intrinsic(hi_16, shift_count), mask);
-
-                #pack_intrinsic(lo_shifted, hi_shifted).simd_into(#token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = #set1_epi8(mask_byte);
+                #shift_intrinsic(#and(val, byte_mask), shift_count).simd_into(#token)
             }
         })
     }

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -1968,6 +1968,8 @@ impl X86 {
                     quote! { #cmpgt(#set0(), val) }
                 };
                 if *self == Self::Avx512 {
+                    // GFNI formulation was also considered, but it regresses latency:
+                    // https://github.com/linebender/fearless_simd/pull/291#issuecomment-5107747999
                     let ternary = intrinsic_ident("ternarylogic", "epi32", ty_bits);
                     quote! {
                         let sign = #sign;

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -1946,28 +1946,41 @@ impl X86 {
     }
 
     fn shr_8bit(&self, op: Op, vec_ty: &VecType) -> TokenStream {
-        let op_name = match vec_ty.scalar {
-            ScalarType::Unsigned => "srl",
-            ScalarType::Int => "sra",
-            _ => unreachable!(),
-        };
         let ty_bits = vec_ty.n_bits();
-        let suffix = op_suffix(vec_ty.scalar, vec_ty.scalar_bits.max(16), false);
-
-        let unpack_hi = unpack_intrinsic(ScalarType::Int, 8, false, ty_bits);
-        let unpack_lo = unpack_intrinsic(ScalarType::Int, 8, true, ty_bits);
-        let set0 = intrinsic_ident("setzero", coarse_type(vec_ty), ty_bits);
-        let shift_intrinsic = intrinsic_ident(op_name, suffix, ty_bits);
-        let pack_intrinsic = pack_intrinsic(16, vec_ty.scalar == ScalarType::Int, ty_bits);
-
-        let sign_extend_bits = match vec_ty.scalar {
-            ScalarType::Unsigned => quote!(#set0()),
+        let and = intrinsic_ident("and", coarse_type(vec_ty), ty_bits);
+        let set1_epi8 = intrinsic_ident("set1", "epi8", ty_bits);
+        let shift_intrinsic = intrinsic_ident("srl", "epi16", ty_bits);
+        let shift_fixup = match vec_ty.scalar {
+            ScalarType::Unsigned => quote! {
+                #and(shifted, byte_mask)
+            },
+            // Signed integers require special handling to implement sign extension
             ScalarType::Int => {
-                if *self == Self::Avx512 && ty_bits == 512 {
-                    quote!(_mm512_movm_epi8(_mm512_cmpgt_epi8_mask(#set0(), val)))
+                let set0 = intrinsic_ident("setzero", coarse_type(vec_ty), ty_bits);
+                let sign = if *self == Self::Avx512 && ty_bits == 512 {
+                    quote! {
+                        // there is no _mm512_cmpgt_epi8, so we need to use _mask variant
+                        // and expand it back into a vector so that ternarylogic can use it
+                        _mm512_movm_epi8(_mm512_cmpgt_epi8_mask(#set0(), val))
+                    }
                 } else {
-                    let cmp_intrinsic = intrinsic_ident("cmpgt", "epi8", ty_bits);
-                    quote!(#cmp_intrinsic(#set0(), val))
+                    let cmpgt = intrinsic_ident("cmpgt", "epi8", ty_bits);
+                    quote! { #cmpgt(#set0(), val) }
+                };
+                if *self == Self::Avx512 {
+                    let ternary = intrinsic_ident("ternarylogic", "epi32", ty_bits);
+                    quote! {
+                        let sign = #sign;
+                        // Select shifted bits where the byte mask is set and sign bits elsewhere.
+                        #ternary::<0xca>(byte_mask, shifted, sign)
+                    }
+                } else {
+                    let andnot = intrinsic_ident("andnot", coarse_type(vec_ty), ty_bits);
+                    let or = intrinsic_ident("or", coarse_type(vec_ty), ty_bits);
+                    quote! {
+                        let sign = #sign;
+                        #or(#and(shifted, byte_mask), #andnot(byte_mask, sign))
+                    }
                 }
             }
             _ => unreachable!(),
@@ -1977,14 +1990,11 @@ impl X86 {
             quote! {
                 let val = a.into();
                 let shift_count = _mm_cvtsi32_si128(shift.cast_signed());
-
-                let lo_16 = #unpack_lo(val, #sign_extend_bits);
-                let hi_16 = #unpack_hi(val, #sign_extend_bits);
-
-                let lo_shifted = #shift_intrinsic(lo_16, shift_count);
-                let hi_shifted = #shift_intrinsic(hi_16, shift_count);
-
-                #pack_intrinsic(lo_shifted, hi_shifted).simd_into(#token)
+                let mask_byte = 0xff_u32.wrapping_shr(shift) as i8;
+                let byte_mask = #set1_epi8(mask_byte);
+                let shifted = #shift_intrinsic(val, shift_count);
+                let result = { #shift_fixup };
+                result.simd_into(#token)
             }
         })
     }

--- a/fearless_simd_tests/Cargo.toml
+++ b/fearless_simd_tests/Cargo.toml
@@ -20,5 +20,6 @@ path = "tests/mod.rs"
 workspace = true
 
 [dependencies]
+fastrand = "2.5.0"
 fearless_simd = { workspace = true, features = ["std"] }
 fearless_simd_dev_macros = { workspace = true }

--- a/fearless_simd_tests/tests/harness/ops/shl.rs
+++ b/fearless_simd_tests/tests/harness/ops/shl.rs
@@ -186,6 +186,10 @@ fn shl_i8x16<S: Simd>(simd: S) {
     let expected: [i8; 16] = core::array::from_fn(|i| values[i] << 1);
     let result = simd.shl_i8x16(a, 1);
     assert_eq!(result.as_slice(), expected.as_slice());
+
+    // Shift that overflows i8, regression test for https://github.com/linebender/fearless_simd/issues/289
+    let a = i8x16::splat(simd, 1);
+    assert_eq!(*(a << 7), *i8x16::splat(simd, -128));
 }
 
 #[simd_test]
@@ -195,6 +199,10 @@ fn shl_u8x16<S: Simd>(simd: S) {
     let expected: [u8; 16] = core::array::from_fn(|i| values[i] << 1);
     let result = simd.shl_u8x16(a, 1);
     assert_eq!(result.as_slice(), expected.as_slice());
+
+    // Shift that overflows u8, regression test for https://github.com/linebender/fearless_simd/issues/287
+    let a = u8x16::splat(simd, 3);
+    assert_eq!(*(a << 7), *u8x16::splat(simd, 128));
 }
 
 #[simd_test]
@@ -204,6 +212,10 @@ fn shl_i8x32<S: Simd>(simd: S) {
     let expected: [i8; 32] = core::array::from_fn(|i| values[i] << 1);
     let result = simd.shl_i8x32(a, 1);
     assert_eq!(result.as_slice(), expected.as_slice());
+
+    // Shift that overflows i8, regression test for https://github.com/linebender/fearless_simd/issues/289
+    let a = i8x32::splat(simd, 1);
+    assert_eq!(*(a << 7), *i8x32::splat(simd, -128));
 }
 
 #[simd_test]
@@ -213,6 +225,10 @@ fn shl_u8x32<S: Simd>(simd: S) {
     let expected: [u8; 32] = core::array::from_fn(|i| values[i] << 1);
     let result = simd.shl_u8x32(a, 1);
     assert_eq!(result.as_slice(), expected.as_slice());
+
+    // Shift that overflows u8, regression test for https://github.com/linebender/fearless_simd/issues/287
+    let a = u8x32::splat(simd, 3);
+    assert_eq!(*(a << 7), *u8x32::splat(simd, 128));
 }
 
 #[simd_test]

--- a/fearless_simd_tests/tests/harness/ops/shr.rs
+++ b/fearless_simd_tests/tests/harness/ops/shr.rs
@@ -279,6 +279,61 @@ fn shr_u8x32<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+#[ignore] // Stress test: run with `cargo test --release shr_8bit_random -- --ignored`.
+fn shr_8bit_random<S: Simd>(simd: S) {
+    let mut rng = fastrand::Rng::with_seed(1337);
+
+    for iteration in 0..100_000 {
+        let mut unsigned = [0_u8; 64];
+        rng.fill(&mut unsigned);
+        let signed = unsigned.map(|value| value as i8);
+
+        let unsigned_16 = u8x16::from_slice(simd, &unsigned[..16]);
+        let unsigned_32 = u8x32::from_slice(simd, &unsigned[..32]);
+        let unsigned_64 = u8x64::from_slice(simd, &unsigned);
+        let signed_16 = i8x16::from_slice(simd, &signed[..16]);
+        let signed_32 = i8x32::from_slice(simd, &signed[..32]);
+        let signed_64 = i8x64::from_slice(simd, &signed);
+
+        for shift in 0..8 {
+            let expected_unsigned = unsigned.map(|value| value >> shift);
+            let expected_signed = signed.map(|value| value >> shift);
+
+            assert_eq!(
+                simd.shr_u8x16(unsigned_16, shift).as_slice(),
+                &expected_unsigned[..16],
+                "u8x16 iteration {iteration}, shift {shift}",
+            );
+            assert_eq!(
+                simd.shr_u8x32(unsigned_32, shift).as_slice(),
+                &expected_unsigned[..32],
+                "u8x32 iteration {iteration}, shift {shift}",
+            );
+            assert_eq!(
+                simd.shr_u8x64(unsigned_64, shift).as_slice(),
+                expected_unsigned.as_slice(),
+                "u8x64 iteration {iteration}, shift {shift}",
+            );
+            assert_eq!(
+                simd.shr_i8x16(signed_16, shift).as_slice(),
+                &expected_signed[..16],
+                "i8x16 iteration {iteration}, shift {shift}",
+            );
+            assert_eq!(
+                simd.shr_i8x32(signed_32, shift).as_slice(),
+                &expected_signed[..32],
+                "i8x32 iteration {iteration}, shift {shift}",
+            );
+            assert_eq!(
+                simd.shr_i8x64(signed_64, shift).as_slice(),
+                expected_signed.as_slice(),
+                "i8x64 iteration {iteration}, shift {shift}",
+            );
+        }
+    }
+}
+
+#[simd_test]
 fn shr_i16x16<S: Simd>(simd: S) {
     let a = i16x16::from_slice(
         simd,

--- a/fearless_simd_tests/tests/harness/ops/shr.rs
+++ b/fearless_simd_tests/tests/harness/ops/shr.rs
@@ -279,6 +279,57 @@ fn shr_u8x32<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn shr_i16x16<S: Simd>(simd: S) {
+    let a = i16x16::from_slice(
+        simd,
+        &[
+            -32768, -16384, -1025, -1, 32767, 16384, 1025, 1, -32768, -16384, -1025, -1, 32767,
+            16384, 1025, 1,
+        ],
+    );
+    assert_eq!(
+        *simd.shr_i16x16(a, 3),
+        [
+            -4096, -2048, -129, -1, 4095, 2048, 128, 0, -4096, -2048, -129, -1, 4095, 2048, 128, 0,
+        ]
+    );
+}
+
+#[simd_test]
+fn shr_u16x16<S: Simd>(simd: S) {
+    let values: [u16; 16] = core::array::from_fn(|i| (i % 31) as u16 + 1_u16);
+    let a = u16x16::from_slice(simd, &values);
+    let expected: [u16; 16] = core::array::from_fn(|i| values[i] >> 1);
+    let result = simd.shr_u16x16(a, 1);
+    assert_eq!(result.as_slice(), expected.as_slice());
+}
+
+#[simd_test]
+fn shr_i32x8<S: Simd>(simd: S) {
+    const MIN: i32 = i32::MIN;
+    const MAX: i32 = i32::MAX;
+    let a = i32x8::from_slice(
+        simd,
+        &[MIN, -1073741824, -65537, -1, MAX, 1073741824, 65537, 1],
+    );
+    assert_eq!(
+        *simd.shr_i32x8(a, 4),
+        [
+            -134217728, -67108864, -4097, -1, 134217727, 67108864, 4096, 0,
+        ]
+    );
+}
+
+#[simd_test]
+fn shr_u32x8<S: Simd>(simd: S) {
+    let values: [u32; 8] = core::array::from_fn(|i| (i % 31) as u32 + 1_u32);
+    let a = u32x8::from_slice(simd, &values);
+    let expected: [u32; 8] = core::array::from_fn(|i| values[i] >> 1);
+    let result = simd.shr_u32x8(a, 1);
+    assert_eq!(result.as_slice(), expected.as_slice());
+}
+
+#[simd_test]
 #[ignore] // Stress test: run with `cargo test --release shr_8bit_random -- --ignored`.
 fn shr_8bit_random<S: Simd>(simd: S) {
     let mut rng = fastrand::Rng::with_seed(1337);
@@ -331,55 +382,4 @@ fn shr_8bit_random<S: Simd>(simd: S) {
             );
         }
     }
-}
-
-#[simd_test]
-fn shr_i16x16<S: Simd>(simd: S) {
-    let a = i16x16::from_slice(
-        simd,
-        &[
-            -32768, -16384, -1025, -1, 32767, 16384, 1025, 1, -32768, -16384, -1025, -1, 32767,
-            16384, 1025, 1,
-        ],
-    );
-    assert_eq!(
-        *simd.shr_i16x16(a, 3),
-        [
-            -4096, -2048, -129, -1, 4095, 2048, 128, 0, -4096, -2048, -129, -1, 4095, 2048, 128, 0,
-        ]
-    );
-}
-
-#[simd_test]
-fn shr_u16x16<S: Simd>(simd: S) {
-    let values: [u16; 16] = core::array::from_fn(|i| (i % 31) as u16 + 1_u16);
-    let a = u16x16::from_slice(simd, &values);
-    let expected: [u16; 16] = core::array::from_fn(|i| values[i] >> 1);
-    let result = simd.shr_u16x16(a, 1);
-    assert_eq!(result.as_slice(), expected.as_slice());
-}
-
-#[simd_test]
-fn shr_i32x8<S: Simd>(simd: S) {
-    const MIN: i32 = i32::MIN;
-    const MAX: i32 = i32::MAX;
-    let a = i32x8::from_slice(
-        simd,
-        &[MIN, -1073741824, -65537, -1, MAX, 1073741824, 65537, 1],
-    );
-    assert_eq!(
-        *simd.shr_i32x8(a, 4),
-        [
-            -134217728, -67108864, -4097, -1, 134217727, 67108864, 4096, 0,
-        ]
-    );
-}
-
-#[simd_test]
-fn shr_u32x8<S: Simd>(simd: S) {
-    let values: [u32; 8] = core::array::from_fn(|i| (i % 31) as u32 + 1_u32);
-    let a = u32x8::from_slice(simd, &values);
-    let expected: [u32; 8] = core::array::from_fn(|i| values[i] >> 1);
-    let result = simd.shr_u32x8(a, 1);
-    assert_eq!(result.as_slice(), expected.as_slice());
 }


### PR DESCRIPTION
I had GPT-5.6 Sol suggest various formulations of these operations and measure them on llvm-mca, then picked the best imlementation for each op.

On top of the usual unit tests I've added ~~(and then reverted)~~ random tests that generate 100k random vectors, apply every possible shift and compare the result against a scalar reference.

I've only measured the AVX-512 path on tigerlake since my llvm-mca is too old to have Zen 4/5 or Sapphire Rapids. @danderson  I'd appreciate modeling on other CPUs for AVX-512 or benchmarks from real algorithms using this.