### PR TITLE
Make conversion to/from arrays generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ You can find its changes [documented below](#060-2026-07-10).
 - `SimdElement::Mask` now declares that a mask lane type is its own mask lane type, exposing this invariant to generic code.
 - `SimdCombine` and `SimdSplit` now declare their associated vector types as inverse operations, enabling generic code to recover the original vector type without additional equality bounds.
 - `SimdBase::Array` now guarantees `Copy` (and therefore `Clone`), `Debug`, by-value `IntoIterator`, `AsRef`, `AsMut`, and conversion from its vector type, while `SimdBase` guarantees construction from its associated array through `SimdFrom`.
+- Breaking change: the 204 vector-specific `Simd` array conversion methods have been replaced by the `SimdBase::load_array`, `load_array_ref`, `as_array`, `as_array_ref`, `as_array_mut`, and `store_array` methods. Masks continue to use `SimdMask::from_slice` and `store_slice`.
 
 ### Removed
 

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -122,36 +122,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_f32x4(self, val: [f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x4(self, val: &[f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x4(self, a: f32x4<Self>) -> [f32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128, [f32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
-        crate::transmute::checked_cast_ref::<__m128, [f32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x4(self, a: &mut f32x4<Self>) -> &mut [f32; 4usize] {
-        crate::transmute::checked_cast_mut::<__m128, [f32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -674,36 +644,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_i8x16(self, val: [i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x16(self, val: &[i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x16(self, a: i8x16<Self>) -> [i8; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x16(self, a: &mut i8x16<Self>) -> &mut [i8; 16usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i8; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         if SHIFT >= 16usize {
             return b;
@@ -1178,36 +1118,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x16(self, val: &[u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x16(self, a: u8x16<Self>) -> [u8; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x16(self, a: &mut u8x16<Self>) -> &mut [u8; 16usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u8; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1693,17 +1603,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask8x16(self, val: [i8; 16usize]) -> mask8x16<Self> {
-        mask8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x16(self, a: mask8x16<Self>) -> [i8; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x16(self, bits: u64) -> mask8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1740,9 +1639,10 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask8x16(*a);
+        let mut lanes = [0 as i8; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x16(lanes);
+        *a = mask8x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -1867,36 +1767,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i16x8(self, val: [i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x8(self, val: &[i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x8(self, a: i16x8<Self>) -> [i16; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x8(self, a: &mut i16x8<Self>) -> &mut [i16; 8usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i16; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
@@ -2302,36 +2172,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x8(self, val: &[u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x8(self, a: u16x8<Self>) -> [u16; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x8(self, a: &mut u16x8<Self>) -> &mut [u16; 8usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u16; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2742,17 +2582,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask16x8(self, val: [i16; 8usize]) -> mask16x8<Self> {
-        mask16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x8(self, a: mask16x8<Self>) -> [i16; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x8(self, bits: u64) -> mask16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2787,9 +2616,10 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask16x8(*a);
+        let mut lanes = [0 as i16; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x8(lanes);
+        *a = mask16x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -2914,36 +2744,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i32x4(self, val: [i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x4(self, val: &[i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x4(self, a: i32x4<Self>) -> [i32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x4(self, a: &mut i32x4<Self>) -> &mut [i32; 4usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
@@ -3333,36 +3133,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x4(self, val: &[u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x4(self, a: u32x4<Self>) -> [u32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x4(self, a: &mut u32x4<Self>) -> &mut [u32; 4usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -3766,17 +3536,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask32x4(self, val: [i32; 4usize]) -> mask32x4<Self> {
-        mask32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x4(self, a: mask32x4<Self>) -> [i32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x4(self, bits: u64) -> mask32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3808,9 +3567,10 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = self.as_array_mask32x4(*a);
+        let mut lanes = [0 as i32; 4usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x4(lanes);
+        *a = mask32x4::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -3935,36 +3695,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_f64x2(self, val: [f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x2(self, val: &[f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x2(self, a: f64x2<Self>) -> [f64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128d, [f64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
-        crate::transmute::checked_cast_ref::<__m128d, [f64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x2(self, a: &mut f64x2<Self>) -> &mut [f64; 2usize] {
-        crate::transmute::checked_cast_mut::<__m128d, [f64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
@@ -4398,36 +4128,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_i64x2(self, val: [i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x2(self, val: &[i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x2(self, a: i64x2<Self>) -> [i64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x2(self, a: &i64x2<Self>) -> &[i64; 2usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x2(self, a: &mut i64x2<Self>) -> &mut [i64; 2usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x2(self, a: i64x2<Self>, dest: &mut [i64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -4784,36 +4484,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u64x2(self, val: [u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x2(self, val: &[u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x2(self, a: u64x2<Self>) -> [u64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x2(self, a: &u64x2<Self>) -> &[u64; 2usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x2(self, a: &mut u64x2<Self>) -> &mut [u64; 2usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x2(self, a: u64x2<Self>, dest: &mut [u64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -5158,17 +4828,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask64x2(self, val: [i64; 2usize]) -> mask64x2<Self> {
-        mask64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x2(self, a: mask64x2<Self>) -> [i64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x2(self, bits: u64) -> mask64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5200,9 +4859,10 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             2usize
         );
-        let mut lanes = self.as_array_mask64x2(*a);
+        let mut lanes = [0 as i64; 2usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x2(lanes);
+        *a = mask64x2::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self> {
@@ -5327,36 +4987,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_f32x8(self, val: [f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x8(self, val: &[f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x8(self, a: f32x8<Self>) -> [f32; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m256, [f32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
-        crate::transmute::checked_cast_ref::<__m256, [f32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x8(self, a: &mut f32x8<Self>) -> &mut [f32; 8usize] {
-        crate::transmute::checked_cast_mut::<__m256, [f32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x8<const SHIFT: usize>(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -5963,36 +5593,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i8x32(self, val: [i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x32(self, val: &[i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x32(self, a: i8x32<Self>) -> [i8; 32usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x32(self, a: &mut i8x32<Self>) -> &mut [i8; 32usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [i8; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x32<const SHIFT: usize>(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -6654,36 +6254,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x32(self, val: &[u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x32(self, a: u8x32<Self>) -> [u8; 32usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [u8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [u8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x32(self, a: &mut u8x32<Self>) -> &mut [u8; 32usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [u8; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u8x32<const SHIFT: usize>(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
@@ -7357,17 +6927,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask8x32(self, val: [i8; 32usize]) -> mask8x32<Self> {
-        mask8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x32(self, a: mask8x32<Self>) -> [i8; 32usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x32(self, bits: u64) -> mask8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7409,9 +6968,10 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = self.as_array_mask8x32(*a);
+        let mut lanes = [0 as i8; 32usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x32(lanes);
+        *a = mask8x32::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
@@ -7546,36 +7106,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i16x16(self, val: [i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x16(self, val: &[i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x16(self, a: i16x16<Self>) -> [i16; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x16(self, a: &mut i16x16<Self>) -> &mut [i16; 16usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [i16; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x16<const SHIFT: usize>(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -8128,36 +7658,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x16(self, val: &[u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x16(self, a: u16x16<Self>) -> [u16; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [u16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [u16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x16(self, a: &mut u16x16<Self>) -> &mut [u16; 16usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [u16; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x16<const SHIFT: usize>(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -8731,17 +8231,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask16x16(self, val: [i16; 16usize]) -> mask16x16<Self> {
-        mask16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x16(self, a: mask16x16<Self>) -> [i16; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x16(self, bits: u64) -> mask16x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -8781,9 +8270,10 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask16x16(*a);
+        let mut lanes = [0 as i16; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x16(lanes);
+        *a = mask16x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
@@ -8918,36 +8408,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i32x8(self, val: [i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x8(self, val: &[i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x8(self, a: i32x8<Self>) -> [i32; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x8(self, a: &mut i32x8<Self>) -> &mut [i32; 8usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [i32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x8<const SHIFT: usize>(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -9424,36 +8884,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x8(self, val: &[u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x8(self, a: u32x8<Self>) -> [u32; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [u32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [u32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x8(self, a: &mut u32x8<Self>) -> &mut [u32; 8usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [u32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u32x8<const SHIFT: usize>(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
@@ -9946,17 +9376,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask32x8(self, val: [i32; 8usize]) -> mask32x8<Self> {
-        mask32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x8(self, a: mask32x8<Self>) -> [i32; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x8(self, bits: u64) -> mask32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -9988,9 +9407,10 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask32x8(*a);
+        let mut lanes = [0 as i32; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x8(lanes);
+        *a = mask32x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
@@ -10125,36 +9545,6 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_f64x4(self, val: [f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x4(self, val: &[f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x4(self, a: f64x4<Self>) -> [f64; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m256d, [f64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
-        crate::transmute::checked_cast_ref::<__m256d, [f64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x4(self, a: &mut f64x4<Self>) -> &mut [f64; 4usize] {
-        crate::transmute::checked_cast_mut::<__m256d, [f64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x4<const SHIFT: usize>(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
@@ -10656,36 +10046,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_i64x4(self, val: [i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x4(self, val: &[i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x4(self, a: i64x4<Self>) -> [i64; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x4(self, a: &i64x4<Self>) -> &[i64; 4usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x4(self, a: &mut i64x4<Self>) -> &mut [i64; 4usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [i64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x4(self, a: i64x4<Self>, dest: &mut [i64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x4<const SHIFT: usize>(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -11124,36 +10484,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u64x4(self, val: [u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x4(self, val: &[u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x4(self, a: u64x4<Self>) -> [u64; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [u64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x4(self, a: &u64x4<Self>) -> &[u64; 4usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [u64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x4(self, a: &mut u64x4<Self>) -> &mut [u64; 4usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [u64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x4(self, a: u64x4<Self>, dest: &mut [u64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u64x4<const SHIFT: usize>(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -11577,17 +10907,6 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask64x4(self, val: [i64; 4usize]) -> mask64x4<Self> {
-        mask64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x4(self, a: mask64x4<Self>) -> [i64; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x4(self, bits: u64) -> mask64x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -11619,9 +10938,10 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = self.as_array_mask64x4(*a);
+        let mut lanes = [0 as i64; 4usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x4(lanes);
+        *a = mask64x4::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x4(self, a: mask64x4<Self>, b: mask64x4<Self>) -> mask64x4<Self> {
@@ -11751,36 +11071,6 @@ impl Simd for Avx2 {
     fn splat_f32x16(self, val: f32) -> f32x16<Self> {
         let half = self.splat_f32x8(val);
         self.combine_f32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f32x16(self, val: [f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x16(self, val: &[f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x16(self, a: f32x16<Self>) -> [f32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m256; 2usize], [f32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m256; 2usize], [f32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x16(self, a: &mut f32x16<Self>) -> &mut [f32; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m256; 2usize], [f32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x16<const SHIFT: usize>(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -12287,36 +11577,6 @@ impl Simd for Avx2 {
     fn splat_i8x64(self, val: i8) -> i8x64<Self> {
         let half = self.splat_i8x32(val);
         self.combine_i8x32(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i8x64(self, val: [i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x64(self, val: &[i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x64(self, a: i8x64<Self>) -> [i8; 64usize] {
-        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
-        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x64(self, a: &mut i8x64<Self>) -> &mut [i8; 64usize] {
-        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [i8; 64usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x64<const SHIFT: usize>(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -12859,36 +12119,6 @@ impl Simd for Avx2 {
     fn splat_u8x64(self, val: u8) -> u8x64<Self> {
         let half = self.splat_u8x32(val);
         self.combine_u8x32(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u8x64(self, val: [u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x64(self, val: &[u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x64(self, a: u8x64<Self>) -> [u8; 64usize] {
-        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [u8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
-        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [u8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x64(self, a: &mut u8x64<Self>) -> &mut [u8; 64usize] {
-        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [u8; 64usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u8x64<const SHIFT: usize>(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -13513,17 +12743,6 @@ impl Simd for Avx2 {
         self.combine_mask8x32(half, half)
     }
     #[inline(always)]
-    fn load_array_mask8x64(self, val: [i8; 64usize]) -> mask8x64<Self> {
-        mask8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x64(self, a: mask8x64<Self>) -> [i8; 64usize] {
-        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x64(self, bits: u64) -> mask8x64<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -13578,9 +12797,10 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             64usize
         );
-        let mut lanes = self.as_array_mask8x64(*a);
+        let mut lanes = [0 as i8; 64usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x64(lanes);
+        *a = mask8x64::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self> {
@@ -13663,36 +12883,6 @@ impl Simd for Avx2 {
     fn splat_i16x32(self, val: i16) -> i16x32<Self> {
         let half = self.splat_i16x16(val);
         self.combine_i16x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i16x32(self, val: [i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x32(self, val: &[i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x32(self, a: i16x32<Self>) -> [i16; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
-        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x32(self, a: &mut i16x32<Self>) -> &mut [i16; 32usize] {
-        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [i16; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x32<const SHIFT: usize>(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -14117,36 +13307,6 @@ impl Simd for Avx2 {
     fn splat_u16x32(self, val: u16) -> u16x32<Self> {
         let half = self.splat_u16x16(val);
         self.combine_u16x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u16x32(self, val: [u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x32(self, val: &[u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x32(self, a: u16x32<Self>) -> [u16; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [u16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
-        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [u16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x32(self, a: &mut u16x32<Self>) -> &mut [u16; 32usize] {
-        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [u16; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x32<const SHIFT: usize>(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -14670,17 +13830,6 @@ impl Simd for Avx2 {
         self.combine_mask16x16(half, half)
     }
     #[inline(always)]
-    fn load_array_mask16x32(self, val: [i16; 32usize]) -> mask16x32<Self> {
-        mask16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x32(self, a: mask16x32<Self>) -> [i16; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x32(self, bits: u64) -> mask16x32<Self> {
         let lo = self.from_bitmask_mask16x16(bits);
         let hi = self.from_bitmask_mask16x16(bits >> 16usize);
@@ -14709,9 +13858,10 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = self.as_array_mask16x32(*a);
+        let mut lanes = [0 as i16; 32usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x32(lanes);
+        *a = mask16x32::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x32(self, a: mask16x32<Self>, b: mask16x32<Self>) -> mask16x32<Self> {
@@ -14797,36 +13947,6 @@ impl Simd for Avx2 {
     fn splat_i32x16(self, val: i32) -> i32x16<Self> {
         let half = self.splat_i32x8(val);
         self.combine_i32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i32x16(self, val: [i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x16(self, val: &[i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x16(self, a: i32x16<Self>) -> [i32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x16(self, a: &mut i32x16<Self>) -> &mut [i32; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [i32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x16<const SHIFT: usize>(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -15186,36 +14306,6 @@ impl Simd for Avx2 {
     fn splat_u32x16(self, val: u32) -> u32x16<Self> {
         let half = self.splat_u32x8(val);
         self.combine_u32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u32x16(self, val: [u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x16(self, val: &[u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x16(self, a: u32x16<Self>) -> [u32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [u32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [u32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x16(self, a: &mut u32x16<Self>) -> &mut [u32; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [u32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u32x16<const SHIFT: usize>(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -15647,17 +14737,6 @@ impl Simd for Avx2 {
         self.combine_mask32x8(half, half)
     }
     #[inline(always)]
-    fn load_array_mask32x16(self, val: [i32; 16usize]) -> mask32x16<Self> {
-        mask32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x16(self, a: mask32x16<Self>) -> [i32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x16(self, bits: u64) -> mask32x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -15698,9 +14777,10 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask32x16(*a);
+        let mut lanes = [0 as i32; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x16(lanes);
+        *a = mask32x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self> {
@@ -15783,36 +14863,6 @@ impl Simd for Avx2 {
     fn splat_f64x8(self, val: f64) -> f64x8<Self> {
         let half = self.splat_f64x4(val);
         self.combine_f64x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f64x8(self, val: [f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x8(self, val: &[f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x8(self, a: f64x8<Self>) -> [f64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m256d; 2usize], [f64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m256d; 2usize], [f64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x8(self, a: &mut f64x8<Self>) -> &mut [f64; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m256d; 2usize], [f64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x8<const SHIFT: usize>(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {
@@ -16184,36 +15234,6 @@ impl Simd for Avx2 {
         self.combine_i64x4(half, half)
     }
     #[inline(always)]
-    fn load_array_i64x8(self, val: [i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x8(self, val: &[i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x8(self, a: i64x8<Self>) -> [i64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x8(self, a: &i64x8<Self>) -> &[i64; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x8(self, a: &mut i64x8<Self>) -> &mut [i64; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [i64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x8(self, a: i64x8<Self>, dest: &mut [i64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x8<const SHIFT: usize>(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -16530,36 +15550,6 @@ impl Simd for Avx2 {
     fn splat_u64x8(self, val: u64) -> u64x8<Self> {
         let half = self.splat_u64x4(val);
         self.combine_u64x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u64x8(self, val: [u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x8(self, val: &[u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x8(self, a: u64x8<Self>) -> [u64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [u64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x8(self, a: &u64x8<Self>) -> &[u64; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m256i; 2usize], [u64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x8(self, a: &mut u64x8<Self>) -> &mut [u64; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m256i; 2usize], [u64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x8(self, a: u64x8<Self>, dest: &mut [u64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u64x8<const SHIFT: usize>(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
@@ -16923,17 +15913,6 @@ impl Simd for Avx2 {
         self.combine_mask64x4(half, half)
     }
     #[inline(always)]
-    fn load_array_mask64x8(self, val: [i64; 8usize]) -> mask64x8<Self> {
-        mask64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x8(self, a: mask64x8<Self>) -> [i64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m256i; 2usize], [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x8(self, bits: u64) -> mask64x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -16972,9 +15951,10 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask64x8(*a);
+        let mut lanes = [0 as i64; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x8(lanes);
+        *a = mask64x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x8(self, a: mask64x8<Self>, b: mask64x8<Self>) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -1639,10 +1639,9 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i8; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -2616,10 +2615,9 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i16; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -3567,10 +3565,9 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = [0 as i32; 4usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 4usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x4::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -4859,10 +4856,9 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             2usize
         );
-        let mut lanes = [0 as i64; 2usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 2usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x2::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self> {
@@ -6968,10 +6964,9 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = [0 as i8; 32usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 32usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x32::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
@@ -8270,10 +8265,9 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i16; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
@@ -9407,10 +9401,9 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i32; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
@@ -10938,10 +10931,9 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = [0 as i64; 4usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 4usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x4::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x4(self, a: mask64x4<Self>, b: mask64x4<Self>) -> mask64x4<Self> {
@@ -12797,10 +12789,9 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             64usize
         );
-        let mut lanes = [0 as i8; 64usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 64usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x64::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self> {
@@ -13858,10 +13849,9 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = [0 as i16; 32usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 32usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x32::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x32(self, a: mask16x32<Self>, b: mask16x32<Self>) -> mask16x32<Self> {
@@ -14777,10 +14767,9 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i32; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self> {
@@ -15951,10 +15940,9 @@ impl Simd for Avx2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i64; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x8(self, a: mask64x8<Self>, b: mask64x8<Self>) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -91,6 +91,270 @@ impl ArchTypes for Avx512 {
     type i64x8 = crate::support::Aligned512<__m512i>;
     type u64x8 = crate::support::Aligned512<__m512i>;
     type mask64x8 = __mmask8;
+    #[inline(always)]
+    fn mask8x16_from_array(self, val: [i8; 16usize]) -> Self::mask8x16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: [i8; 16usize]) -> __mmask16 {
+                let lanes = crate::transmute::checked_transmute_copy(&val);
+                _mm_movepi8_mask(lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask8x16_to_array(self, val: Self::mask8x16) -> [i8; 16usize] {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: __mmask16) -> [i8; 16usize] {
+                let lanes = _mm_movm_epi8(val);
+                crate::transmute::checked_transmute_copy(&lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask16x8_from_array(self, val: [i16; 8usize]) -> Self::mask16x8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: [i16; 8usize]) -> __mmask8 {
+                let lanes = crate::transmute::checked_transmute_copy(&val);
+                _mm_movepi16_mask(lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask16x8_to_array(self, val: Self::mask16x8) -> [i16; 8usize] {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: __mmask8) -> [i16; 8usize] {
+                let lanes = _mm_movm_epi16(val);
+                crate::transmute::checked_transmute_copy(&lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask32x4_from_array(self, val: [i32; 4usize]) -> Self::mask32x4 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: [i32; 4usize]) -> __mmask8 {
+                let lanes = crate::transmute::checked_transmute_copy(&val);
+                _mm_movepi32_mask(lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask32x4_to_array(self, val: Self::mask32x4) -> [i32; 4usize] {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: __mmask8) -> [i32; 4usize] {
+                let lanes = _mm_movm_epi32(val);
+                crate::transmute::checked_transmute_copy(&lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask64x2_from_array(self, val: [i64; 2usize]) -> Self::mask64x2 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: [i64; 2usize]) -> __mmask8 {
+                let lanes = crate::transmute::checked_transmute_copy(&val);
+                _mm_movepi64_mask(lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask64x2_to_array(self, val: Self::mask64x2) -> [i64; 2usize] {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: __mmask8) -> [i64; 2usize] {
+                let lanes = _mm_movm_epi64(val);
+                crate::transmute::checked_transmute_copy(&lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask8x32_from_array(self, val: [i8; 32usize]) -> Self::mask8x32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: [i8; 32usize]) -> __mmask32 {
+                let lanes = crate::transmute::checked_transmute_copy(&val);
+                _mm256_movepi8_mask(lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask8x32_to_array(self, val: Self::mask8x32) -> [i8; 32usize] {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: __mmask32) -> [i8; 32usize] {
+                let lanes = _mm256_movm_epi8(val);
+                crate::transmute::checked_transmute_copy(&lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask16x16_from_array(self, val: [i16; 16usize]) -> Self::mask16x16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: [i16; 16usize]) -> __mmask16 {
+                let lanes = crate::transmute::checked_transmute_copy(&val);
+                _mm256_movepi16_mask(lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask16x16_to_array(self, val: Self::mask16x16) -> [i16; 16usize] {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: __mmask16) -> [i16; 16usize] {
+                let lanes = _mm256_movm_epi16(val);
+                crate::transmute::checked_transmute_copy(&lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask32x8_from_array(self, val: [i32; 8usize]) -> Self::mask32x8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: [i32; 8usize]) -> __mmask8 {
+                let lanes = crate::transmute::checked_transmute_copy(&val);
+                _mm256_movepi32_mask(lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask32x8_to_array(self, val: Self::mask32x8) -> [i32; 8usize] {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: __mmask8) -> [i32; 8usize] {
+                let lanes = _mm256_movm_epi32(val);
+                crate::transmute::checked_transmute_copy(&lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask64x4_from_array(self, val: [i64; 4usize]) -> Self::mask64x4 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: [i64; 4usize]) -> __mmask8 {
+                let lanes = crate::transmute::checked_transmute_copy(&val);
+                _mm256_movepi64_mask(lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask64x4_to_array(self, val: Self::mask64x4) -> [i64; 4usize] {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: __mmask8) -> [i64; 4usize] {
+                let lanes = _mm256_movm_epi64(val);
+                crate::transmute::checked_transmute_copy(&lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask8x64_from_array(self, val: [i8; 64usize]) -> Self::mask8x64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: [i8; 64usize]) -> __mmask64 {
+                let lanes = crate::transmute::checked_transmute_copy(&val);
+                _mm512_movepi8_mask(lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask8x64_to_array(self, val: Self::mask8x64) -> [i8; 64usize] {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: __mmask64) -> [i8; 64usize] {
+                let lanes = _mm512_movm_epi8(val);
+                crate::transmute::checked_transmute_copy(&lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask16x32_from_array(self, val: [i16; 32usize]) -> Self::mask16x32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: [i16; 32usize]) -> __mmask32 {
+                let lanes = crate::transmute::checked_transmute_copy(&val);
+                _mm512_movepi16_mask(lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask16x32_to_array(self, val: Self::mask16x32) -> [i16; 32usize] {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: __mmask32) -> [i16; 32usize] {
+                let lanes = _mm512_movm_epi16(val);
+                crate::transmute::checked_transmute_copy(&lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask32x16_from_array(self, val: [i32; 16usize]) -> Self::mask32x16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: [i32; 16usize]) -> __mmask16 {
+                let lanes = crate::transmute::checked_transmute_copy(&val);
+                _mm512_movepi32_mask(lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask32x16_to_array(self, val: Self::mask32x16) -> [i32; 16usize] {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: __mmask16) -> [i32; 16usize] {
+                let lanes = _mm512_movm_epi32(val);
+                crate::transmute::checked_transmute_copy(&lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask64x8_from_array(self, val: [i64; 8usize]) -> Self::mask64x8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: [i64; 8usize]) -> __mmask8 {
+                let lanes = crate::transmute::checked_transmute_copy(&val);
+                _mm512_movepi64_mask(lanes)
+            }
+        );
+        kernel(self, val)
+    }
+    #[inline(always)]
+    fn mask64x8_to_array(self, val: Self::mask64x8) -> [i64; 8usize] {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(_token: Avx512, val: __mmask8) -> [i64; 8usize] {
+                let lanes = _mm512_movm_epi64(val);
+                crate::transmute::checked_transmute_copy(&lanes)
+            }
+        );
+        kernel(self, val)
+    }
 }
 impl Simd for Avx512 {
     type f32s = f32x16<Self>;
@@ -130,36 +394,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_f32x4(self, val: [f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x4(self, val: &[f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x4(self, a: f32x4<Self>) -> [f32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128, [f32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
-        crate::transmute::checked_cast_ref::<__m128, [f32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x4(self, a: &mut f32x4<Self>) -> &mut [f32; 4usize] {
-        crate::transmute::checked_cast_mut::<__m128, [f32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
@@ -682,36 +916,6 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_i8x16(self, val: [i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x16(self, val: &[i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x16(self, a: i8x16<Self>) -> [i8; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x16(self, a: &mut i8x16<Self>) -> &mut [i8; 16usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i8; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         if SHIFT >= 16usize {
             return b;
@@ -1228,36 +1432,6 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x16(self, val: &[u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x16(self, a: u8x16<Self>) -> [u8; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x16(self, a: &mut u8x16<Self>) -> &mut [u8; 16usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u8; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
         if SHIFT >= 16usize {
             return b;
@@ -1768,31 +1942,6 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
-    fn load_array_mask8x16(self, val: [i8; 16usize]) -> mask8x16<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, val: [i8; 16usize]) -> mask8x16<Avx512> {
-                let lanes = crate::transmute::checked_transmute_copy(&val);
-                mask8x16 {
-                    val: _mm_movepi8_mask(lanes),
-                    simd: token,
-                }
-            }
-        );
-        kernel(self, val)
-    }
-    #[inline(always)]
-    fn as_array_mask8x16(self, a: mask8x16<Self>) -> [i8; 16usize] {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, a: mask8x16<Avx512>) -> [i8; 16usize] {
-                let lanes = _mm_movm_epi8(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
-            }
-        );
-        kernel(self, a)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x16(self, bits: u64) -> mask8x16<Self> {
         mask8x16 {
             val: (bits & 65535u64) as _,
@@ -1904,36 +2053,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i16x8(self, val: [i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x8(self, val: &[i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x8(self, a: i16x8<Self>) -> [i16; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x8(self, a: &mut i16x8<Self>) -> &mut [i16; 8usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i16; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
@@ -2370,36 +2489,6 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x8(self, val: &[u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x8(self, a: u16x8<Self>) -> [u16; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x8(self, a: &mut u16x8<Self>) -> &mut [u16; 8usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u16; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -2821,31 +2910,6 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
-    fn load_array_mask16x8(self, val: [i16; 8usize]) -> mask16x8<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, val: [i16; 8usize]) -> mask16x8<Avx512> {
-                let lanes = crate::transmute::checked_transmute_copy(&val);
-                mask16x8 {
-                    val: _mm_movepi16_mask(lanes),
-                    simd: token,
-                }
-            }
-        );
-        kernel(self, val)
-    }
-    #[inline(always)]
-    fn as_array_mask16x8(self, a: mask16x8<Self>) -> [i16; 8usize] {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, a: mask16x8<Avx512>) -> [i16; 8usize] {
-                let lanes = _mm_movm_epi16(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
-            }
-        );
-        kernel(self, a)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x8(self, bits: u64) -> mask16x8<Self> {
         mask16x8 {
             val: (bits & 255u64) as _,
@@ -2957,36 +3021,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i32x4(self, val: [i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x4(self, val: &[i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x4(self, a: i32x4<Self>) -> [i32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x4(self, a: &mut i32x4<Self>) -> &mut [i32; 4usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
@@ -3407,36 +3441,6 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x4(self, val: &[u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x4(self, a: u32x4<Self>) -> [u32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x4(self, a: &mut u32x4<Self>) -> &mut [u32; 4usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -3843,31 +3847,6 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
-    fn load_array_mask32x4(self, val: [i32; 4usize]) -> mask32x4<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, val: [i32; 4usize]) -> mask32x4<Avx512> {
-                let lanes = crate::transmute::checked_transmute_copy(&val);
-                mask32x4 {
-                    val: _mm_movepi32_mask(lanes),
-                    simd: token,
-                }
-            }
-        );
-        kernel(self, val)
-    }
-    #[inline(always)]
-    fn as_array_mask32x4(self, a: mask32x4<Self>) -> [i32; 4usize] {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, a: mask32x4<Avx512>) -> [i32; 4usize] {
-                let lanes = _mm_movm_epi32(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
-            }
-        );
-        kernel(self, a)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x4(self, bits: u64) -> mask32x4<Self> {
         mask32x4 {
             val: (bits & 15u64) as _,
@@ -3979,36 +3958,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_f64x2(self, val: [f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x2(self, val: &[f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x2(self, a: f64x2<Self>) -> [f64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128d, [f64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
-        crate::transmute::checked_cast_ref::<__m128d, [f64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x2(self, a: &mut f64x2<Self>) -> &mut [f64; 2usize] {
-        crate::transmute::checked_cast_mut::<__m128d, [f64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
@@ -4470,36 +4419,6 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_i64x2(self, val: [i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x2(self, val: &[i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x2(self, a: i64x2<Self>) -> [i64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x2(self, a: &i64x2<Self>) -> &[i64; 2usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x2(self, a: &mut i64x2<Self>) -> &mut [i64; 2usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x2(self, a: i64x2<Self>, dest: &mut [i64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -4898,36 +4817,6 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u64x2(self, val: [u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x2(self, val: &[u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x2(self, a: u64x2<Self>) -> [u64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x2(self, a: &u64x2<Self>) -> &[u64; 2usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x2(self, a: &mut u64x2<Self>) -> &mut [u64; 2usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x2(self, a: u64x2<Self>, dest: &mut [u64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -5313,31 +5202,6 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
-    fn load_array_mask64x2(self, val: [i64; 2usize]) -> mask64x2<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, val: [i64; 2usize]) -> mask64x2<Avx512> {
-                let lanes = crate::transmute::checked_transmute_copy(&val);
-                mask64x2 {
-                    val: _mm_movepi64_mask(lanes),
-                    simd: token,
-                }
-            }
-        );
-        kernel(self, val)
-    }
-    #[inline(always)]
-    fn as_array_mask64x2(self, a: mask64x2<Self>) -> [i64; 2usize] {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, a: mask64x2<Avx512>) -> [i64; 2usize] {
-                let lanes = _mm_movm_epi64(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
-            }
-        );
-        kernel(self, a)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x2(self, bits: u64) -> mask64x2<Self> {
         mask64x2 {
             val: (bits & 3u64) as _,
@@ -5449,36 +5313,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_f32x8(self, val: [f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x8(self, val: &[f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x8(self, a: f32x8<Self>) -> [f32; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m256, [f32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
-        crate::transmute::checked_cast_ref::<__m256, [f32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x8(self, a: &mut f32x8<Self>) -> &mut [f32; 8usize] {
-        crate::transmute::checked_cast_mut::<__m256, [f32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x8<const SHIFT: usize>(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -6116,36 +5950,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i8x32(self, val: [i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x32(self, val: &[i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x32(self, a: i8x32<Self>) -> [i8; 32usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x32(self, a: &mut i8x32<Self>) -> &mut [i8; 32usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [i8; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x32<const SHIFT: usize>(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -6835,36 +6639,6 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x32(self, val: &[u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x32(self, a: u8x32<Self>) -> [u8; 32usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [u8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [u8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x32(self, a: &mut u8x32<Self>) -> &mut [u8; 32usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [u8; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u8x32<const SHIFT: usize>(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7546,31 +7320,6 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
-    fn load_array_mask8x32(self, val: [i8; 32usize]) -> mask8x32<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, val: [i8; 32usize]) -> mask8x32<Avx512> {
-                let lanes = crate::transmute::checked_transmute_copy(&val);
-                mask8x32 {
-                    val: _mm256_movepi8_mask(lanes),
-                    simd: token,
-                }
-            }
-        );
-        kernel(self, val)
-    }
-    #[inline(always)]
-    fn as_array_mask8x32(self, a: mask8x32<Self>) -> [i8; 32usize] {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, a: mask8x32<Avx512>) -> [i8; 32usize] {
-                let lanes = _mm256_movm_epi8(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
-            }
-        );
-        kernel(self, a)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x32(self, bits: u64) -> mask8x32<Self> {
         mask8x32 {
             val: (bits & 4294967295u64) as _,
@@ -7696,36 +7445,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i16x16(self, val: [i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x16(self, val: &[i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x16(self, a: i16x16<Self>) -> [i16; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x16(self, a: &mut i16x16<Self>) -> &mut [i16; 16usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [i16; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x16<const SHIFT: usize>(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -8289,36 +8008,6 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x16(self, val: &[u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x16(self, a: u16x16<Self>) -> [u16; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [u16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [u16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x16(self, a: &mut u16x16<Self>) -> &mut [u16; 16usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [u16; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u16x16<const SHIFT: usize>(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -8877,31 +8566,6 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
-    fn load_array_mask16x16(self, val: [i16; 16usize]) -> mask16x16<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, val: [i16; 16usize]) -> mask16x16<Avx512> {
-                let lanes = crate::transmute::checked_transmute_copy(&val);
-                mask16x16 {
-                    val: _mm256_movepi16_mask(lanes),
-                    simd: token,
-                }
-            }
-        );
-        kernel(self, val)
-    }
-    #[inline(always)]
-    fn as_array_mask16x16(self, a: mask16x16<Self>) -> [i16; 16usize] {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, a: mask16x16<Avx512>) -> [i16; 16usize] {
-                let lanes = _mm256_movm_epi16(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
-            }
-        );
-        kernel(self, a)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x16(self, bits: u64) -> mask16x16<Self> {
         mask16x16 {
             val: (bits & 65535u64) as _,
@@ -9027,36 +8691,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i32x8(self, val: [i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x8(self, val: &[i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x8(self, a: i32x8<Self>) -> [i32; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x8(self, a: &mut i32x8<Self>) -> &mut [i32; 8usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [i32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x8<const SHIFT: usize>(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -9572,36 +9206,6 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x8(self, val: &[u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x8(self, a: u32x8<Self>) -> [u32; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [u32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [u32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x8(self, a: &mut u32x8<Self>) -> &mut [u32; 8usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [u32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u32x8<const SHIFT: usize>(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -10103,31 +9707,6 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
-    fn load_array_mask32x8(self, val: [i32; 8usize]) -> mask32x8<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, val: [i32; 8usize]) -> mask32x8<Avx512> {
-                let lanes = crate::transmute::checked_transmute_copy(&val);
-                mask32x8 {
-                    val: _mm256_movepi32_mask(lanes),
-                    simd: token,
-                }
-            }
-        );
-        kernel(self, val)
-    }
-    #[inline(always)]
-    fn as_array_mask32x8(self, a: mask32x8<Self>) -> [i32; 8usize] {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, a: mask32x8<Avx512>) -> [i32; 8usize] {
-                let lanes = _mm256_movm_epi32(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
-            }
-        );
-        kernel(self, a)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x8(self, bits: u64) -> mask32x8<Self> {
         mask32x8 {
             val: (bits & 255u64) as _,
@@ -10253,36 +9832,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_f64x4(self, val: [f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x4(self, val: &[f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x4(self, a: f64x4<Self>) -> [f64; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m256d, [f64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
-        crate::transmute::checked_cast_ref::<__m256d, [f64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x4(self, a: &mut f64x4<Self>) -> &mut [f64; 4usize] {
-        crate::transmute::checked_cast_mut::<__m256d, [f64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x4<const SHIFT: usize>(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
@@ -10831,36 +10380,6 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_i64x4(self, val: [i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x4(self, val: &[i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x4(self, a: i64x4<Self>) -> [i64; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x4(self, a: &i64x4<Self>) -> &[i64; 4usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x4(self, a: &mut i64x4<Self>) -> &mut [i64; 4usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [i64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x4(self, a: i64x4<Self>, dest: &mut [i64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x4<const SHIFT: usize>(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -11332,36 +10851,6 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u64x4(self, val: [u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x4(self, val: &[u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x4(self, a: u64x4<Self>) -> [u64; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m256i, [u64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x4(self, a: &u64x4<Self>) -> &[u64; 4usize] {
-        crate::transmute::checked_cast_ref::<__m256i, [u64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x4(self, a: &mut u64x4<Self>) -> &mut [u64; 4usize] {
-        crate::transmute::checked_cast_mut::<__m256i, [u64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x4(self, a: u64x4<Self>, dest: &mut [u64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u64x4<const SHIFT: usize>(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -11820,31 +11309,6 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
-    fn load_array_mask64x4(self, val: [i64; 4usize]) -> mask64x4<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, val: [i64; 4usize]) -> mask64x4<Avx512> {
-                let lanes = crate::transmute::checked_transmute_copy(&val);
-                mask64x4 {
-                    val: _mm256_movepi64_mask(lanes),
-                    simd: token,
-                }
-            }
-        );
-        kernel(self, val)
-    }
-    #[inline(always)]
-    fn as_array_mask64x4(self, a: mask64x4<Self>) -> [i64; 4usize] {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, a: mask64x4<Avx512>) -> [i64; 4usize] {
-                let lanes = _mm256_movm_epi64(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
-            }
-        );
-        kernel(self, a)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x4(self, bits: u64) -> mask64x4<Self> {
         mask64x4 {
             val: (bits & 15u64) as _,
@@ -11970,36 +11434,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_f32x16(self, val: [f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x16(self, val: &[f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x16(self, a: f32x16<Self>) -> [f32; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m512, [f32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
-        crate::transmute::checked_cast_ref::<__m512, [f32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x16(self, a: &mut f32x16<Self>) -> &mut [f32; 16usize] {
-        crate::transmute::checked_cast_mut::<__m512, [f32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x16<const SHIFT: usize>(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -12716,36 +12150,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i8x64(self, val: [i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x64(self, val: &[i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x64(self, a: i8x64<Self>) -> [i8; 64usize] {
-        crate::transmute::checked_transmute_copy::<__m512i, [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
-        crate::transmute::checked_cast_ref::<__m512i, [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x64(self, a: &mut i8x64<Self>) -> &mut [i8; 64usize] {
-        crate::transmute::checked_cast_mut::<__m512i, [i8; 64usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x64<const SHIFT: usize>(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -13569,36 +12973,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u8x64(self, val: [u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x64(self, val: &[u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x64(self, a: u8x64<Self>) -> [u8; 64usize] {
-        crate::transmute::checked_transmute_copy::<__m512i, [u8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
-        crate::transmute::checked_cast_ref::<__m512i, [u8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x64(self, a: &mut u8x64<Self>) -> &mut [u8; 64usize] {
-        crate::transmute::checked_cast_mut::<__m512i, [u8; 64usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u8x64<const SHIFT: usize>(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -14447,31 +13821,6 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
-    fn load_array_mask8x64(self, val: [i8; 64usize]) -> mask8x64<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, val: [i8; 64usize]) -> mask8x64<Avx512> {
-                let lanes = crate::transmute::checked_transmute_copy(&val);
-                mask8x64 {
-                    val: _mm512_movepi8_mask(lanes),
-                    simd: token,
-                }
-            }
-        );
-        kernel(self, val)
-    }
-    #[inline(always)]
-    fn as_array_mask8x64(self, a: mask8x64<Self>) -> [i8; 64usize] {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, a: mask8x64<Avx512>) -> [i8; 64usize] {
-                let lanes = _mm512_movm_epi8(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
-            }
-        );
-        kernel(self, a)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x64(self, bits: u64) -> mask8x64<Self> {
         mask8x64 {
             val: bits & u64::MAX,
@@ -14589,36 +13938,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i16x32(self, val: [i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x32(self, val: &[i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x32(self, a: i16x32<Self>) -> [i16; 32usize] {
-        crate::transmute::checked_transmute_copy::<__m512i, [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
-        crate::transmute::checked_cast_ref::<__m512i, [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x32(self, a: &mut i16x32<Self>) -> &mut [i16; 32usize] {
-        crate::transmute::checked_cast_mut::<__m512i, [i16; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x32<const SHIFT: usize>(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -15253,36 +14572,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u16x32(self, val: [u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x32(self, val: &[u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x32(self, a: u16x32<Self>) -> [u16; 32usize] {
-        crate::transmute::checked_transmute_copy::<__m512i, [u16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
-        crate::transmute::checked_cast_ref::<__m512i, [u16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x32(self, a: &mut u16x32<Self>) -> &mut [u16; 32usize] {
-        crate::transmute::checked_cast_mut::<__m512i, [u16; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x32<const SHIFT: usize>(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -15952,31 +15241,6 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
-    fn load_array_mask16x32(self, val: [i16; 32usize]) -> mask16x32<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, val: [i16; 32usize]) -> mask16x32<Avx512> {
-                let lanes = crate::transmute::checked_transmute_copy(&val);
-                mask16x32 {
-                    val: _mm512_movepi16_mask(lanes),
-                    simd: token,
-                }
-            }
-        );
-        kernel(self, val)
-    }
-    #[inline(always)]
-    fn as_array_mask16x32(self, a: mask16x32<Self>) -> [i16; 32usize] {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, a: mask16x32<Avx512>) -> [i16; 32usize] {
-                let lanes = _mm512_movm_epi16(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
-            }
-        );
-        kernel(self, a)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x32(self, bits: u64) -> mask16x32<Self> {
         mask16x32 {
             val: (bits & 4294967295u64) as _,
@@ -16094,36 +15358,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i32x16(self, val: [i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x16(self, val: &[i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x16(self, a: i32x16<Self>) -> [i32; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m512i, [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
-        crate::transmute::checked_cast_ref::<__m512i, [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x16(self, a: &mut i32x16<Self>) -> &mut [i32; 16usize] {
-        crate::transmute::checked_cast_mut::<__m512i, [i32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x16<const SHIFT: usize>(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -16686,36 +15920,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u32x16(self, val: [u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x16(self, val: &[u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x16(self, a: u32x16<Self>) -> [u32; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m512i, [u32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
-        crate::transmute::checked_cast_ref::<__m512i, [u32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x16(self, a: &mut u32x16<Self>) -> &mut [u32; 16usize] {
-        crate::transmute::checked_cast_mut::<__m512i, [u32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u32x16<const SHIFT: usize>(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -17297,31 +16501,6 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
-    fn load_array_mask32x16(self, val: [i32; 16usize]) -> mask32x16<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, val: [i32; 16usize]) -> mask32x16<Avx512> {
-                let lanes = crate::transmute::checked_transmute_copy(&val);
-                mask32x16 {
-                    val: _mm512_movepi32_mask(lanes),
-                    simd: token,
-                }
-            }
-        );
-        kernel(self, val)
-    }
-    #[inline(always)]
-    fn as_array_mask32x16(self, a: mask32x16<Self>) -> [i32; 16usize] {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, a: mask32x16<Avx512>) -> [i32; 16usize] {
-                let lanes = _mm512_movm_epi32(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
-            }
-        );
-        kernel(self, a)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x16(self, bits: u64) -> mask32x16<Self> {
         mask32x16 {
             val: (bits & 65535u64) as _,
@@ -17439,36 +16618,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_f64x8(self, val: [f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x8(self, val: &[f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x8(self, a: f64x8<Self>) -> [f64; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m512d, [f64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
-        crate::transmute::checked_cast_ref::<__m512d, [f64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x8(self, a: &mut f64x8<Self>) -> &mut [f64; 8usize] {
-        crate::transmute::checked_cast_mut::<__m512d, [f64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x8<const SHIFT: usize>(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {
@@ -18044,36 +17193,6 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_i64x8(self, val: [i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x8(self, val: &[i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x8(self, a: i64x8<Self>) -> [i64; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m512i, [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x8(self, a: &i64x8<Self>) -> &[i64; 8usize] {
-        crate::transmute::checked_cast_ref::<__m512i, [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x8(self, a: &mut i64x8<Self>) -> &mut [i64; 8usize] {
-        crate::transmute::checked_cast_mut::<__m512i, [i64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x8(self, a: i64x8<Self>, dest: &mut [i64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x8<const SHIFT: usize>(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -18566,36 +17685,6 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u64x8(self, val: [u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x8(self, val: &[u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x8(self, a: u64x8<Self>) -> [u64; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m512i, [u64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x8(self, a: &u64x8<Self>) -> &[u64; 8usize] {
-        crate::transmute::checked_cast_ref::<__m512i, [u64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x8(self, a: &mut u64x8<Self>) -> &mut [u64; 8usize] {
-        crate::transmute::checked_cast_mut::<__m512i, [u64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x8(self, a: u64x8<Self>, dest: &mut [u64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u64x8<const SHIFT: usize>(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
@@ -19102,31 +18191,6 @@ impl Simd for Avx512 {
             val: (if val { 255u64 } else { 0 }) as _,
             simd: self,
         }
-    }
-    #[inline(always)]
-    fn load_array_mask64x8(self, val: [i64; 8usize]) -> mask64x8<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, val: [i64; 8usize]) -> mask64x8<Avx512> {
-                let lanes = crate::transmute::checked_transmute_copy(&val);
-                mask64x8 {
-                    val: _mm512_movepi64_mask(lanes),
-                    simd: token,
-                }
-            }
-        );
-        kernel(self, val)
-    }
-    #[inline(always)]
-    fn as_array_mask64x8(self, a: mask64x8<Self>) -> [i64; 8usize] {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Avx512, a: mask64x8<Avx512>) -> [i64; 8usize] {
-                let lanes = _mm512_movm_epi64(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
-            }
-        );
-        kernel(self, a)
     }
     #[inline(always)]
     fn from_bitmask_mask64x8(self, bits: u64) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -169,36 +169,6 @@ impl Simd for Fallback {
         [val; 4usize].simd_into(self)
     }
     #[inline(always)]
-    fn load_array_f32x4(self, val: [f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x4(self, val: &[f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::support::Aligned128(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x4(self, a: f32x4<Self>) -> [f32; 4usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x4(self, a: &mut f32x4<Self>) -> &mut [f32; 4usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
-        *dest = a.val.0;
-    }
-    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         let mut dest = [Default::default(); 4usize];
         dest[..4usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -681,36 +651,6 @@ impl Simd for Fallback {
     #[inline(always)]
     fn splat_i8x16(self, val: i8) -> i8x16<Self> {
         [val; 16usize].simd_into(self)
-    }
-    #[inline(always)]
-    fn load_array_i8x16(self, val: [i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x16(self, val: &[i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::support::Aligned128(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x16(self, a: i8x16<Self>) -> [i8; 16usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x16(self, a: &mut i8x16<Self>) -> &mut [i8; 16usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
@@ -1468,36 +1408,6 @@ impl Simd for Fallback {
     #[inline(always)]
     fn splat_u8x16(self, val: u8) -> u8x16<Self> {
         [val; 16usize].simd_into(self)
-    }
-    #[inline(always)]
-    fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x16(self, val: &[u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::support::Aligned128(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x16(self, a: u8x16<Self>) -> [u8; 16usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x16(self, a: &mut u8x16<Self>) -> &mut [u8; 16usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -2258,17 +2168,6 @@ impl Simd for Fallback {
         [val; 16usize].simd_into(self)
     }
     #[inline(always)]
-    fn load_array_mask8x16(self, val: [i8; 16usize]) -> mask8x16<Self> {
-        mask8x16 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x16(self, a: mask8x16<Self>) -> [i8; 16usize] {
-        a.val.0
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x16(self, bits: u64) -> mask8x16<Self> {
         let lanes: [i8; 16usize] = [
             if bits & 1 != 0 { !0 } else { 0 },
@@ -2292,7 +2191,8 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn to_bitmask_mask8x16(self, a: mask8x16<Self>) -> u64 {
-        let lanes = self.as_array_mask8x16(a);
+        let mut lanes = [0 as i8; 16usize];
+        a.store_slice(&mut lanes);
         let mut bits = 0u64;
         let mut i = 0;
         while i < 16usize {
@@ -2310,9 +2210,10 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask8x16(*a);
+        let mut lanes = [0 as i8; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x16(lanes);
+        *a = mask8x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -2601,36 +2502,6 @@ impl Simd for Fallback {
     #[inline(always)]
     fn splat_i16x8(self, val: i16) -> i16x8<Self> {
         [val; 8usize].simd_into(self)
-    }
-    #[inline(always)]
-    fn load_array_i16x8(self, val: [i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x8(self, val: &[i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::support::Aligned128(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x8(self, a: i16x8<Self>) -> [i16; 8usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x8(self, a: &mut i16x8<Self>) -> &mut [i16; 8usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
@@ -3159,36 +3030,6 @@ impl Simd for Fallback {
         [val; 8usize].simd_into(self)
     }
     #[inline(always)]
-    fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x8(self, val: &[u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::support::Aligned128(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x8(self, a: u16x8<Self>) -> [u16; 8usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x8(self, a: &mut u16x8<Self>) -> &mut [u16; 8usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
-        *dest = a.val.0;
-    }
-    #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
         let mut dest = [Default::default(); 8usize];
         dest[..8usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -3702,17 +3543,6 @@ impl Simd for Fallback {
         [val; 8usize].simd_into(self)
     }
     #[inline(always)]
-    fn load_array_mask16x8(self, val: [i16; 8usize]) -> mask16x8<Self> {
-        mask16x8 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x8(self, a: mask16x8<Self>) -> [i16; 8usize] {
-        a.val.0
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x8(self, bits: u64) -> mask16x8<Self> {
         let lanes: [i16; 8usize] = [
             if bits & 1 != 0 { !0 } else { 0 },
@@ -3728,7 +3558,8 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn to_bitmask_mask16x8(self, a: mask16x8<Self>) -> u64 {
-        let lanes = self.as_array_mask16x8(a);
+        let mut lanes = [0 as i16; 8usize];
+        a.store_slice(&mut lanes);
         let mut bits = 0u64;
         let mut i = 0;
         while i < 8usize {
@@ -3746,9 +3577,10 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask16x8(*a);
+        let mut lanes = [0 as i16; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x8(lanes);
+        *a = mask16x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -3925,36 +3757,6 @@ impl Simd for Fallback {
     #[inline(always)]
     fn splat_i32x4(self, val: i32) -> i32x4<Self> {
         [val; 4usize].simd_into(self)
-    }
-    #[inline(always)]
-    fn load_array_i32x4(self, val: [i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x4(self, val: &[i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::support::Aligned128(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x4(self, a: i32x4<Self>) -> [i32; 4usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x4(self, a: &mut i32x4<Self>) -> &mut [i32; 4usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
@@ -4369,36 +4171,6 @@ impl Simd for Fallback {
         [val; 4usize].simd_into(self)
     }
     #[inline(always)]
-    fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x4(self, val: &[u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::support::Aligned128(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x4(self, a: u32x4<Self>) -> [u32; 4usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x4(self, a: &mut u32x4<Self>) -> &mut [u32; 4usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
-        *dest = a.val.0;
-    }
-    #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
         let mut dest = [Default::default(); 4usize];
         dest[..4usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -4802,17 +4574,6 @@ impl Simd for Fallback {
         [val; 4usize].simd_into(self)
     }
     #[inline(always)]
-    fn load_array_mask32x4(self, val: [i32; 4usize]) -> mask32x4<Self> {
-        mask32x4 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x4(self, a: mask32x4<Self>) -> [i32; 4usize] {
-        a.val.0
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x4(self, bits: u64) -> mask32x4<Self> {
         let lanes: [i32; 4usize] = [
             if bits & 1 != 0 { !0 } else { 0 },
@@ -4824,7 +4585,8 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn to_bitmask_mask32x4(self, a: mask32x4<Self>) -> u64 {
-        let lanes = self.as_array_mask32x4(a);
+        let mut lanes = [0 as i32; 4usize];
+        a.store_slice(&mut lanes);
         let mut bits = 0u64;
         let mut i = 0;
         while i < 4usize {
@@ -4842,9 +4604,10 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = self.as_array_mask32x4(*a);
+        let mut lanes = [0 as i32; 4usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x4(lanes);
+        *a = mask32x4::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -4953,36 +4716,6 @@ impl Simd for Fallback {
     #[inline(always)]
     fn splat_f64x2(self, val: f64) -> f64x2<Self> {
         [val; 2usize].simd_into(self)
-    }
-    #[inline(always)]
-    fn load_array_f64x2(self, val: [f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x2(self, val: &[f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::support::Aligned128(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x2(self, a: f64x2<Self>) -> [f64; 2usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x2(self, a: &mut f64x2<Self>) -> &mut [f64; 2usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
@@ -5339,36 +5072,6 @@ impl Simd for Fallback {
         [val; 2usize].simd_into(self)
     }
     #[inline(always)]
-    fn load_array_i64x2(self, val: [i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x2(self, val: &[i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::support::Aligned128(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x2(self, a: i64x2<Self>) -> [i64; 2usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x2(self, a: &i64x2<Self>) -> &[i64; 2usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x2(self, a: &mut i64x2<Self>) -> &mut [i64; 2usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_i64x2(self, a: i64x2<Self>, dest: &mut [i64; 2usize]) -> () {
-        *dest = a.val.0;
-    }
-    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         let mut dest = [Default::default(); 2usize];
         dest[..2usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -5707,36 +5410,6 @@ impl Simd for Fallback {
         [val; 2usize].simd_into(self)
     }
     #[inline(always)]
-    fn load_array_u64x2(self, val: [u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x2(self, val: &[u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::support::Aligned128(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x2(self, a: u64x2<Self>) -> [u64; 2usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x2(self, a: &u64x2<Self>) -> &[u64; 2usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x2(self, a: &mut u64x2<Self>) -> &mut [u64; 2usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_u64x2(self, a: u64x2<Self>, dest: &mut [u64; 2usize]) -> () {
-        *dest = a.val.0;
-    }
-    #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
         let mut dest = [Default::default(); 2usize];
         dest[..2usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -6072,17 +5745,6 @@ impl Simd for Fallback {
         [val; 2usize].simd_into(self)
     }
     #[inline(always)]
-    fn load_array_mask64x2(self, val: [i64; 2usize]) -> mask64x2<Self> {
-        mask64x2 {
-            val: crate::support::Aligned128(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x2(self, a: mask64x2<Self>) -> [i64; 2usize] {
-        a.val.0
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x2(self, bits: u64) -> mask64x2<Self> {
         let lanes: [i64; 2usize] = [
             if bits & 1 != 0 { !0 } else { 0 },
@@ -6092,7 +5754,8 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn to_bitmask_mask64x2(self, a: mask64x2<Self>) -> u64 {
-        let lanes = self.as_array_mask64x2(a);
+        let mut lanes = [0 as i64; 2usize];
+        a.store_slice(&mut lanes);
         let mut bits = 0u64;
         let mut i = 0;
         while i < 2usize {
@@ -6110,9 +5773,10 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             2usize
         );
-        let mut lanes = self.as_array_mask64x2(*a);
+        let mut lanes = [0 as i64; 2usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x2(lanes);
+        *a = mask64x2::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self> {
@@ -6198,36 +5862,6 @@ impl Simd for Fallback {
     fn splat_f32x8(self, val: f32) -> f32x8<Self> {
         let half = self.splat_f32x4(val);
         self.combine_f32x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f32x8(self, val: [f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x8(self, val: &[f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::support::Aligned256(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x8(self, a: f32x8<Self>) -> [f32; 8usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x8(self, a: &mut f32x8<Self>) -> &mut [f32; 8usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_f32x8<const SHIFT: usize>(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -6601,36 +6235,6 @@ impl Simd for Fallback {
     fn splat_i8x32(self, val: i8) -> i8x32<Self> {
         let half = self.splat_i8x16(val);
         self.combine_i8x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i8x32(self, val: [i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x32(self, val: &[i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::support::Aligned256(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x32(self, a: i8x32<Self>) -> [i8; 32usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x32(self, a: &mut i8x32<Self>) -> &mut [i8; 32usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_i8x32<const SHIFT: usize>(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -7025,36 +6629,6 @@ impl Simd for Fallback {
         self.combine_u8x16(half, half)
     }
     #[inline(always)]
-    fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x32(self, val: &[u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::support::Aligned256(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x32(self, a: u8x32<Self>) -> [u8; 32usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x32(self, a: &mut u8x32<Self>) -> &mut [u8; 32usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
-        *dest = a.val.0;
-    }
-    #[inline(always)]
     fn slide_u8x32<const SHIFT: usize>(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
         let mut dest = [Default::default(); 32usize];
         dest[..32usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -7447,17 +7021,6 @@ impl Simd for Fallback {
         self.combine_mask8x16(half, half)
     }
     #[inline(always)]
-    fn load_array_mask8x32(self, val: [i8; 32usize]) -> mask8x32<Self> {
-        mask8x32 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x32(self, a: mask8x32<Self>) -> [i8; 32usize] {
-        a.val.0
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x32(self, bits: u64) -> mask8x32<Self> {
         let lo = self.from_bitmask_mask8x16(bits);
         let hi = self.from_bitmask_mask8x16(bits >> 16usize);
@@ -7477,9 +7040,10 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = self.as_array_mask8x32(*a);
+        let mut lanes = [0 as i8; 32usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x32(lanes);
+        *a = mask8x32::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
@@ -7564,36 +7128,6 @@ impl Simd for Fallback {
     fn splat_i16x16(self, val: i16) -> i16x16<Self> {
         let half = self.splat_i16x8(val);
         self.combine_i16x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i16x16(self, val: [i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x16(self, val: &[i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::support::Aligned256(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x16(self, a: i16x16<Self>) -> [i16; 16usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x16(self, a: &mut i16x16<Self>) -> &mut [i16; 16usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_i16x16<const SHIFT: usize>(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -7926,36 +7460,6 @@ impl Simd for Fallback {
     fn splat_u16x16(self, val: u16) -> u16x16<Self> {
         let half = self.splat_u16x8(val);
         self.combine_u16x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x16(self, val: &[u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::support::Aligned256(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x16(self, a: u16x16<Self>) -> [u16; 16usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x16(self, a: &mut u16x16<Self>) -> &mut [u16; 16usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_u16x16<const SHIFT: usize>(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -8307,17 +7811,6 @@ impl Simd for Fallback {
         self.combine_mask16x8(half, half)
     }
     #[inline(always)]
-    fn load_array_mask16x16(self, val: [i16; 16usize]) -> mask16x16<Self> {
-        mask16x16 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x16(self, a: mask16x16<Self>) -> [i16; 16usize] {
-        a.val.0
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x16(self, bits: u64) -> mask16x16<Self> {
         let lo = self.from_bitmask_mask16x8(bits);
         let hi = self.from_bitmask_mask16x8(bits >> 8usize);
@@ -8337,9 +7830,10 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask16x16(*a);
+        let mut lanes = [0 as i16; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x16(lanes);
+        *a = mask16x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
@@ -8424,36 +7918,6 @@ impl Simd for Fallback {
     fn splat_i32x8(self, val: i32) -> i32x8<Self> {
         let half = self.splat_i32x4(val);
         self.combine_i32x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i32x8(self, val: [i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x8(self, val: &[i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::support::Aligned256(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x8(self, a: i32x8<Self>) -> [i32; 8usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x8(self, a: &mut i32x8<Self>) -> &mut [i32; 8usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_i32x8<const SHIFT: usize>(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -8757,36 +8221,6 @@ impl Simd for Fallback {
         self.combine_u32x4(half, half)
     }
     #[inline(always)]
-    fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x8(self, val: &[u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::support::Aligned256(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x8(self, a: u32x8<Self>) -> [u32; 8usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x8(self, a: &mut u32x8<Self>) -> &mut [u32; 8usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
-        *dest = a.val.0;
-    }
-    #[inline(always)]
     fn slide_u32x8<const SHIFT: usize>(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
         let mut dest = [Default::default(); 8usize];
         dest[..8usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -9083,17 +8517,6 @@ impl Simd for Fallback {
         self.combine_mask32x4(half, half)
     }
     #[inline(always)]
-    fn load_array_mask32x8(self, val: [i32; 8usize]) -> mask32x8<Self> {
-        mask32x8 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x8(self, a: mask32x8<Self>) -> [i32; 8usize] {
-        a.val.0
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x8(self, bits: u64) -> mask32x8<Self> {
         let lo = self.from_bitmask_mask32x4(bits);
         let hi = self.from_bitmask_mask32x4(bits >> 4usize);
@@ -9113,9 +8536,10 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask32x8(*a);
+        let mut lanes = [0 as i32; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x8(lanes);
+        *a = mask32x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
@@ -9200,36 +8624,6 @@ impl Simd for Fallback {
     fn splat_f64x4(self, val: f64) -> f64x4<Self> {
         let half = self.splat_f64x2(val);
         self.combine_f64x2(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f64x4(self, val: [f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x4(self, val: &[f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::support::Aligned256(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x4(self, a: f64x4<Self>) -> [f64; 4usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x4(self, a: &mut f64x4<Self>) -> &mut [f64; 4usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_f64x4<const SHIFT: usize>(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
@@ -9563,36 +8957,6 @@ impl Simd for Fallback {
         self.combine_i64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_i64x4(self, val: [i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x4(self, val: &[i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::support::Aligned256(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x4(self, a: i64x4<Self>) -> [i64; 4usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x4(self, a: &i64x4<Self>) -> &[i64; 4usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x4(self, a: &mut i64x4<Self>) -> &mut [i64; 4usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_i64x4(self, a: i64x4<Self>, dest: &mut [i64; 4usize]) -> () {
-        *dest = a.val.0;
-    }
-    #[inline(always)]
     fn slide_i64x4<const SHIFT: usize>(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         let mut dest = [Default::default(); 4usize];
         dest[..4usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -9873,36 +9237,6 @@ impl Simd for Fallback {
         self.combine_u64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_u64x4(self, val: [u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x4(self, val: &[u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::support::Aligned256(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x4(self, a: u64x4<Self>) -> [u64; 4usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x4(self, a: &u64x4<Self>) -> &[u64; 4usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x4(self, a: &mut u64x4<Self>) -> &mut [u64; 4usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_u64x4(self, a: u64x4<Self>, dest: &mut [u64; 4usize]) -> () {
-        *dest = a.val.0;
-    }
-    #[inline(always)]
     fn slide_u64x4<const SHIFT: usize>(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
         let mut dest = [Default::default(); 4usize];
         dest[..4usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -10178,17 +9512,6 @@ impl Simd for Fallback {
         self.combine_mask64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_mask64x4(self, val: [i64; 4usize]) -> mask64x4<Self> {
-        mask64x4 {
-            val: crate::support::Aligned256(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x4(self, a: mask64x4<Self>) -> [i64; 4usize] {
-        a.val.0
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x4(self, bits: u64) -> mask64x4<Self> {
         let lo = self.from_bitmask_mask64x2(bits);
         let hi = self.from_bitmask_mask64x2(bits >> 2usize);
@@ -10208,9 +9531,10 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = self.as_array_mask64x4(*a);
+        let mut lanes = [0 as i64; 4usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x4(lanes);
+        *a = mask64x4::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x4(self, a: mask64x4<Self>, b: mask64x4<Self>) -> mask64x4<Self> {
@@ -10295,36 +9619,6 @@ impl Simd for Fallback {
     fn splat_f32x16(self, val: f32) -> f32x16<Self> {
         let half = self.splat_f32x8(val);
         self.combine_f32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f32x16(self, val: [f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x16(self, val: &[f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::support::Aligned512(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x16(self, a: f32x16<Self>) -> [f32; 16usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x16(self, a: &mut f32x16<Self>) -> &mut [f32; 16usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_f32x16<const SHIFT: usize>(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -10757,36 +10051,6 @@ impl Simd for Fallback {
     fn splat_i8x64(self, val: i8) -> i8x64<Self> {
         let half = self.splat_i8x32(val);
         self.combine_i8x32(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i8x64(self, val: [i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x64(self, val: &[i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::support::Aligned512(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x64(self, a: i8x64<Self>) -> [i8; 64usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x64(self, a: &mut i8x64<Self>) -> &mut [i8; 64usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_i8x64<const SHIFT: usize>(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -11300,36 +10564,6 @@ impl Simd for Fallback {
     fn splat_u8x64(self, val: u8) -> u8x64<Self> {
         let half = self.splat_u8x32(val);
         self.combine_u8x32(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u8x64(self, val: [u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x64(self, val: &[u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::support::Aligned512(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x64(self, a: u8x64<Self>) -> [u8; 64usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x64(self, a: &mut u8x64<Self>) -> &mut [u8; 64usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_u8x64<const SHIFT: usize>(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -11925,17 +11159,6 @@ impl Simd for Fallback {
         self.combine_mask8x32(half, half)
     }
     #[inline(always)]
-    fn load_array_mask8x64(self, val: [i8; 64usize]) -> mask8x64<Self> {
-        mask8x64 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x64(self, a: mask8x64<Self>) -> [i8; 64usize] {
-        a.val.0
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x64(self, bits: u64) -> mask8x64<Self> {
         let lo = self.from_bitmask_mask8x32(bits);
         let hi = self.from_bitmask_mask8x32(bits >> 32usize);
@@ -11955,9 +11178,10 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             64usize
         );
-        let mut lanes = self.as_array_mask8x64(*a);
+        let mut lanes = [0 as i8; 64usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x64(lanes);
+        *a = mask8x64::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self> {
@@ -12035,36 +11259,6 @@ impl Simd for Fallback {
     fn splat_i16x32(self, val: i16) -> i16x32<Self> {
         let half = self.splat_i16x16(val);
         self.combine_i16x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i16x32(self, val: [i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x32(self, val: &[i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::support::Aligned512(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x32(self, a: i16x32<Self>) -> [i16; 32usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x32(self, a: &mut i16x32<Self>) -> &mut [i16; 32usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_i16x32<const SHIFT: usize>(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -12460,36 +11654,6 @@ impl Simd for Fallback {
     fn splat_u16x32(self, val: u16) -> u16x32<Self> {
         let half = self.splat_u16x16(val);
         self.combine_u16x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u16x32(self, val: [u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x32(self, val: &[u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::support::Aligned512(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x32(self, a: u16x32<Self>) -> [u16; 32usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x32(self, a: &mut u16x32<Self>) -> &mut [u16; 32usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_u16x32<const SHIFT: usize>(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -12935,17 +12099,6 @@ impl Simd for Fallback {
         self.combine_mask16x16(half, half)
     }
     #[inline(always)]
-    fn load_array_mask16x32(self, val: [i16; 32usize]) -> mask16x32<Self> {
-        mask16x32 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x32(self, a: mask16x32<Self>) -> [i16; 32usize] {
-        a.val.0
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x32(self, bits: u64) -> mask16x32<Self> {
         let lo = self.from_bitmask_mask16x16(bits);
         let hi = self.from_bitmask_mask16x16(bits >> 16usize);
@@ -12965,9 +12118,10 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = self.as_array_mask16x32(*a);
+        let mut lanes = [0 as i16; 32usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x32(lanes);
+        *a = mask16x32::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x32(self, a: mask16x32<Self>, b: mask16x32<Self>) -> mask16x32<Self> {
@@ -13048,36 +12202,6 @@ impl Simd for Fallback {
     fn splat_i32x16(self, val: i32) -> i32x16<Self> {
         let half = self.splat_i32x8(val);
         self.combine_i32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i32x16(self, val: [i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x16(self, val: &[i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::support::Aligned512(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x16(self, a: i32x16<Self>) -> [i32; 16usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x16(self, a: &mut i32x16<Self>) -> &mut [i32; 16usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_i32x16<const SHIFT: usize>(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -13408,36 +12532,6 @@ impl Simd for Fallback {
     fn splat_u32x16(self, val: u32) -> u32x16<Self> {
         let half = self.splat_u32x8(val);
         self.combine_u32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u32x16(self, val: [u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x16(self, val: &[u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::support::Aligned512(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x16(self, a: u32x16<Self>) -> [u32; 16usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x16(self, a: &mut u32x16<Self>) -> &mut [u32; 16usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_u32x16<const SHIFT: usize>(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -13795,17 +12889,6 @@ impl Simd for Fallback {
         self.combine_mask32x8(half, half)
     }
     #[inline(always)]
-    fn load_array_mask32x16(self, val: [i32; 16usize]) -> mask32x16<Self> {
-        mask32x16 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x16(self, a: mask32x16<Self>) -> [i32; 16usize] {
-        a.val.0
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x16(self, bits: u64) -> mask32x16<Self> {
         let lo = self.from_bitmask_mask32x8(bits);
         let hi = self.from_bitmask_mask32x8(bits >> 8usize);
@@ -13825,9 +12908,10 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask32x16(*a);
+        let mut lanes = [0 as i32; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x16(lanes);
+        *a = mask32x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self> {
@@ -13905,36 +12989,6 @@ impl Simd for Fallback {
     fn splat_f64x8(self, val: f64) -> f64x8<Self> {
         let half = self.splat_f64x4(val);
         self.combine_f64x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f64x8(self, val: [f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x8(self, val: &[f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::support::Aligned512(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x8(self, a: f64x8<Self>) -> [f64; 8usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x8(self, a: &mut f64x8<Self>) -> &mut [f64; 8usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_f64x8<const SHIFT: usize>(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {
@@ -14277,36 +13331,6 @@ impl Simd for Fallback {
         self.combine_i64x4(half, half)
     }
     #[inline(always)]
-    fn load_array_i64x8(self, val: [i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x8(self, val: &[i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::support::Aligned512(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x8(self, a: i64x8<Self>) -> [i64; 8usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x8(self, a: &i64x8<Self>) -> &[i64; 8usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x8(self, a: &mut i64x8<Self>) -> &mut [i64; 8usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_i64x8(self, a: i64x8<Self>, dest: &mut [i64; 8usize]) -> () {
-        *dest = a.val.0;
-    }
-    #[inline(always)]
     fn slide_i64x8<const SHIFT: usize>(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         let mut dest = [Default::default(); 8usize];
         dest[..8usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -14594,36 +13618,6 @@ impl Simd for Fallback {
     fn splat_u64x8(self, val: u64) -> u64x8<Self> {
         let half = self.splat_u64x4(val);
         self.combine_u64x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u64x8(self, val: [u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x8(self, val: &[u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::support::Aligned512(*val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x8(self, a: u64x8<Self>) -> [u64; 8usize] {
-        a.val.0
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x8(self, a: &u64x8<Self>) -> &[u64; 8usize] {
-        &a.val.0
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x8(self, a: &mut u64x8<Self>) -> &mut [u64; 8usize] {
-        &mut a.val.0
-    }
-    #[inline(always)]
-    fn store_array_u64x8(self, a: u64x8<Self>, dest: &mut [u64; 8usize]) -> () {
-        *dest = a.val.0;
     }
     #[inline(always)]
     fn slide_u64x8<const SHIFT: usize>(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
@@ -14930,17 +13924,6 @@ impl Simd for Fallback {
         self.combine_mask64x4(half, half)
     }
     #[inline(always)]
-    fn load_array_mask64x8(self, val: [i64; 8usize]) -> mask64x8<Self> {
-        mask64x8 {
-            val: crate::support::Aligned512(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x8(self, a: mask64x8<Self>) -> [i64; 8usize] {
-        a.val.0
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x8(self, bits: u64) -> mask64x8<Self> {
         let lo = self.from_bitmask_mask64x4(bits);
         let hi = self.from_bitmask_mask64x4(bits >> 4usize);
@@ -14960,9 +13943,10 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask64x8(*a);
+        let mut lanes = [0 as i64; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x8(lanes);
+        *a = mask64x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x8(self, a: mask64x8<Self>, b: mask64x8<Self>) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -2191,8 +2191,7 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn to_bitmask_mask8x16(self, a: mask8x16<Self>) -> u64 {
-        let mut lanes = [0 as i8; 16usize];
-        a.store_slice(&mut lanes);
+        let lanes: [i8; 16usize] = a.into();
         let mut bits = 0u64;
         let mut i = 0;
         while i < 16usize {
@@ -2210,10 +2209,9 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i8; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -3558,8 +3556,7 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn to_bitmask_mask16x8(self, a: mask16x8<Self>) -> u64 {
-        let mut lanes = [0 as i16; 8usize];
-        a.store_slice(&mut lanes);
+        let lanes: [i16; 8usize] = a.into();
         let mut bits = 0u64;
         let mut i = 0;
         while i < 8usize {
@@ -3577,10 +3574,9 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i16; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -4585,8 +4581,7 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn to_bitmask_mask32x4(self, a: mask32x4<Self>) -> u64 {
-        let mut lanes = [0 as i32; 4usize];
-        a.store_slice(&mut lanes);
+        let lanes: [i32; 4usize] = a.into();
         let mut bits = 0u64;
         let mut i = 0;
         while i < 4usize {
@@ -4604,10 +4599,9 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = [0 as i32; 4usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 4usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x4::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -5754,8 +5748,7 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn to_bitmask_mask64x2(self, a: mask64x2<Self>) -> u64 {
-        let mut lanes = [0 as i64; 2usize];
-        a.store_slice(&mut lanes);
+        let lanes: [i64; 2usize] = a.into();
         let mut bits = 0u64;
         let mut i = 0;
         while i < 2usize {
@@ -5773,10 +5766,9 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             2usize
         );
-        let mut lanes = [0 as i64; 2usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 2usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x2::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self> {
@@ -7040,10 +7032,9 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = [0 as i8; 32usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 32usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x32::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
@@ -7830,10 +7821,9 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i16; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
@@ -8536,10 +8526,9 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i32; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
@@ -9531,10 +9520,9 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = [0 as i64; 4usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 4usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x4::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x4(self, a: mask64x4<Self>, b: mask64x4<Self>) -> mask64x4<Self> {
@@ -11178,10 +11166,9 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             64usize
         );
-        let mut lanes = [0 as i8; 64usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 64usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x64::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self> {
@@ -12118,10 +12105,9 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = [0 as i16; 32usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 32usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x32::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x32(self, a: mask16x32<Self>, b: mask16x32<Self>) -> mask16x32<Self> {
@@ -12908,10 +12894,9 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i32; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self> {
@@ -13943,10 +13928,9 @@ impl Simd for Fallback {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i64; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x8(self, a: mask64x8<Self>, b: mask64x8<Self>) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -1494,10 +1494,9 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i8; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -2449,10 +2448,9 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i16; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -3391,10 +3389,9 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = [0 as i32; 4usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 4usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x4::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -4721,10 +4718,9 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             2usize
         );
-        let mut lanes = [0 as i64; 2usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 2usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x2::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self> {
@@ -6151,10 +6147,9 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = [0 as i8; 32usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 32usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x32::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
@@ -7023,10 +7018,9 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i16; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
@@ -7820,10 +7814,9 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i32; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
@@ -8948,10 +8941,9 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = [0 as i64; 4usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 4usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x4::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x4(self, a: mask64x4<Self>, b: mask64x4<Self>) -> mask64x4<Self> {
@@ -10689,10 +10681,9 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             64usize
         );
-        let mut lanes = [0 as i8; 64usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 64usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x64::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self> {
@@ -11718,10 +11709,9 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = [0 as i16; 32usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 32usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x32::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x32(self, a: mask16x32<Self>, b: mask16x32<Self>) -> mask16x32<Self> {
@@ -12615,10 +12605,9 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i32; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self> {
@@ -13829,10 +13818,9 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i64; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x8(self, a: mask64x8<Self>, b: mask64x8<Self>) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -115,36 +115,6 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_f32x4(self, val: [f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x4(self, val: &[f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x4(self, a: f32x4<Self>) -> [f32; 4usize] {
-        crate::transmute::checked_transmute_copy::<float32x4_t, [f32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
-        crate::transmute::checked_cast_ref::<float32x4_t, [f32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x4(self, a: &mut f32x4<Self>) -> &mut [f32; 4usize] {
-        crate::transmute::checked_cast_mut::<float32x4_t, [f32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -618,36 +588,6 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_i8x16(self, val: [i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x16(self, val: &[i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x16(self, a: i8x16<Self>) -> [i8; 16usize] {
-        crate::transmute::checked_transmute_copy::<int8x16_t, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
-        crate::transmute::checked_cast_ref::<int8x16_t, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x16(self, a: &mut i8x16<Self>) -> &mut [i8; 16usize] {
-        crate::transmute::checked_cast_mut::<int8x16_t, [i8; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         if SHIFT >= 16usize {
             return b;
@@ -1076,36 +1016,6 @@ impl Simd for Neon {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x16(self, val: &[u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x16(self, a: u8x16<Self>) -> [u8; 16usize] {
-        crate::transmute::checked_transmute_copy::<uint8x16_t, [u8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
-        crate::transmute::checked_cast_ref::<uint8x16_t, [u8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x16(self, a: &mut u8x16<Self>) -> &mut [u8; 16usize] {
-        crate::transmute::checked_cast_mut::<uint8x16_t, [u8; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1541,17 +1451,6 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask8x16(self, val: [i8; 16usize]) -> mask8x16<Self> {
-        mask8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x16(self, a: mask8x16<Self>) -> [i8; 16usize] {
-        crate::transmute::checked_transmute_copy::<int8x16_t, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x16(self, bits: u64) -> mask8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1595,9 +1494,10 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask8x16(*a);
+        let mut lanes = [0 as i8; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x16(lanes);
+        *a = mask8x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -1725,36 +1625,6 @@ impl Simd for Neon {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i16x8(self, val: [i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x8(self, val: &[i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x8(self, a: i16x8<Self>) -> [i16; 8usize] {
-        crate::transmute::checked_transmute_copy::<int16x8_t, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
-        crate::transmute::checked_cast_ref::<int16x8_t, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x8(self, a: &mut i16x8<Self>) -> &mut [i16; 8usize] {
-        crate::transmute::checked_cast_mut::<int16x8_t, [i16; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
@@ -2155,36 +2025,6 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x8(self, val: &[u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x8(self, a: u16x8<Self>) -> [u16; 8usize] {
-        crate::transmute::checked_transmute_copy::<uint16x8_t, [u16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
-        crate::transmute::checked_cast_ref::<uint16x8_t, [u16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x8(self, a: &mut u16x8<Self>) -> &mut [u16; 8usize] {
-        crate::transmute::checked_cast_mut::<uint16x8_t, [u16; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -2574,17 +2414,6 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask16x8(self, val: [i16; 8usize]) -> mask16x8<Self> {
-        mask16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x8(self, a: mask16x8<Self>) -> [i16; 8usize] {
-        crate::transmute::checked_transmute_copy::<int16x8_t, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x8(self, bits: u64) -> mask16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2620,9 +2449,10 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask16x8(*a);
+        let mut lanes = [0 as i16; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x8(lanes);
+        *a = mask16x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -2750,36 +2580,6 @@ impl Simd for Neon {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i32x4(self, val: [i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x4(self, val: &[i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x4(self, a: i32x4<Self>) -> [i32; 4usize] {
-        crate::transmute::checked_transmute_copy::<int32x4_t, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
-        crate::transmute::checked_cast_ref::<int32x4_t, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x4(self, a: &mut i32x4<Self>) -> &mut [i32; 4usize] {
-        crate::transmute::checked_cast_mut::<int32x4_t, [i32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
@@ -3174,36 +2974,6 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x4(self, val: &[u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x4(self, a: u32x4<Self>) -> [u32; 4usize] {
-        crate::transmute::checked_transmute_copy::<uint32x4_t, [u32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
-        crate::transmute::checked_cast_ref::<uint32x4_t, [u32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x4(self, a: &mut u32x4<Self>) -> &mut [u32; 4usize] {
-        crate::transmute::checked_cast_mut::<uint32x4_t, [u32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -3587,17 +3357,6 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask32x4(self, val: [i32; 4usize]) -> mask32x4<Self> {
-        mask32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x4(self, a: mask32x4<Self>) -> [i32; 4usize] {
-        crate::transmute::checked_transmute_copy::<int32x4_t, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x4(self, bits: u64) -> mask32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3632,9 +3391,10 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = self.as_array_mask32x4(*a);
+        let mut lanes = [0 as i32; 4usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x4(lanes);
+        *a = mask32x4::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -3762,36 +3522,6 @@ impl Simd for Neon {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_f64x2(self, val: [f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x2(self, val: &[f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x2(self, a: f64x2<Self>) -> [f64; 2usize] {
-        crate::transmute::checked_transmute_copy::<float64x2_t, [f64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
-        crate::transmute::checked_cast_ref::<float64x2_t, [f64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x2(self, a: &mut f64x2<Self>) -> &mut [f64; 2usize] {
-        crate::transmute::checked_cast_mut::<float64x2_t, [f64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
@@ -4231,36 +3961,6 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_i64x2(self, val: [i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x2(self, val: &[i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x2(self, a: i64x2<Self>) -> [i64; 2usize] {
-        crate::transmute::checked_transmute_copy::<int64x2_t, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x2(self, a: &i64x2<Self>) -> &[i64; 2usize] {
-        crate::transmute::checked_cast_ref::<int64x2_t, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x2(self, a: &mut i64x2<Self>) -> &mut [i64; 2usize] {
-        crate::transmute::checked_cast_mut::<int64x2_t, [i64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x2(self, a: i64x2<Self>, dest: &mut [i64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -4629,36 +4329,6 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u64x2(self, val: [u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x2(self, val: &[u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x2(self, a: u64x2<Self>) -> [u64; 2usize] {
-        crate::transmute::checked_transmute_copy::<uint64x2_t, [u64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x2(self, a: &u64x2<Self>) -> &[u64; 2usize] {
-        crate::transmute::checked_cast_ref::<uint64x2_t, [u64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x2(self, a: &mut u64x2<Self>) -> &mut [u64; 2usize] {
-        crate::transmute::checked_cast_mut::<uint64x2_t, [u64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x2(self, a: u64x2<Self>, dest: &mut [u64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -5018,17 +4688,6 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask64x2(self, val: [i64; 2usize]) -> mask64x2<Self> {
-        mask64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x2(self, a: mask64x2<Self>) -> [i64; 2usize] {
-        crate::transmute::checked_transmute_copy::<int64x2_t, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x2(self, bits: u64) -> mask64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5062,9 +4721,10 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             2usize
         );
-        let mut lanes = self.as_array_mask64x2(*a);
+        let mut lanes = [0 as i64; 2usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x2(lanes);
+        *a = mask64x2::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self> {
@@ -5187,36 +4847,6 @@ impl Simd for Neon {
     fn splat_f32x8(self, val: f32) -> f32x8<Self> {
         let half = self.splat_f32x4(val);
         self.combine_f32x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f32x8(self, val: [f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x8(self, val: &[f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x8(self, a: f32x8<Self>) -> [f32; 8usize] {
-        crate::transmute::checked_transmute_copy::<float32x4x2_t, [f32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
-        crate::transmute::checked_cast_ref::<float32x4x2_t, [f32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x8(self, a: &mut f32x8<Self>) -> &mut [f32; 8usize] {
-        crate::transmute::checked_cast_mut::<float32x4x2_t, [f32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x8<const SHIFT: usize>(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -5632,36 +5262,6 @@ impl Simd for Neon {
     fn splat_i8x32(self, val: i8) -> i8x32<Self> {
         let half = self.splat_i8x16(val);
         self.combine_i8x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i8x32(self, val: [i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x32(self, val: &[i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x32(self, a: i8x32<Self>) -> [i8; 32usize] {
-        crate::transmute::checked_transmute_copy::<int8x16x2_t, [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
-        crate::transmute::checked_cast_ref::<int8x16x2_t, [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x32(self, a: &mut i8x32<Self>) -> &mut [i8; 32usize] {
-        crate::transmute::checked_cast_mut::<int8x16x2_t, [i8; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x32<const SHIFT: usize>(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -6098,36 +5698,6 @@ impl Simd for Neon {
         self.combine_u8x16(half, half)
     }
     #[inline(always)]
-    fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x32(self, val: &[u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x32(self, a: u8x32<Self>) -> [u8; 32usize] {
-        crate::transmute::checked_transmute_copy::<uint8x16x2_t, [u8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
-        crate::transmute::checked_cast_ref::<uint8x16x2_t, [u8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x32(self, a: &mut u8x32<Self>) -> &mut [u8; 32usize] {
-        crate::transmute::checked_cast_mut::<uint8x16x2_t, [u8; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u8x32<const SHIFT: usize>(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
         if SHIFT >= 32usize {
             return b;
@@ -6562,17 +6132,6 @@ impl Simd for Neon {
         self.combine_mask8x16(half, half)
     }
     #[inline(always)]
-    fn load_array_mask8x32(self, val: [i8; 32usize]) -> mask8x32<Self> {
-        mask8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x32(self, a: mask8x32<Self>) -> [i8; 32usize] {
-        crate::transmute::checked_transmute_copy::<int8x16x2_t, [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x32(self, bits: u64) -> mask8x32<Self> {
         let lo = self.from_bitmask_mask8x16(bits);
         let hi = self.from_bitmask_mask8x16(bits >> 16usize);
@@ -6592,9 +6151,10 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = self.as_array_mask8x32(*a);
+        let mut lanes = [0 as i8; 32usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x32(lanes);
+        *a = mask8x32::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
@@ -6686,36 +6246,6 @@ impl Simd for Neon {
     fn splat_i16x16(self, val: i16) -> i16x16<Self> {
         let half = self.splat_i16x8(val);
         self.combine_i16x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i16x16(self, val: [i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x16(self, val: &[i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x16(self, a: i16x16<Self>) -> [i16; 16usize] {
-        crate::transmute::checked_transmute_copy::<int16x8x2_t, [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
-        crate::transmute::checked_cast_ref::<int16x8x2_t, [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x16(self, a: &mut i16x16<Self>) -> &mut [i16; 16usize] {
-        crate::transmute::checked_cast_mut::<int16x8x2_t, [i16; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x16<const SHIFT: usize>(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -7090,36 +6620,6 @@ impl Simd for Neon {
     fn splat_u16x16(self, val: u16) -> u16x16<Self> {
         let half = self.splat_u16x8(val);
         self.combine_u16x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x16(self, val: &[u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x16(self, a: u16x16<Self>) -> [u16; 16usize] {
-        crate::transmute::checked_transmute_copy::<uint16x8x2_t, [u16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
-        crate::transmute::checked_cast_ref::<uint16x8x2_t, [u16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x16(self, a: &mut u16x16<Self>) -> &mut [u16; 16usize] {
-        crate::transmute::checked_cast_mut::<uint16x8x2_t, [u16; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x16<const SHIFT: usize>(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -7504,17 +7004,6 @@ impl Simd for Neon {
         self.combine_mask16x8(half, half)
     }
     #[inline(always)]
-    fn load_array_mask16x16(self, val: [i16; 16usize]) -> mask16x16<Self> {
-        mask16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x16(self, a: mask16x16<Self>) -> [i16; 16usize] {
-        crate::transmute::checked_transmute_copy::<int16x8x2_t, [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x16(self, bits: u64) -> mask16x16<Self> {
         let lo = self.from_bitmask_mask16x8(bits);
         let hi = self.from_bitmask_mask16x8(bits >> 8usize);
@@ -7534,9 +7023,10 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask16x16(*a);
+        let mut lanes = [0 as i16; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x16(lanes);
+        *a = mask16x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
@@ -7628,36 +7118,6 @@ impl Simd for Neon {
     fn splat_i32x8(self, val: i32) -> i32x8<Self> {
         let half = self.splat_i32x4(val);
         self.combine_i32x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i32x8(self, val: [i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x8(self, val: &[i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x8(self, a: i32x8<Self>) -> [i32; 8usize] {
-        crate::transmute::checked_transmute_copy::<int32x4x2_t, [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
-        crate::transmute::checked_cast_ref::<int32x4x2_t, [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x8(self, a: &mut i32x8<Self>) -> &mut [i32; 8usize] {
-        crate::transmute::checked_cast_mut::<int32x4x2_t, [i32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x8<const SHIFT: usize>(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -8003,36 +7463,6 @@ impl Simd for Neon {
         self.combine_u32x4(half, half)
     }
     #[inline(always)]
-    fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x8(self, val: &[u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x8(self, a: u32x8<Self>) -> [u32; 8usize] {
-        crate::transmute::checked_transmute_copy::<uint32x4x2_t, [u32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
-        crate::transmute::checked_cast_ref::<uint32x4x2_t, [u32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x8(self, a: &mut u32x8<Self>) -> &mut [u32; 8usize] {
-        crate::transmute::checked_cast_mut::<uint32x4x2_t, [u32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u32x8<const SHIFT: usize>(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -8371,17 +7801,6 @@ impl Simd for Neon {
         self.combine_mask32x4(half, half)
     }
     #[inline(always)]
-    fn load_array_mask32x8(self, val: [i32; 8usize]) -> mask32x8<Self> {
-        mask32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x8(self, a: mask32x8<Self>) -> [i32; 8usize] {
-        crate::transmute::checked_transmute_copy::<int32x4x2_t, [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x8(self, bits: u64) -> mask32x8<Self> {
         let lo = self.from_bitmask_mask32x4(bits);
         let hi = self.from_bitmask_mask32x4(bits >> 4usize);
@@ -8401,9 +7820,10 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask32x8(*a);
+        let mut lanes = [0 as i32; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x8(lanes);
+        *a = mask32x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
@@ -8495,36 +7915,6 @@ impl Simd for Neon {
     fn splat_f64x4(self, val: f64) -> f64x4<Self> {
         let half = self.splat_f64x2(val);
         self.combine_f64x2(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f64x4(self, val: [f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x4(self, val: &[f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x4(self, a: f64x4<Self>) -> [f64; 4usize] {
-        crate::transmute::checked_transmute_copy::<float64x2x2_t, [f64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
-        crate::transmute::checked_cast_ref::<float64x2x2_t, [f64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x4(self, a: &mut f64x4<Self>) -> &mut [f64; 4usize] {
-        crate::transmute::checked_cast_mut::<float64x2x2_t, [f64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x4<const SHIFT: usize>(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
@@ -8900,36 +8290,6 @@ impl Simd for Neon {
         self.combine_i64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_i64x4(self, val: [i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x4(self, val: &[i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x4(self, a: i64x4<Self>) -> [i64; 4usize] {
-        crate::transmute::checked_transmute_copy::<int64x2x2_t, [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x4(self, a: &i64x4<Self>) -> &[i64; 4usize] {
-        crate::transmute::checked_cast_ref::<int64x2x2_t, [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x4(self, a: &mut i64x4<Self>) -> &mut [i64; 4usize] {
-        crate::transmute::checked_cast_mut::<int64x2x2_t, [i64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x4(self, a: i64x4<Self>, dest: &mut [i64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x4<const SHIFT: usize>(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -9252,36 +8612,6 @@ impl Simd for Neon {
         self.combine_u64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_u64x4(self, val: [u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x4(self, val: &[u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x4(self, a: u64x4<Self>) -> [u64; 4usize] {
-        crate::transmute::checked_transmute_copy::<uint64x2x2_t, [u64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x4(self, a: &u64x4<Self>) -> &[u64; 4usize] {
-        crate::transmute::checked_cast_ref::<uint64x2x2_t, [u64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x4(self, a: &mut u64x4<Self>) -> &mut [u64; 4usize] {
-        crate::transmute::checked_cast_mut::<uint64x2x2_t, [u64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x4(self, a: u64x4<Self>, dest: &mut [u64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u64x4<const SHIFT: usize>(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -9599,17 +8929,6 @@ impl Simd for Neon {
         self.combine_mask64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_mask64x4(self, val: [i64; 4usize]) -> mask64x4<Self> {
-        mask64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x4(self, a: mask64x4<Self>) -> [i64; 4usize] {
-        crate::transmute::checked_transmute_copy::<int64x2x2_t, [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x4(self, bits: u64) -> mask64x4<Self> {
         let lo = self.from_bitmask_mask64x2(bits);
         let hi = self.from_bitmask_mask64x2(bits >> 2usize);
@@ -9629,9 +8948,10 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = self.as_array_mask64x4(*a);
+        let mut lanes = [0 as i64; 4usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x4(lanes);
+        *a = mask64x4::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x4(self, a: mask64x4<Self>, b: mask64x4<Self>) -> mask64x4<Self> {
@@ -9723,36 +9043,6 @@ impl Simd for Neon {
     fn splat_f32x16(self, val: f32) -> f32x16<Self> {
         let half = self.splat_f32x8(val);
         self.combine_f32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f32x16(self, val: [f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x16(self, val: &[f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x16(self, a: f32x16<Self>) -> [f32; 16usize] {
-        crate::transmute::checked_transmute_copy::<float32x4x4_t, [f32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
-        crate::transmute::checked_cast_ref::<float32x4x4_t, [f32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x16(self, a: &mut f32x16<Self>) -> &mut [f32; 16usize] {
-        crate::transmute::checked_cast_mut::<float32x4x4_t, [f32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x16<const SHIFT: usize>(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -10225,36 +9515,6 @@ impl Simd for Neon {
     fn splat_i8x64(self, val: i8) -> i8x64<Self> {
         let half = self.splat_i8x32(val);
         self.combine_i8x32(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i8x64(self, val: [i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x64(self, val: &[i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x64(self, a: i8x64<Self>) -> [i8; 64usize] {
-        crate::transmute::checked_transmute_copy::<int8x16x4_t, [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
-        crate::transmute::checked_cast_ref::<int8x16x4_t, [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x64(self, a: &mut i8x64<Self>) -> &mut [i8; 64usize] {
-        crate::transmute::checked_cast_mut::<int8x16x4_t, [i8; 64usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x64<const SHIFT: usize>(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -10830,36 +10090,6 @@ impl Simd for Neon {
     fn splat_u8x64(self, val: u8) -> u8x64<Self> {
         let half = self.splat_u8x32(val);
         self.combine_u8x32(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u8x64(self, val: [u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x64(self, val: &[u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x64(self, a: u8x64<Self>) -> [u8; 64usize] {
-        crate::transmute::checked_transmute_copy::<uint8x16x4_t, [u8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
-        crate::transmute::checked_cast_ref::<uint8x16x4_t, [u8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x64(self, a: &mut u8x64<Self>) -> &mut [u8; 64usize] {
-        crate::transmute::checked_cast_mut::<uint8x16x4_t, [u8; 64usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u8x64<const SHIFT: usize>(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -11440,17 +10670,6 @@ impl Simd for Neon {
         self.combine_mask8x32(half, half)
     }
     #[inline(always)]
-    fn load_array_mask8x64(self, val: [i8; 64usize]) -> mask8x64<Self> {
-        mask8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x64(self, a: mask8x64<Self>) -> [i8; 64usize] {
-        crate::transmute::checked_transmute_copy::<int8x16x4_t, [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x64(self, bits: u64) -> mask8x64<Self> {
         let lo = self.from_bitmask_mask8x32(bits);
         let hi = self.from_bitmask_mask8x32(bits >> 32usize);
@@ -11470,9 +10689,10 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             64usize
         );
-        let mut lanes = self.as_array_mask8x64(*a);
+        let mut lanes = [0 as i8; 64usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x64(lanes);
+        *a = mask8x64::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self> {
@@ -11555,36 +10775,6 @@ impl Simd for Neon {
     fn splat_i16x32(self, val: i16) -> i16x32<Self> {
         let half = self.splat_i16x16(val);
         self.combine_i16x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i16x32(self, val: [i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x32(self, val: &[i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x32(self, a: i16x32<Self>) -> [i16; 32usize] {
-        crate::transmute::checked_transmute_copy::<int16x8x4_t, [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
-        crate::transmute::checked_cast_ref::<int16x8x4_t, [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x32(self, a: &mut i16x32<Self>) -> &mut [i16; 32usize] {
-        crate::transmute::checked_cast_mut::<int16x8x4_t, [i16; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x32<const SHIFT: usize>(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -12042,36 +11232,6 @@ impl Simd for Neon {
     fn splat_u16x32(self, val: u16) -> u16x32<Self> {
         let half = self.splat_u16x16(val);
         self.combine_u16x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u16x32(self, val: [u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x32(self, val: &[u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x32(self, a: u16x32<Self>) -> [u16; 32usize] {
-        crate::transmute::checked_transmute_copy::<uint16x8x4_t, [u16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
-        crate::transmute::checked_cast_ref::<uint16x8x4_t, [u16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x32(self, a: &mut u16x32<Self>) -> &mut [u16; 32usize] {
-        crate::transmute::checked_cast_mut::<uint16x8x4_t, [u16; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x32<const SHIFT: usize>(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -12539,17 +11699,6 @@ impl Simd for Neon {
         self.combine_mask16x16(half, half)
     }
     #[inline(always)]
-    fn load_array_mask16x32(self, val: [i16; 32usize]) -> mask16x32<Self> {
-        mask16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x32(self, a: mask16x32<Self>) -> [i16; 32usize] {
-        crate::transmute::checked_transmute_copy::<int16x8x4_t, [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x32(self, bits: u64) -> mask16x32<Self> {
         let lo = self.from_bitmask_mask16x16(bits);
         let hi = self.from_bitmask_mask16x16(bits >> 16usize);
@@ -12569,9 +11718,10 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = self.as_array_mask16x32(*a);
+        let mut lanes = [0 as i16; 32usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x32(lanes);
+        *a = mask16x32::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x32(self, a: mask16x32<Self>, b: mask16x32<Self>) -> mask16x32<Self> {
@@ -12657,36 +11807,6 @@ impl Simd for Neon {
     fn splat_i32x16(self, val: i32) -> i32x16<Self> {
         let half = self.splat_i32x8(val);
         self.combine_i32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i32x16(self, val: [i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x16(self, val: &[i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x16(self, a: i32x16<Self>) -> [i32; 16usize] {
-        crate::transmute::checked_transmute_copy::<int32x4x4_t, [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
-        crate::transmute::checked_cast_ref::<int32x4x4_t, [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x16(self, a: &mut i32x16<Self>) -> &mut [i32; 16usize] {
-        crate::transmute::checked_cast_mut::<int32x4x4_t, [i32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x16<const SHIFT: usize>(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -13079,36 +12199,6 @@ impl Simd for Neon {
     fn splat_u32x16(self, val: u32) -> u32x16<Self> {
         let half = self.splat_u32x8(val);
         self.combine_u32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u32x16(self, val: [u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x16(self, val: &[u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x16(self, a: u32x16<Self>) -> [u32; 16usize] {
-        crate::transmute::checked_transmute_copy::<uint32x4x4_t, [u32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
-        crate::transmute::checked_cast_ref::<uint32x4x4_t, [u32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x16(self, a: &mut u32x16<Self>) -> &mut [u32; 16usize] {
-        crate::transmute::checked_cast_mut::<uint32x4x4_t, [u32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u32x16<const SHIFT: usize>(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -13506,17 +12596,6 @@ impl Simd for Neon {
         self.combine_mask32x8(half, half)
     }
     #[inline(always)]
-    fn load_array_mask32x16(self, val: [i32; 16usize]) -> mask32x16<Self> {
-        mask32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x16(self, a: mask32x16<Self>) -> [i32; 16usize] {
-        crate::transmute::checked_transmute_copy::<int32x4x4_t, [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x16(self, bits: u64) -> mask32x16<Self> {
         let lo = self.from_bitmask_mask32x8(bits);
         let hi = self.from_bitmask_mask32x8(bits >> 8usize);
@@ -13536,9 +12615,10 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask32x16(*a);
+        let mut lanes = [0 as i32; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x16(lanes);
+        *a = mask32x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self> {
@@ -13621,36 +12701,6 @@ impl Simd for Neon {
     fn splat_f64x8(self, val: f64) -> f64x8<Self> {
         let half = self.splat_f64x4(val);
         self.combine_f64x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f64x8(self, val: [f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x8(self, val: &[f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x8(self, a: f64x8<Self>) -> [f64; 8usize] {
-        crate::transmute::checked_transmute_copy::<float64x2x4_t, [f64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
-        crate::transmute::checked_cast_ref::<float64x2x4_t, [f64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x8(self, a: &mut f64x8<Self>) -> &mut [f64; 8usize] {
-        crate::transmute::checked_cast_mut::<float64x2x4_t, [f64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x8<const SHIFT: usize>(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {
@@ -14055,36 +13105,6 @@ impl Simd for Neon {
         self.combine_i64x4(half, half)
     }
     #[inline(always)]
-    fn load_array_i64x8(self, val: [i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x8(self, val: &[i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x8(self, a: i64x8<Self>) -> [i64; 8usize] {
-        crate::transmute::checked_transmute_copy::<int64x2x4_t, [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x8(self, a: &i64x8<Self>) -> &[i64; 8usize] {
-        crate::transmute::checked_cast_ref::<int64x2x4_t, [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x8(self, a: &mut i64x8<Self>) -> &mut [i64; 8usize] {
-        crate::transmute::checked_cast_mut::<int64x2x4_t, [i64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x8(self, a: i64x8<Self>, dest: &mut [i64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x8<const SHIFT: usize>(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -14434,36 +13454,6 @@ impl Simd for Neon {
     fn splat_u64x8(self, val: u64) -> u64x8<Self> {
         let half = self.splat_u64x4(val);
         self.combine_u64x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u64x8(self, val: [u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x8(self, val: &[u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x8(self, a: u64x8<Self>) -> [u64; 8usize] {
-        crate::transmute::checked_transmute_copy::<uint64x2x4_t, [u64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x8(self, a: &u64x8<Self>) -> &[u64; 8usize] {
-        crate::transmute::checked_cast_ref::<uint64x2x4_t, [u64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x8(self, a: &mut u64x8<Self>) -> &mut [u64; 8usize] {
-        crate::transmute::checked_cast_mut::<uint64x2x4_t, [u64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x8(self, a: u64x8<Self>, dest: &mut [u64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u64x8<const SHIFT: usize>(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
@@ -14820,17 +13810,6 @@ impl Simd for Neon {
         self.combine_mask64x4(half, half)
     }
     #[inline(always)]
-    fn load_array_mask64x8(self, val: [i64; 8usize]) -> mask64x8<Self> {
-        mask64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x8(self, a: mask64x8<Self>) -> [i64; 8usize] {
-        crate::transmute::checked_transmute_copy::<int64x2x4_t, [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x8(self, bits: u64) -> mask64x8<Self> {
         let lo = self.from_bitmask_mask64x4(bits);
         let hi = self.from_bitmask_mask64x4(bits >> 4usize);
@@ -14850,9 +13829,10 @@ impl Simd for Neon {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask64x8(*a);
+        let mut lanes = [0 as i64; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x8(lanes);
+        *a = mask64x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x8(self, a: mask64x8<Self>, b: mask64x8<Self>) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -163,18 +163,6 @@ pub trait Simd:
     fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_f32x4(self, val: f32) -> f32x4<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_f32x4(self, val: [f32; 4usize]) -> f32x4<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_f32x4(self, val: &[f32; 4usize]) -> f32x4<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_f32x4(self, a: f32x4<Self>) -> [f32; 4usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_f32x4(self, a: &mut f32x4<Self>) -> &mut [f32; 4usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -279,18 +267,6 @@ pub trait Simd:
     fn cvt_i32_precise_f32x4(self, a: f32x4<Self>) -> i32x4<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i8x16(self, val: i8) -> i8x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_i8x16(self, val: [i8; 16usize]) -> i8x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_i8x16(self, val: &[i8; 16usize]) -> i8x16<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_i8x16(self, a: i8x16<Self>) -> [i8; 16usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_i8x16(self, a: &mut i8x16<Self>) -> &mut [i8; 16usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -375,18 +351,6 @@ pub trait Simd:
     fn neg_i8x16(self, a: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u8x16(self, val: u8) -> u8x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_u8x16(self, val: &[u8; 16usize]) -> u8x16<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_u8x16(self, a: u8x16<Self>) -> [u8; 16usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_u8x16(self, a: &mut u8x16<Self>) -> &mut [u8; 16usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -471,10 +435,6 @@ pub trait Simd:
     fn widen_u8x16(self, a: u8x16<Self>) -> u16x16<Self>;
     #[doc = "Create a SIMD mask with all lanes set from the given boolean value."]
     fn splat_mask8x16(self, val: bool) -> mask8x16<Self>;
-    #[doc = "Create a SIMD mask from signed integer mask lanes."]
-    fn load_array_mask8x16(self, val: [i8; 16usize]) -> mask8x16<Self>;
-    #[doc = "Convert a SIMD mask to signed integer mask lanes."]
-    fn as_array_mask8x16(self, a: mask8x16<Self>) -> [i8; 16usize];
     #[doc = "Create a SIMD mask from a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are ignored."]
     fn from_bitmask_mask8x16(self, bits: u64) -> mask8x16<Self>;
     #[doc = "Convert a SIMD mask to a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are cleared."]
@@ -510,18 +470,6 @@ pub trait Simd:
     fn combine_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x32<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i16x8(self, val: i16) -> i16x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_i16x8(self, val: [i16; 8usize]) -> i16x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_i16x8(self, val: &[i16; 8usize]) -> i16x8<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_i16x8(self, a: i16x8<Self>) -> [i16; 8usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_i16x8(self, a: &mut i16x8<Self>) -> &mut [i16; 8usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -606,18 +554,6 @@ pub trait Simd:
     fn neg_i16x8(self, a: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u16x8(self, val: u16) -> u16x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_u16x8(self, val: &[u16; 8usize]) -> u16x8<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_u16x8(self, a: u16x8<Self>) -> [u16; 8usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_u16x8(self, a: &mut u16x8<Self>) -> &mut [u16; 8usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -700,10 +636,6 @@ pub trait Simd:
     fn combine_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x16<Self>;
     #[doc = "Create a SIMD mask with all lanes set from the given boolean value."]
     fn splat_mask16x8(self, val: bool) -> mask16x8<Self>;
-    #[doc = "Create a SIMD mask from signed integer mask lanes."]
-    fn load_array_mask16x8(self, val: [i16; 8usize]) -> mask16x8<Self>;
-    #[doc = "Convert a SIMD mask to signed integer mask lanes."]
-    fn as_array_mask16x8(self, a: mask16x8<Self>) -> [i16; 8usize];
     #[doc = "Create a SIMD mask from a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are ignored."]
     fn from_bitmask_mask16x8(self, bits: u64) -> mask16x8<Self>;
     #[doc = "Convert a SIMD mask to a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are cleared."]
@@ -739,18 +671,6 @@ pub trait Simd:
     fn combine_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x16<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i32x4(self, val: i32) -> i32x4<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_i32x4(self, val: [i32; 4usize]) -> i32x4<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_i32x4(self, val: &[i32; 4usize]) -> i32x4<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_i32x4(self, a: i32x4<Self>) -> [i32; 4usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_i32x4(self, a: &mut i32x4<Self>) -> &mut [i32; 4usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -837,18 +757,6 @@ pub trait Simd:
     fn cvt_f32_i32x4(self, a: i32x4<Self>) -> f32x4<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u32x4(self, val: u32) -> u32x4<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_u32x4(self, val: &[u32; 4usize]) -> u32x4<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_u32x4(self, a: u32x4<Self>) -> [u32; 4usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_u32x4(self, a: &mut u32x4<Self>) -> &mut [u32; 4usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -933,10 +841,6 @@ pub trait Simd:
     fn cvt_f32_u32x4(self, a: u32x4<Self>) -> f32x4<Self>;
     #[doc = "Create a SIMD mask with all lanes set from the given boolean value."]
     fn splat_mask32x4(self, val: bool) -> mask32x4<Self>;
-    #[doc = "Create a SIMD mask from signed integer mask lanes."]
-    fn load_array_mask32x4(self, val: [i32; 4usize]) -> mask32x4<Self>;
-    #[doc = "Convert a SIMD mask to signed integer mask lanes."]
-    fn as_array_mask32x4(self, a: mask32x4<Self>) -> [i32; 4usize];
     #[doc = "Create a SIMD mask from a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are ignored."]
     fn from_bitmask_mask32x4(self, bits: u64) -> mask32x4<Self>;
     #[doc = "Convert a SIMD mask to a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are cleared."]
@@ -972,18 +876,6 @@ pub trait Simd:
     fn combine_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x8<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_f64x2(self, val: f64) -> f64x2<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_f64x2(self, val: [f64; 2usize]) -> f64x2<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_f64x2(self, val: &[f64; 2usize]) -> f64x2<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_f64x2(self, a: f64x2<Self>) -> [f64; 2usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_f64x2(self, a: &mut f64x2<Self>) -> &mut [f64; 2usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -1080,18 +972,6 @@ pub trait Simd:
     fn combine_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x4<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i64x2(self, val: i64) -> i64x2<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_i64x2(self, val: [i64; 2usize]) -> i64x2<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_i64x2(self, val: &[i64; 2usize]) -> i64x2<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_i64x2(self, a: i64x2<Self>) -> [i64; 2usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_i64x2(self, a: &i64x2<Self>) -> &[i64; 2usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_i64x2(self, a: &mut i64x2<Self>) -> &mut [i64; 2usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_i64x2(self, a: i64x2<Self>, dest: &mut [i64; 2usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -1176,18 +1056,6 @@ pub trait Simd:
     fn neg_i64x2(self, a: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u64x2(self, val: u64) -> u64x2<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_u64x2(self, val: [u64; 2usize]) -> u64x2<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_u64x2(self, val: &[u64; 2usize]) -> u64x2<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_u64x2(self, a: u64x2<Self>) -> [u64; 2usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_u64x2(self, a: &u64x2<Self>) -> &[u64; 2usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_u64x2(self, a: &mut u64x2<Self>) -> &mut [u64; 2usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_u64x2(self, a: u64x2<Self>, dest: &mut [u64; 2usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -1270,10 +1138,6 @@ pub trait Simd:
     fn combine_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x4<Self>;
     #[doc = "Create a SIMD mask with all lanes set from the given boolean value."]
     fn splat_mask64x2(self, val: bool) -> mask64x2<Self>;
-    #[doc = "Create a SIMD mask from signed integer mask lanes."]
-    fn load_array_mask64x2(self, val: [i64; 2usize]) -> mask64x2<Self>;
-    #[doc = "Convert a SIMD mask to signed integer mask lanes."]
-    fn as_array_mask64x2(self, a: mask64x2<Self>) -> [i64; 2usize];
     #[doc = "Create a SIMD mask from a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are ignored."]
     fn from_bitmask_mask64x2(self, bits: u64) -> mask64x2<Self>;
     #[doc = "Convert a SIMD mask to a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are cleared."]
@@ -1309,18 +1173,6 @@ pub trait Simd:
     fn combine_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x4<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_f32x8(self, val: f32) -> f32x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_f32x8(self, val: [f32; 8usize]) -> f32x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_f32x8(self, val: &[f32; 8usize]) -> f32x8<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_f32x8(self, a: f32x8<Self>) -> [f32; 8usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_f32x8(self, a: &mut f32x8<Self>) -> &mut [f32; 8usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f32x8<const SHIFT: usize>(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -1427,18 +1279,6 @@ pub trait Simd:
     fn cvt_i32_precise_f32x8(self, a: f32x8<Self>) -> i32x8<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i8x32(self, val: i8) -> i8x32<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_i8x32(self, val: [i8; 32usize]) -> i8x32<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_i8x32(self, val: &[i8; 32usize]) -> i8x32<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_i8x32(self, a: i8x32<Self>) -> [i8; 32usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_i8x32(self, a: &mut i8x32<Self>) -> &mut [i8; 32usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i8x32<const SHIFT: usize>(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -1525,18 +1365,6 @@ pub trait Simd:
     fn neg_i8x32(self, a: i8x32<Self>) -> i8x32<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u8x32(self, val: u8) -> u8x32<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_u8x32(self, val: &[u8; 32usize]) -> u8x32<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_u8x32(self, a: u8x32<Self>) -> [u8; 32usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_u8x32(self, a: &mut u8x32<Self>) -> &mut [u8; 32usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u8x32<const SHIFT: usize>(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -1623,10 +1451,6 @@ pub trait Simd:
     fn widen_u8x32(self, a: u8x32<Self>) -> u16x32<Self>;
     #[doc = "Create a SIMD mask with all lanes set from the given boolean value."]
     fn splat_mask8x32(self, val: bool) -> mask8x32<Self>;
-    #[doc = "Create a SIMD mask from signed integer mask lanes."]
-    fn load_array_mask8x32(self, val: [i8; 32usize]) -> mask8x32<Self>;
-    #[doc = "Convert a SIMD mask to signed integer mask lanes."]
-    fn as_array_mask8x32(self, a: mask8x32<Self>) -> [i8; 32usize];
     #[doc = "Create a SIMD mask from a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are ignored."]
     fn from_bitmask_mask8x32(self, bits: u64) -> mask8x32<Self>;
     #[doc = "Convert a SIMD mask to a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are cleared."]
@@ -1664,18 +1488,6 @@ pub trait Simd:
     fn split_mask8x32(self, a: mask8x32<Self>) -> (mask8x16<Self>, mask8x16<Self>);
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i16x16(self, val: i16) -> i16x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_i16x16(self, val: [i16; 16usize]) -> i16x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_i16x16(self, val: &[i16; 16usize]) -> i16x16<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_i16x16(self, a: i16x16<Self>) -> [i16; 16usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_i16x16(self, a: &mut i16x16<Self>) -> &mut [i16; 16usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i16x16<const SHIFT: usize>(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -1766,18 +1578,6 @@ pub trait Simd:
     fn neg_i16x16(self, a: i16x16<Self>) -> i16x16<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u16x16(self, val: u16) -> u16x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_u16x16(self, val: &[u16; 16usize]) -> u16x16<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_u16x16(self, a: u16x16<Self>) -> [u16; 16usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_u16x16(self, a: &mut u16x16<Self>) -> &mut [u16; 16usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u16x16<const SHIFT: usize>(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -1868,10 +1668,6 @@ pub trait Simd:
     fn narrow_u16x16(self, a: u16x16<Self>) -> u8x16<Self>;
     #[doc = "Create a SIMD mask with all lanes set from the given boolean value."]
     fn splat_mask16x16(self, val: bool) -> mask16x16<Self>;
-    #[doc = "Create a SIMD mask from signed integer mask lanes."]
-    fn load_array_mask16x16(self, val: [i16; 16usize]) -> mask16x16<Self>;
-    #[doc = "Convert a SIMD mask to signed integer mask lanes."]
-    fn as_array_mask16x16(self, a: mask16x16<Self>) -> [i16; 16usize];
     #[doc = "Create a SIMD mask from a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are ignored."]
     fn from_bitmask_mask16x16(self, bits: u64) -> mask16x16<Self>;
     #[doc = "Convert a SIMD mask to a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are cleared."]
@@ -1909,18 +1705,6 @@ pub trait Simd:
     fn split_mask16x16(self, a: mask16x16<Self>) -> (mask16x8<Self>, mask16x8<Self>);
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i32x8(self, val: i32) -> i32x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_i32x8(self, val: [i32; 8usize]) -> i32x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_i32x8(self, val: &[i32; 8usize]) -> i32x8<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_i32x8(self, a: i32x8<Self>) -> [i32; 8usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_i32x8(self, a: &mut i32x8<Self>) -> &mut [i32; 8usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i32x8<const SHIFT: usize>(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -2009,18 +1793,6 @@ pub trait Simd:
     fn cvt_f32_i32x8(self, a: i32x8<Self>) -> f32x8<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u32x8(self, val: u32) -> u32x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_u32x8(self, val: &[u32; 8usize]) -> u32x8<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_u32x8(self, a: u32x8<Self>) -> [u32; 8usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_u32x8(self, a: &mut u32x8<Self>) -> &mut [u32; 8usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u32x8<const SHIFT: usize>(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -2107,10 +1879,6 @@ pub trait Simd:
     fn cvt_f32_u32x8(self, a: u32x8<Self>) -> f32x8<Self>;
     #[doc = "Create a SIMD mask with all lanes set from the given boolean value."]
     fn splat_mask32x8(self, val: bool) -> mask32x8<Self>;
-    #[doc = "Create a SIMD mask from signed integer mask lanes."]
-    fn load_array_mask32x8(self, val: [i32; 8usize]) -> mask32x8<Self>;
-    #[doc = "Convert a SIMD mask to signed integer mask lanes."]
-    fn as_array_mask32x8(self, a: mask32x8<Self>) -> [i32; 8usize];
     #[doc = "Create a SIMD mask from a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are ignored."]
     fn from_bitmask_mask32x8(self, bits: u64) -> mask32x8<Self>;
     #[doc = "Convert a SIMD mask to a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are cleared."]
@@ -2148,18 +1916,6 @@ pub trait Simd:
     fn split_mask32x8(self, a: mask32x8<Self>) -> (mask32x4<Self>, mask32x4<Self>);
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_f64x4(self, val: f64) -> f64x4<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_f64x4(self, val: [f64; 4usize]) -> f64x4<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_f64x4(self, val: &[f64; 4usize]) -> f64x4<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_f64x4(self, a: f64x4<Self>) -> [f64; 4usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_f64x4(self, a: &mut f64x4<Self>) -> &mut [f64; 4usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f64x4<const SHIFT: usize>(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -2258,18 +2014,6 @@ pub trait Simd:
     fn split_f64x4(self, a: f64x4<Self>) -> (f64x2<Self>, f64x2<Self>);
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i64x4(self, val: i64) -> i64x4<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_i64x4(self, val: [i64; 4usize]) -> i64x4<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_i64x4(self, val: &[i64; 4usize]) -> i64x4<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_i64x4(self, a: i64x4<Self>) -> [i64; 4usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_i64x4(self, a: &i64x4<Self>) -> &[i64; 4usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_i64x4(self, a: &mut i64x4<Self>) -> &mut [i64; 4usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_i64x4(self, a: i64x4<Self>, dest: &mut [i64; 4usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i64x4<const SHIFT: usize>(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -2356,18 +2100,6 @@ pub trait Simd:
     fn neg_i64x4(self, a: i64x4<Self>) -> i64x4<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u64x4(self, val: u64) -> u64x4<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_u64x4(self, val: [u64; 4usize]) -> u64x4<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_u64x4(self, val: &[u64; 4usize]) -> u64x4<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_u64x4(self, a: u64x4<Self>) -> [u64; 4usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_u64x4(self, a: &u64x4<Self>) -> &[u64; 4usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_u64x4(self, a: &mut u64x4<Self>) -> &mut [u64; 4usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_u64x4(self, a: u64x4<Self>, dest: &mut [u64; 4usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u64x4<const SHIFT: usize>(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -2452,10 +2184,6 @@ pub trait Simd:
     fn split_u64x4(self, a: u64x4<Self>) -> (u64x2<Self>, u64x2<Self>);
     #[doc = "Create a SIMD mask with all lanes set from the given boolean value."]
     fn splat_mask64x4(self, val: bool) -> mask64x4<Self>;
-    #[doc = "Create a SIMD mask from signed integer mask lanes."]
-    fn load_array_mask64x4(self, val: [i64; 4usize]) -> mask64x4<Self>;
-    #[doc = "Convert a SIMD mask to signed integer mask lanes."]
-    fn as_array_mask64x4(self, a: mask64x4<Self>) -> [i64; 4usize];
     #[doc = "Create a SIMD mask from a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are ignored."]
     fn from_bitmask_mask64x4(self, bits: u64) -> mask64x4<Self>;
     #[doc = "Convert a SIMD mask to a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are cleared."]
@@ -2493,18 +2221,6 @@ pub trait Simd:
     fn split_mask64x4(self, a: mask64x4<Self>) -> (mask64x2<Self>, mask64x2<Self>);
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_f32x16(self, val: f32) -> f32x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_f32x16(self, val: [f32; 16usize]) -> f32x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_f32x16(self, val: &[f32; 16usize]) -> f32x16<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_f32x16(self, a: f32x16<Self>) -> [f32; 16usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_f32x16(self, a: &mut f32x16<Self>) -> &mut [f32; 16usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f32x16<const SHIFT: usize>(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -2617,18 +2333,6 @@ pub trait Simd:
     fn cvt_i32_precise_f32x16(self, a: f32x16<Self>) -> i32x16<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i8x64(self, val: i8) -> i8x64<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_i8x64(self, val: [i8; 64usize]) -> i8x64<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_i8x64(self, val: &[i8; 64usize]) -> i8x64<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_i8x64(self, a: i8x64<Self>) -> [i8; 64usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_i8x64(self, a: &mut i8x64<Self>) -> &mut [i8; 64usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i8x64<const SHIFT: usize>(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -2713,18 +2417,6 @@ pub trait Simd:
     fn neg_i8x64(self, a: i8x64<Self>) -> i8x64<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u8x64(self, val: u8) -> u8x64<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_u8x64(self, val: [u8; 64usize]) -> u8x64<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_u8x64(self, val: &[u8; 64usize]) -> u8x64<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_u8x64(self, a: u8x64<Self>) -> [u8; 64usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_u8x64(self, a: &mut u8x64<Self>) -> &mut [u8; 64usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u8x64<const SHIFT: usize>(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -2811,10 +2503,6 @@ pub trait Simd:
     fn store_interleaved_128_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> ();
     #[doc = "Create a SIMD mask with all lanes set from the given boolean value."]
     fn splat_mask8x64(self, val: bool) -> mask8x64<Self>;
-    #[doc = "Create a SIMD mask from signed integer mask lanes."]
-    fn load_array_mask8x64(self, val: [i8; 64usize]) -> mask8x64<Self>;
-    #[doc = "Convert a SIMD mask to signed integer mask lanes."]
-    fn as_array_mask8x64(self, a: mask8x64<Self>) -> [i8; 64usize];
     #[doc = "Create a SIMD mask from a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are ignored."]
     fn from_bitmask_mask8x64(self, bits: u64) -> mask8x64<Self>;
     #[doc = "Convert a SIMD mask to a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are cleared."]
@@ -2850,18 +2538,6 @@ pub trait Simd:
     fn split_mask8x64(self, a: mask8x64<Self>) -> (mask8x32<Self>, mask8x32<Self>);
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i16x32(self, val: i16) -> i16x32<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_i16x32(self, val: [i16; 32usize]) -> i16x32<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_i16x32(self, val: &[i16; 32usize]) -> i16x32<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_i16x32(self, a: i16x32<Self>) -> [i16; 32usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_i16x32(self, a: &mut i16x32<Self>) -> &mut [i16; 32usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i16x32<const SHIFT: usize>(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -2950,18 +2626,6 @@ pub trait Simd:
     fn neg_i16x32(self, a: i16x32<Self>) -> i16x32<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u16x32(self, val: u16) -> u16x32<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_u16x32(self, val: [u16; 32usize]) -> u16x32<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_u16x32(self, val: &[u16; 32usize]) -> u16x32<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_u16x32(self, a: u16x32<Self>) -> [u16; 32usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_u16x32(self, a: &mut u16x32<Self>) -> &mut [u16; 32usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u16x32<const SHIFT: usize>(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -3054,10 +2718,6 @@ pub trait Simd:
     fn narrow_u16x32(self, a: u16x32<Self>) -> u8x32<Self>;
     #[doc = "Create a SIMD mask with all lanes set from the given boolean value."]
     fn splat_mask16x32(self, val: bool) -> mask16x32<Self>;
-    #[doc = "Create a SIMD mask from signed integer mask lanes."]
-    fn load_array_mask16x32(self, val: [i16; 32usize]) -> mask16x32<Self>;
-    #[doc = "Convert a SIMD mask to signed integer mask lanes."]
-    fn as_array_mask16x32(self, a: mask16x32<Self>) -> [i16; 32usize];
     #[doc = "Create a SIMD mask from a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are ignored."]
     fn from_bitmask_mask16x32(self, bits: u64) -> mask16x32<Self>;
     #[doc = "Convert a SIMD mask to a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are cleared."]
@@ -3093,18 +2753,6 @@ pub trait Simd:
     fn split_mask16x32(self, a: mask16x32<Self>) -> (mask16x16<Self>, mask16x16<Self>);
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i32x16(self, val: i32) -> i32x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_i32x16(self, val: [i32; 16usize]) -> i32x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_i32x16(self, val: &[i32; 16usize]) -> i32x16<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_i32x16(self, a: i32x16<Self>) -> [i32; 16usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_i32x16(self, a: &mut i32x16<Self>) -> &mut [i32; 16usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i32x16<const SHIFT: usize>(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -3195,18 +2843,6 @@ pub trait Simd:
     fn cvt_f32_i32x16(self, a: i32x16<Self>) -> f32x16<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u32x16(self, val: u32) -> u32x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_u32x16(self, val: [u32; 16usize]) -> u32x16<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_u32x16(self, val: &[u32; 16usize]) -> u32x16<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_u32x16(self, a: u32x16<Self>) -> [u32; 16usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_u32x16(self, a: &mut u32x16<Self>) -> &mut [u32; 16usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u32x16<const SHIFT: usize>(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -3299,10 +2935,6 @@ pub trait Simd:
     fn cvt_f32_u32x16(self, a: u32x16<Self>) -> f32x16<Self>;
     #[doc = "Create a SIMD mask with all lanes set from the given boolean value."]
     fn splat_mask32x16(self, val: bool) -> mask32x16<Self>;
-    #[doc = "Create a SIMD mask from signed integer mask lanes."]
-    fn load_array_mask32x16(self, val: [i32; 16usize]) -> mask32x16<Self>;
-    #[doc = "Convert a SIMD mask to signed integer mask lanes."]
-    fn as_array_mask32x16(self, a: mask32x16<Self>) -> [i32; 16usize];
     #[doc = "Create a SIMD mask from a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are ignored."]
     fn from_bitmask_mask32x16(self, bits: u64) -> mask32x16<Self>;
     #[doc = "Convert a SIMD mask to a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are cleared."]
@@ -3338,18 +2970,6 @@ pub trait Simd:
     fn split_mask32x16(self, a: mask32x16<Self>) -> (mask32x8<Self>, mask32x8<Self>);
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_f64x8(self, val: f64) -> f64x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_f64x8(self, val: [f64; 8usize]) -> f64x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_f64x8(self, val: &[f64; 8usize]) -> f64x8<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_f64x8(self, a: f64x8<Self>) -> [f64; 8usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_f64x8(self, a: &mut f64x8<Self>) -> &mut [f64; 8usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f64x8<const SHIFT: usize>(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -3446,18 +3066,6 @@ pub trait Simd:
     fn split_f64x8(self, a: f64x8<Self>) -> (f64x4<Self>, f64x4<Self>);
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i64x8(self, val: i64) -> i64x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_i64x8(self, val: [i64; 8usize]) -> i64x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_i64x8(self, val: &[i64; 8usize]) -> i64x8<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_i64x8(self, a: i64x8<Self>) -> [i64; 8usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_i64x8(self, a: &i64x8<Self>) -> &[i64; 8usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_i64x8(self, a: &mut i64x8<Self>) -> &mut [i64; 8usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_i64x8(self, a: i64x8<Self>, dest: &mut [i64; 8usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i64x8<const SHIFT: usize>(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -3542,18 +3150,6 @@ pub trait Simd:
     fn neg_i64x8(self, a: i64x8<Self>) -> i64x8<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u64x8(self, val: u64) -> u64x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_u64x8(self, val: [u64; 8usize]) -> u64x8<Self>;
-    #[doc = "Create a SIMD vector from an array of the same length."]
-    fn load_array_ref_u64x8(self, val: &[u64; 8usize]) -> u64x8<Self>;
-    #[doc = "Convert a SIMD vector to an array."]
-    fn as_array_u64x8(self, a: u64x8<Self>) -> [u64; 8usize];
-    #[doc = "Project a reference to a SIMD vector to a reference to the equivalent array."]
-    fn as_array_ref_u64x8(self, a: &u64x8<Self>) -> &[u64; 8usize];
-    #[doc = "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array."]
-    fn as_array_mut_u64x8(self, a: &mut u64x8<Self>) -> &mut [u64; 8usize];
-    #[doc = "Store a SIMD vector into an array of the same length."]
-    fn store_array_u64x8(self, a: u64x8<Self>, dest: &mut [u64; 8usize]) -> ();
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u64x8<const SHIFT: usize>(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -3640,10 +3236,6 @@ pub trait Simd:
     fn store_interleaved_128_u64x8(self, a: u64x8<Self>, dest: &mut [u64; 8usize]) -> ();
     #[doc = "Create a SIMD mask with all lanes set from the given boolean value."]
     fn splat_mask64x8(self, val: bool) -> mask64x8<Self>;
-    #[doc = "Create a SIMD mask from signed integer mask lanes."]
-    fn load_array_mask64x8(self, val: [i64; 8usize]) -> mask64x8<Self>;
-    #[doc = "Convert a SIMD mask to signed integer mask lanes."]
-    fn as_array_mask64x8(self, a: mask64x8<Self>) -> [i64; 8usize];
     #[doc = "Create a SIMD mask from a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are ignored."]
     fn from_bitmask_mask64x8(self, bits: u64) -> mask64x8<Self>;
     #[doc = "Convert a SIMD mask to a compact bitmask.\n\nBit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above the number of lanes in this mask are cleared."]
@@ -3684,7 +3276,7 @@ pub(crate) mod arch_types {
         unnameable_types,
         reason = "The native vector types that back a `Simd` implementation are an internal implementation detail, and intentionally kept private"
     )]
-    pub trait ArchTypes {
+    pub trait ArchTypes: Sized {
         type f32x4: Copy + Send + Sync + SimdPod;
         type i8x16: Copy + Send + Sync + SimdPod;
         type u8x16: Copy + Send + Sync + SimdPod;
@@ -3727,6 +3319,102 @@ pub(crate) mod arch_types {
         type i64x8: Copy + Send + Sync + SimdPod;
         type u64x8: Copy + Send + Sync + SimdPod;
         type mask64x8: Copy + Send + Sync + SimdPod;
+        #[inline(always)]
+        fn mask8x16_from_array(self, val: [i8; 16usize]) -> Self::mask8x16 {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask8x16_to_array(self, val: Self::mask8x16) -> [i8; 16usize] {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask16x8_from_array(self, val: [i16; 8usize]) -> Self::mask16x8 {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask16x8_to_array(self, val: Self::mask16x8) -> [i16; 8usize] {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask32x4_from_array(self, val: [i32; 4usize]) -> Self::mask32x4 {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask32x4_to_array(self, val: Self::mask32x4) -> [i32; 4usize] {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask64x2_from_array(self, val: [i64; 2usize]) -> Self::mask64x2 {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask64x2_to_array(self, val: Self::mask64x2) -> [i64; 2usize] {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask8x32_from_array(self, val: [i8; 32usize]) -> Self::mask8x32 {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask8x32_to_array(self, val: Self::mask8x32) -> [i8; 32usize] {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask16x16_from_array(self, val: [i16; 16usize]) -> Self::mask16x16 {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask16x16_to_array(self, val: Self::mask16x16) -> [i16; 16usize] {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask32x8_from_array(self, val: [i32; 8usize]) -> Self::mask32x8 {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask32x8_to_array(self, val: Self::mask32x8) -> [i32; 8usize] {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask64x4_from_array(self, val: [i64; 4usize]) -> Self::mask64x4 {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask64x4_to_array(self, val: Self::mask64x4) -> [i64; 4usize] {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask8x64_from_array(self, val: [i8; 64usize]) -> Self::mask8x64 {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask8x64_to_array(self, val: Self::mask8x64) -> [i8; 64usize] {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask16x32_from_array(self, val: [i16; 32usize]) -> Self::mask16x32 {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask16x32_to_array(self, val: Self::mask16x32) -> [i16; 32usize] {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask32x16_from_array(self, val: [i32; 16usize]) -> Self::mask32x16 {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask32x16_to_array(self, val: Self::mask32x16) -> [i32; 16usize] {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask64x8_from_array(self, val: [i64; 8usize]) -> Self::mask64x8 {
+            crate::transmute::checked_transmute_copy(&val)
+        }
+        #[inline(always)]
+        fn mask64x8_to_array(self, val: Self::mask64x8) -> [i64; 8usize] {
+            crate::transmute::checked_transmute_copy(&val)
+        }
     }
 }
 #[doc = r" Base functionality implemented by all SIMD vectors."]
@@ -3788,6 +3476,36 @@ pub trait SimdBase<S: Simd>:
     #[doc = r""]
     #[doc = r" The slice must be exactly the size of the SIMD vector."]
     fn store_slice(&self, slice: &mut [Self::Element]);
+    #[doc = r" Create a SIMD vector from its corresponding lane array."]
+    #[inline(always)]
+    fn load_array(simd: S, val: Self::Array) -> Self {
+        Self::simd_from(simd, val)
+    }
+    #[doc = r" Create a SIMD vector from a reference to its corresponding lane array."]
+    #[inline(always)]
+    fn load_array_ref(simd: S, val: &Self::Array) -> Self {
+        Self::load_array(simd, *val)
+    }
+    #[doc = r" Convert this SIMD vector to its corresponding lane array."]
+    #[inline(always)]
+    fn as_array(self) -> Self::Array {
+        *self
+    }
+    #[doc = r" Project this SIMD vector reference to its corresponding lane array reference."]
+    #[inline(always)]
+    fn as_array_ref(&self) -> &Self::Array {
+        self
+    }
+    #[doc = r" Project this mutable SIMD vector reference to its corresponding mutable lane array reference."]
+    #[inline(always)]
+    fn as_array_mut(&mut self) -> &mut Self::Array {
+        self
+    }
+    #[doc = r" Store this SIMD vector into its corresponding lane array."]
+    #[inline(always)]
+    fn store_array(self, dest: &mut Self::Array) {
+        *dest = self.as_array();
+    }
     #[doc = r" Create a SIMD vector from a 128-bit vector of the same scalar"]
     #[doc = r" type, repeated."]
     fn block_splat(block: Self::Block) -> Self;

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -18,31 +18,34 @@ impl<S: Simd> Seal for f32x4<S> {}
 impl<S: Simd> SimdFrom<[f32; 4], S> for f32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [f32; 4]) -> Self {
-        simd.load_array_f32x4(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<f32x4<S>> for [f32; 4] {
     #[inline(always)]
     fn from(value: f32x4<S>) -> Self {
-        value.simd.as_array_f32x4(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for f32x4<S> {
     type Target = [f32; 4];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_f32x4(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for f32x4<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_f32x4(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for f32x4<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "f32x4", &self.simd, self.simd.as_array_ref_f32x4(self))
+        crate::support::simd_debug_impl(f, "f32x4", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<f32, S> for f32x4<S> {
@@ -55,13 +58,13 @@ impl<S: Simd> core::ops::Index<usize> for f32x4<S> {
     type Output = f32;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_f32x4(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for f32x4<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_f32x4(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<f32x4<S>> for mask32x4<S> {
@@ -100,20 +103,19 @@ impl<S: Simd> SimdBase<S> for f32x4<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[f32] {
-        self.simd.as_array_ref_f32x4(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [f32] {
-        self.simd.as_array_mut_f32x4(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[f32]) -> Self {
-        simd.load_array_ref_f32x4(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [f32]) {
-        self.simd
-            .store_array_f32x4(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: f32) -> Self {
@@ -125,7 +127,7 @@ impl<S: Simd> SimdBase<S> for f32x4<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> f32) -> Self {
-        simd.load_array_f32x4([f(0usize), f(1usize), f(2usize), f(3usize)])
+        Self::load_array(simd, [f(0usize), f(1usize), f(2usize), f(3usize)])
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -305,31 +307,34 @@ impl<S: Simd> Seal for i8x16<S> {}
 impl<S: Simd> SimdFrom<[i8; 16], S> for i8x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i8; 16]) -> Self {
-        simd.load_array_i8x16(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<i8x16<S>> for [i8; 16] {
     #[inline(always)]
     fn from(value: i8x16<S>) -> Self {
-        value.simd.as_array_i8x16(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for i8x16<S> {
     type Target = [i8; 16];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_i8x16(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for i8x16<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_i8x16(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for i8x16<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "i8x16", &self.simd, self.simd.as_array_ref_i8x16(self))
+        crate::support::simd_debug_impl(f, "i8x16", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<i8, S> for i8x16<S> {
@@ -342,13 +347,13 @@ impl<S: Simd> core::ops::Index<usize> for i8x16<S> {
     type Output = i8;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_i8x16(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for i8x16<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_i8x16(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<i8x16<S>> for mask8x16<S> {
@@ -387,20 +392,19 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[i8] {
-        self.simd.as_array_ref_i8x16(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [i8] {
-        self.simd.as_array_mut_i8x16(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i8]) -> Self {
-        simd.load_array_ref_i8x16(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i8]) {
-        self.simd
-            .store_array_i8x16(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: i8) -> Self {
@@ -412,24 +416,27 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> i8) -> Self {
-        simd.load_array_i8x16([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -541,31 +548,34 @@ impl<S: Simd> Seal for u8x16<S> {}
 impl<S: Simd> SimdFrom<[u8; 16], S> for u8x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [u8; 16]) -> Self {
-        simd.load_array_u8x16(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<u8x16<S>> for [u8; 16] {
     #[inline(always)]
     fn from(value: u8x16<S>) -> Self {
-        value.simd.as_array_u8x16(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for u8x16<S> {
     type Target = [u8; 16];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_u8x16(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for u8x16<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_u8x16(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for u8x16<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "u8x16", &self.simd, self.simd.as_array_ref_u8x16(self))
+        crate::support::simd_debug_impl(f, "u8x16", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<u8, S> for u8x16<S> {
@@ -578,13 +588,13 @@ impl<S: Simd> core::ops::Index<usize> for u8x16<S> {
     type Output = u8;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_u8x16(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for u8x16<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_u8x16(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<u8x16<S>> for mask8x16<S> {
@@ -623,20 +633,19 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[u8] {
-        self.simd.as_array_ref_u8x16(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [u8] {
-        self.simd.as_array_mut_u8x16(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u8]) -> Self {
-        simd.load_array_ref_u8x16(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u8]) {
-        self.simd
-            .store_array_u8x16(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: u8) -> Self {
@@ -648,24 +657,27 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> u8) -> Self {
-        simd.load_array_u8x16([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -776,18 +788,21 @@ impl<S: Simd> Seal for mask8x16<S> {}
 impl<S: Simd> SimdFrom<[i8; 16], S> for mask8x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i8; 16]) -> Self {
-        simd.load_array_mask8x16(val)
+        Self {
+            val: <S as crate::arch_types::ArchTypes>::mask8x16_from_array(simd, val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<mask8x16<S>> for [i8; 16] {
     #[inline(always)]
     fn from(value: mask8x16<S>) -> Self {
-        value.simd.as_array_mask8x16(value)
+        <S as crate::arch_types::ArchTypes>::mask8x16_to_array(value.simd, value.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for mask8x16<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let lanes = self.simd.as_array_mask8x16(*self);
+        let lanes: [i8; 16] = (*self).into();
         crate::support::simd_debug_impl(f, "mask8x16", &self.simd, &lanes)
     }
 }
@@ -829,12 +844,12 @@ impl<S: Simd> SimdMask<S> for mask8x16<S> {
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i8]) -> Self {
         let slice: &[i8; 16] = slice.try_into().unwrap();
-        simd.load_array_mask8x16(*slice)
+        Self::simd_from(simd, *slice)
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i8]) {
         let slice: &mut [i8; 16] = slice.try_into().unwrap();
-        *slice = self.simd.as_array_mask8x16(*self);
+        *slice = (*self).into();
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -868,31 +883,34 @@ impl<S: Simd> Seal for i16x8<S> {}
 impl<S: Simd> SimdFrom<[i16; 8], S> for i16x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i16; 8]) -> Self {
-        simd.load_array_i16x8(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<i16x8<S>> for [i16; 8] {
     #[inline(always)]
     fn from(value: i16x8<S>) -> Self {
-        value.simd.as_array_i16x8(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for i16x8<S> {
     type Target = [i16; 8];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_i16x8(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for i16x8<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_i16x8(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for i16x8<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "i16x8", &self.simd, self.simd.as_array_ref_i16x8(self))
+        crate::support::simd_debug_impl(f, "i16x8", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<i16, S> for i16x8<S> {
@@ -905,13 +923,13 @@ impl<S: Simd> core::ops::Index<usize> for i16x8<S> {
     type Output = i16;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_i16x8(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for i16x8<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_i16x8(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<i16x8<S>> for mask16x8<S> {
@@ -950,20 +968,19 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[i16] {
-        self.simd.as_array_ref_i16x8(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [i16] {
-        self.simd.as_array_mut_i16x8(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i16]) -> Self {
-        simd.load_array_ref_i16x8(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i16]) {
-        self.simd
-            .store_array_i16x8(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: i16) -> Self {
@@ -975,16 +992,19 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> i16) -> Self {
-        simd.load_array_i16x8([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -1096,31 +1116,34 @@ impl<S: Simd> Seal for u16x8<S> {}
 impl<S: Simd> SimdFrom<[u16; 8], S> for u16x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [u16; 8]) -> Self {
-        simd.load_array_u16x8(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<u16x8<S>> for [u16; 8] {
     #[inline(always)]
     fn from(value: u16x8<S>) -> Self {
-        value.simd.as_array_u16x8(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for u16x8<S> {
     type Target = [u16; 8];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_u16x8(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for u16x8<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_u16x8(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for u16x8<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "u16x8", &self.simd, self.simd.as_array_ref_u16x8(self))
+        crate::support::simd_debug_impl(f, "u16x8", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<u16, S> for u16x8<S> {
@@ -1133,13 +1156,13 @@ impl<S: Simd> core::ops::Index<usize> for u16x8<S> {
     type Output = u16;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_u16x8(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for u16x8<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_u16x8(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<u16x8<S>> for mask16x8<S> {
@@ -1178,20 +1201,19 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[u16] {
-        self.simd.as_array_ref_u16x8(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [u16] {
-        self.simd.as_array_mut_u16x8(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u16]) -> Self {
-        simd.load_array_ref_u16x8(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u16]) {
-        self.simd
-            .store_array_u16x8(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: u16) -> Self {
@@ -1203,16 +1225,19 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> u16) -> Self {
-        simd.load_array_u16x8([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -1323,18 +1348,21 @@ impl<S: Simd> Seal for mask16x8<S> {}
 impl<S: Simd> SimdFrom<[i16; 8], S> for mask16x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i16; 8]) -> Self {
-        simd.load_array_mask16x8(val)
+        Self {
+            val: <S as crate::arch_types::ArchTypes>::mask16x8_from_array(simd, val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<mask16x8<S>> for [i16; 8] {
     #[inline(always)]
     fn from(value: mask16x8<S>) -> Self {
-        value.simd.as_array_mask16x8(value)
+        <S as crate::arch_types::ArchTypes>::mask16x8_to_array(value.simd, value.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for mask16x8<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let lanes = self.simd.as_array_mask16x8(*self);
+        let lanes: [i16; 8] = (*self).into();
         crate::support::simd_debug_impl(f, "mask16x8", &self.simd, &lanes)
     }
 }
@@ -1376,12 +1404,12 @@ impl<S: Simd> SimdMask<S> for mask16x8<S> {
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i16]) -> Self {
         let slice: &[i16; 8] = slice.try_into().unwrap();
-        simd.load_array_mask16x8(*slice)
+        Self::simd_from(simd, *slice)
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i16]) {
         let slice: &mut [i16; 8] = slice.try_into().unwrap();
-        *slice = self.simd.as_array_mask16x8(*self);
+        *slice = (*self).into();
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -1415,31 +1443,34 @@ impl<S: Simd> Seal for i32x4<S> {}
 impl<S: Simd> SimdFrom<[i32; 4], S> for i32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i32; 4]) -> Self {
-        simd.load_array_i32x4(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<i32x4<S>> for [i32; 4] {
     #[inline(always)]
     fn from(value: i32x4<S>) -> Self {
-        value.simd.as_array_i32x4(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for i32x4<S> {
     type Target = [i32; 4];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_i32x4(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for i32x4<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_i32x4(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for i32x4<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "i32x4", &self.simd, self.simd.as_array_ref_i32x4(self))
+        crate::support::simd_debug_impl(f, "i32x4", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<i32, S> for i32x4<S> {
@@ -1452,13 +1483,13 @@ impl<S: Simd> core::ops::Index<usize> for i32x4<S> {
     type Output = i32;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_i32x4(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for i32x4<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_i32x4(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<i32x4<S>> for mask32x4<S> {
@@ -1497,20 +1528,19 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[i32] {
-        self.simd.as_array_ref_i32x4(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [i32] {
-        self.simd.as_array_mut_i32x4(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i32]) -> Self {
-        simd.load_array_ref_i32x4(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i32]) {
-        self.simd
-            .store_array_i32x4(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: i32) -> Self {
@@ -1522,7 +1552,7 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> i32) -> Self {
-        simd.load_array_i32x4([f(0usize), f(1usize), f(2usize), f(3usize)])
+        Self::load_array(simd, [f(0usize), f(1usize), f(2usize), f(3usize)])
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -1646,31 +1676,34 @@ impl<S: Simd> Seal for u32x4<S> {}
 impl<S: Simd> SimdFrom<[u32; 4], S> for u32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [u32; 4]) -> Self {
-        simd.load_array_u32x4(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<u32x4<S>> for [u32; 4] {
     #[inline(always)]
     fn from(value: u32x4<S>) -> Self {
-        value.simd.as_array_u32x4(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for u32x4<S> {
     type Target = [u32; 4];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_u32x4(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for u32x4<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_u32x4(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for u32x4<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "u32x4", &self.simd, self.simd.as_array_ref_u32x4(self))
+        crate::support::simd_debug_impl(f, "u32x4", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<u32, S> for u32x4<S> {
@@ -1683,13 +1716,13 @@ impl<S: Simd> core::ops::Index<usize> for u32x4<S> {
     type Output = u32;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_u32x4(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for u32x4<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_u32x4(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<u32x4<S>> for mask32x4<S> {
@@ -1728,20 +1761,19 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[u32] {
-        self.simd.as_array_ref_u32x4(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [u32] {
-        self.simd.as_array_mut_u32x4(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u32]) -> Self {
-        simd.load_array_ref_u32x4(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u32]) {
-        self.simd
-            .store_array_u32x4(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: u32) -> Self {
@@ -1753,7 +1785,7 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> u32) -> Self {
-        simd.load_array_u32x4([f(0usize), f(1usize), f(2usize), f(3usize)])
+        Self::load_array(simd, [f(0usize), f(1usize), f(2usize), f(3usize)])
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -1876,18 +1908,21 @@ impl<S: Simd> Seal for mask32x4<S> {}
 impl<S: Simd> SimdFrom<[i32; 4], S> for mask32x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i32; 4]) -> Self {
-        simd.load_array_mask32x4(val)
+        Self {
+            val: <S as crate::arch_types::ArchTypes>::mask32x4_from_array(simd, val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<mask32x4<S>> for [i32; 4] {
     #[inline(always)]
     fn from(value: mask32x4<S>) -> Self {
-        value.simd.as_array_mask32x4(value)
+        <S as crate::arch_types::ArchTypes>::mask32x4_to_array(value.simd, value.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for mask32x4<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let lanes = self.simd.as_array_mask32x4(*self);
+        let lanes: [i32; 4] = (*self).into();
         crate::support::simd_debug_impl(f, "mask32x4", &self.simd, &lanes)
     }
 }
@@ -1929,12 +1964,12 @@ impl<S: Simd> SimdMask<S> for mask32x4<S> {
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i32]) -> Self {
         let slice: &[i32; 4] = slice.try_into().unwrap();
-        simd.load_array_mask32x4(*slice)
+        Self::simd_from(simd, *slice)
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i32]) {
         let slice: &mut [i32; 4] = slice.try_into().unwrap();
-        *slice = self.simd.as_array_mask32x4(*self);
+        *slice = (*self).into();
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -1968,31 +2003,34 @@ impl<S: Simd> Seal for f64x2<S> {}
 impl<S: Simd> SimdFrom<[f64; 2], S> for f64x2<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [f64; 2]) -> Self {
-        simd.load_array_f64x2(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<f64x2<S>> for [f64; 2] {
     #[inline(always)]
     fn from(value: f64x2<S>) -> Self {
-        value.simd.as_array_f64x2(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for f64x2<S> {
     type Target = [f64; 2];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_f64x2(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for f64x2<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_f64x2(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for f64x2<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "f64x2", &self.simd, self.simd.as_array_ref_f64x2(self))
+        crate::support::simd_debug_impl(f, "f64x2", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<f64, S> for f64x2<S> {
@@ -2005,13 +2043,13 @@ impl<S: Simd> core::ops::Index<usize> for f64x2<S> {
     type Output = f64;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_f64x2(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for f64x2<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_f64x2(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<f64x2<S>> for mask64x2<S> {
@@ -2050,20 +2088,19 @@ impl<S: Simd> SimdBase<S> for f64x2<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[f64] {
-        self.simd.as_array_ref_f64x2(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [f64] {
-        self.simd.as_array_mut_f64x2(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[f64]) -> Self {
-        simd.load_array_ref_f64x2(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [f64]) {
-        self.simd
-            .store_array_f64x2(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: f64) -> Self {
@@ -2075,7 +2112,7 @@ impl<S: Simd> SimdBase<S> for f64x2<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> f64) -> Self {
-        simd.load_array_f64x2([f(0usize), f(1usize)])
+        Self::load_array(simd, [f(0usize), f(1usize)])
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -2241,31 +2278,34 @@ impl<S: Simd> Seal for i64x2<S> {}
 impl<S: Simd> SimdFrom<[i64; 2], S> for i64x2<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i64; 2]) -> Self {
-        simd.load_array_i64x2(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<i64x2<S>> for [i64; 2] {
     #[inline(always)]
     fn from(value: i64x2<S>) -> Self {
-        value.simd.as_array_i64x2(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for i64x2<S> {
     type Target = [i64; 2];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_i64x2(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for i64x2<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_i64x2(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for i64x2<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "i64x2", &self.simd, self.simd.as_array_ref_i64x2(self))
+        crate::support::simd_debug_impl(f, "i64x2", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<i64, S> for i64x2<S> {
@@ -2278,13 +2318,13 @@ impl<S: Simd> core::ops::Index<usize> for i64x2<S> {
     type Output = i64;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_i64x2(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for i64x2<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_i64x2(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<i64x2<S>> for mask64x2<S> {
@@ -2323,20 +2363,19 @@ impl<S: Simd> SimdBase<S> for i64x2<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[i64] {
-        self.simd.as_array_ref_i64x2(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [i64] {
-        self.simd.as_array_mut_i64x2(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i64]) -> Self {
-        simd.load_array_ref_i64x2(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i64]) {
-        self.simd
-            .store_array_i64x2(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: i64) -> Self {
@@ -2348,7 +2387,7 @@ impl<S: Simd> SimdBase<S> for i64x2<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> i64) -> Self {
-        simd.load_array_i64x2([f(0usize), f(1usize)])
+        Self::load_array(simd, [f(0usize), f(1usize)])
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -2460,31 +2499,34 @@ impl<S: Simd> Seal for u64x2<S> {}
 impl<S: Simd> SimdFrom<[u64; 2], S> for u64x2<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [u64; 2]) -> Self {
-        simd.load_array_u64x2(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<u64x2<S>> for [u64; 2] {
     #[inline(always)]
     fn from(value: u64x2<S>) -> Self {
-        value.simd.as_array_u64x2(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for u64x2<S> {
     type Target = [u64; 2];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_u64x2(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for u64x2<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_u64x2(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for u64x2<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "u64x2", &self.simd, self.simd.as_array_ref_u64x2(self))
+        crate::support::simd_debug_impl(f, "u64x2", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<u64, S> for u64x2<S> {
@@ -2497,13 +2539,13 @@ impl<S: Simd> core::ops::Index<usize> for u64x2<S> {
     type Output = u64;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_u64x2(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for u64x2<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_u64x2(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<u64x2<S>> for mask64x2<S> {
@@ -2542,20 +2584,19 @@ impl<S: Simd> SimdBase<S> for u64x2<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[u64] {
-        self.simd.as_array_ref_u64x2(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [u64] {
-        self.simd.as_array_mut_u64x2(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u64]) -> Self {
-        simd.load_array_ref_u64x2(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u64]) {
-        self.simd
-            .store_array_u64x2(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: u64) -> Self {
@@ -2567,7 +2608,7 @@ impl<S: Simd> SimdBase<S> for u64x2<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> u64) -> Self {
-        simd.load_array_u64x2([f(0usize), f(1usize)])
+        Self::load_array(simd, [f(0usize), f(1usize)])
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -2678,18 +2719,21 @@ impl<S: Simd> Seal for mask64x2<S> {}
 impl<S: Simd> SimdFrom<[i64; 2], S> for mask64x2<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i64; 2]) -> Self {
-        simd.load_array_mask64x2(val)
+        Self {
+            val: <S as crate::arch_types::ArchTypes>::mask64x2_from_array(simd, val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<mask64x2<S>> for [i64; 2] {
     #[inline(always)]
     fn from(value: mask64x2<S>) -> Self {
-        value.simd.as_array_mask64x2(value)
+        <S as crate::arch_types::ArchTypes>::mask64x2_to_array(value.simd, value.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for mask64x2<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let lanes = self.simd.as_array_mask64x2(*self);
+        let lanes: [i64; 2] = (*self).into();
         crate::support::simd_debug_impl(f, "mask64x2", &self.simd, &lanes)
     }
 }
@@ -2731,12 +2775,12 @@ impl<S: Simd> SimdMask<S> for mask64x2<S> {
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i64]) -> Self {
         let slice: &[i64; 2] = slice.try_into().unwrap();
-        simd.load_array_mask64x2(*slice)
+        Self::simd_from(simd, *slice)
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i64]) {
         let slice: &mut [i64; 2] = slice.try_into().unwrap();
-        *slice = self.simd.as_array_mask64x2(*self);
+        *slice = (*self).into();
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -2770,31 +2814,34 @@ impl<S: Simd> Seal for f32x8<S> {}
 impl<S: Simd> SimdFrom<[f32; 8], S> for f32x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [f32; 8]) -> Self {
-        simd.load_array_f32x8(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<f32x8<S>> for [f32; 8] {
     #[inline(always)]
     fn from(value: f32x8<S>) -> Self {
-        value.simd.as_array_f32x8(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for f32x8<S> {
     type Target = [f32; 8];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_f32x8(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for f32x8<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_f32x8(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for f32x8<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "f32x8", &self.simd, self.simd.as_array_ref_f32x8(self))
+        crate::support::simd_debug_impl(f, "f32x8", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<f32, S> for f32x8<S> {
@@ -2807,13 +2854,13 @@ impl<S: Simd> core::ops::Index<usize> for f32x8<S> {
     type Output = f32;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_f32x8(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for f32x8<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_f32x8(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<f32x8<S>> for mask32x8<S> {
@@ -2852,20 +2899,19 @@ impl<S: Simd> SimdBase<S> for f32x8<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[f32] {
-        self.simd.as_array_ref_f32x8(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [f32] {
-        self.simd.as_array_mut_f32x8(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[f32]) -> Self {
-        simd.load_array_ref_f32x8(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [f32]) {
-        self.simd
-            .store_array_f32x8(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: f32) -> Self {
@@ -2877,16 +2923,19 @@ impl<S: Simd> SimdBase<S> for f32x8<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> f32) -> Self {
-        simd.load_array_f32x8([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -3073,31 +3122,34 @@ impl<S: Simd> Seal for i8x32<S> {}
 impl<S: Simd> SimdFrom<[i8; 32], S> for i8x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i8; 32]) -> Self {
-        simd.load_array_i8x32(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<i8x32<S>> for [i8; 32] {
     #[inline(always)]
     fn from(value: i8x32<S>) -> Self {
-        value.simd.as_array_i8x32(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for i8x32<S> {
     type Target = [i8; 32];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_i8x32(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for i8x32<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_i8x32(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for i8x32<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "i8x32", &self.simd, self.simd.as_array_ref_i8x32(self))
+        crate::support::simd_debug_impl(f, "i8x32", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<i8, S> for i8x32<S> {
@@ -3110,13 +3162,13 @@ impl<S: Simd> core::ops::Index<usize> for i8x32<S> {
     type Output = i8;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_i8x32(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for i8x32<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_i8x32(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<i8x32<S>> for mask8x32<S> {
@@ -3155,20 +3207,19 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[i8] {
-        self.simd.as_array_ref_i8x32(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [i8] {
-        self.simd.as_array_mut_i8x32(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i8]) -> Self {
-        simd.load_array_ref_i8x32(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i8]) {
-        self.simd
-            .store_array_i8x32(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: i8) -> Self {
@@ -3180,40 +3231,43 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> i8) -> Self {
-        simd.load_array_i8x32([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-            f(16usize),
-            f(17usize),
-            f(18usize),
-            f(19usize),
-            f(20usize),
-            f(21usize),
-            f(22usize),
-            f(23usize),
-            f(24usize),
-            f(25usize),
-            f(26usize),
-            f(27usize),
-            f(28usize),
-            f(29usize),
-            f(30usize),
-            f(31usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+                f(16usize),
+                f(17usize),
+                f(18usize),
+                f(19usize),
+                f(20usize),
+                f(21usize),
+                f(22usize),
+                f(23usize),
+                f(24usize),
+                f(25usize),
+                f(26usize),
+                f(27usize),
+                f(28usize),
+                f(29usize),
+                f(30usize),
+                f(31usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -3332,31 +3386,34 @@ impl<S: Simd> Seal for u8x32<S> {}
 impl<S: Simd> SimdFrom<[u8; 32], S> for u8x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [u8; 32]) -> Self {
-        simd.load_array_u8x32(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<u8x32<S>> for [u8; 32] {
     #[inline(always)]
     fn from(value: u8x32<S>) -> Self {
-        value.simd.as_array_u8x32(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for u8x32<S> {
     type Target = [u8; 32];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_u8x32(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for u8x32<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_u8x32(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for u8x32<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "u8x32", &self.simd, self.simd.as_array_ref_u8x32(self))
+        crate::support::simd_debug_impl(f, "u8x32", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<u8, S> for u8x32<S> {
@@ -3369,13 +3426,13 @@ impl<S: Simd> core::ops::Index<usize> for u8x32<S> {
     type Output = u8;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_u8x32(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for u8x32<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_u8x32(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<u8x32<S>> for mask8x32<S> {
@@ -3414,20 +3471,19 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[u8] {
-        self.simd.as_array_ref_u8x32(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [u8] {
-        self.simd.as_array_mut_u8x32(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u8]) -> Self {
-        simd.load_array_ref_u8x32(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u8]) {
-        self.simd
-            .store_array_u8x32(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: u8) -> Self {
@@ -3439,40 +3495,43 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> u8) -> Self {
-        simd.load_array_u8x32([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-            f(16usize),
-            f(17usize),
-            f(18usize),
-            f(19usize),
-            f(20usize),
-            f(21usize),
-            f(22usize),
-            f(23usize),
-            f(24usize),
-            f(25usize),
-            f(26usize),
-            f(27usize),
-            f(28usize),
-            f(29usize),
-            f(30usize),
-            f(31usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+                f(16usize),
+                f(17usize),
+                f(18usize),
+                f(19usize),
+                f(20usize),
+                f(21usize),
+                f(22usize),
+                f(23usize),
+                f(24usize),
+                f(25usize),
+                f(26usize),
+                f(27usize),
+                f(28usize),
+                f(29usize),
+                f(30usize),
+                f(31usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -3590,18 +3649,21 @@ impl<S: Simd> Seal for mask8x32<S> {}
 impl<S: Simd> SimdFrom<[i8; 32], S> for mask8x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i8; 32]) -> Self {
-        simd.load_array_mask8x32(val)
+        Self {
+            val: <S as crate::arch_types::ArchTypes>::mask8x32_from_array(simd, val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<mask8x32<S>> for [i8; 32] {
     #[inline(always)]
     fn from(value: mask8x32<S>) -> Self {
-        value.simd.as_array_mask8x32(value)
+        <S as crate::arch_types::ArchTypes>::mask8x32_to_array(value.simd, value.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for mask8x32<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let lanes = self.simd.as_array_mask8x32(*self);
+        let lanes: [i8; 32] = (*self).into();
         crate::support::simd_debug_impl(f, "mask8x32", &self.simd, &lanes)
     }
 }
@@ -3643,12 +3705,12 @@ impl<S: Simd> SimdMask<S> for mask8x32<S> {
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i8]) -> Self {
         let slice: &[i8; 32] = slice.try_into().unwrap();
-        simd.load_array_mask8x32(*slice)
+        Self::simd_from(simd, *slice)
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i8]) {
         let slice: &mut [i8; 32] = slice.try_into().unwrap();
-        *slice = self.simd.as_array_mask8x32(*self);
+        *slice = (*self).into();
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -3682,36 +3744,34 @@ impl<S: Simd> Seal for i16x16<S> {}
 impl<S: Simd> SimdFrom<[i16; 16], S> for i16x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i16; 16]) -> Self {
-        simd.load_array_i16x16(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<i16x16<S>> for [i16; 16] {
     #[inline(always)]
     fn from(value: i16x16<S>) -> Self {
-        value.simd.as_array_i16x16(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for i16x16<S> {
     type Target = [i16; 16];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_i16x16(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for i16x16<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_i16x16(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for i16x16<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(
-            f,
-            "i16x16",
-            &self.simd,
-            self.simd.as_array_ref_i16x16(self),
-        )
+        crate::support::simd_debug_impl(f, "i16x16", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<i16, S> for i16x16<S> {
@@ -3724,13 +3784,13 @@ impl<S: Simd> core::ops::Index<usize> for i16x16<S> {
     type Output = i16;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_i16x16(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for i16x16<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_i16x16(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<i16x16<S>> for mask16x16<S> {
@@ -3769,20 +3829,19 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[i16] {
-        self.simd.as_array_ref_i16x16(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [i16] {
-        self.simd.as_array_mut_i16x16(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i16]) -> Self {
-        simd.load_array_ref_i16x16(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i16]) {
-        self.simd
-            .store_array_i16x16(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: i16) -> Self {
@@ -3794,24 +3853,27 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> i16) -> Self {
-        simd.load_array_i16x16([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -3932,36 +3994,34 @@ impl<S: Simd> Seal for u16x16<S> {}
 impl<S: Simd> SimdFrom<[u16; 16], S> for u16x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [u16; 16]) -> Self {
-        simd.load_array_u16x16(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<u16x16<S>> for [u16; 16] {
     #[inline(always)]
     fn from(value: u16x16<S>) -> Self {
-        value.simd.as_array_u16x16(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for u16x16<S> {
     type Target = [u16; 16];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_u16x16(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for u16x16<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_u16x16(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for u16x16<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(
-            f,
-            "u16x16",
-            &self.simd,
-            self.simd.as_array_ref_u16x16(self),
-        )
+        crate::support::simd_debug_impl(f, "u16x16", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<u16, S> for u16x16<S> {
@@ -3974,13 +4034,13 @@ impl<S: Simd> core::ops::Index<usize> for u16x16<S> {
     type Output = u16;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_u16x16(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for u16x16<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_u16x16(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<u16x16<S>> for mask16x16<S> {
@@ -4019,20 +4079,19 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[u16] {
-        self.simd.as_array_ref_u16x16(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [u16] {
-        self.simd.as_array_mut_u16x16(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u16]) -> Self {
-        simd.load_array_ref_u16x16(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u16]) {
-        self.simd
-            .store_array_u16x16(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: u16) -> Self {
@@ -4044,24 +4103,27 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> u16) -> Self {
-        simd.load_array_u16x16([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -4181,18 +4243,21 @@ impl<S: Simd> Seal for mask16x16<S> {}
 impl<S: Simd> SimdFrom<[i16; 16], S> for mask16x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i16; 16]) -> Self {
-        simd.load_array_mask16x16(val)
+        Self {
+            val: <S as crate::arch_types::ArchTypes>::mask16x16_from_array(simd, val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<mask16x16<S>> for [i16; 16] {
     #[inline(always)]
     fn from(value: mask16x16<S>) -> Self {
-        value.simd.as_array_mask16x16(value)
+        <S as crate::arch_types::ArchTypes>::mask16x16_to_array(value.simd, value.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for mask16x16<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let lanes = self.simd.as_array_mask16x16(*self);
+        let lanes: [i16; 16] = (*self).into();
         crate::support::simd_debug_impl(f, "mask16x16", &self.simd, &lanes)
     }
 }
@@ -4234,12 +4299,12 @@ impl<S: Simd> SimdMask<S> for mask16x16<S> {
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i16]) -> Self {
         let slice: &[i16; 16] = slice.try_into().unwrap();
-        simd.load_array_mask16x16(*slice)
+        Self::simd_from(simd, *slice)
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i16]) {
         let slice: &mut [i16; 16] = slice.try_into().unwrap();
-        *slice = self.simd.as_array_mask16x16(*self);
+        *slice = (*self).into();
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -4273,31 +4338,34 @@ impl<S: Simd> Seal for i32x8<S> {}
 impl<S: Simd> SimdFrom<[i32; 8], S> for i32x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i32; 8]) -> Self {
-        simd.load_array_i32x8(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<i32x8<S>> for [i32; 8] {
     #[inline(always)]
     fn from(value: i32x8<S>) -> Self {
-        value.simd.as_array_i32x8(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for i32x8<S> {
     type Target = [i32; 8];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_i32x8(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for i32x8<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_i32x8(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for i32x8<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "i32x8", &self.simd, self.simd.as_array_ref_i32x8(self))
+        crate::support::simd_debug_impl(f, "i32x8", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<i32, S> for i32x8<S> {
@@ -4310,13 +4378,13 @@ impl<S: Simd> core::ops::Index<usize> for i32x8<S> {
     type Output = i32;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_i32x8(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for i32x8<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_i32x8(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<i32x8<S>> for mask32x8<S> {
@@ -4355,20 +4423,19 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[i32] {
-        self.simd.as_array_ref_i32x8(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [i32] {
-        self.simd.as_array_mut_i32x8(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i32]) -> Self {
-        simd.load_array_ref_i32x8(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i32]) {
-        self.simd
-            .store_array_i32x8(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: i32) -> Self {
@@ -4380,16 +4447,19 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> i32) -> Self {
-        simd.load_array_i32x8([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -4520,31 +4590,34 @@ impl<S: Simd> Seal for u32x8<S> {}
 impl<S: Simd> SimdFrom<[u32; 8], S> for u32x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [u32; 8]) -> Self {
-        simd.load_array_u32x8(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<u32x8<S>> for [u32; 8] {
     #[inline(always)]
     fn from(value: u32x8<S>) -> Self {
-        value.simd.as_array_u32x8(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for u32x8<S> {
     type Target = [u32; 8];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_u32x8(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for u32x8<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_u32x8(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for u32x8<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "u32x8", &self.simd, self.simd.as_array_ref_u32x8(self))
+        crate::support::simd_debug_impl(f, "u32x8", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<u32, S> for u32x8<S> {
@@ -4557,13 +4630,13 @@ impl<S: Simd> core::ops::Index<usize> for u32x8<S> {
     type Output = u32;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_u32x8(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for u32x8<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_u32x8(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<u32x8<S>> for mask32x8<S> {
@@ -4602,20 +4675,19 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[u32] {
-        self.simd.as_array_ref_u32x8(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [u32] {
-        self.simd.as_array_mut_u32x8(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u32]) -> Self {
-        simd.load_array_ref_u32x8(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u32]) {
-        self.simd
-            .store_array_u32x8(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: u32) -> Self {
@@ -4627,16 +4699,19 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> u32) -> Self {
-        simd.load_array_u32x8([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -4766,18 +4841,21 @@ impl<S: Simd> Seal for mask32x8<S> {}
 impl<S: Simd> SimdFrom<[i32; 8], S> for mask32x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i32; 8]) -> Self {
-        simd.load_array_mask32x8(val)
+        Self {
+            val: <S as crate::arch_types::ArchTypes>::mask32x8_from_array(simd, val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<mask32x8<S>> for [i32; 8] {
     #[inline(always)]
     fn from(value: mask32x8<S>) -> Self {
-        value.simd.as_array_mask32x8(value)
+        <S as crate::arch_types::ArchTypes>::mask32x8_to_array(value.simd, value.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for mask32x8<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let lanes = self.simd.as_array_mask32x8(*self);
+        let lanes: [i32; 8] = (*self).into();
         crate::support::simd_debug_impl(f, "mask32x8", &self.simd, &lanes)
     }
 }
@@ -4819,12 +4897,12 @@ impl<S: Simd> SimdMask<S> for mask32x8<S> {
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i32]) -> Self {
         let slice: &[i32; 8] = slice.try_into().unwrap();
-        simd.load_array_mask32x8(*slice)
+        Self::simd_from(simd, *slice)
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i32]) {
         let slice: &mut [i32; 8] = slice.try_into().unwrap();
-        *slice = self.simd.as_array_mask32x8(*self);
+        *slice = (*self).into();
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -4858,31 +4936,34 @@ impl<S: Simd> Seal for f64x4<S> {}
 impl<S: Simd> SimdFrom<[f64; 4], S> for f64x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [f64; 4]) -> Self {
-        simd.load_array_f64x4(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<f64x4<S>> for [f64; 4] {
     #[inline(always)]
     fn from(value: f64x4<S>) -> Self {
-        value.simd.as_array_f64x4(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for f64x4<S> {
     type Target = [f64; 4];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_f64x4(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for f64x4<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_f64x4(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for f64x4<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "f64x4", &self.simd, self.simd.as_array_ref_f64x4(self))
+        crate::support::simd_debug_impl(f, "f64x4", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<f64, S> for f64x4<S> {
@@ -4895,13 +4976,13 @@ impl<S: Simd> core::ops::Index<usize> for f64x4<S> {
     type Output = f64;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_f64x4(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for f64x4<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_f64x4(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<f64x4<S>> for mask64x4<S> {
@@ -4940,20 +5021,19 @@ impl<S: Simd> SimdBase<S> for f64x4<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[f64] {
-        self.simd.as_array_ref_f64x4(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [f64] {
-        self.simd.as_array_mut_f64x4(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[f64]) -> Self {
-        simd.load_array_ref_f64x4(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [f64]) {
-        self.simd
-            .store_array_f64x4(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: f64) -> Self {
@@ -4965,7 +5045,7 @@ impl<S: Simd> SimdBase<S> for f64x4<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> f64) -> Self {
-        simd.load_array_f64x4([f(0usize), f(1usize), f(2usize), f(3usize)])
+        Self::load_array(simd, [f(0usize), f(1usize), f(2usize), f(3usize)])
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -5138,31 +5218,34 @@ impl<S: Simd> Seal for i64x4<S> {}
 impl<S: Simd> SimdFrom<[i64; 4], S> for i64x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i64; 4]) -> Self {
-        simd.load_array_i64x4(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<i64x4<S>> for [i64; 4] {
     #[inline(always)]
     fn from(value: i64x4<S>) -> Self {
-        value.simd.as_array_i64x4(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for i64x4<S> {
     type Target = [i64; 4];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_i64x4(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for i64x4<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_i64x4(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for i64x4<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "i64x4", &self.simd, self.simd.as_array_ref_i64x4(self))
+        crate::support::simd_debug_impl(f, "i64x4", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<i64, S> for i64x4<S> {
@@ -5175,13 +5258,13 @@ impl<S: Simd> core::ops::Index<usize> for i64x4<S> {
     type Output = i64;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_i64x4(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for i64x4<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_i64x4(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<i64x4<S>> for mask64x4<S> {
@@ -5220,20 +5303,19 @@ impl<S: Simd> SimdBase<S> for i64x4<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[i64] {
-        self.simd.as_array_ref_i64x4(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [i64] {
-        self.simd.as_array_mut_i64x4(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i64]) -> Self {
-        simd.load_array_ref_i64x4(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i64]) {
-        self.simd
-            .store_array_i64x4(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: i64) -> Self {
@@ -5245,7 +5327,7 @@ impl<S: Simd> SimdBase<S> for i64x4<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> i64) -> Self {
-        simd.load_array_i64x4([f(0usize), f(1usize), f(2usize), f(3usize)])
+        Self::load_array(simd, [f(0usize), f(1usize), f(2usize), f(3usize)])
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -5364,31 +5446,34 @@ impl<S: Simd> Seal for u64x4<S> {}
 impl<S: Simd> SimdFrom<[u64; 4], S> for u64x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [u64; 4]) -> Self {
-        simd.load_array_u64x4(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<u64x4<S>> for [u64; 4] {
     #[inline(always)]
     fn from(value: u64x4<S>) -> Self {
-        value.simd.as_array_u64x4(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for u64x4<S> {
     type Target = [u64; 4];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_u64x4(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for u64x4<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_u64x4(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for u64x4<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "u64x4", &self.simd, self.simd.as_array_ref_u64x4(self))
+        crate::support::simd_debug_impl(f, "u64x4", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<u64, S> for u64x4<S> {
@@ -5401,13 +5486,13 @@ impl<S: Simd> core::ops::Index<usize> for u64x4<S> {
     type Output = u64;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_u64x4(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for u64x4<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_u64x4(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<u64x4<S>> for mask64x4<S> {
@@ -5446,20 +5531,19 @@ impl<S: Simd> SimdBase<S> for u64x4<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[u64] {
-        self.simd.as_array_ref_u64x4(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [u64] {
-        self.simd.as_array_mut_u64x4(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u64]) -> Self {
-        simd.load_array_ref_u64x4(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u64]) {
-        self.simd
-            .store_array_u64x4(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: u64) -> Self {
@@ -5471,7 +5555,7 @@ impl<S: Simd> SimdBase<S> for u64x4<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> u64) -> Self {
-        simd.load_array_u64x4([f(0usize), f(1usize), f(2usize), f(3usize)])
+        Self::load_array(simd, [f(0usize), f(1usize), f(2usize), f(3usize)])
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -5589,18 +5673,21 @@ impl<S: Simd> Seal for mask64x4<S> {}
 impl<S: Simd> SimdFrom<[i64; 4], S> for mask64x4<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i64; 4]) -> Self {
-        simd.load_array_mask64x4(val)
+        Self {
+            val: <S as crate::arch_types::ArchTypes>::mask64x4_from_array(simd, val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<mask64x4<S>> for [i64; 4] {
     #[inline(always)]
     fn from(value: mask64x4<S>) -> Self {
-        value.simd.as_array_mask64x4(value)
+        <S as crate::arch_types::ArchTypes>::mask64x4_to_array(value.simd, value.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for mask64x4<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let lanes = self.simd.as_array_mask64x4(*self);
+        let lanes: [i64; 4] = (*self).into();
         crate::support::simd_debug_impl(f, "mask64x4", &self.simd, &lanes)
     }
 }
@@ -5642,12 +5729,12 @@ impl<S: Simd> SimdMask<S> for mask64x4<S> {
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i64]) -> Self {
         let slice: &[i64; 4] = slice.try_into().unwrap();
-        simd.load_array_mask64x4(*slice)
+        Self::simd_from(simd, *slice)
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i64]) {
         let slice: &mut [i64; 4] = slice.try_into().unwrap();
-        *slice = self.simd.as_array_mask64x4(*self);
+        *slice = (*self).into();
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -5681,36 +5768,34 @@ impl<S: Simd> Seal for f32x16<S> {}
 impl<S: Simd> SimdFrom<[f32; 16], S> for f32x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [f32; 16]) -> Self {
-        simd.load_array_f32x16(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<f32x16<S>> for [f32; 16] {
     #[inline(always)]
     fn from(value: f32x16<S>) -> Self {
-        value.simd.as_array_f32x16(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for f32x16<S> {
     type Target = [f32; 16];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_f32x16(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for f32x16<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_f32x16(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for f32x16<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(
-            f,
-            "f32x16",
-            &self.simd,
-            self.simd.as_array_ref_f32x16(self),
-        )
+        crate::support::simd_debug_impl(f, "f32x16", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<f32, S> for f32x16<S> {
@@ -5723,13 +5808,13 @@ impl<S: Simd> core::ops::Index<usize> for f32x16<S> {
     type Output = f32;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_f32x16(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for f32x16<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_f32x16(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<f32x16<S>> for mask32x16<S> {
@@ -5768,20 +5853,19 @@ impl<S: Simd> SimdBase<S> for f32x16<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[f32] {
-        self.simd.as_array_ref_f32x16(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [f32] {
-        self.simd.as_array_mut_f32x16(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[f32]) -> Self {
-        simd.load_array_ref_f32x16(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [f32]) {
-        self.simd
-            .store_array_f32x16(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: f32) -> Self {
@@ -5794,24 +5878,27 @@ impl<S: Simd> SimdBase<S> for f32x16<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> f32) -> Self {
-        simd.load_array_f32x16([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -5993,31 +6080,34 @@ impl<S: Simd> Seal for i8x64<S> {}
 impl<S: Simd> SimdFrom<[i8; 64], S> for i8x64<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i8; 64]) -> Self {
-        simd.load_array_i8x64(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<i8x64<S>> for [i8; 64] {
     #[inline(always)]
     fn from(value: i8x64<S>) -> Self {
-        value.simd.as_array_i8x64(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for i8x64<S> {
     type Target = [i8; 64];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_i8x64(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for i8x64<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_i8x64(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for i8x64<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "i8x64", &self.simd, self.simd.as_array_ref_i8x64(self))
+        crate::support::simd_debug_impl(f, "i8x64", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<i8, S> for i8x64<S> {
@@ -6030,13 +6120,13 @@ impl<S: Simd> core::ops::Index<usize> for i8x64<S> {
     type Output = i8;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_i8x64(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for i8x64<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_i8x64(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<i8x64<S>> for mask8x64<S> {
@@ -6075,20 +6165,19 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[i8] {
-        self.simd.as_array_ref_i8x64(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [i8] {
-        self.simd.as_array_mut_i8x64(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i8]) -> Self {
-        simd.load_array_ref_i8x64(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i8]) {
-        self.simd
-            .store_array_i8x64(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: i8) -> Self {
@@ -6101,72 +6190,75 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> i8) -> Self {
-        simd.load_array_i8x64([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-            f(16usize),
-            f(17usize),
-            f(18usize),
-            f(19usize),
-            f(20usize),
-            f(21usize),
-            f(22usize),
-            f(23usize),
-            f(24usize),
-            f(25usize),
-            f(26usize),
-            f(27usize),
-            f(28usize),
-            f(29usize),
-            f(30usize),
-            f(31usize),
-            f(32usize),
-            f(33usize),
-            f(34usize),
-            f(35usize),
-            f(36usize),
-            f(37usize),
-            f(38usize),
-            f(39usize),
-            f(40usize),
-            f(41usize),
-            f(42usize),
-            f(43usize),
-            f(44usize),
-            f(45usize),
-            f(46usize),
-            f(47usize),
-            f(48usize),
-            f(49usize),
-            f(50usize),
-            f(51usize),
-            f(52usize),
-            f(53usize),
-            f(54usize),
-            f(55usize),
-            f(56usize),
-            f(57usize),
-            f(58usize),
-            f(59usize),
-            f(60usize),
-            f(61usize),
-            f(62usize),
-            f(63usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+                f(16usize),
+                f(17usize),
+                f(18usize),
+                f(19usize),
+                f(20usize),
+                f(21usize),
+                f(22usize),
+                f(23usize),
+                f(24usize),
+                f(25usize),
+                f(26usize),
+                f(27usize),
+                f(28usize),
+                f(29usize),
+                f(30usize),
+                f(31usize),
+                f(32usize),
+                f(33usize),
+                f(34usize),
+                f(35usize),
+                f(36usize),
+                f(37usize),
+                f(38usize),
+                f(39usize),
+                f(40usize),
+                f(41usize),
+                f(42usize),
+                f(43usize),
+                f(44usize),
+                f(45usize),
+                f(46usize),
+                f(47usize),
+                f(48usize),
+                f(49usize),
+                f(50usize),
+                f(51usize),
+                f(52usize),
+                f(53usize),
+                f(54usize),
+                f(55usize),
+                f(56usize),
+                f(57usize),
+                f(58usize),
+                f(59usize),
+                f(60usize),
+                f(61usize),
+                f(62usize),
+                f(63usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -6278,31 +6370,34 @@ impl<S: Simd> Seal for u8x64<S> {}
 impl<S: Simd> SimdFrom<[u8; 64], S> for u8x64<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [u8; 64]) -> Self {
-        simd.load_array_u8x64(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<u8x64<S>> for [u8; 64] {
     #[inline(always)]
     fn from(value: u8x64<S>) -> Self {
-        value.simd.as_array_u8x64(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for u8x64<S> {
     type Target = [u8; 64];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_u8x64(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for u8x64<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_u8x64(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for u8x64<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "u8x64", &self.simd, self.simd.as_array_ref_u8x64(self))
+        crate::support::simd_debug_impl(f, "u8x64", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<u8, S> for u8x64<S> {
@@ -6315,13 +6410,13 @@ impl<S: Simd> core::ops::Index<usize> for u8x64<S> {
     type Output = u8;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_u8x64(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for u8x64<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_u8x64(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<u8x64<S>> for mask8x64<S> {
@@ -6360,20 +6455,19 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[u8] {
-        self.simd.as_array_ref_u8x64(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [u8] {
-        self.simd.as_array_mut_u8x64(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u8]) -> Self {
-        simd.load_array_ref_u8x64(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u8]) {
-        self.simd
-            .store_array_u8x64(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: u8) -> Self {
@@ -6386,72 +6480,75 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> u8) -> Self {
-        simd.load_array_u8x64([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-            f(16usize),
-            f(17usize),
-            f(18usize),
-            f(19usize),
-            f(20usize),
-            f(21usize),
-            f(22usize),
-            f(23usize),
-            f(24usize),
-            f(25usize),
-            f(26usize),
-            f(27usize),
-            f(28usize),
-            f(29usize),
-            f(30usize),
-            f(31usize),
-            f(32usize),
-            f(33usize),
-            f(34usize),
-            f(35usize),
-            f(36usize),
-            f(37usize),
-            f(38usize),
-            f(39usize),
-            f(40usize),
-            f(41usize),
-            f(42usize),
-            f(43usize),
-            f(44usize),
-            f(45usize),
-            f(46usize),
-            f(47usize),
-            f(48usize),
-            f(49usize),
-            f(50usize),
-            f(51usize),
-            f(52usize),
-            f(53usize),
-            f(54usize),
-            f(55usize),
-            f(56usize),
-            f(57usize),
-            f(58usize),
-            f(59usize),
-            f(60usize),
-            f(61usize),
-            f(62usize),
-            f(63usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+                f(16usize),
+                f(17usize),
+                f(18usize),
+                f(19usize),
+                f(20usize),
+                f(21usize),
+                f(22usize),
+                f(23usize),
+                f(24usize),
+                f(25usize),
+                f(26usize),
+                f(27usize),
+                f(28usize),
+                f(29usize),
+                f(30usize),
+                f(31usize),
+                f(32usize),
+                f(33usize),
+                f(34usize),
+                f(35usize),
+                f(36usize),
+                f(37usize),
+                f(38usize),
+                f(39usize),
+                f(40usize),
+                f(41usize),
+                f(42usize),
+                f(43usize),
+                f(44usize),
+                f(45usize),
+                f(46usize),
+                f(47usize),
+                f(48usize),
+                f(49usize),
+                f(50usize),
+                f(51usize),
+                f(52usize),
+                f(53usize),
+                f(54usize),
+                f(55usize),
+                f(56usize),
+                f(57usize),
+                f(58usize),
+                f(59usize),
+                f(60usize),
+                f(61usize),
+                f(62usize),
+                f(63usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -6562,18 +6659,21 @@ impl<S: Simd> Seal for mask8x64<S> {}
 impl<S: Simd> SimdFrom<[i8; 64], S> for mask8x64<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i8; 64]) -> Self {
-        simd.load_array_mask8x64(val)
+        Self {
+            val: <S as crate::arch_types::ArchTypes>::mask8x64_from_array(simd, val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<mask8x64<S>> for [i8; 64] {
     #[inline(always)]
     fn from(value: mask8x64<S>) -> Self {
-        value.simd.as_array_mask8x64(value)
+        <S as crate::arch_types::ArchTypes>::mask8x64_to_array(value.simd, value.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for mask8x64<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let lanes = self.simd.as_array_mask8x64(*self);
+        let lanes: [i8; 64] = (*self).into();
         crate::support::simd_debug_impl(f, "mask8x64", &self.simd, &lanes)
     }
 }
@@ -6615,12 +6715,12 @@ impl<S: Simd> SimdMask<S> for mask8x64<S> {
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i8]) -> Self {
         let slice: &[i8; 64] = slice.try_into().unwrap();
-        simd.load_array_mask8x64(*slice)
+        Self::simd_from(simd, *slice)
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i8]) {
         let slice: &mut [i8; 64] = slice.try_into().unwrap();
-        *slice = self.simd.as_array_mask8x64(*self);
+        *slice = (*self).into();
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -6654,36 +6754,34 @@ impl<S: Simd> Seal for i16x32<S> {}
 impl<S: Simd> SimdFrom<[i16; 32], S> for i16x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i16; 32]) -> Self {
-        simd.load_array_i16x32(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<i16x32<S>> for [i16; 32] {
     #[inline(always)]
     fn from(value: i16x32<S>) -> Self {
-        value.simd.as_array_i16x32(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for i16x32<S> {
     type Target = [i16; 32];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_i16x32(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for i16x32<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_i16x32(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for i16x32<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(
-            f,
-            "i16x32",
-            &self.simd,
-            self.simd.as_array_ref_i16x32(self),
-        )
+        crate::support::simd_debug_impl(f, "i16x32", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<i16, S> for i16x32<S> {
@@ -6696,13 +6794,13 @@ impl<S: Simd> core::ops::Index<usize> for i16x32<S> {
     type Output = i16;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_i16x32(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for i16x32<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_i16x32(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<i16x32<S>> for mask16x32<S> {
@@ -6741,20 +6839,19 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[i16] {
-        self.simd.as_array_ref_i16x32(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [i16] {
-        self.simd.as_array_mut_i16x32(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i16]) -> Self {
-        simd.load_array_ref_i16x32(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i16]) {
-        self.simd
-            .store_array_i16x32(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: i16) -> Self {
@@ -6767,40 +6864,43 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> i16) -> Self {
-        simd.load_array_i16x32([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-            f(16usize),
-            f(17usize),
-            f(18usize),
-            f(19usize),
-            f(20usize),
-            f(21usize),
-            f(22usize),
-            f(23usize),
-            f(24usize),
-            f(25usize),
-            f(26usize),
-            f(27usize),
-            f(28usize),
-            f(29usize),
-            f(30usize),
-            f(31usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+                f(16usize),
+                f(17usize),
+                f(18usize),
+                f(19usize),
+                f(20usize),
+                f(21usize),
+                f(22usize),
+                f(23usize),
+                f(24usize),
+                f(25usize),
+                f(26usize),
+                f(27usize),
+                f(28usize),
+                f(29usize),
+                f(30usize),
+                f(31usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -6914,36 +7014,34 @@ impl<S: Simd> Seal for u16x32<S> {}
 impl<S: Simd> SimdFrom<[u16; 32], S> for u16x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [u16; 32]) -> Self {
-        simd.load_array_u16x32(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<u16x32<S>> for [u16; 32] {
     #[inline(always)]
     fn from(value: u16x32<S>) -> Self {
-        value.simd.as_array_u16x32(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for u16x32<S> {
     type Target = [u16; 32];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_u16x32(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for u16x32<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_u16x32(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for u16x32<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(
-            f,
-            "u16x32",
-            &self.simd,
-            self.simd.as_array_ref_u16x32(self),
-        )
+        crate::support::simd_debug_impl(f, "u16x32", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<u16, S> for u16x32<S> {
@@ -6956,13 +7054,13 @@ impl<S: Simd> core::ops::Index<usize> for u16x32<S> {
     type Output = u16;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_u16x32(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for u16x32<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_u16x32(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<u16x32<S>> for mask16x32<S> {
@@ -7001,20 +7099,19 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[u16] {
-        self.simd.as_array_ref_u16x32(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [u16] {
-        self.simd.as_array_mut_u16x32(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u16]) -> Self {
-        simd.load_array_ref_u16x32(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u16]) {
-        self.simd
-            .store_array_u16x32(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: u16) -> Self {
@@ -7027,40 +7124,43 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> u16) -> Self {
-        simd.load_array_u16x32([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-            f(16usize),
-            f(17usize),
-            f(18usize),
-            f(19usize),
-            f(20usize),
-            f(21usize),
-            f(22usize),
-            f(23usize),
-            f(24usize),
-            f(25usize),
-            f(26usize),
-            f(27usize),
-            f(28usize),
-            f(29usize),
-            f(30usize),
-            f(31usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+                f(16usize),
+                f(17usize),
+                f(18usize),
+                f(19usize),
+                f(20usize),
+                f(21usize),
+                f(22usize),
+                f(23usize),
+                f(24usize),
+                f(25usize),
+                f(26usize),
+                f(27usize),
+                f(28usize),
+                f(29usize),
+                f(30usize),
+                f(31usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -7173,18 +7273,21 @@ impl<S: Simd> Seal for mask16x32<S> {}
 impl<S: Simd> SimdFrom<[i16; 32], S> for mask16x32<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i16; 32]) -> Self {
-        simd.load_array_mask16x32(val)
+        Self {
+            val: <S as crate::arch_types::ArchTypes>::mask16x32_from_array(simd, val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<mask16x32<S>> for [i16; 32] {
     #[inline(always)]
     fn from(value: mask16x32<S>) -> Self {
-        value.simd.as_array_mask16x32(value)
+        <S as crate::arch_types::ArchTypes>::mask16x32_to_array(value.simd, value.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for mask16x32<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let lanes = self.simd.as_array_mask16x32(*self);
+        let lanes: [i16; 32] = (*self).into();
         crate::support::simd_debug_impl(f, "mask16x32", &self.simd, &lanes)
     }
 }
@@ -7226,12 +7329,12 @@ impl<S: Simd> SimdMask<S> for mask16x32<S> {
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i16]) -> Self {
         let slice: &[i16; 32] = slice.try_into().unwrap();
-        simd.load_array_mask16x32(*slice)
+        Self::simd_from(simd, *slice)
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i16]) {
         let slice: &mut [i16; 32] = slice.try_into().unwrap();
-        *slice = self.simd.as_array_mask16x32(*self);
+        *slice = (*self).into();
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -7265,36 +7368,34 @@ impl<S: Simd> Seal for i32x16<S> {}
 impl<S: Simd> SimdFrom<[i32; 16], S> for i32x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i32; 16]) -> Self {
-        simd.load_array_i32x16(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<i32x16<S>> for [i32; 16] {
     #[inline(always)]
     fn from(value: i32x16<S>) -> Self {
-        value.simd.as_array_i32x16(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for i32x16<S> {
     type Target = [i32; 16];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_i32x16(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for i32x16<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_i32x16(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for i32x16<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(
-            f,
-            "i32x16",
-            &self.simd,
-            self.simd.as_array_ref_i32x16(self),
-        )
+        crate::support::simd_debug_impl(f, "i32x16", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<i32, S> for i32x16<S> {
@@ -7307,13 +7408,13 @@ impl<S: Simd> core::ops::Index<usize> for i32x16<S> {
     type Output = i32;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_i32x16(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for i32x16<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_i32x16(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<i32x16<S>> for mask32x16<S> {
@@ -7352,20 +7453,19 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[i32] {
-        self.simd.as_array_ref_i32x16(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [i32] {
-        self.simd.as_array_mut_i32x16(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i32]) -> Self {
-        simd.load_array_ref_i32x16(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i32]) {
-        self.simd
-            .store_array_i32x16(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: i32) -> Self {
@@ -7378,24 +7478,27 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> i32) -> Self {
-        simd.load_array_i32x16([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -7521,36 +7624,34 @@ impl<S: Simd> Seal for u32x16<S> {}
 impl<S: Simd> SimdFrom<[u32; 16], S> for u32x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [u32; 16]) -> Self {
-        simd.load_array_u32x16(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<u32x16<S>> for [u32; 16] {
     #[inline(always)]
     fn from(value: u32x16<S>) -> Self {
-        value.simd.as_array_u32x16(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for u32x16<S> {
     type Target = [u32; 16];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_u32x16(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for u32x16<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_u32x16(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for u32x16<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(
-            f,
-            "u32x16",
-            &self.simd,
-            self.simd.as_array_ref_u32x16(self),
-        )
+        crate::support::simd_debug_impl(f, "u32x16", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<u32, S> for u32x16<S> {
@@ -7563,13 +7664,13 @@ impl<S: Simd> core::ops::Index<usize> for u32x16<S> {
     type Output = u32;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_u32x16(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for u32x16<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_u32x16(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<u32x16<S>> for mask32x16<S> {
@@ -7608,20 +7709,19 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[u32] {
-        self.simd.as_array_ref_u32x16(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [u32] {
-        self.simd.as_array_mut_u32x16(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u32]) -> Self {
-        simd.load_array_ref_u32x16(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u32]) {
-        self.simd
-            .store_array_u32x16(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: u32) -> Self {
@@ -7634,24 +7734,27 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> u32) -> Self {
-        simd.load_array_u32x16([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-            f(8usize),
-            f(9usize),
-            f(10usize),
-            f(11usize),
-            f(12usize),
-            f(13usize),
-            f(14usize),
-            f(15usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+                f(8usize),
+                f(9usize),
+                f(10usize),
+                f(11usize),
+                f(12usize),
+                f(13usize),
+                f(14usize),
+                f(15usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -7776,18 +7879,21 @@ impl<S: Simd> Seal for mask32x16<S> {}
 impl<S: Simd> SimdFrom<[i32; 16], S> for mask32x16<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i32; 16]) -> Self {
-        simd.load_array_mask32x16(val)
+        Self {
+            val: <S as crate::arch_types::ArchTypes>::mask32x16_from_array(simd, val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<mask32x16<S>> for [i32; 16] {
     #[inline(always)]
     fn from(value: mask32x16<S>) -> Self {
-        value.simd.as_array_mask32x16(value)
+        <S as crate::arch_types::ArchTypes>::mask32x16_to_array(value.simd, value.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for mask32x16<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let lanes = self.simd.as_array_mask32x16(*self);
+        let lanes: [i32; 16] = (*self).into();
         crate::support::simd_debug_impl(f, "mask32x16", &self.simd, &lanes)
     }
 }
@@ -7829,12 +7935,12 @@ impl<S: Simd> SimdMask<S> for mask32x16<S> {
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i32]) -> Self {
         let slice: &[i32; 16] = slice.try_into().unwrap();
-        simd.load_array_mask32x16(*slice)
+        Self::simd_from(simd, *slice)
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i32]) {
         let slice: &mut [i32; 16] = slice.try_into().unwrap();
-        *slice = self.simd.as_array_mask32x16(*self);
+        *slice = (*self).into();
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -7868,31 +7974,34 @@ impl<S: Simd> Seal for f64x8<S> {}
 impl<S: Simd> SimdFrom<[f64; 8], S> for f64x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [f64; 8]) -> Self {
-        simd.load_array_f64x8(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<f64x8<S>> for [f64; 8] {
     #[inline(always)]
     fn from(value: f64x8<S>) -> Self {
-        value.simd.as_array_f64x8(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for f64x8<S> {
     type Target = [f64; 8];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_f64x8(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for f64x8<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_f64x8(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for f64x8<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "f64x8", &self.simd, self.simd.as_array_ref_f64x8(self))
+        crate::support::simd_debug_impl(f, "f64x8", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<f64, S> for f64x8<S> {
@@ -7905,13 +8014,13 @@ impl<S: Simd> core::ops::Index<usize> for f64x8<S> {
     type Output = f64;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_f64x8(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for f64x8<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_f64x8(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<f64x8<S>> for mask64x8<S> {
@@ -7950,20 +8059,19 @@ impl<S: Simd> SimdBase<S> for f64x8<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[f64] {
-        self.simd.as_array_ref_f64x8(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [f64] {
-        self.simd.as_array_mut_f64x8(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[f64]) -> Self {
-        simd.load_array_ref_f64x8(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [f64]) {
-        self.simd
-            .store_array_f64x8(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: f64) -> Self {
@@ -7976,16 +8084,19 @@ impl<S: Simd> SimdBase<S> for f64x8<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> f64) -> Self {
-        simd.load_array_f64x8([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -8151,31 +8262,34 @@ impl<S: Simd> Seal for i64x8<S> {}
 impl<S: Simd> SimdFrom<[i64; 8], S> for i64x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i64; 8]) -> Self {
-        simd.load_array_i64x8(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<i64x8<S>> for [i64; 8] {
     #[inline(always)]
     fn from(value: i64x8<S>) -> Self {
-        value.simd.as_array_i64x8(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for i64x8<S> {
     type Target = [i64; 8];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_i64x8(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for i64x8<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_i64x8(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for i64x8<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "i64x8", &self.simd, self.simd.as_array_ref_i64x8(self))
+        crate::support::simd_debug_impl(f, "i64x8", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<i64, S> for i64x8<S> {
@@ -8188,13 +8302,13 @@ impl<S: Simd> core::ops::Index<usize> for i64x8<S> {
     type Output = i64;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_i64x8(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for i64x8<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_i64x8(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<i64x8<S>> for mask64x8<S> {
@@ -8233,20 +8347,19 @@ impl<S: Simd> SimdBase<S> for i64x8<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[i64] {
-        self.simd.as_array_ref_i64x8(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [i64] {
-        self.simd.as_array_mut_i64x8(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i64]) -> Self {
-        simd.load_array_ref_i64x8(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i64]) {
-        self.simd
-            .store_array_i64x8(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: i64) -> Self {
@@ -8259,16 +8372,19 @@ impl<S: Simd> SimdBase<S> for i64x8<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> i64) -> Self {
-        simd.load_array_i64x8([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -8380,31 +8496,34 @@ impl<S: Simd> Seal for u64x8<S> {}
 impl<S: Simd> SimdFrom<[u64; 8], S> for u64x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [u64; 8]) -> Self {
-        simd.load_array_u64x8(val)
+        Self {
+            val: crate::transmute::checked_transmute_copy(&val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<u64x8<S>> for [u64; 8] {
     #[inline(always)]
     fn from(value: u64x8<S>) -> Self {
-        value.simd.as_array_u64x8(value)
+        crate::transmute::checked_transmute_copy(&value.val)
     }
 }
 impl<S: Simd> core::ops::Deref for u64x8<S> {
     type Target = [u64; 8];
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.simd.as_array_ref_u64x8(self)
+        crate::transmute::checked_cast_ref(&self.val)
     }
 }
 impl<S: Simd> core::ops::DerefMut for u64x8<S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.simd.as_array_mut_u64x8(self)
+        crate::transmute::checked_cast_mut(&mut self.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for u64x8<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        crate::support::simd_debug_impl(f, "u64x8", &self.simd, self.simd.as_array_ref_u64x8(self))
+        crate::support::simd_debug_impl(f, "u64x8", &self.simd, self.as_array_ref())
     }
 }
 impl<S: Simd> SimdFrom<u64, S> for u64x8<S> {
@@ -8417,13 +8536,13 @@ impl<S: Simd> core::ops::Index<usize> for u64x8<S> {
     type Output = u64;
     #[inline(always)]
     fn index(&self, i: usize) -> &Self::Output {
-        &self.simd.as_array_ref_u64x8(self)[i]
+        &self.as_array_ref()[i]
     }
 }
 impl<S: Simd> core::ops::IndexMut<usize> for u64x8<S> {
     #[inline(always)]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        &mut self.simd.as_array_mut_u64x8(self)[i]
+        &mut self.as_array_mut()[i]
     }
 }
 impl<S: Simd> Select<u64x8<S>> for mask64x8<S> {
@@ -8462,20 +8581,19 @@ impl<S: Simd> SimdBase<S> for u64x8<S> {
     }
     #[inline(always)]
     fn as_slice(&self) -> &[u64] {
-        self.simd.as_array_ref_u64x8(self).as_slice()
+        self.as_array_ref().as_slice()
     }
     #[inline(always)]
     fn as_mut_slice(&mut self) -> &mut [u64] {
-        self.simd.as_array_mut_u64x8(self).as_mut_slice()
+        self.as_array_mut().as_mut_slice()
     }
     #[inline(always)]
     fn from_slice(simd: S, slice: &[u64]) -> Self {
-        simd.load_array_ref_u64x8(slice.try_into().unwrap())
+        Self::load_array_ref(simd, slice.try_into().unwrap())
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [u64]) {
-        self.simd
-            .store_array_u64x8(*self, slice.try_into().unwrap());
+        (*self).store_array(slice.try_into().unwrap());
     }
     #[inline(always)]
     fn splat(simd: S, val: u64) -> Self {
@@ -8488,16 +8606,19 @@ impl<S: Simd> SimdBase<S> for u64x8<S> {
     }
     #[inline(always)]
     fn from_fn(simd: S, mut f: impl FnMut(usize) -> u64) -> Self {
-        simd.load_array_u64x8([
-            f(0usize),
-            f(1usize),
-            f(2usize),
-            f(3usize),
-            f(4usize),
-            f(5usize),
-            f(6usize),
-            f(7usize),
-        ])
+        Self::load_array(
+            simd,
+            [
+                f(0usize),
+                f(1usize),
+                f(2usize),
+                f(3usize),
+                f(4usize),
+                f(5usize),
+                f(6usize),
+                f(7usize),
+            ],
+        )
     }
     #[inline(always)]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -8608,18 +8729,21 @@ impl<S: Simd> Seal for mask64x8<S> {}
 impl<S: Simd> SimdFrom<[i64; 8], S> for mask64x8<S> {
     #[inline(always)]
     fn simd_from(simd: S, val: [i64; 8]) -> Self {
-        simd.load_array_mask64x8(val)
+        Self {
+            val: <S as crate::arch_types::ArchTypes>::mask64x8_from_array(simd, val),
+            simd,
+        }
     }
 }
 impl<S: Simd> From<mask64x8<S>> for [i64; 8] {
     #[inline(always)]
     fn from(value: mask64x8<S>) -> Self {
-        value.simd.as_array_mask64x8(value)
+        <S as crate::arch_types::ArchTypes>::mask64x8_to_array(value.simd, value.val)
     }
 }
 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for mask64x8<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let lanes = self.simd.as_array_mask64x8(*self);
+        let lanes: [i64; 8] = (*self).into();
         crate::support::simd_debug_impl(f, "mask64x8", &self.simd, &lanes)
     }
 }
@@ -8661,12 +8785,12 @@ impl<S: Simd> SimdMask<S> for mask64x8<S> {
     #[inline(always)]
     fn from_slice(simd: S, slice: &[i64]) -> Self {
         let slice: &[i64; 8] = slice.try_into().unwrap();
-        simd.load_array_mask64x8(*slice)
+        Self::simd_from(simd, *slice)
     }
     #[inline(always)]
     fn store_slice(&self, slice: &mut [i64]) {
         let slice: &mut [i64; 8] = slice.try_into().unwrap();
-        *slice = self.simd.as_array_mask64x8(*self);
+        *slice = (*self).into();
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -187,36 +187,6 @@ impl Simd for Sse2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_f32x4(self, val: [f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x4(self, val: &[f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x4(self, a: f32x4<Self>) -> [f32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128, [f32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
-        crate::transmute::checked_cast_ref::<__m128, [f32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x4(self, a: &mut f32x4<Self>) -> &mut [f32; 4usize] {
-        crate::transmute::checked_cast_mut::<__m128, [f32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -749,36 +719,6 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i8x16(self, val: [i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x16(self, val: &[i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x16(self, a: i8x16<Self>) -> [i8; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x16(self, a: &mut i8x16<Self>) -> &mut [i8; 16usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i8; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
@@ -1320,36 +1260,6 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x16(self, val: &[u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x16(self, a: u8x16<Self>) -> [u8; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x16(self, a: &mut u8x16<Self>) -> &mut [u8; 16usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u8; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1908,17 +1818,6 @@ impl Simd for Sse2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask8x16(self, val: [i8; 16usize]) -> mask8x16<Self> {
-        mask8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x16(self, a: mask8x16<Self>) -> [i8; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x16(self, bits: u64) -> mask8x16<Self> {
         let lanes: [i8; 16usize] = [
             if bits & 1 != 0 { !0 } else { 0 },
@@ -1957,9 +1856,10 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask8x16(*a);
+        let mut lanes = [0 as i8; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x16(lanes);
+        *a = mask8x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -2085,36 +1985,6 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i16x8(self, val: [i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x8(self, val: &[i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x8(self, a: i16x8<Self>) -> [i16; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x8(self, a: &mut i16x8<Self>) -> &mut [i16; 8usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i16; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
@@ -2569,36 +2439,6 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x8(self, val: &[u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x8(self, a: u16x8<Self>) -> [u16; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x8(self, a: &mut u16x8<Self>) -> &mut [u16; 8usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u16; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -3096,17 +2936,6 @@ impl Simd for Sse2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask16x8(self, val: [i16; 8usize]) -> mask16x8<Self> {
-        mask16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x8(self, a: mask16x8<Self>) -> [i16; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x8(self, bits: u64) -> mask16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3141,9 +2970,10 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask16x8(*a);
+        let mut lanes = [0 as i16; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x8(lanes);
+        *a = mask16x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -3269,36 +3099,6 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i32x4(self, val: [i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x4(self, val: &[i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x4(self, a: i32x4<Self>) -> [i32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x4(self, a: &mut i32x4<Self>) -> &mut [i32; 4usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
@@ -3761,36 +3561,6 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x4(self, val: &[u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x4(self, a: u32x4<Self>) -> [u32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x4(self, a: &mut u32x4<Self>) -> &mut [u32; 4usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4284,17 +4054,6 @@ impl Simd for Sse2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask32x4(self, val: [i32; 4usize]) -> mask32x4<Self> {
-        mask32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x4(self, a: mask32x4<Self>) -> [i32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x4(self, bits: u64) -> mask32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -4326,9 +4085,10 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = self.as_array_mask32x4(*a);
+        let mut lanes = [0 as i32; 4usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x4(lanes);
+        *a = mask32x4::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -4454,36 +4214,6 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_f64x2(self, val: [f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x2(self, val: &[f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x2(self, a: f64x2<Self>) -> [f64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128d, [f64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
-        crate::transmute::checked_cast_ref::<__m128d, [f64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x2(self, a: &mut f64x2<Self>) -> &mut [f64; 2usize] {
-        crate::transmute::checked_cast_mut::<__m128d, [f64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
@@ -4946,36 +4676,6 @@ impl Simd for Sse2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_i64x2(self, val: [i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x2(self, val: &[i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x2(self, a: i64x2<Self>) -> [i64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x2(self, a: &i64x2<Self>) -> &[i64; 2usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x2(self, a: &mut i64x2<Self>) -> &mut [i64; 2usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x2(self, a: i64x2<Self>, dest: &mut [i64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -5381,36 +5081,6 @@ impl Simd for Sse2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u64x2(self, val: [u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x2(self, val: &[u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x2(self, a: u64x2<Self>) -> [u64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x2(self, a: &u64x2<Self>) -> &[u64; 2usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x2(self, a: &mut u64x2<Self>) -> &mut [u64; 2usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x2(self, a: u64x2<Self>, dest: &mut [u64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -5809,17 +5479,6 @@ impl Simd for Sse2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask64x2(self, val: [i64; 2usize]) -> mask64x2<Self> {
-        mask64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x2(self, a: mask64x2<Self>) -> [i64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x2(self, bits: u64) -> mask64x2<Self> {
         let lanes: [i64; 2usize] = [
             if bits & 1 != 0 { !0 } else { 0 },
@@ -5844,9 +5503,10 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             2usize
         );
-        let mut lanes = self.as_array_mask64x2(*a);
+        let mut lanes = [0 as i64; 2usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x2(lanes);
+        *a = mask64x2::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self> {
@@ -5972,36 +5632,6 @@ impl Simd for Sse2 {
     fn splat_f32x8(self, val: f32) -> f32x8<Self> {
         let half = self.splat_f32x4(val);
         self.combine_f32x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f32x8(self, val: [f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x8(self, val: &[f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x8(self, a: f32x8<Self>) -> [f32; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128; 2usize], [f32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m128; 2usize], [f32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x8(self, a: &mut f32x8<Self>) -> &mut [f32; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m128; 2usize], [f32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x8<const SHIFT: usize>(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -6389,36 +6019,6 @@ impl Simd for Sse2 {
     fn splat_i8x32(self, val: i8) -> i8x32<Self> {
         let half = self.splat_i8x16(val);
         self.combine_i8x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i8x32(self, val: [i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x32(self, val: &[i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x32(self, a: i8x32<Self>) -> [i8; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x32(self, a: &mut i8x32<Self>) -> &mut [i8; 32usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [i8; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x32<const SHIFT: usize>(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -6827,36 +6427,6 @@ impl Simd for Sse2 {
         self.combine_u8x16(half, half)
     }
     #[inline(always)]
-    fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x32(self, val: &[u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x32(self, a: u8x32<Self>) -> [u8; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [u8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [u8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x32(self, a: &mut u8x32<Self>) -> &mut [u8; 32usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [u8; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u8x32<const SHIFT: usize>(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
         if SHIFT >= 32usize {
             return b;
@@ -7263,17 +6833,6 @@ impl Simd for Sse2 {
         self.combine_mask8x16(half, half)
     }
     #[inline(always)]
-    fn load_array_mask8x32(self, val: [i8; 32usize]) -> mask8x32<Self> {
-        mask8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x32(self, a: mask8x32<Self>) -> [i8; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x32(self, bits: u64) -> mask8x32<Self> {
         let lo = self.from_bitmask_mask8x16(bits);
         let hi = self.from_bitmask_mask8x16(bits >> 16usize);
@@ -7293,9 +6852,10 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = self.as_array_mask8x32(*a);
+        let mut lanes = [0 as i8; 32usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x32(lanes);
+        *a = mask8x32::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
@@ -7385,36 +6945,6 @@ impl Simd for Sse2 {
     fn splat_i16x16(self, val: i16) -> i16x16<Self> {
         let half = self.splat_i16x8(val);
         self.combine_i16x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i16x16(self, val: [i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x16(self, val: &[i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x16(self, a: i16x16<Self>) -> [i16; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x16(self, a: &mut i16x16<Self>) -> &mut [i16; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [i16; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x16<const SHIFT: usize>(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -7761,36 +7291,6 @@ impl Simd for Sse2 {
     fn splat_u16x16(self, val: u16) -> u16x16<Self> {
         let half = self.splat_u16x8(val);
         self.combine_u16x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x16(self, val: &[u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x16(self, a: u16x16<Self>) -> [u16; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [u16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [u16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x16(self, a: &mut u16x16<Self>) -> &mut [u16; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [u16; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x16<const SHIFT: usize>(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -8149,17 +7649,6 @@ impl Simd for Sse2 {
         self.combine_mask16x8(half, half)
     }
     #[inline(always)]
-    fn load_array_mask16x16(self, val: [i16; 16usize]) -> mask16x16<Self> {
-        mask16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x16(self, a: mask16x16<Self>) -> [i16; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x16(self, bits: u64) -> mask16x16<Self> {
         let lo = self.from_bitmask_mask16x8(bits);
         let hi = self.from_bitmask_mask16x8(bits >> 8usize);
@@ -8185,9 +7674,10 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask16x16(*a);
+        let mut lanes = [0 as i16; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x16(lanes);
+        *a = mask16x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
@@ -8277,36 +7767,6 @@ impl Simd for Sse2 {
     fn splat_i32x8(self, val: i32) -> i32x8<Self> {
         let half = self.splat_i32x4(val);
         self.combine_i32x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i32x8(self, val: [i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x8(self, val: &[i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x8(self, a: i32x8<Self>) -> [i32; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x8(self, a: &mut i32x8<Self>) -> &mut [i32; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [i32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x8<const SHIFT: usize>(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -8624,36 +8084,6 @@ impl Simd for Sse2 {
         self.combine_u32x4(half, half)
     }
     #[inline(always)]
-    fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x8(self, val: &[u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x8(self, a: u32x8<Self>) -> [u32; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [u32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [u32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x8(self, a: &mut u32x8<Self>) -> &mut [u32; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [u32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u32x8<const SHIFT: usize>(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -8964,17 +8394,6 @@ impl Simd for Sse2 {
         self.combine_mask32x4(half, half)
     }
     #[inline(always)]
-    fn load_array_mask32x8(self, val: [i32; 8usize]) -> mask32x8<Self> {
-        mask32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x8(self, a: mask32x8<Self>) -> [i32; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x8(self, bits: u64) -> mask32x8<Self> {
         let lo = self.from_bitmask_mask32x4(bits);
         let hi = self.from_bitmask_mask32x4(bits >> 4usize);
@@ -8994,9 +8413,10 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask32x8(*a);
+        let mut lanes = [0 as i32; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x8(lanes);
+        *a = mask32x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
@@ -9086,36 +8506,6 @@ impl Simd for Sse2 {
     fn splat_f64x4(self, val: f64) -> f64x4<Self> {
         let half = self.splat_f64x2(val);
         self.combine_f64x2(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f64x4(self, val: [f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x4(self, val: &[f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x4(self, a: f64x4<Self>) -> [f64; 4usize] {
-        crate::transmute::checked_transmute_copy::<[__m128d; 2usize], [f64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
-        crate::transmute::checked_cast_ref::<[__m128d; 2usize], [f64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x4(self, a: &mut f64x4<Self>) -> &mut [f64; 4usize] {
-        crate::transmute::checked_cast_mut::<[__m128d; 2usize], [f64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x4<const SHIFT: usize>(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
@@ -9463,36 +8853,6 @@ impl Simd for Sse2 {
         self.combine_i64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_i64x4(self, val: [i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x4(self, val: &[i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x4(self, a: i64x4<Self>) -> [i64; 4usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x4(self, a: &i64x4<Self>) -> &[i64; 4usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x4(self, a: &mut i64x4<Self>) -> &mut [i64; 4usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [i64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x4(self, a: i64x4<Self>, dest: &mut [i64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x4<const SHIFT: usize>(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -9787,36 +9147,6 @@ impl Simd for Sse2 {
         self.combine_u64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_u64x4(self, val: [u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x4(self, val: &[u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x4(self, a: u64x4<Self>) -> [u64; 4usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [u64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x4(self, a: &u64x4<Self>) -> &[u64; 4usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [u64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x4(self, a: &mut u64x4<Self>) -> &mut [u64; 4usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [u64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x4(self, a: u64x4<Self>, dest: &mut [u64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u64x4<const SHIFT: usize>(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -10106,17 +9436,6 @@ impl Simd for Sse2 {
         self.combine_mask64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_mask64x4(self, val: [i64; 4usize]) -> mask64x4<Self> {
-        mask64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x4(self, a: mask64x4<Self>) -> [i64; 4usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x4(self, bits: u64) -> mask64x4<Self> {
         let lo = self.from_bitmask_mask64x2(bits);
         let hi = self.from_bitmask_mask64x2(bits >> 2usize);
@@ -10136,9 +9455,10 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = self.as_array_mask64x4(*a);
+        let mut lanes = [0 as i64; 4usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x4(lanes);
+        *a = mask64x4::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x4(self, a: mask64x4<Self>, b: mask64x4<Self>) -> mask64x4<Self> {
@@ -10228,36 +9548,6 @@ impl Simd for Sse2 {
     fn splat_f32x16(self, val: f32) -> f32x16<Self> {
         let half = self.splat_f32x8(val);
         self.combine_f32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f32x16(self, val: [f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x16(self, val: &[f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x16(self, a: f32x16<Self>) -> [f32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128; 4usize], [f32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m128; 4usize], [f32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x16(self, a: &mut f32x16<Self>) -> &mut [f32; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m128; 4usize], [f32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x16<const SHIFT: usize>(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -10749,36 +10039,6 @@ impl Simd for Sse2 {
     fn splat_i8x64(self, val: i8) -> i8x64<Self> {
         let half = self.splat_i8x32(val);
         self.combine_i8x32(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i8x64(self, val: [i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x64(self, val: &[i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x64(self, a: i8x64<Self>) -> [i8; 64usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x64(self, a: &mut i8x64<Self>) -> &mut [i8; 64usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [i8; 64usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x64<const SHIFT: usize>(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -11306,36 +10566,6 @@ impl Simd for Sse2 {
     fn splat_u8x64(self, val: u8) -> u8x64<Self> {
         let half = self.splat_u8x32(val);
         self.combine_u8x32(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u8x64(self, val: [u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x64(self, val: &[u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x64(self, a: u8x64<Self>) -> [u8; 64usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [u8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [u8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x64(self, a: &mut u8x64<Self>) -> &mut [u8; 64usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [u8; 64usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u8x64<const SHIFT: usize>(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -11945,17 +11175,6 @@ impl Simd for Sse2 {
         self.combine_mask8x32(half, half)
     }
     #[inline(always)]
-    fn load_array_mask8x64(self, val: [i8; 64usize]) -> mask8x64<Self> {
-        mask8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x64(self, a: mask8x64<Self>) -> [i8; 64usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x64(self, bits: u64) -> mask8x64<Self> {
         let lo = self.from_bitmask_mask8x32(bits);
         let hi = self.from_bitmask_mask8x32(bits >> 32usize);
@@ -11975,9 +11194,10 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             64usize
         );
-        let mut lanes = self.as_array_mask8x64(*a);
+        let mut lanes = [0 as i8; 64usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x64(lanes);
+        *a = mask8x64::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self> {
@@ -12060,36 +11280,6 @@ impl Simd for Sse2 {
     fn splat_i16x32(self, val: i16) -> i16x32<Self> {
         let half = self.splat_i16x16(val);
         self.combine_i16x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i16x32(self, val: [i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x32(self, val: &[i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x32(self, a: i16x32<Self>) -> [i16; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x32(self, a: &mut i16x32<Self>) -> &mut [i16; 32usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [i16; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x32<const SHIFT: usize>(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -12499,36 +11689,6 @@ impl Simd for Sse2 {
     fn splat_u16x32(self, val: u16) -> u16x32<Self> {
         let half = self.splat_u16x16(val);
         self.combine_u16x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u16x32(self, val: [u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x32(self, val: &[u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x32(self, a: u16x32<Self>) -> [u16; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [u16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [u16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x32(self, a: &mut u16x32<Self>) -> &mut [u16; 32usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [u16; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x32<const SHIFT: usize>(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -12988,17 +12148,6 @@ impl Simd for Sse2 {
         self.combine_mask16x16(half, half)
     }
     #[inline(always)]
-    fn load_array_mask16x32(self, val: [i16; 32usize]) -> mask16x32<Self> {
-        mask16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x32(self, a: mask16x32<Self>) -> [i16; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x32(self, bits: u64) -> mask16x32<Self> {
         let lo = self.from_bitmask_mask16x16(bits);
         let hi = self.from_bitmask_mask16x16(bits >> 16usize);
@@ -13027,9 +12176,10 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = self.as_array_mask16x32(*a);
+        let mut lanes = [0 as i16; 32usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x32(lanes);
+        *a = mask16x32::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x32(self, a: mask16x32<Self>, b: mask16x32<Self>) -> mask16x32<Self> {
@@ -13115,36 +12265,6 @@ impl Simd for Sse2 {
     fn splat_i32x16(self, val: i32) -> i32x16<Self> {
         let half = self.splat_i32x8(val);
         self.combine_i32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i32x16(self, val: [i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x16(self, val: &[i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x16(self, a: i32x16<Self>) -> [i32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x16(self, a: &mut i32x16<Self>) -> &mut [i32; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [i32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x16<const SHIFT: usize>(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -13489,36 +12609,6 @@ impl Simd for Sse2 {
     fn splat_u32x16(self, val: u32) -> u32x16<Self> {
         let half = self.splat_u32x8(val);
         self.combine_u32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u32x16(self, val: [u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x16(self, val: &[u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x16(self, a: u32x16<Self>) -> [u32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [u32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [u32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x16(self, a: &mut u32x16<Self>) -> &mut [u32; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [u32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u32x16<const SHIFT: usize>(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -13935,17 +13025,6 @@ impl Simd for Sse2 {
         self.combine_mask32x8(half, half)
     }
     #[inline(always)]
-    fn load_array_mask32x16(self, val: [i32; 16usize]) -> mask32x16<Self> {
-        mask32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x16(self, a: mask32x16<Self>) -> [i32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x16(self, bits: u64) -> mask32x16<Self> {
         let lo = self.from_bitmask_mask32x8(bits);
         let hi = self.from_bitmask_mask32x8(bits >> 8usize);
@@ -13965,9 +13044,10 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask32x16(*a);
+        let mut lanes = [0 as i32; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x16(lanes);
+        *a = mask32x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self> {
@@ -14050,36 +13130,6 @@ impl Simd for Sse2 {
     fn splat_f64x8(self, val: f64) -> f64x8<Self> {
         let half = self.splat_f64x4(val);
         self.combine_f64x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f64x8(self, val: [f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x8(self, val: &[f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x8(self, a: f64x8<Self>) -> [f64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128d; 4usize], [f64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m128d; 4usize], [f64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x8(self, a: &mut f64x8<Self>) -> &mut [f64; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m128d; 4usize], [f64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x8<const SHIFT: usize>(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {
@@ -14436,36 +13486,6 @@ impl Simd for Sse2 {
         self.combine_i64x4(half, half)
     }
     #[inline(always)]
-    fn load_array_i64x8(self, val: [i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x8(self, val: &[i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x8(self, a: i64x8<Self>) -> [i64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x8(self, a: &i64x8<Self>) -> &[i64; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x8(self, a: &mut i64x8<Self>) -> &mut [i64; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [i64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x8(self, a: i64x8<Self>, dest: &mut [i64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x8<const SHIFT: usize>(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -14767,36 +13787,6 @@ impl Simd for Sse2 {
     fn splat_u64x8(self, val: u64) -> u64x8<Self> {
         let half = self.splat_u64x4(val);
         self.combine_u64x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u64x8(self, val: [u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x8(self, val: &[u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x8(self, a: u64x8<Self>) -> [u64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [u64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x8(self, a: &u64x8<Self>) -> &[u64; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [u64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x8(self, a: &mut u64x8<Self>) -> &mut [u64; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [u64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x8(self, a: u64x8<Self>, dest: &mut [u64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u64x8<const SHIFT: usize>(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
@@ -15164,17 +14154,6 @@ impl Simd for Sse2 {
         self.combine_mask64x4(half, half)
     }
     #[inline(always)]
-    fn load_array_mask64x8(self, val: [i64; 8usize]) -> mask64x8<Self> {
-        mask64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x8(self, a: mask64x8<Self>) -> [i64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x8(self, bits: u64) -> mask64x8<Self> {
         let lo = self.from_bitmask_mask64x4(bits);
         let hi = self.from_bitmask_mask64x4(bits >> 4usize);
@@ -15194,9 +14173,10 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask64x8(*a);
+        let mut lanes = [0 as i64; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x8(lanes);
+        *a = mask64x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x8(self, a: mask64x8<Self>, b: mask64x8<Self>) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -1856,10 +1856,9 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i8; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -2970,10 +2969,9 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i16; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -4085,10 +4083,9 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = [0 as i32; 4usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 4usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x4::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -5503,10 +5500,9 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             2usize
         );
-        let mut lanes = [0 as i64; 2usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 2usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x2::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self> {
@@ -6852,10 +6848,9 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = [0 as i8; 32usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 32usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x32::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
@@ -7674,10 +7669,9 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i16; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
@@ -8413,10 +8407,9 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i32; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
@@ -9455,10 +9448,9 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = [0 as i64; 4usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 4usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x4::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x4(self, a: mask64x4<Self>, b: mask64x4<Self>) -> mask64x4<Self> {
@@ -11194,10 +11186,9 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             64usize
         );
-        let mut lanes = [0 as i8; 64usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 64usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x64::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self> {
@@ -12176,10 +12167,9 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = [0 as i16; 32usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 32usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x32::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x32(self, a: mask16x32<Self>, b: mask16x32<Self>) -> mask16x32<Self> {
@@ -13044,10 +13034,9 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i32; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self> {
@@ -14173,10 +14162,9 @@ impl Simd for Sse2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i64; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x8(self, a: mask64x8<Self>, b: mask64x8<Self>) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -120,36 +120,6 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_f32x4(self, val: [f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x4(self, val: &[f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x4(self, a: f32x4<Self>) -> [f32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128, [f32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
-        crate::transmute::checked_cast_ref::<__m128, [f32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x4(self, a: &mut f32x4<Self>) -> &mut [f32; 4usize] {
-        crate::transmute::checked_cast_mut::<__m128, [f32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -657,36 +627,6 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_i8x16(self, val: [i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x16(self, val: &[i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x16(self, a: i8x16<Self>) -> [i8; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x16(self, a: &mut i8x16<Self>) -> &mut [i8; 16usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i8; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         if SHIFT >= 16usize {
             return b;
@@ -1158,36 +1098,6 @@ impl Simd for Sse4_2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x16(self, val: &[u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x16(self, a: u8x16<Self>) -> [u8; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x16(self, a: &mut u8x16<Self>) -> &mut [u8; 16usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u8; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1673,17 +1583,6 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask8x16(self, val: [i8; 16usize]) -> mask8x16<Self> {
-        mask8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x16(self, a: mask8x16<Self>) -> [i8; 16usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x16(self, bits: u64) -> mask8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1720,9 +1619,10 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask8x16(*a);
+        let mut lanes = [0 as i8; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x16(lanes);
+        *a = mask8x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -1844,36 +1744,6 @@ impl Simd for Sse4_2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i16x8(self, val: [i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x8(self, val: &[i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x8(self, a: i16x8<Self>) -> [i16; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x8(self, a: &mut i16x8<Self>) -> &mut [i16; 8usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i16; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
@@ -2276,36 +2146,6 @@ impl Simd for Sse4_2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x8(self, val: &[u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x8(self, a: u16x8<Self>) -> [u16; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x8(self, a: &mut u16x8<Self>) -> &mut [u16; 8usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u16; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2713,17 +2553,6 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask16x8(self, val: [i16; 8usize]) -> mask16x8<Self> {
-        mask16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x8(self, a: mask16x8<Self>) -> [i16; 8usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x8(self, bits: u64) -> mask16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2758,9 +2587,10 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask16x8(*a);
+        let mut lanes = [0 as i16; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x8(lanes);
+        *a = mask16x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -2882,36 +2712,6 @@ impl Simd for Sse4_2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_i32x4(self, val: [i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x4(self, val: &[i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x4(self, a: i32x4<Self>) -> [i32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x4(self, a: &mut i32x4<Self>) -> &mut [i32; 4usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
@@ -3298,36 +3098,6 @@ impl Simd for Sse4_2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x4(self, val: &[u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x4(self, a: u32x4<Self>) -> [u32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x4(self, a: &mut u32x4<Self>) -> &mut [u32; 4usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -3728,17 +3498,6 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask32x4(self, val: [i32; 4usize]) -> mask32x4<Self> {
-        mask32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x4(self, a: mask32x4<Self>) -> [i32; 4usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x4(self, bits: u64) -> mask32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3770,9 +3529,10 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = self.as_array_mask32x4(*a);
+        let mut lanes = [0 as i32; 4usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x4(lanes);
+        *a = mask32x4::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -3894,36 +3654,6 @@ impl Simd for Sse4_2 {
             }
         );
         kernel(self, val)
-    }
-    #[inline(always)]
-    fn load_array_f64x2(self, val: [f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x2(self, val: &[f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x2(self, a: f64x2<Self>) -> [f64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128d, [f64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
-        crate::transmute::checked_cast_ref::<__m128d, [f64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x2(self, a: &mut f64x2<Self>) -> &mut [f64; 2usize] {
-        crate::transmute::checked_cast_mut::<__m128d, [f64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
@@ -4342,36 +4072,6 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_i64x2(self, val: [i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x2(self, val: &[i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x2(self, a: i64x2<Self>) -> [i64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x2(self, a: &i64x2<Self>) -> &[i64; 2usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x2(self, a: &mut i64x2<Self>) -> &mut [i64; 2usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [i64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x2(self, a: i64x2<Self>, dest: &mut [i64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -4716,36 +4416,6 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_u64x2(self, val: [u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x2(self, val: &[u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x2(self, a: u64x2<Self>) -> [u64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [u64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x2(self, a: &u64x2<Self>) -> &[u64; 2usize] {
-        crate::transmute::checked_cast_ref::<__m128i, [u64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x2(self, a: &mut u64x2<Self>) -> &mut [u64; 2usize] {
-        crate::transmute::checked_cast_mut::<__m128i, [u64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x2(self, a: u64x2<Self>, dest: &mut [u64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -5083,17 +4753,6 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
-    fn load_array_mask64x2(self, val: [i64; 2usize]) -> mask64x2<Self> {
-        mask64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x2(self, a: mask64x2<Self>) -> [i64; 2usize] {
-        crate::transmute::checked_transmute_copy::<__m128i, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x2(self, bits: u64) -> mask64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5125,9 +4784,10 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             2usize
         );
-        let mut lanes = self.as_array_mask64x2(*a);
+        let mut lanes = [0 as i64; 2usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x2(lanes);
+        *a = mask64x2::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self> {
@@ -5244,36 +4904,6 @@ impl Simd for Sse4_2 {
     fn splat_f32x8(self, val: f32) -> f32x8<Self> {
         let half = self.splat_f32x4(val);
         self.combine_f32x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f32x8(self, val: [f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x8(self, val: &[f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x8(self, a: f32x8<Self>) -> [f32; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128; 2usize], [f32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m128; 2usize], [f32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x8(self, a: &mut f32x8<Self>) -> &mut [f32; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m128; 2usize], [f32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x8<const SHIFT: usize>(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -5676,36 +5306,6 @@ impl Simd for Sse4_2 {
     fn splat_i8x32(self, val: i8) -> i8x32<Self> {
         let half = self.splat_i8x16(val);
         self.combine_i8x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i8x32(self, val: [i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x32(self, val: &[i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x32(self, a: i8x32<Self>) -> [i8; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x32(self, a: &mut i8x32<Self>) -> &mut [i8; 32usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [i8; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x32<const SHIFT: usize>(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -6129,36 +5729,6 @@ impl Simd for Sse4_2 {
         self.combine_u8x16(half, half)
     }
     #[inline(always)]
-    fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x32(self, val: &[u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x32(self, a: u8x32<Self>) -> [u8; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [u8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [u8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x32(self, a: &mut u8x32<Self>) -> &mut [u8; 32usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [u8; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u8x32<const SHIFT: usize>(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
         if SHIFT >= 32usize {
             return b;
@@ -6580,17 +6150,6 @@ impl Simd for Sse4_2 {
         self.combine_mask8x16(half, half)
     }
     #[inline(always)]
-    fn load_array_mask8x32(self, val: [i8; 32usize]) -> mask8x32<Self> {
-        mask8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x32(self, a: mask8x32<Self>) -> [i8; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x32(self, bits: u64) -> mask8x32<Self> {
         let lo = self.from_bitmask_mask8x16(bits);
         let hi = self.from_bitmask_mask8x16(bits >> 16usize);
@@ -6610,9 +6169,10 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = self.as_array_mask8x32(*a);
+        let mut lanes = [0 as i8; 32usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x32(lanes);
+        *a = mask8x32::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
@@ -6702,36 +6262,6 @@ impl Simd for Sse4_2 {
     fn splat_i16x16(self, val: i16) -> i16x16<Self> {
         let half = self.splat_i16x8(val);
         self.combine_i16x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i16x16(self, val: [i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x16(self, val: &[i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x16(self, a: i16x16<Self>) -> [i16; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x16(self, a: &mut i16x16<Self>) -> &mut [i16; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [i16; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x16<const SHIFT: usize>(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -7093,36 +6623,6 @@ impl Simd for Sse4_2 {
     fn splat_u16x16(self, val: u16) -> u16x16<Self> {
         let half = self.splat_u16x8(val);
         self.combine_u16x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x16(self, val: &[u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x16(self, a: u16x16<Self>) -> [u16; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [u16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [u16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x16(self, a: &mut u16x16<Self>) -> &mut [u16; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [u16; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x16<const SHIFT: usize>(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -7496,17 +6996,6 @@ impl Simd for Sse4_2 {
         self.combine_mask16x8(half, half)
     }
     #[inline(always)]
-    fn load_array_mask16x16(self, val: [i16; 16usize]) -> mask16x16<Self> {
-        mask16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x16(self, a: mask16x16<Self>) -> [i16; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x16(self, bits: u64) -> mask16x16<Self> {
         let lo = self.from_bitmask_mask16x8(bits);
         let hi = self.from_bitmask_mask16x8(bits >> 8usize);
@@ -7532,9 +7021,10 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask16x16(*a);
+        let mut lanes = [0 as i16; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x16(lanes);
+        *a = mask16x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
@@ -7624,36 +7114,6 @@ impl Simd for Sse4_2 {
     fn splat_i32x8(self, val: i32) -> i32x8<Self> {
         let half = self.splat_i32x4(val);
         self.combine_i32x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i32x8(self, val: [i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x8(self, val: &[i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x8(self, a: i32x8<Self>) -> [i32; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x8(self, a: &mut i32x8<Self>) -> &mut [i32; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [i32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x8<const SHIFT: usize>(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -7986,36 +7446,6 @@ impl Simd for Sse4_2 {
         self.combine_u32x4(half, half)
     }
     #[inline(always)]
-    fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x8(self, val: &[u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x8(self, a: u32x8<Self>) -> [u32; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [u32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [u32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x8(self, a: &mut u32x8<Self>) -> &mut [u32; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [u32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u32x8<const SHIFT: usize>(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -8341,17 +7771,6 @@ impl Simd for Sse4_2 {
         self.combine_mask32x4(half, half)
     }
     #[inline(always)]
-    fn load_array_mask32x8(self, val: [i32; 8usize]) -> mask32x8<Self> {
-        mask32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x8(self, a: mask32x8<Self>) -> [i32; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x8(self, bits: u64) -> mask32x8<Self> {
         let lo = self.from_bitmask_mask32x4(bits);
         let hi = self.from_bitmask_mask32x4(bits >> 4usize);
@@ -8371,9 +7790,10 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask32x8(*a);
+        let mut lanes = [0 as i32; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x8(lanes);
+        *a = mask32x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
@@ -8463,36 +7883,6 @@ impl Simd for Sse4_2 {
     fn splat_f64x4(self, val: f64) -> f64x4<Self> {
         let half = self.splat_f64x2(val);
         self.combine_f64x2(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f64x4(self, val: [f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x4(self, val: &[f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x4(self, a: f64x4<Self>) -> [f64; 4usize] {
-        crate::transmute::checked_transmute_copy::<[__m128d; 2usize], [f64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
-        crate::transmute::checked_cast_ref::<[__m128d; 2usize], [f64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x4(self, a: &mut f64x4<Self>) -> &mut [f64; 4usize] {
-        crate::transmute::checked_cast_mut::<[__m128d; 2usize], [f64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x4<const SHIFT: usize>(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
@@ -8855,36 +8245,6 @@ impl Simd for Sse4_2 {
         self.combine_i64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_i64x4(self, val: [i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x4(self, val: &[i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x4(self, a: i64x4<Self>) -> [i64; 4usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x4(self, a: &i64x4<Self>) -> &[i64; 4usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x4(self, a: &mut i64x4<Self>) -> &mut [i64; 4usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [i64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x4(self, a: i64x4<Self>, dest: &mut [i64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x4<const SHIFT: usize>(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -9194,36 +8554,6 @@ impl Simd for Sse4_2 {
         self.combine_u64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_u64x4(self, val: [u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x4(self, val: &[u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x4(self, a: u64x4<Self>) -> [u64; 4usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [u64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x4(self, a: &u64x4<Self>) -> &[u64; 4usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 2usize], [u64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x4(self, a: &mut u64x4<Self>) -> &mut [u64; 4usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 2usize], [u64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x4(self, a: u64x4<Self>, dest: &mut [u64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u64x4<const SHIFT: usize>(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -9528,17 +8858,6 @@ impl Simd for Sse4_2 {
         self.combine_mask64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_mask64x4(self, val: [i64; 4usize]) -> mask64x4<Self> {
-        mask64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x4(self, a: mask64x4<Self>) -> [i64; 4usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 2usize], [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x4(self, bits: u64) -> mask64x4<Self> {
         let lo = self.from_bitmask_mask64x2(bits);
         let hi = self.from_bitmask_mask64x2(bits >> 2usize);
@@ -9558,9 +8877,10 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = self.as_array_mask64x4(*a);
+        let mut lanes = [0 as i64; 4usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x4(lanes);
+        *a = mask64x4::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x4(self, a: mask64x4<Self>, b: mask64x4<Self>) -> mask64x4<Self> {
@@ -9650,36 +8970,6 @@ impl Simd for Sse4_2 {
     fn splat_f32x16(self, val: f32) -> f32x16<Self> {
         let half = self.splat_f32x8(val);
         self.combine_f32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f32x16(self, val: [f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x16(self, val: &[f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x16(self, a: f32x16<Self>) -> [f32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128; 4usize], [f32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m128; 4usize], [f32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x16(self, a: &mut f32x16<Self>) -> &mut [f32; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m128; 4usize], [f32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x16<const SHIFT: usize>(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -10171,36 +9461,6 @@ impl Simd for Sse4_2 {
     fn splat_i8x64(self, val: i8) -> i8x64<Self> {
         let half = self.splat_i8x32(val);
         self.combine_i8x32(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i8x64(self, val: [i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x64(self, val: &[i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x64(self, a: i8x64<Self>) -> [i8; 64usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x64(self, a: &mut i8x64<Self>) -> &mut [i8; 64usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [i8; 64usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x64<const SHIFT: usize>(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -10728,36 +9988,6 @@ impl Simd for Sse4_2 {
     fn splat_u8x64(self, val: u8) -> u8x64<Self> {
         let half = self.splat_u8x32(val);
         self.combine_u8x32(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u8x64(self, val: [u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x64(self, val: &[u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x64(self, a: u8x64<Self>) -> [u8; 64usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [u8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [u8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x64(self, a: &mut u8x64<Self>) -> &mut [u8; 64usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [u8; 64usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u8x64<const SHIFT: usize>(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -11367,17 +10597,6 @@ impl Simd for Sse4_2 {
         self.combine_mask8x32(half, half)
     }
     #[inline(always)]
-    fn load_array_mask8x64(self, val: [i8; 64usize]) -> mask8x64<Self> {
-        mask8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x64(self, a: mask8x64<Self>) -> [i8; 64usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x64(self, bits: u64) -> mask8x64<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -11438,9 +10657,10 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             64usize
         );
-        let mut lanes = self.as_array_mask8x64(*a);
+        let mut lanes = [0 as i8; 64usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x64(lanes);
+        *a = mask8x64::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self> {
@@ -11523,36 +10743,6 @@ impl Simd for Sse4_2 {
     fn splat_i16x32(self, val: i16) -> i16x32<Self> {
         let half = self.splat_i16x16(val);
         self.combine_i16x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i16x32(self, val: [i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x32(self, val: &[i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x32(self, a: i16x32<Self>) -> [i16; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x32(self, a: &mut i16x32<Self>) -> &mut [i16; 32usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [i16; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x32<const SHIFT: usize>(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -11962,36 +11152,6 @@ impl Simd for Sse4_2 {
     fn splat_u16x32(self, val: u16) -> u16x32<Self> {
         let half = self.splat_u16x16(val);
         self.combine_u16x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u16x32(self, val: [u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x32(self, val: &[u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x32(self, a: u16x32<Self>) -> [u16; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [u16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [u16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x32(self, a: &mut u16x32<Self>) -> &mut [u16; 32usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [u16; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x32<const SHIFT: usize>(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -12488,17 +11648,6 @@ impl Simd for Sse4_2 {
         self.combine_mask16x16(half, half)
     }
     #[inline(always)]
-    fn load_array_mask16x32(self, val: [i16; 32usize]) -> mask16x32<Self> {
-        mask16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x32(self, a: mask16x32<Self>) -> [i16; 32usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x32(self, bits: u64) -> mask16x32<Self> {
         let lo = self.from_bitmask_mask16x16(bits);
         let hi = self.from_bitmask_mask16x16(bits >> 16usize);
@@ -12527,9 +11676,10 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = self.as_array_mask16x32(*a);
+        let mut lanes = [0 as i16; 32usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x32(lanes);
+        *a = mask16x32::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x32(self, a: mask16x32<Self>, b: mask16x32<Self>) -> mask16x32<Self> {
@@ -12615,36 +11765,6 @@ impl Simd for Sse4_2 {
     fn splat_i32x16(self, val: i32) -> i32x16<Self> {
         let half = self.splat_i32x8(val);
         self.combine_i32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i32x16(self, val: [i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x16(self, val: &[i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x16(self, a: i32x16<Self>) -> [i32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x16(self, a: &mut i32x16<Self>) -> &mut [i32; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [i32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x16<const SHIFT: usize>(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -12989,36 +12109,6 @@ impl Simd for Sse4_2 {
     fn splat_u32x16(self, val: u32) -> u32x16<Self> {
         let half = self.splat_u32x8(val);
         self.combine_u32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u32x16(self, val: [u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x16(self, val: &[u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x16(self, a: u32x16<Self>) -> [u32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [u32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [u32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x16(self, a: &mut u32x16<Self>) -> &mut [u32; 16usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [u32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u32x16<const SHIFT: usize>(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -13435,17 +12525,6 @@ impl Simd for Sse4_2 {
         self.combine_mask32x8(half, half)
     }
     #[inline(always)]
-    fn load_array_mask32x16(self, val: [i32; 16usize]) -> mask32x16<Self> {
-        mask32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x16(self, a: mask32x16<Self>) -> [i32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x16(self, bits: u64) -> mask32x16<Self> {
         let lo = self.from_bitmask_mask32x8(bits);
         let hi = self.from_bitmask_mask32x8(bits >> 8usize);
@@ -13465,9 +12544,10 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask32x16(*a);
+        let mut lanes = [0 as i32; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x16(lanes);
+        *a = mask32x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self> {
@@ -13550,36 +12630,6 @@ impl Simd for Sse4_2 {
     fn splat_f64x8(self, val: f64) -> f64x8<Self> {
         let half = self.splat_f64x4(val);
         self.combine_f64x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f64x8(self, val: [f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x8(self, val: &[f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x8(self, a: f64x8<Self>) -> [f64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128d; 4usize], [f64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m128d; 4usize], [f64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x8(self, a: &mut f64x8<Self>) -> &mut [f64; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m128d; 4usize], [f64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x8<const SHIFT: usize>(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {
@@ -13936,36 +12986,6 @@ impl Simd for Sse4_2 {
         self.combine_i64x4(half, half)
     }
     #[inline(always)]
-    fn load_array_i64x8(self, val: [i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x8(self, val: &[i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x8(self, a: i64x8<Self>) -> [i64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x8(self, a: &i64x8<Self>) -> &[i64; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x8(self, a: &mut i64x8<Self>) -> &mut [i64; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [i64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x8(self, a: i64x8<Self>, dest: &mut [i64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x8<const SHIFT: usize>(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -14267,36 +13287,6 @@ impl Simd for Sse4_2 {
     fn splat_u64x8(self, val: u64) -> u64x8<Self> {
         let half = self.splat_u64x4(val);
         self.combine_u64x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u64x8(self, val: [u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x8(self, val: &[u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x8(self, a: u64x8<Self>) -> [u64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [u64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x8(self, a: &u64x8<Self>) -> &[u64; 8usize] {
-        crate::transmute::checked_cast_ref::<[__m128i; 4usize], [u64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x8(self, a: &mut u64x8<Self>) -> &mut [u64; 8usize] {
-        crate::transmute::checked_cast_mut::<[__m128i; 4usize], [u64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x8(self, a: u64x8<Self>, dest: &mut [u64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u64x8<const SHIFT: usize>(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
@@ -14664,17 +13654,6 @@ impl Simd for Sse4_2 {
         self.combine_mask64x4(half, half)
     }
     #[inline(always)]
-    fn load_array_mask64x8(self, val: [i64; 8usize]) -> mask64x8<Self> {
-        mask64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x8(self, a: mask64x8<Self>) -> [i64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[__m128i; 4usize], [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x8(self, bits: u64) -> mask64x8<Self> {
         let lo = self.from_bitmask_mask64x4(bits);
         let hi = self.from_bitmask_mask64x4(bits >> 4usize);
@@ -14694,9 +13673,10 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask64x8(*a);
+        let mut lanes = [0 as i64; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x8(lanes);
+        *a = mask64x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x8(self, a: mask64x8<Self>, b: mask64x8<Self>) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -1619,10 +1619,9 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i8; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -2587,10 +2586,9 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i16; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -3529,10 +3527,9 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = [0 as i32; 4usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 4usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x4::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -4784,10 +4781,9 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             2usize
         );
-        let mut lanes = [0 as i64; 2usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 2usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x2::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self> {
@@ -6169,10 +6165,9 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = [0 as i8; 32usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 32usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x32::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
@@ -7021,10 +7016,9 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i16; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
@@ -7790,10 +7784,9 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i32; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
@@ -8877,10 +8870,9 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = [0 as i64; 4usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 4usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x4::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x4(self, a: mask64x4<Self>, b: mask64x4<Self>) -> mask64x4<Self> {
@@ -10657,10 +10649,9 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             64usize
         );
-        let mut lanes = [0 as i8; 64usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 64usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x64::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self> {
@@ -11676,10 +11667,9 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = [0 as i16; 32usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 32usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x32::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x32(self, a: mask16x32<Self>, b: mask16x32<Self>) -> mask16x32<Self> {
@@ -12544,10 +12534,9 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i32; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self> {
@@ -13673,10 +13662,9 @@ impl Simd for Sse4_2 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i64; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x8(self, a: mask64x8<Self>, b: mask64x8<Self>) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -104,36 +104,6 @@ impl Simd for WasmSimd128 {
         f32x4_splat(val).simd_into(self)
     }
     #[inline(always)]
-    fn load_array_f32x4(self, val: [f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x4(self, val: &[f32; 4usize]) -> f32x4<Self> {
-        f32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x4(self, a: f32x4<Self>) -> [f32; 4usize] {
-        crate::transmute::checked_transmute_copy::<v128, [f32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x4(self, a: &f32x4<Self>) -> &[f32; 4usize] {
-        crate::transmute::checked_cast_ref::<v128, [f32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x4(self, a: &mut f32x4<Self>) -> &mut [f32; 4usize] {
-        crate::transmute::checked_cast_mut::<v128, [f32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x4(self, a: f32x4<Self>, dest: &mut [f32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -434,36 +404,6 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn splat_i8x16(self, val: i8) -> i8x16<Self> {
         i8x16_splat(val).simd_into(self)
-    }
-    #[inline(always)]
-    fn load_array_i8x16(self, val: [i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x16(self, val: &[i8; 16usize]) -> i8x16<Self> {
-        i8x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x16(self, a: i8x16<Self>) -> [i8; 16usize] {
-        crate::transmute::checked_transmute_copy::<v128, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x16(self, a: &i8x16<Self>) -> &[i8; 16usize] {
-        crate::transmute::checked_cast_ref::<v128, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x16(self, a: &mut i8x16<Self>) -> &mut [i8; 16usize] {
-        crate::transmute::checked_cast_mut::<v128, [i8; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x16(self, a: i8x16<Self>, dest: &mut [i8; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
@@ -773,36 +713,6 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn splat_u8x16(self, val: u8) -> u8x16<Self> {
         u8x16_splat(val).simd_into(self)
-    }
-    #[inline(always)]
-    fn load_array_u8x16(self, val: [u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x16(self, val: &[u8; 16usize]) -> u8x16<Self> {
-        u8x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x16(self, a: u8x16<Self>) -> [u8; 16usize] {
-        crate::transmute::checked_transmute_copy::<v128, [u8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x16(self, a: &u8x16<Self>) -> &[u8; 16usize] {
-        crate::transmute::checked_cast_ref::<v128, [u8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x16(self, a: &mut u8x16<Self>) -> &mut [u8; 16usize] {
-        crate::transmute::checked_cast_mut::<v128, [u8; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x16(self, a: u8x16<Self>, dest: &mut [u8; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1117,17 +1027,6 @@ impl Simd for WasmSimd128 {
         i8x16_splat(val).simd_into(self)
     }
     #[inline(always)]
-    fn load_array_mask8x16(self, val: [i8; 16usize]) -> mask8x16<Self> {
-        mask8x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x16(self, a: mask8x16<Self>) -> [i8; 16usize] {
-        crate::transmute::checked_transmute_copy::<v128, [i8; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x16(self, bits: u64) -> mask8x16<Self> {
         let lo = i8x16_splat(bits as i8);
         let hi = i8x16_splat((bits >> 8) as i8);
@@ -1147,9 +1046,10 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask8x16(*a);
+        let mut lanes = [0 as i8; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x16(lanes);
+        *a = mask8x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -1213,36 +1113,6 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn splat_i16x8(self, val: i16) -> i16x8<Self> {
         i16x8_splat(val).simd_into(self)
-    }
-    #[inline(always)]
-    fn load_array_i16x8(self, val: [i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x8(self, val: &[i16; 8usize]) -> i16x8<Self> {
-        i16x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x8(self, a: i16x8<Self>) -> [i16; 8usize] {
-        crate::transmute::checked_transmute_copy::<v128, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x8(self, a: &i16x8<Self>) -> &[i16; 8usize] {
-        crate::transmute::checked_cast_ref::<v128, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x8(self, a: &mut i16x8<Self>) -> &mut [i16; 8usize] {
-        crate::transmute::checked_cast_mut::<v128, [i16; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x8(self, a: i16x8<Self>, dest: &mut [i16; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
@@ -1494,36 +1364,6 @@ impl Simd for WasmSimd128 {
         u16x8_splat(val).simd_into(self)
     }
     #[inline(always)]
-    fn load_array_u16x8(self, val: [u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x8(self, val: &[u16; 8usize]) -> u16x8<Self> {
-        u16x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x8(self, a: u16x8<Self>) -> [u16; 8usize] {
-        crate::transmute::checked_transmute_copy::<v128, [u16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x8(self, a: &u16x8<Self>) -> &[u16; 8usize] {
-        crate::transmute::checked_cast_ref::<v128, [u16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x8(self, a: &mut u16x8<Self>) -> &mut [u16; 8usize] {
-        crate::transmute::checked_cast_mut::<v128, [u16; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x8(self, a: u16x8<Self>, dest: &mut [u16; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -1770,17 +1610,6 @@ impl Simd for WasmSimd128 {
         i16x8_splat(val).simd_into(self)
     }
     #[inline(always)]
-    fn load_array_mask16x8(self, val: [i16; 8usize]) -> mask16x8<Self> {
-        mask16x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x8(self, a: mask16x8<Self>) -> [i16; 8usize] {
-        crate::transmute::checked_transmute_copy::<v128, [i16; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x8(self, bits: u64) -> mask16x8<Self> {
         let bitset = i16x8_splat(bits as i16);
         let powers = u16x8(1, 2, 4, 8, 16, 32, 64, 128);
@@ -1798,9 +1627,10 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask16x8(*a);
+        let mut lanes = [0 as i16; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x8(lanes);
+        *a = mask16x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -1864,36 +1694,6 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn splat_i32x4(self, val: i32) -> i32x4<Self> {
         i32x4_splat(val).simd_into(self)
-    }
-    #[inline(always)]
-    fn load_array_i32x4(self, val: [i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x4(self, val: &[i32; 4usize]) -> i32x4<Self> {
-        i32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x4(self, a: i32x4<Self>) -> [i32; 4usize] {
-        crate::transmute::checked_transmute_copy::<v128, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x4(self, a: &i32x4<Self>) -> &[i32; 4usize] {
-        crate::transmute::checked_cast_ref::<v128, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x4(self, a: &mut i32x4<Self>) -> &mut [i32; 4usize] {
-        crate::transmute::checked_cast_mut::<v128, [i32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x4(self, a: i32x4<Self>, dest: &mut [i32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
@@ -2125,36 +1925,6 @@ impl Simd for WasmSimd128 {
         u32x4_splat(val).simd_into(self)
     }
     #[inline(always)]
-    fn load_array_u32x4(self, val: [u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x4(self, val: &[u32; 4usize]) -> u32x4<Self> {
-        u32x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x4(self, a: u32x4<Self>) -> [u32; 4usize] {
-        crate::transmute::checked_transmute_copy::<v128, [u32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x4(self, a: &u32x4<Self>) -> &[u32; 4usize] {
-        crate::transmute::checked_cast_ref::<v128, [u32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x4(self, a: &mut u32x4<Self>) -> &mut [u32; 4usize] {
-        crate::transmute::checked_cast_mut::<v128, [u32; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x4(self, a: u32x4<Self>, dest: &mut [u32; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -2381,17 +2151,6 @@ impl Simd for WasmSimd128 {
         i32x4_splat(val).simd_into(self)
     }
     #[inline(always)]
-    fn load_array_mask32x4(self, val: [i32; 4usize]) -> mask32x4<Self> {
-        mask32x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x4(self, a: mask32x4<Self>) -> [i32; 4usize] {
-        crate::transmute::checked_transmute_copy::<v128, [i32; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x4(self, bits: u64) -> mask32x4<Self> {
         let bitset = i32x4_splat(bits as i32);
         let powers = u32x4(1, 2, 4, 8);
@@ -2409,9 +2168,10 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = self.as_array_mask32x4(*a);
+        let mut lanes = [0 as i32; 4usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x4(lanes);
+        *a = mask32x4::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -2475,36 +2235,6 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn splat_f64x2(self, val: f64) -> f64x2<Self> {
         f64x2_splat(val).simd_into(self)
-    }
-    #[inline(always)]
-    fn load_array_f64x2(self, val: [f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x2(self, val: &[f64; 2usize]) -> f64x2<Self> {
-        f64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x2(self, a: f64x2<Self>) -> [f64; 2usize] {
-        crate::transmute::checked_transmute_copy::<v128, [f64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x2(self, a: &f64x2<Self>) -> &[f64; 2usize] {
-        crate::transmute::checked_cast_ref::<v128, [f64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x2(self, a: &mut f64x2<Self>) -> &mut [f64; 2usize] {
-        crate::transmute::checked_cast_mut::<v128, [f64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x2(self, a: f64x2<Self>, dest: &mut [f64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
@@ -2771,36 +2501,6 @@ impl Simd for WasmSimd128 {
         i64x2_splat(val).simd_into(self)
     }
     #[inline(always)]
-    fn load_array_i64x2(self, val: [i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x2(self, val: &[i64; 2usize]) -> i64x2<Self> {
-        i64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x2(self, a: i64x2<Self>) -> [i64; 2usize] {
-        crate::transmute::checked_transmute_copy::<v128, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x2(self, a: &i64x2<Self>) -> &[i64; 2usize] {
-        crate::transmute::checked_cast_ref::<v128, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x2(self, a: &mut i64x2<Self>) -> &mut [i64; 2usize] {
-        crate::transmute::checked_cast_mut::<v128, [i64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x2(self, a: i64x2<Self>, dest: &mut [i64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -3020,36 +2720,6 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn splat_u64x2(self, val: u64) -> u64x2<Self> {
         u64x2_splat(val).simd_into(self)
-    }
-    #[inline(always)]
-    fn load_array_u64x2(self, val: [u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x2(self, val: &[u64; 2usize]) -> u64x2<Self> {
-        u64x2 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x2(self, a: u64x2<Self>) -> [u64; 2usize] {
-        crate::transmute::checked_transmute_copy::<v128, [u64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x2(self, a: &u64x2<Self>) -> &[u64; 2usize] {
-        crate::transmute::checked_cast_ref::<v128, [u64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x2(self, a: &mut u64x2<Self>) -> &mut [u64; 2usize] {
-        crate::transmute::checked_cast_mut::<v128, [u64; 2usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x2(self, a: u64x2<Self>, dest: &mut [u64; 2usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
@@ -3290,17 +2960,6 @@ impl Simd for WasmSimd128 {
         i64x2_splat(val).simd_into(self)
     }
     #[inline(always)]
-    fn load_array_mask64x2(self, val: [i64; 2usize]) -> mask64x2<Self> {
-        mask64x2 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x2(self, a: mask64x2<Self>) -> [i64; 2usize] {
-        crate::transmute::checked_transmute_copy::<v128, [i64; 2usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x2(self, bits: u64) -> mask64x2<Self> {
         let bitset = i64x2_splat(bits as i64);
         let powers = u64x2(1, 2);
@@ -3318,9 +2977,10 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             2usize
         );
-        let mut lanes = self.as_array_mask64x2(*a);
+        let mut lanes = [0 as i64; 2usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x2(lanes);
+        *a = mask64x2::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self> {
@@ -3385,36 +3045,6 @@ impl Simd for WasmSimd128 {
     fn splat_f32x8(self, val: f32) -> f32x8<Self> {
         let half = self.splat_f32x4(val);
         self.combine_f32x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f32x8(self, val: [f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x8(self, val: &[f32; 8usize]) -> f32x8<Self> {
-        f32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x8(self, a: f32x8<Self>) -> [f32; 8usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [f32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x8(self, a: &f32x8<Self>) -> &[f32; 8usize] {
-        crate::transmute::checked_cast_ref::<[v128; 2usize], [f32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x8(self, a: &mut f32x8<Self>) -> &mut [f32; 8usize] {
-        crate::transmute::checked_cast_mut::<[v128; 2usize], [f32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x8(self, a: f32x8<Self>, dest: &mut [f32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x8<const SHIFT: usize>(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -3806,36 +3436,6 @@ impl Simd for WasmSimd128 {
     fn splat_i8x32(self, val: i8) -> i8x32<Self> {
         let half = self.splat_i8x16(val);
         self.combine_i8x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i8x32(self, val: [i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x32(self, val: &[i8; 32usize]) -> i8x32<Self> {
-        i8x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x32(self, a: i8x32<Self>) -> [i8; 32usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x32(self, a: &i8x32<Self>) -> &[i8; 32usize] {
-        crate::transmute::checked_cast_ref::<[v128; 2usize], [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x32(self, a: &mut i8x32<Self>) -> &mut [i8; 32usize] {
-        crate::transmute::checked_cast_mut::<[v128; 2usize], [i8; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x32(self, a: i8x32<Self>, dest: &mut [i8; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x32<const SHIFT: usize>(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -4245,36 +3845,6 @@ impl Simd for WasmSimd128 {
         self.combine_u8x16(half, half)
     }
     #[inline(always)]
-    fn load_array_u8x32(self, val: [u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x32(self, val: &[u8; 32usize]) -> u8x32<Self> {
-        u8x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x32(self, a: u8x32<Self>) -> [u8; 32usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [u8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x32(self, a: &u8x32<Self>) -> &[u8; 32usize] {
-        crate::transmute::checked_cast_ref::<[v128; 2usize], [u8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x32(self, a: &mut u8x32<Self>) -> &mut [u8; 32usize] {
-        crate::transmute::checked_cast_mut::<[v128; 2usize], [u8; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x32(self, a: u8x32<Self>, dest: &mut [u8; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u8x32<const SHIFT: usize>(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
         if SHIFT >= 32usize {
             return b;
@@ -4682,17 +4252,6 @@ impl Simd for WasmSimd128 {
         self.combine_mask8x16(half, half)
     }
     #[inline(always)]
-    fn load_array_mask8x32(self, val: [i8; 32usize]) -> mask8x32<Self> {
-        mask8x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x32(self, a: mask8x32<Self>) -> [i8; 32usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i8; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x32(self, bits: u64) -> mask8x32<Self> {
         let lo = self.from_bitmask_mask8x16(bits);
         let hi = self.from_bitmask_mask8x16(bits >> 16usize);
@@ -4712,9 +4271,10 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = self.as_array_mask8x32(*a);
+        let mut lanes = [0 as i8; 32usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x32(lanes);
+        *a = mask8x32::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
@@ -4804,36 +4364,6 @@ impl Simd for WasmSimd128 {
     fn splat_i16x16(self, val: i16) -> i16x16<Self> {
         let half = self.splat_i16x8(val);
         self.combine_i16x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i16x16(self, val: [i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x16(self, val: &[i16; 16usize]) -> i16x16<Self> {
-        i16x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x16(self, a: i16x16<Self>) -> [i16; 16usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x16(self, a: &i16x16<Self>) -> &[i16; 16usize] {
-        crate::transmute::checked_cast_ref::<[v128; 2usize], [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x16(self, a: &mut i16x16<Self>) -> &mut [i16; 16usize] {
-        crate::transmute::checked_cast_mut::<[v128; 2usize], [i16; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x16(self, a: i16x16<Self>, dest: &mut [i16; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x16<const SHIFT: usize>(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -5184,36 +4714,6 @@ impl Simd for WasmSimd128 {
     fn splat_u16x16(self, val: u16) -> u16x16<Self> {
         let half = self.splat_u16x8(val);
         self.combine_u16x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u16x16(self, val: [u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x16(self, val: &[u16; 16usize]) -> u16x16<Self> {
-        u16x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x16(self, a: u16x16<Self>) -> [u16; 16usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [u16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x16(self, a: &u16x16<Self>) -> &[u16; 16usize] {
-        crate::transmute::checked_cast_ref::<[v128; 2usize], [u16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x16(self, a: &mut u16x16<Self>) -> &mut [u16; 16usize] {
-        crate::transmute::checked_cast_mut::<[v128; 2usize], [u16; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x16(self, a: u16x16<Self>, dest: &mut [u16; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x16<const SHIFT: usize>(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -5570,17 +5070,6 @@ impl Simd for WasmSimd128 {
         self.combine_mask16x8(half, half)
     }
     #[inline(always)]
-    fn load_array_mask16x16(self, val: [i16; 16usize]) -> mask16x16<Self> {
-        mask16x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x16(self, a: mask16x16<Self>) -> [i16; 16usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i16; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x16(self, bits: u64) -> mask16x16<Self> {
         let lo = self.from_bitmask_mask16x8(bits);
         let hi = self.from_bitmask_mask16x8(bits >> 8usize);
@@ -5600,9 +5089,10 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask16x16(*a);
+        let mut lanes = [0 as i16; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x16(lanes);
+        *a = mask16x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
@@ -5692,36 +5182,6 @@ impl Simd for WasmSimd128 {
     fn splat_i32x8(self, val: i32) -> i32x8<Self> {
         let half = self.splat_i32x4(val);
         self.combine_i32x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i32x8(self, val: [i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x8(self, val: &[i32; 8usize]) -> i32x8<Self> {
-        i32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x8(self, a: i32x8<Self>) -> [i32; 8usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x8(self, a: &i32x8<Self>) -> &[i32; 8usize] {
-        crate::transmute::checked_cast_ref::<[v128; 2usize], [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x8(self, a: &mut i32x8<Self>) -> &mut [i32; 8usize] {
-        crate::transmute::checked_cast_mut::<[v128; 2usize], [i32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x8(self, a: i32x8<Self>, dest: &mut [i32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x8<const SHIFT: usize>(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -6043,36 +5503,6 @@ impl Simd for WasmSimd128 {
         self.combine_u32x4(half, half)
     }
     #[inline(always)]
-    fn load_array_u32x8(self, val: [u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x8(self, val: &[u32; 8usize]) -> u32x8<Self> {
-        u32x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x8(self, a: u32x8<Self>) -> [u32; 8usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [u32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x8(self, a: &u32x8<Self>) -> &[u32; 8usize] {
-        crate::transmute::checked_cast_ref::<[v128; 2usize], [u32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x8(self, a: &mut u32x8<Self>) -> &mut [u32; 8usize] {
-        crate::transmute::checked_cast_mut::<[v128; 2usize], [u32; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x8(self, a: u32x8<Self>, dest: &mut [u32; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u32x8<const SHIFT: usize>(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -6387,17 +5817,6 @@ impl Simd for WasmSimd128 {
         self.combine_mask32x4(half, half)
     }
     #[inline(always)]
-    fn load_array_mask32x8(self, val: [i32; 8usize]) -> mask32x8<Self> {
-        mask32x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x8(self, a: mask32x8<Self>) -> [i32; 8usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i32; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x8(self, bits: u64) -> mask32x8<Self> {
         let lo = self.from_bitmask_mask32x4(bits);
         let hi = self.from_bitmask_mask32x4(bits >> 4usize);
@@ -6417,9 +5836,10 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask32x8(*a);
+        let mut lanes = [0 as i32; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x8(lanes);
+        *a = mask32x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
@@ -6509,36 +5929,6 @@ impl Simd for WasmSimd128 {
     fn splat_f64x4(self, val: f64) -> f64x4<Self> {
         let half = self.splat_f64x2(val);
         self.combine_f64x2(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f64x4(self, val: [f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x4(self, val: &[f64; 4usize]) -> f64x4<Self> {
-        f64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x4(self, a: f64x4<Self>) -> [f64; 4usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [f64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x4(self, a: &f64x4<Self>) -> &[f64; 4usize] {
-        crate::transmute::checked_cast_ref::<[v128; 2usize], [f64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x4(self, a: &mut f64x4<Self>) -> &mut [f64; 4usize] {
-        crate::transmute::checked_cast_mut::<[v128; 2usize], [f64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x4(self, a: f64x4<Self>, dest: &mut [f64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x4<const SHIFT: usize>(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
@@ -6890,36 +6280,6 @@ impl Simd for WasmSimd128 {
         self.combine_i64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_i64x4(self, val: [i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x4(self, val: &[i64; 4usize]) -> i64x4<Self> {
-        i64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x4(self, a: i64x4<Self>) -> [i64; 4usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x4(self, a: &i64x4<Self>) -> &[i64; 4usize] {
-        crate::transmute::checked_cast_ref::<[v128; 2usize], [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x4(self, a: &mut i64x4<Self>) -> &mut [i64; 4usize] {
-        crate::transmute::checked_cast_mut::<[v128; 2usize], [i64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x4(self, a: i64x4<Self>, dest: &mut [i64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x4<const SHIFT: usize>(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -7218,36 +6578,6 @@ impl Simd for WasmSimd128 {
         self.combine_u64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_u64x4(self, val: [u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x4(self, val: &[u64; 4usize]) -> u64x4<Self> {
-        u64x4 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x4(self, a: u64x4<Self>) -> [u64; 4usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [u64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x4(self, a: &u64x4<Self>) -> &[u64; 4usize] {
-        crate::transmute::checked_cast_ref::<[v128; 2usize], [u64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x4(self, a: &mut u64x4<Self>) -> &mut [u64; 4usize] {
-        crate::transmute::checked_cast_mut::<[v128; 2usize], [u64; 4usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x4(self, a: u64x4<Self>, dest: &mut [u64; 4usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_u64x4<const SHIFT: usize>(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -7541,17 +6871,6 @@ impl Simd for WasmSimd128 {
         self.combine_mask64x2(half, half)
     }
     #[inline(always)]
-    fn load_array_mask64x4(self, val: [i64; 4usize]) -> mask64x4<Self> {
-        mask64x4 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x4(self, a: mask64x4<Self>) -> [i64; 4usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 2usize], [i64; 4usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x4(self, bits: u64) -> mask64x4<Self> {
         let lo = self.from_bitmask_mask64x2(bits);
         let hi = self.from_bitmask_mask64x2(bits >> 2usize);
@@ -7571,9 +6890,10 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = self.as_array_mask64x4(*a);
+        let mut lanes = [0 as i64; 4usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x4(lanes);
+        *a = mask64x4::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x4(self, a: mask64x4<Self>, b: mask64x4<Self>) -> mask64x4<Self> {
@@ -7663,36 +6983,6 @@ impl Simd for WasmSimd128 {
     fn splat_f32x16(self, val: f32) -> f32x16<Self> {
         let half = self.splat_f32x8(val);
         self.combine_f32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f32x16(self, val: [f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f32x16(self, val: &[f32; 16usize]) -> f32x16<Self> {
-        f32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f32x16(self, a: f32x16<Self>) -> [f32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [f32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f32x16(self, a: &f32x16<Self>) -> &[f32; 16usize] {
-        crate::transmute::checked_cast_ref::<[v128; 4usize], [f32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f32x16(self, a: &mut f32x16<Self>) -> &mut [f32; 16usize] {
-        crate::transmute::checked_cast_mut::<[v128; 4usize], [f32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f32x16<const SHIFT: usize>(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -8154,36 +7444,6 @@ impl Simd for WasmSimd128 {
     fn splat_i8x64(self, val: i8) -> i8x64<Self> {
         let half = self.splat_i8x32(val);
         self.combine_i8x32(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i8x64(self, val: [i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i8x64(self, val: &[i8; 64usize]) -> i8x64<Self> {
-        i8x64 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i8x64(self, a: i8x64<Self>) -> [i8; 64usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i8x64(self, a: &i8x64<Self>) -> &[i8; 64usize] {
-        crate::transmute::checked_cast_ref::<[v128; 4usize], [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i8x64(self, a: &mut i8x64<Self>) -> &mut [i8; 64usize] {
-        crate::transmute::checked_cast_mut::<[v128; 4usize], [i8; 64usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i8x64(self, a: i8x64<Self>, dest: &mut [i8; 64usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i8x64<const SHIFT: usize>(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -8707,36 +7967,6 @@ impl Simd for WasmSimd128 {
     fn splat_u8x64(self, val: u8) -> u8x64<Self> {
         let half = self.splat_u8x32(val);
         self.combine_u8x32(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u8x64(self, val: [u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u8x64(self, val: &[u8; 64usize]) -> u8x64<Self> {
-        u8x64 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u8x64(self, a: u8x64<Self>) -> [u8; 64usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [u8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u8x64(self, a: &u8x64<Self>) -> &[u8; 64usize] {
-        crate::transmute::checked_cast_ref::<[v128; 4usize], [u8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u8x64(self, a: &mut u8x64<Self>) -> &mut [u8; 64usize] {
-        crate::transmute::checked_cast_mut::<[v128; 4usize], [u8; 64usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u8x64<const SHIFT: usize>(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -9327,17 +8557,6 @@ impl Simd for WasmSimd128 {
         self.combine_mask8x32(half, half)
     }
     #[inline(always)]
-    fn load_array_mask8x64(self, val: [i8; 64usize]) -> mask8x64<Self> {
-        mask8x64 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask8x64(self, a: mask8x64<Self>) -> [i8; 64usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i8; 64usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask8x64(self, bits: u64) -> mask8x64<Self> {
         let lo = self.from_bitmask_mask8x32(bits);
         let hi = self.from_bitmask_mask8x32(bits >> 32usize);
@@ -9357,9 +8576,10 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             64usize
         );
-        let mut lanes = self.as_array_mask8x64(*a);
+        let mut lanes = [0 as i8; 64usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask8x64(lanes);
+        *a = mask8x64::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self> {
@@ -9442,36 +8662,6 @@ impl Simd for WasmSimd128 {
     fn splat_i16x32(self, val: i16) -> i16x32<Self> {
         let half = self.splat_i16x16(val);
         self.combine_i16x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i16x32(self, val: [i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i16x32(self, val: &[i16; 32usize]) -> i16x32<Self> {
-        i16x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i16x32(self, a: i16x32<Self>) -> [i16; 32usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i16x32(self, a: &i16x32<Self>) -> &[i16; 32usize] {
-        crate::transmute::checked_cast_ref::<[v128; 4usize], [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i16x32(self, a: &mut i16x32<Self>) -> &mut [i16; 32usize] {
-        crate::transmute::checked_cast_mut::<[v128; 4usize], [i16; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i16x32(self, a: i16x32<Self>, dest: &mut [i16; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i16x32<const SHIFT: usize>(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -9880,36 +9070,6 @@ impl Simd for WasmSimd128 {
     fn splat_u16x32(self, val: u16) -> u16x32<Self> {
         let half = self.splat_u16x16(val);
         self.combine_u16x16(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u16x32(self, val: [u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u16x32(self, val: &[u16; 32usize]) -> u16x32<Self> {
-        u16x32 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u16x32(self, a: u16x32<Self>) -> [u16; 32usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [u16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u16x32(self, a: &u16x32<Self>) -> &[u16; 32usize] {
-        crate::transmute::checked_cast_ref::<[v128; 4usize], [u16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u16x32(self, a: &mut u16x32<Self>) -> &mut [u16; 32usize] {
-        crate::transmute::checked_cast_mut::<[v128; 4usize], [u16; 32usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u16x32<const SHIFT: usize>(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -10366,17 +9526,6 @@ impl Simd for WasmSimd128 {
         self.combine_mask16x16(half, half)
     }
     #[inline(always)]
-    fn load_array_mask16x32(self, val: [i16; 32usize]) -> mask16x32<Self> {
-        mask16x32 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask16x32(self, a: mask16x32<Self>) -> [i16; 32usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i16; 32usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask16x32(self, bits: u64) -> mask16x32<Self> {
         let lo = self.from_bitmask_mask16x16(bits);
         let hi = self.from_bitmask_mask16x16(bits >> 16usize);
@@ -10396,9 +9545,10 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = self.as_array_mask16x32(*a);
+        let mut lanes = [0 as i16; 32usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask16x32(lanes);
+        *a = mask16x32::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask16x32(self, a: mask16x32<Self>, b: mask16x32<Self>) -> mask16x32<Self> {
@@ -10484,36 +9634,6 @@ impl Simd for WasmSimd128 {
     fn splat_i32x16(self, val: i32) -> i32x16<Self> {
         let half = self.splat_i32x8(val);
         self.combine_i32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_i32x16(self, val: [i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i32x16(self, val: &[i32; 16usize]) -> i32x16<Self> {
-        i32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i32x16(self, a: i32x16<Self>) -> [i32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i32x16(self, a: &i32x16<Self>) -> &[i32; 16usize] {
-        crate::transmute::checked_cast_ref::<[v128; 4usize], [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i32x16(self, a: &mut i32x16<Self>) -> &mut [i32; 16usize] {
-        crate::transmute::checked_cast_mut::<[v128; 4usize], [i32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i32x16(self, a: i32x16<Self>, dest: &mut [i32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_i32x16<const SHIFT: usize>(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -10857,36 +9977,6 @@ impl Simd for WasmSimd128 {
     fn splat_u32x16(self, val: u32) -> u32x16<Self> {
         let half = self.splat_u32x8(val);
         self.combine_u32x8(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u32x16(self, val: [u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u32x16(self, val: &[u32; 16usize]) -> u32x16<Self> {
-        u32x16 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u32x16(self, a: u32x16<Self>) -> [u32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [u32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u32x16(self, a: &u32x16<Self>) -> &[u32; 16usize] {
-        crate::transmute::checked_cast_ref::<[v128; 4usize], [u32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u32x16(self, a: &mut u32x16<Self>) -> &mut [u32; 16usize] {
-        crate::transmute::checked_cast_mut::<[v128; 4usize], [u32; 16usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u32x16<const SHIFT: usize>(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -11273,17 +10363,6 @@ impl Simd for WasmSimd128 {
         self.combine_mask32x8(half, half)
     }
     #[inline(always)]
-    fn load_array_mask32x16(self, val: [i32; 16usize]) -> mask32x16<Self> {
-        mask32x16 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask32x16(self, a: mask32x16<Self>) -> [i32; 16usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i32; 16usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask32x16(self, bits: u64) -> mask32x16<Self> {
         let lo = self.from_bitmask_mask32x8(bits);
         let hi = self.from_bitmask_mask32x8(bits >> 8usize);
@@ -11303,9 +10382,10 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = self.as_array_mask32x16(*a);
+        let mut lanes = [0 as i32; 16usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask32x16(lanes);
+        *a = mask32x16::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self> {
@@ -11388,36 +10468,6 @@ impl Simd for WasmSimd128 {
     fn splat_f64x8(self, val: f64) -> f64x8<Self> {
         let half = self.splat_f64x4(val);
         self.combine_f64x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_f64x8(self, val: [f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_f64x8(self, val: &[f64; 8usize]) -> f64x8<Self> {
-        f64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_f64x8(self, a: f64x8<Self>) -> [f64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [f64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_f64x8(self, a: &f64x8<Self>) -> &[f64; 8usize] {
-        crate::transmute::checked_cast_ref::<[v128; 4usize], [f64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_f64x8(self, a: &mut f64x8<Self>) -> &mut [f64; 8usize] {
-        crate::transmute::checked_cast_mut::<[v128; 4usize], [f64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_f64x8(self, a: f64x8<Self>, dest: &mut [f64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_f64x8<const SHIFT: usize>(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {
@@ -11773,36 +10823,6 @@ impl Simd for WasmSimd128 {
         self.combine_i64x4(half, half)
     }
     #[inline(always)]
-    fn load_array_i64x8(self, val: [i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_i64x8(self, val: &[i64; 8usize]) -> i64x8<Self> {
-        i64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_i64x8(self, a: i64x8<Self>) -> [i64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_i64x8(self, a: &i64x8<Self>) -> &[i64; 8usize] {
-        crate::transmute::checked_cast_ref::<[v128; 4usize], [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_i64x8(self, a: &mut i64x8<Self>) -> &mut [i64; 8usize] {
-        crate::transmute::checked_cast_mut::<[v128; 4usize], [i64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_i64x8(self, a: i64x8<Self>, dest: &mut [i64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
-    }
-    #[inline(always)]
     fn slide_i64x8<const SHIFT: usize>(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -12103,36 +11123,6 @@ impl Simd for WasmSimd128 {
     fn splat_u64x8(self, val: u64) -> u64x8<Self> {
         let half = self.splat_u64x4(val);
         self.combine_u64x4(half, half)
-    }
-    #[inline(always)]
-    fn load_array_u64x8(self, val: [u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn load_array_ref_u64x8(self, val: &[u64; 8usize]) -> u64x8<Self> {
-        u64x8 {
-            val: crate::transmute::checked_transmute_copy(val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_u64x8(self, a: u64x8<Self>) -> [u64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [u64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_ref_u64x8(self, a: &u64x8<Self>) -> &[u64; 8usize] {
-        crate::transmute::checked_cast_ref::<[v128; 4usize], [u64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
-    fn as_array_mut_u64x8(self, a: &mut u64x8<Self>) -> &mut [u64; 8usize] {
-        crate::transmute::checked_cast_mut::<[v128; 4usize], [u64; 8usize]>(&mut a.val.0)
-    }
-    #[inline(always)]
-    fn store_array_u64x8(self, a: u64x8<Self>, dest: &mut [u64; 8usize]) -> () {
-        crate::transmute::checked_transmute_store(a.val.0, dest);
     }
     #[inline(always)]
     fn slide_u64x8<const SHIFT: usize>(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
@@ -12470,17 +11460,6 @@ impl Simd for WasmSimd128 {
         self.combine_mask64x4(half, half)
     }
     #[inline(always)]
-    fn load_array_mask64x8(self, val: [i64; 8usize]) -> mask64x8<Self> {
-        mask64x8 {
-            val: crate::transmute::checked_transmute_copy(&val),
-            simd: self,
-        }
-    }
-    #[inline(always)]
-    fn as_array_mask64x8(self, a: mask64x8<Self>) -> [i64; 8usize] {
-        crate::transmute::checked_transmute_copy::<[v128; 4usize], [i64; 8usize]>(&a.val.0)
-    }
-    #[inline(always)]
     fn from_bitmask_mask64x8(self, bits: u64) -> mask64x8<Self> {
         let lo = self.from_bitmask_mask64x4(bits);
         let hi = self.from_bitmask_mask64x4(bits >> 4usize);
@@ -12500,9 +11479,10 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = self.as_array_mask64x8(*a);
+        let mut lanes = [0 as i64; 8usize];
+        a.store_slice(&mut lanes);
         lanes[index] = if value { !0 } else { 0 };
-        *a = self.load_array_mask64x8(lanes);
+        *a = mask64x8::from_slice(self, &lanes);
     }
     #[inline(always)]
     fn and_mask64x8(self, a: mask64x8<Self>, b: mask64x8<Self>) -> mask64x8<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -1046,10 +1046,9 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i8; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -1627,10 +1626,9 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i16; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -2168,10 +2166,9 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = [0 as i32; 4usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 4usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x4::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -2977,10 +2974,9 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             2usize
         );
-        let mut lanes = [0 as i64; 2usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 2usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x2::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self> {
@@ -4271,10 +4267,9 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = [0 as i8; 32usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 32usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x32::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
@@ -5089,10 +5084,9 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i16; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
@@ -5836,10 +5830,9 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i32; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
@@ -6890,10 +6883,9 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             4usize
         );
-        let mut lanes = [0 as i64; 4usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 4usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x4::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x4(self, a: mask64x4<Self>, b: mask64x4<Self>) -> mask64x4<Self> {
@@ -8576,10 +8568,9 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             64usize
         );
-        let mut lanes = [0 as i8; 64usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i8; 64usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask8x64::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self> {
@@ -9545,10 +9536,9 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             32usize
         );
-        let mut lanes = [0 as i16; 32usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i16; 32usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask16x32::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask16x32(self, a: mask16x32<Self>, b: mask16x32<Self>) -> mask16x32<Self> {
@@ -10382,10 +10372,9 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             16usize
         );
-        let mut lanes = [0 as i32; 16usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i32; 16usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask32x16::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self> {
@@ -11479,10 +11468,9 @@ impl Simd for WasmSimd128 {
             "mask lane index {index} is out of bounds for {} lanes",
             8usize
         );
-        let mut lanes = [0 as i64; 8usize];
-        a.store_slice(&mut lanes);
+        let mut lanes: [i64; 8usize] = (*a).into();
         lanes[index] = if value { !0 } else { 0 };
-        *a = mask64x8::from_slice(self, &lanes);
+        *a = lanes.simd_into(self);
     }
     #[inline(always)]
     fn and_mask64x8(self, a: mask64x8<Self>, b: mask64x8<Self>) -> mask64x8<Self> {

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -6,7 +6,7 @@ use quote::{ToTokens, quote};
 
 use crate::{
     level::Level,
-    ops::{ElementDirection, Op, OpSig, RefKind, SlideGranularity},
+    ops::{ElementDirection, Op, OpSig, SlideGranularity},
     types::{ScalarType, VecType},
 };
 
@@ -298,11 +298,7 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
         OpSig::StoreInterleaved { .. } => {
             panic!("The generic fallback is not implemented for this operation")
         }
-        OpSig::Split { .. }
-        | OpSig::Combine { .. }
-        | OpSig::AsArray { .. }
-        | OpSig::FromArray { .. }
-        | OpSig::StoreArray => {
+        OpSig::Split { .. } | OpSig::Combine { .. } => {
             panic!("These operations require more information about the target platform");
         }
         OpSig::Interleave => {
@@ -538,71 +534,6 @@ pub(crate) fn generic_block_combine(
     }
 }
 
-pub(crate) fn generic_from_array(
-    method_sig: TokenStream,
-    vec_ty: &VecType,
-    kind: RefKind,
-) -> TokenStream {
-    let inner_ref = if kind == RefKind::Value {
-        quote! { &val }
-    } else {
-        quote! { val }
-    };
-    // There are architecture-specific "load" intrinsics, but they can actually be *worse* for performance. If they
-    // lower to LLVM intrinsics, they will likely not be optimized until much later in the pipeline (if at all),
-    // resulting in substantially worse codegen. See https://github.com/linebender/fearless_simd/pull/185.
-    let expr = quote! {
-        crate::transmute::checked_transmute_copy(#inner_ref)
-    };
-    let vec_rust = vec_ty.rust();
-
-    quote! {
-        #method_sig {
-            #vec_rust { val: #expr, simd: self }
-        }
-    }
-}
-
-pub(crate) fn generic_as_array<T: ToTokens>(
-    method_sig: TokenStream,
-    vec_ty: &VecType,
-    kind: RefKind,
-    max_block_size: usize,
-    arch_ty: impl Fn(&VecType) -> T,
-) -> TokenStream {
-    let rust_scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
-    let num_scalars = vec_ty.len;
-
-    let native_ty =
-        vec_ty.wrapped_native_ty(|vec_ty| arch_ty(vec_ty).into_token_stream(), max_block_size);
-
-    match kind {
-        RefKind::Value => quote! {
-            #method_sig {
-                crate::transmute::checked_transmute_copy::<#native_ty, [#rust_scalar; #num_scalars]>(&a.val.0)
-            }
-        },
-        RefKind::Ref => quote! {
-            #method_sig {
-                crate::transmute::checked_cast_ref::<#native_ty, [#rust_scalar; #num_scalars]>(&a.val.0)
-            }
-        },
-        RefKind::Mut => quote! {
-            #method_sig {
-                crate::transmute::checked_cast_mut::<#native_ty, [#rust_scalar; #num_scalars]>(&mut a.val.0)
-            }
-        },
-    }
-}
-
-pub(crate) fn generic_store_array(method_sig: TokenStream, _vec_ty: &VecType) -> TokenStream {
-    quote! {
-        #method_sig {
-            crate::transmute::checked_transmute_store(a.val.0, dest);
-        }
-    }
-}
-
 pub(crate) fn generic_mask_from_bitmask(method_sig: TokenStream, vec_ty: &VecType) -> TokenStream {
     let scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
     let len = vec_ty.len;
@@ -624,12 +555,13 @@ pub(crate) fn generic_mask_from_bitmask(method_sig: TokenStream, vec_ty: &VecTyp
 }
 
 pub(crate) fn generic_mask_to_bitmask(method_sig: TokenStream, vec_ty: &VecType) -> TokenStream {
-    let as_array = generic_op_name("as_array", vec_ty);
+    let scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
     let len = vec_ty.len;
 
     quote! {
         #method_sig {
-            let lanes = self.#as_array(a);
+            let mut lanes = [0 as #scalar; #len];
+            a.store_slice(&mut lanes);
             let mut bits = 0u64;
             let mut i = 0;
             while i < #len {
@@ -644,8 +576,8 @@ pub(crate) fn generic_mask_to_bitmask(method_sig: TokenStream, vec_ty: &VecType)
 }
 
 pub(crate) fn generic_mask_set(method_sig: TokenStream, vec_ty: &VecType) -> TokenStream {
-    let from_array = generic_op_name("load_array", vec_ty);
-    let as_array = generic_op_name("as_array", vec_ty);
+    let scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
+    let vec_rust = vec_ty.rust();
     let len = vec_ty.len;
 
     quote! {
@@ -655,9 +587,10 @@ pub(crate) fn generic_mask_set(method_sig: TokenStream, vec_ty: &VecType) -> Tok
                 "mask lane index {index} is out of bounds for {} lanes",
                 #len
             );
-            let mut lanes = self.#as_array(*a);
+            let mut lanes = [0 as #scalar; #len];
+            a.store_slice(&mut lanes);
             lanes[index] = if value { !0 } else { 0 };
-            *a = self.#from_array(lanes);
+            *a = #vec_rust::from_slice(self, &lanes);
         }
     }
 }

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -560,8 +560,7 @@ pub(crate) fn generic_mask_to_bitmask(method_sig: TokenStream, vec_ty: &VecType)
 
     quote! {
         #method_sig {
-            let mut lanes = [0 as #scalar; #len];
-            a.store_slice(&mut lanes);
+            let lanes: [#scalar; #len] = a.into();
             let mut bits = 0u64;
             let mut i = 0;
             while i < #len {
@@ -577,7 +576,6 @@ pub(crate) fn generic_mask_to_bitmask(method_sig: TokenStream, vec_ty: &VecType)
 
 pub(crate) fn generic_mask_set(method_sig: TokenStream, vec_ty: &VecType) -> TokenStream {
     let scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
-    let vec_rust = vec_ty.rust();
     let len = vec_ty.len;
 
     quote! {
@@ -587,10 +585,9 @@ pub(crate) fn generic_mask_set(method_sig: TokenStream, vec_ty: &VecType) -> Tok
                 "mask lane index {index} is out of bounds for {} lanes",
                 #len
             );
-            let mut lanes = [0 as #scalar; #len];
-            a.store_slice(&mut lanes);
+            let mut lanes: [#scalar; #len] = (*a).into();
             lanes[index] = if value { !0 } else { 0 };
-            *a = #vec_rust::from_slice(self, &lanes);
+            *a = lanes.simd_into(self);
         }
     }
 }

--- a/fearless_simd_gen/src/level.rs
+++ b/fearless_simd_gen/src/level.rs
@@ -75,20 +75,30 @@ pub(crate) trait Level {
         op.simd_trait_kernel_method(self.token(), vec_ty, body)
     }
 
+    /// Override the default lane-array conversion hooks for compact mask storage.
+    fn custom_mask_array_conversion(&self, _vec_ty: &VecType) -> Option<TokenStream> {
+        None
+    }
+
     fn impl_arch_types(&self) -> TokenStream {
         let mut assoc_types = vec![];
+        let mut mask_array_conversions = vec![];
         for vec_ty in SIMD_TYPES {
             let ty_ident = vec_ty.rust();
             let wrapper_ty = self.arch_storage_ty(vec_ty);
             assoc_types.push(quote! {
                 type #ty_ident = #wrapper_ty;
             });
+            if let Some(conversion) = self.custom_mask_array_conversion(vec_ty) {
+                mask_array_conversions.push(conversion);
+            }
         }
         let level_tok = self.token();
 
         quote! {
             impl ArchTypes for #level_tok {
                 #( #assoc_types )*
+                #( #mask_array_conversions )*
             }
         }
     }

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -7,7 +7,7 @@ use crate::generic::{
     integer_lane_mask_splat_arg,
 };
 use crate::level::Level;
-use crate::ops::{Op, OpSig, RefKind};
+use crate::ops::{Op, OpSig};
 use crate::types::{ScalarType, VecType};
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -538,34 +538,6 @@ impl Level for Fallback {
                 quote! {
                     #method_sig {
                         *dest = #items;
-                    }
-                }
-            }
-            OpSig::FromArray { kind } => {
-                let vec_rust = vec_ty.rust();
-                let wrapper = vec_ty.aligned_wrapper();
-                let expr = match kind {
-                    RefKind::Value => quote! { val },
-                    RefKind::Ref | RefKind::Mut => quote! { *val },
-                };
-                quote! {
-                    #method_sig {
-                        #vec_rust { val: #wrapper(#expr), simd: self }
-                    }
-                }
-            }
-            OpSig::AsArray { kind } => {
-                let ref_tok = kind.token();
-                quote! {
-                    #method_sig {
-                        #ref_tok a.val.0
-                    }
-                }
-            }
-            OpSig::StoreArray => {
-                quote! {
-                    #method_sig {
-                        *dest = a.val.0;
                     }
                 }
             }

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -5,8 +5,7 @@ use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{ToTokens as _, format_ident, quote};
 
 use crate::generic::{
-    fallback_method, generic_as_array, generic_from_array, generic_mask_set, generic_op_name,
-    generic_store_array, integer_lane_mask_splat_arg,
+    fallback_method, generic_mask_set, generic_op_name, integer_lane_mask_splat_arg,
 };
 use crate::level::Level;
 use crate::ops::{Op, SlideGranularity};
@@ -561,13 +560,6 @@ impl Level for Neon {
             OpSig::MaskFromBitmask => self.handle_mask_from_bitmask(op, vec_ty),
             OpSig::MaskToBitmask => self.handle_mask_to_bitmask(op, vec_ty),
             OpSig::MaskSet => generic_mask_set(method_sig, vec_ty),
-            OpSig::FromArray { kind } => generic_from_array(method_sig, vec_ty, kind),
-            OpSig::AsArray { kind } => {
-                generic_as_array(method_sig, vec_ty, kind, self.max_block_size(), |vec_ty| {
-                    self.arch_ty(vec_ty)
-                })
-            }
-            OpSig::StoreArray => generic_store_array(method_sig, vec_ty),
             OpSig::Interleave => {
                 let zip_low = generic_op_name("zip_low", vec_ty);
                 let zip_high = generic_op_name("zip_high", vec_ty);

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -116,11 +116,29 @@ pub(crate) fn mk_simd_trait() -> TokenStream {
 
 pub(crate) fn mk_arch_types() -> TokenStream {
     let mut types = vec![];
+    let mut mask_array_methods = vec![];
     for vec_ty in SIMD_TYPES {
         let ty_name = vec_ty.rust();
         types.push(quote! {
             type #ty_name: Copy + Send + Sync + SimdPod;
         });
+        if vec_ty.scalar == ScalarType::Mask {
+            let from_array = format_ident!("{}_from_array", vec_ty.rust_name());
+            let to_array = format_ident!("{}_to_array", vec_ty.rust_name());
+            let scalar = ScalarType::Int.rust(vec_ty.scalar_bits);
+            let len = vec_ty.len;
+            mask_array_methods.push(quote! {
+                #[inline(always)]
+                fn #from_array(self, val: [#scalar; #len]) -> Self::#ty_name {
+                    crate::transmute::checked_transmute_copy(&val)
+                }
+
+                #[inline(always)]
+                fn #to_array(self, val: Self::#ty_name) -> [#scalar; #len] {
+                    crate::transmute::checked_transmute_copy(&val)
+                }
+            });
+        }
     }
 
     quote! {
@@ -131,8 +149,9 @@ pub(crate) fn mk_arch_types() -> TokenStream {
                 unnameable_types,
                 reason = "The native vector types that back a `Simd` implementation are an internal implementation detail, and intentionally kept private"
             )]
-            pub trait ArchTypes {
+            pub trait ArchTypes: Sized {
                 #( #types )*
+                #( #mask_array_methods )*
             }
         }
     }
@@ -203,6 +222,36 @@ fn mk_simd_base() -> TokenStream {
             ///
             /// The slice must be exactly the size of the SIMD vector.
             fn store_slice(&self, slice: &mut [Self::Element]);
+            /// Create a SIMD vector from its corresponding lane array.
+            #[inline(always)]
+            fn load_array(simd: S, val: Self::Array) -> Self {
+                Self::simd_from(simd, val)
+            }
+            /// Create a SIMD vector from a reference to its corresponding lane array.
+            #[inline(always)]
+            fn load_array_ref(simd: S, val: &Self::Array) -> Self {
+                Self::load_array(simd, *val)
+            }
+            /// Convert this SIMD vector to its corresponding lane array.
+            #[inline(always)]
+            fn as_array(self) -> Self::Array {
+                *self
+            }
+            /// Project this SIMD vector reference to its corresponding lane array reference.
+            #[inline(always)]
+            fn as_array_ref(&self) -> &Self::Array {
+                self
+            }
+            /// Project this mutable SIMD vector reference to its corresponding mutable lane array reference.
+            #[inline(always)]
+            fn as_array_mut(&mut self) -> &mut Self::Array {
+                self
+            }
+            /// Store this SIMD vector into its corresponding lane array.
+            #[inline(always)]
+            fn store_array(self, dest: &mut Self::Array) {
+                *dest = self.as_array();
+            }
             /// Create a SIMD vector from a 128-bit vector of the same scalar
             /// type, repeated.
             fn block_splat(block: Self::Block) -> Self;

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -26,16 +26,14 @@ pub(crate) fn mk_simd_types() -> TokenStream {
         let len = Literal::usize_unsuffixed(ty.len);
         let rust_scalar = ty.scalar.rust(ty.scalar_bits);
         let select = generic_op_name("select", ty);
-        let from_array_op = generic_op_name("load_array", ty);
-        let as_array_op = generic_op_name("as_array", ty);
-        let as_array_ref_op = generic_op_name("as_array_ref", ty);
-        let as_array_mut_op = generic_op_name("as_array_mut", ty);
         let bytes = ty.bytes_ty().rust();
         let mask = ty.mask_ty().rust();
 
         if ty.scalar == ScalarType::Mask {
             let splat = Ident::new(&format!("splat_{}", ty.rust_name()), Span::call_site());
             let impl_block = simd_mask_impl(ty);
+            let mask_from_array = format_ident!("{}_from_array", ty.rust_name());
+            let mask_to_array = format_ident!("{}_to_array", ty.rust_name());
             result.extend(quote! {
                 #[doc = #doc]
                 #[derive(Clone, Copy)]
@@ -49,20 +47,26 @@ pub(crate) fn mk_simd_types() -> TokenStream {
                 impl<S: Simd> SimdFrom<[#rust_scalar; #len], S> for #name<S> {
                     #[inline(always)]
                     fn simd_from(simd: S, val: [#rust_scalar; #len]) -> Self {
-                        simd.#from_array_op(val)
+                        Self {
+                            val: <S as crate::arch_types::ArchTypes>::#mask_from_array(simd, val),
+                            simd,
+                        }
                     }
                 }
 
                 impl<S: Simd> From<#name<S>> for [#rust_scalar; #len] {
                     #[inline(always)]
                     fn from(value: #name<S>) -> Self {
-                        value.simd.#as_array_op(value)
+                        <S as crate::arch_types::ArchTypes>::#mask_to_array(
+                            value.simd,
+                            value.val,
+                        )
                     }
                 }
 
                 impl<S: Simd + core::fmt::Debug> core::fmt::Debug for #name<S> {
                     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                        let lanes = self.simd.#as_array_op(*self);
+                        let lanes: [#rust_scalar; #len] = (*self).into();
                         crate::support::simd_debug_impl(f, #name_str, &self.simd, &lanes)
                     }
                 }
@@ -100,14 +104,14 @@ pub(crate) fn mk_simd_types() -> TokenStream {
                     type Output = #rust_scalar;
                     #[inline(always)]
                     fn index(&self, i: usize) -> &Self::Output {
-                        &self.simd.#as_array_ref_op(self)[i]
+                        &self.as_array_ref()[i]
                     }
                 }
 
                 impl<S: Simd> core::ops::IndexMut<usize> for #name<S> {
                     #[inline(always)]
                     fn index_mut (&mut self, i: usize) -> &mut Self::Output {
-                        &mut self.simd.#as_array_mut_op(self)[i]
+                        &mut self.as_array_mut()[i]
                     }
                 }
             }
@@ -226,14 +230,17 @@ pub(crate) fn mk_simd_types() -> TokenStream {
             impl<S: Simd> SimdFrom<[#rust_scalar; #len], S> for #name<S> {
                 #[inline(always)]
                 fn simd_from(simd: S, val: [#rust_scalar; #len]) -> Self {
-                    simd.#from_array_op(val)
+                    Self {
+                        val: crate::transmute::checked_transmute_copy(&val),
+                        simd,
+                    }
                 }
             }
 
             impl<S: Simd> From<#name<S>> for [#rust_scalar; #len] {
                 #[inline(always)]
                 fn from(value: #name<S>) -> Self {
-                    value.simd.#as_array_op(value)
+                    crate::transmute::checked_transmute_copy(&value.val)
                 }
             }
 
@@ -241,20 +248,20 @@ pub(crate) fn mk_simd_types() -> TokenStream {
                 type Target = [#rust_scalar; #len];
                 #[inline(always)]
                 fn deref(&self) -> &Self::Target {
-                    self.simd.#as_array_ref_op(self)
+                    crate::transmute::checked_cast_ref(&self.val)
                 }
             }
 
             impl<S: Simd> core::ops::DerefMut for #name<S> {
                 #[inline(always)]
                 fn deref_mut(&mut self) -> &mut Self::Target {
-                    self.simd.#as_array_mut_op(self)
+                    crate::transmute::checked_cast_mut(&mut self.val)
                 }
             }
 
             impl<S: Simd + core::fmt::Debug> core::fmt::Debug for #name<S> {
                 fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                    crate::support::simd_debug_impl(f, #name_str, &self.simd, self.simd.#as_array_ref_op(self))
+                    crate::support::simd_debug_impl(f, #name_str, &self.simd, self.as_array_ref())
                 }
             }
 
@@ -303,8 +310,6 @@ fn simd_mask_impl(ty: &VecType) -> TokenStream {
     let from_bitmask_op = generic_op_name("from_bitmask", ty);
     let to_bitmask_op = generic_op_name("to_bitmask", ty);
     let set_op = generic_op_name("set", ty);
-    let from_array_op = generic_op_name("load_array", ty);
-    let as_array_op = generic_op_name("as_array", ty);
     let mut methods = vec![];
     for op in vec_trait_ops_for(ty.scalar) {
         let Op { sig, method, .. } = op;
@@ -360,13 +365,13 @@ fn simd_mask_impl(ty: &VecType) -> TokenStream {
             #[inline(always)]
             fn from_slice(simd: S, slice: &[#scalar]) -> Self {
                 let slice: &[#scalar; #len] = slice.try_into().unwrap();
-                simd.#from_array_op(*slice)
+                Self::simd_from(simd, *slice)
             }
 
             #[inline(always)]
             fn store_slice(&self, slice: &mut [#scalar]) {
                 let slice: &mut [#scalar; #len] = slice.try_into().unwrap();
-                *slice = self.simd.#as_array_op(*self);
+                *slice = (*self).into();
             }
 
             #( #methods )*
@@ -428,11 +433,6 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
         }
         _ => unreachable!(),
     };
-    let from_array_op = generic_op_name("load_array", ty);
-    let from_array_ref_op = generic_op_name("load_array_ref", ty);
-    let store_array_op = generic_op_name("store_array", ty);
-    let as_array_ref_op = generic_op_name("as_array_ref", ty);
-    let as_array_mut_op = generic_op_name("as_array_mut", ty);
     let slide_op = generic_op_name("slide", ty);
     let slide_blockwise_op = generic_op_name("slide_within_blocks", ty);
     let rotate_elements_left_op = generic_op_name("rotate_elements_left", ty);
@@ -457,22 +457,22 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
 
             #[inline(always)]
             fn as_slice(&self) -> &[#scalar] {
-                self.simd.#as_array_ref_op(self).as_slice()
+                self.as_array_ref().as_slice()
             }
 
             #[inline(always)]
             fn as_mut_slice(&mut self) -> &mut [#scalar] {
-                self.simd.#as_array_mut_op(self).as_mut_slice()
+                self.as_array_mut().as_mut_slice()
             }
 
             #[inline(always)]
             fn from_slice(simd: S, slice: &[#scalar]) -> Self {
-                simd.#from_array_ref_op(slice.try_into().unwrap())
+                Self::load_array_ref(simd, slice.try_into().unwrap())
             }
 
             #[inline(always)]
             fn store_slice(&self, slice: &mut [#scalar]) {
-                self.simd.#store_array_op(*self, slice.try_into().unwrap());
+                (*self).store_array(slice.try_into().unwrap());
             }
 
             #[inline(always)]
@@ -487,7 +487,7 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
 
             #[inline(always)]
             fn from_fn(simd: S, mut f: impl FnMut(usize) -> #scalar) -> Self {
-                simd.#from_array_op(#from_fn_items)
+                Self::load_array(simd, #from_fn_items)
             }
 
             #[inline(always)]

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -216,6 +216,9 @@ pub(crate) fn mk_simd_types() -> TokenStream {
                 }
             });
         }
+        // There are architecture-specific "load" intrinsics, but they can actually be *worse* for performance. If they
+        // lower to LLVM intrinsics, they will likely not be optimized until much later in the pipeline (if at all),
+        // resulting in substantially worse codegen. See https://github.com/linebender/fearless_simd/pull/185.
         result.extend(quote! {
             #[doc = #doc]
             #[derive(Clone, Copy)]

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -6,8 +6,7 @@ use quote::{format_ident, quote};
 
 use crate::arch::wasm::{arch_prefix, v128_intrinsic};
 use crate::generic::{
-    fallback_method, generic_as_array, generic_block_combine, generic_block_split,
-    generic_from_array, generic_mask_set, generic_op_name, generic_store_array,
+    fallback_method, generic_block_combine, generic_block_split, generic_mask_set, generic_op_name,
     integer_lane_mask_splat_arg, recursive_swizzle_dyn_precise_body,
 };
 use crate::level::Level;
@@ -851,13 +850,6 @@ impl Level for WasmSimd128 {
                     }
                 }
             }
-            OpSig::FromArray { kind } => generic_from_array(method_sig, vec_ty, kind),
-            OpSig::AsArray { kind } => {
-                generic_as_array(method_sig, vec_ty, kind, self.max_block_size(), |_| {
-                    Ident::new("v128", Span::call_site())
-                })
-            }
-            OpSig::StoreArray => generic_store_array(method_sig, vec_ty),
             OpSig::Interleave => {
                 let zip_low = generic_op_name("zip_low", vec_ty);
                 let zip_high = generic_op_name("zip_high", vec_ty);

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -7,9 +7,9 @@ use crate::arch::x86::{
     unpack_intrinsic,
 };
 use crate::generic::{
-    fallback_method, generic_as_array, generic_block_combine, generic_block_split,
-    generic_from_array, generic_mask_from_bitmask, generic_mask_set, generic_op_name,
-    generic_store_array, integer_lane_mask_splat_arg, recursive_swizzle_dyn_precise_body,
+    fallback_method, generic_block_combine, generic_block_split, generic_mask_from_bitmask,
+    generic_mask_set, generic_op_name, integer_lane_mask_splat_arg,
+    recursive_swizzle_dyn_precise_body,
 };
 use crate::level::Level;
 use crate::ops::{Op, OpSig, Quantifier, SlideGranularity};
@@ -87,6 +87,14 @@ impl Level for X86 {
         } else {
             vec_ty.aligned_wrapper_ty(|vec_ty| self.arch_ty(vec_ty), self.max_block_size())
         }
+    }
+
+    fn custom_mask_array_conversion(&self, vec_ty: &VecType) -> Option<TokenStream> {
+        if *self != Self::Avx512 || vec_ty.scalar != ScalarType::Mask {
+            return None;
+        }
+
+        Some(self.avx512_mask_array_conversion(vec_ty))
     }
 
     fn token_doc(&self) -> &'static str {
@@ -326,23 +334,6 @@ impl Level for X86 {
                 block_size,
                 block_count,
             } => self.handle_store_interleaved(op, vec_ty, block_size, block_count),
-            OpSig::FromArray { kind }
-                if *self == Self::Avx512 && vec_ty.scalar == ScalarType::Mask =>
-            {
-                self.handle_avx512_mask_from_array(op, vec_ty, kind)
-            }
-            OpSig::FromArray { kind } => generic_from_array(method_sig, vec_ty, kind),
-            OpSig::AsArray { kind }
-                if *self == Self::Avx512 && vec_ty.scalar == ScalarType::Mask =>
-            {
-                self.handle_avx512_mask_as_array(op, vec_ty, kind)
-            }
-            OpSig::AsArray { kind } => {
-                generic_as_array(method_sig, vec_ty, kind, self.max_block_size(), |vec_ty| {
-                    self.arch_ty(vec_ty)
-                })
-            }
-            OpSig::StoreArray => generic_store_array(method_sig, vec_ty),
             OpSig::Interleave => self.handle_interleave(op, vec_ty),
             OpSig::Deinterleave => self.handle_deinterleave(op, vec_ty),
         }
@@ -1097,68 +1088,59 @@ impl X86 {
         vec_ty.scalar == ScalarType::Mask && vec_ty.scalar_bits == 16
     }
 
-    pub(crate) fn handle_avx512_mask_from_array(
-        &self,
-        op: Op,
-        vec_ty: &VecType,
-        kind: crate::ops::RefKind,
-    ) -> TokenStream {
+    fn avx512_mask_array_conversion(&self, vec_ty: &VecType) -> TokenStream {
+        assert!(
+            *self == Self::Avx512,
+            "compact mask array conversions are only generated for AVX-512"
+        );
         assert_eq!(
             vec_ty.scalar,
             ScalarType::Mask,
-            "AVX-512 mask array loads only operate on mask types"
+            "compact mask array conversions are only generated for mask types"
         );
+
+        let storage = self.arch_storage_ty(vec_ty);
+        let storage_assoc = vec_ty.rust();
+        let scalar = ScalarType::Int.rust(vec_ty.scalar_bits);
+        let len = vec_ty.len;
+        let from_array = format_ident!("{}_from_array", vec_ty.rust_name());
+        let to_array = format_ident!("{}_to_array", vec_ty.rust_name());
         let movepi_mask = intrinsic_ident(
             &format!("movepi{}", vec_ty.scalar_bits),
             "mask",
             vec_ty.n_bits(),
-        );
-        let transmute_src = if kind == crate::ops::RefKind::Value {
-            quote! { &val }
-        } else {
-            quote! { val }
-        };
-        // Mask arrays are specified as either 0 or -1 per lane, so the sign bit is the
-        // truth value. Other lane values have unspecified results.
-        self.kernel_method(op, vec_ty, |token| {
-            let result = avx512_mask_register_value_with_simd(
-                vec_ty,
-                quote! { #movepi_mask(lanes) },
-                quote! { #token },
-            );
-            quote! {
-                let lanes = crate::transmute::checked_transmute_copy(#transmute_src);
-                #result
-            }
-        })
-    }
-
-    pub(crate) fn handle_avx512_mask_as_array(
-        &self,
-        op: Op,
-        vec_ty: &VecType,
-        kind: crate::ops::RefKind,
-    ) -> TokenStream {
-        assert_eq!(
-            vec_ty.scalar,
-            ScalarType::Mask,
-            "AVX-512 mask array stores only operate on mask types"
-        );
-        assert!(
-            kind == crate::ops::RefKind::Value,
-            "mask array references are not exposed"
         );
         let movm = intrinsic_ident(
             "movm",
             op_suffix(vec_ty.scalar, vec_ty.scalar_bits, true),
             vec_ty.n_bits(),
         );
-        self.kernel_method(op, vec_ty, |_| {
-            quote! {
-                let lanes = #movm(a.val);
-                crate::transmute::checked_transmute_copy(&lanes)
+
+        quote! {
+            #[inline(always)]
+            fn #from_array(self, val: [#scalar; #len]) -> Self::#storage_assoc {
+                crate::kernel!(
+                    #[inline(always)]
+                    fn kernel(_token: Avx512, val: [#scalar; #len]) -> #storage {
+                        let lanes = crate::transmute::checked_transmute_copy(&val);
+                        #movepi_mask(lanes)
+                    }
+                );
+                kernel(self, val)
             }
-        })
+
+            #[inline(always)]
+            fn #to_array(self, val: Self::#storage_assoc) -> [#scalar; #len] {
+                crate::kernel!(
+                    #[inline(always)]
+                    fn kernel(_token: Avx512, val: #storage) -> [#scalar; #len] {
+                        let lanes = #movm(val);
+                        crate::transmute::checked_transmute_copy(&lanes)
+                    }
+                );
+                kernel(self, val)
+            }
+        }
     }
 
     pub(crate) fn handle_avx512_mask_set(

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -1116,6 +1116,8 @@ impl X86 {
             vec_ty.n_bits(),
         );
 
+        // Mask arrays are specified as either 0 or -1 per lane, so the sign bit is the
+        // truth value. Other lane values have unspecified results.
         quote! {
             #[inline(always)]
             fn #from_array(self, val: [#scalar; #len]) -> Self::#storage_assoc {

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -27,23 +27,6 @@ impl Quantifier {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) enum RefKind {
-    Value,
-    Ref,
-    Mut,
-}
-
-impl RefKind {
-    pub(crate) fn token(&self) -> Option<TokenStream> {
-        match self {
-            Self::Value => None,
-            Self::Ref => Some(quote! { & }),
-            Self::Mut => Some(quote! { &mut }),
-        }
-    }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SlideGranularity {
     WithinBlocks,
     AcrossBlocks,
@@ -133,14 +116,6 @@ pub(crate) enum OpSig {
     /// The inverse of [`OpSig::LoadInterleaved`]. Takes a vector argument with the length (`block_size` * `block_count`) /
     /// [scalar type's byte size], and a mutable reference to a scalar array of the same length, and returns nothing.
     StoreInterleaved { block_size: u16, block_count: u16 },
-    /// Takes a single argument of the array type corresponding to the vector type (e.g. `[f32; 4]` for `f32x4<S>`), or
-    /// a reference to it, and returns that vector type.
-    FromArray { kind: RefKind },
-    /// Takes a single argument of the vector type, or a reference to it, and returns the corresponding array type (e.g.
-    /// `[f32; 4]` for `f32x4<S>`) or a reference to it.
-    AsArray { kind: RefKind },
-    /// Takes a vector and a mutable reference to an array, and stores the vector elements into the array.
-    StoreArray,
 }
 
 /// Where this operation is defined, and how it is called.
@@ -235,8 +210,7 @@ impl Op {
         let arg_decls = sig.arg_decls();
         let call_args = &sig.arg_names;
         let ret = &sig.ret;
-        let kernel_call = if matches!(self.sig, OpSig::StoreInterleaved { .. } | OpSig::StoreArray)
-        {
+        let kernel_call = if matches!(self.sig, OpSig::StoreInterleaved { .. }) {
             quote! { kernel(self #(, #call_args)*); }
         } else {
             quote! { kernel(self #(, #call_args)*) }
@@ -346,29 +320,6 @@ impl Op {
                     vec,
                 )
             }
-            OpSig::FromArray { kind } => {
-                let ref_tok = kind.token();
-                let rust_scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
-                let len = vec_ty.len;
-                let array_ty = quote! { [#rust_scalar; #len] };
-                (vec![quote! { #ref_tok #array_ty }], vec)
-            }
-            OpSig::AsArray { kind } => {
-                let ref_tok = kind.token();
-                let rust_scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
-                let len = vec_ty.len;
-                let array_ty = quote! { [#rust_scalar; #len] };
-                (
-                    vec![quote! { #ref_tok #vec }],
-                    quote! { #ref_tok #array_ty },
-                )
-            }
-            OpSig::StoreArray => {
-                let rust_scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
-                let len = vec_ty.len;
-                let array_ty = quote! { [#rust_scalar; #len] };
-                (vec![vec, quote! { &mut #array_ty }], quote! { () })
-            }
         };
 
         SimdTraitSigParts {
@@ -393,7 +344,7 @@ impl Op {
                 let arg1 = &arg_names[1];
                 quote! { (#arg0: S, #arg1: Self::Element) -> Self }
             }
-            OpSig::LoadInterleaved { .. } | OpSig::StoreInterleaved { .. } | OpSig::StoreArray => {
+            OpSig::LoadInterleaved { .. } | OpSig::StoreInterleaved { .. } => {
                 return None;
             }
             OpSig::MaskFromBitmask | OpSig::MaskToBitmask | OpSig::MaskSet => return None,
@@ -454,10 +405,7 @@ impl Op {
             // masks.
             OpSig::Select => return None,
             // These signatures involve types not in the Simd trait
-            OpSig::Split { .. }
-            | OpSig::Combine { .. }
-            | OpSig::FromArray { .. }
-            | OpSig::AsArray { .. } => return None,
+            OpSig::Split { .. } | OpSig::Combine { .. } => return None,
         };
         Some(quote! { fn #method_ident #sig_inner })
     }
@@ -523,46 +471,6 @@ const BASE_OPS: &[Op] = &[
         OpKind::BaseTraitMethod,
         OpSig::Splat,
         "Create a SIMD vector with all elements set to the given value.",
-    ),
-    Op::new(
-        "load_array",
-        OpKind::AssociatedOnly,
-        OpSig::FromArray {
-            kind: RefKind::Value,
-        },
-        "Create a SIMD vector from an array of the same length.",
-    ),
-    Op::new(
-        "load_array_ref",
-        OpKind::AssociatedOnly,
-        OpSig::FromArray { kind: RefKind::Ref },
-        "Create a SIMD vector from an array of the same length.",
-    ),
-    Op::new(
-        "as_array",
-        OpKind::AssociatedOnly,
-        OpSig::AsArray {
-            kind: RefKind::Value,
-        },
-        "Convert a SIMD vector to an array.",
-    ),
-    Op::new(
-        "as_array_ref",
-        OpKind::AssociatedOnly,
-        OpSig::AsArray { kind: RefKind::Ref },
-        "Project a reference to a SIMD vector to a reference to the equivalent array.",
-    ),
-    Op::new(
-        "as_array_mut",
-        OpKind::AssociatedOnly,
-        OpSig::AsArray { kind: RefKind::Mut },
-        "Project a mutable reference to a SIMD vector to a mutable reference to the equivalent array.",
-    ),
-    Op::new(
-        "store_array",
-        OpKind::AssociatedOnly,
-        OpSig::StoreArray,
-        "Store a SIMD vector into an array of the same length.",
     ),
     Op::new(
         "slide",
@@ -645,22 +553,6 @@ const MASK_REPRESENTATION_OPS: &[Op] = &[
         OpKind::BaseTraitMethod,
         OpSig::Splat,
         "Create a SIMD mask with all lanes set from the given boolean value.",
-    ),
-    Op::new(
-        "load_array",
-        OpKind::AssociatedOnly,
-        OpSig::FromArray {
-            kind: RefKind::Value,
-        },
-        "Create a SIMD mask from signed integer mask lanes.",
-    ),
-    Op::new(
-        "as_array",
-        OpKind::AssociatedOnly,
-        OpSig::AsArray {
-            kind: RefKind::Value,
-        },
-        "Convert a SIMD mask to signed integer mask lanes.",
     ),
     Op::new(
         "from_bitmask",
@@ -1566,9 +1458,6 @@ impl OpSig {
                 | Self::Combine { .. }
                 | Self::LoadInterleaved { .. }
                 | Self::StoreInterleaved { .. }
-                | Self::FromArray { .. }
-                | Self::AsArray { .. }
-                | Self::StoreArray
                 | Self::MaskSet
                 | Self::SwizzleDynPrecise
                 | Self::Slide {
@@ -1598,7 +1487,7 @@ impl OpSig {
 
     fn simd_trait_arg_names(&self) -> &'static [&'static str] {
         match self {
-            Self::Splat | Self::FromArray { .. } => &["val"],
+            Self::Splat => &["val"],
             Self::MaskFromBitmask => &["bits"],
             Self::MaskSet => &["a", "index", "value"],
             Self::Unary
@@ -1606,8 +1495,7 @@ impl OpSig {
             | Self::Cvt { .. }
             | Self::WidenNarrow { .. }
             | Self::MaskReduce { .. }
-            | Self::MaskToBitmask
-            | Self::AsArray { .. } => &["a"],
+            | Self::MaskToBitmask => &["a"],
             Self::SwizzleDynWithinBlocks | Self::SwizzleDynPrecise => &["a", "indices"],
             Self::Binary
             | Self::Compare
@@ -1622,7 +1510,7 @@ impl OpSig {
             Self::Ternary | Self::Select => &["a", "b", "c"],
             Self::Shift => &["a", "shift"],
             Self::LoadInterleaved { .. } => &["src"],
-            Self::StoreInterleaved { .. } | Self::StoreArray => &["a", "dest"],
+            Self::StoreInterleaved { .. } => &["a", "dest"],
         }
     }
     fn vec_trait_arg_names(&self) -> &'static [&'static str] {
@@ -1630,16 +1518,12 @@ impl OpSig {
             Self::Splat => &["simd", "val"],
             Self::LoadInterleaved { .. }
             | Self::StoreInterleaved { .. }
-            | Self::FromArray { .. }
             | Self::MaskFromBitmask
             | Self::MaskToBitmask
-            | Self::MaskSet
-            | Self::StoreArray => &[],
-            Self::Unary
-            | Self::Cvt { .. }
-            | Self::WidenNarrow { .. }
-            | Self::MaskReduce { .. }
-            | Self::AsArray { .. } => &["self"],
+            | Self::MaskSet => &[],
+            Self::Unary | Self::Cvt { .. } | Self::WidenNarrow { .. } | Self::MaskReduce { .. } => {
+                &["self"]
+            }
             Self::SwizzleDynWithinBlocks | Self::SwizzleDynPrecise => &["self", "indices"],
             Self::Binary
             | Self::Compare
@@ -1700,9 +1584,6 @@ impl OpSig {
             | Self::MaskSet
             | Self::LoadInterleaved { .. }
             | Self::StoreInterleaved { .. }
-            | Self::FromArray { .. }
-            | Self::AsArray { .. }
-            | Self::StoreArray
             | Self::SwizzleDynWithinBlocks
             | Self::SwizzleDynPrecise
             | Self::Slide { .. } => return None,

--- a/fearless_simd_tests/tests/generics.rs
+++ b/fearless_simd_tests/tests/generics.rs
@@ -67,7 +67,8 @@ fn generic_array_roundtrip<S: Simd, V: SimdBase<S>>(vector: V) -> V {
     fn require_debug<T: core::fmt::Debug>(_: &T) {}
 
     let simd = vector.witness();
-    let mut array: V::Array = vector.into();
+    let mut vector = vector;
+    let mut array = vector.as_array();
     let array_copy = array;
     #[expect(clippy::clone_on_copy, reason = "Deliberate test")]
     let array_clone = array.clone();
@@ -75,5 +76,9 @@ fn generic_array_roundtrip<S: Simd, V: SimdBase<S>>(vector: V) -> V {
     let _: Option<V::Element> = array_clone.into_iter().next();
     let _: &[V::Element] = array.as_ref();
     let _: &mut [V::Element] = array.as_mut();
-    V::simd_from(simd, array_copy)
+    let _: &V::Array = vector.as_array_ref();
+    let _: &mut V::Array = vector.as_array_mut();
+    let _ = V::load_array_ref(simd, &array_copy);
+    vector.store_array(&mut array);
+    V::load_array(simd, array)
 }

--- a/fearless_simd_tests/tests/harness/ops/as_array.rs
+++ b/fearless_simd_tests/tests/harness/ops/as_array.rs
@@ -9,13 +9,13 @@ use fearless_simd_dev_macros::simd_test;
 #[simd_test]
 fn as_array_i64x2<S: Simd>(simd: S) {
     let a = i64x2::from_slice(simd, &[1_i64, -2_i64]);
-    assert_eq!(simd.as_array_i64x2(a), [1_i64, -2_i64]);
+    assert_eq!(a.as_array(), [1_i64, -2_i64]);
 }
 
 #[simd_test]
 fn as_array_i64x4<S: Simd>(simd: S) {
     let a = i64x4::from_slice(simd, &[1_i64, -2_i64, 3_i64, -4_i64]);
-    assert_eq!(simd.as_array_i64x4(a), [1_i64, -2_i64, 3_i64, -4_i64]);
+    assert_eq!(a.as_array(), [1_i64, -2_i64, 3_i64, -4_i64]);
 }
 
 #[simd_test]
@@ -25,7 +25,7 @@ fn as_array_i64x8<S: Simd>(simd: S) {
         &[1_i64, -2_i64, 3_i64, -4_i64, 5_i64, -6_i64, 7_i64, -8_i64],
     );
     assert_eq!(
-        simd.as_array_i64x8(a),
+        a.as_array(),
         [1_i64, -2_i64, 3_i64, -4_i64, 5_i64, -6_i64, 7_i64, -8_i64]
     );
 }
@@ -33,13 +33,13 @@ fn as_array_i64x8<S: Simd>(simd: S) {
 #[simd_test]
 fn as_array_u64x2<S: Simd>(simd: S) {
     let a = u64x2::from_slice(simd, &[1_u64, 2_u64]);
-    assert_eq!(simd.as_array_u64x2(a), [1_u64, 2_u64]);
+    assert_eq!(a.as_array(), [1_u64, 2_u64]);
 }
 
 #[simd_test]
 fn as_array_u64x4<S: Simd>(simd: S) {
     let a = u64x4::from_slice(simd, &[1_u64, 2_u64, 3_u64, 4_u64]);
-    assert_eq!(simd.as_array_u64x4(a), [1_u64, 2_u64, 3_u64, 4_u64]);
+    assert_eq!(a.as_array(), [1_u64, 2_u64, 3_u64, 4_u64]);
 }
 
 #[simd_test]
@@ -49,32 +49,8 @@ fn as_array_u64x8<S: Simd>(simd: S) {
         &[1_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64],
     );
     assert_eq!(
-        simd.as_array_u64x8(a),
+        a.as_array(),
         [1_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64]
-    );
-}
-
-#[simd_test]
-fn as_array_mask64x2<S: Simd>(simd: S) {
-    let a = mask64x2::from_slice(simd, &[-1_i64, 0_i64]);
-    assert_eq!(simd.as_array_mask64x2(a), [-1_i64, 0_i64]);
-}
-
-#[simd_test]
-fn as_array_mask64x4<S: Simd>(simd: S) {
-    let a = mask64x4::from_slice(simd, &[-1_i64, 0_i64, -1_i64, 0_i64]);
-    assert_eq!(simd.as_array_mask64x4(a), [-1_i64, 0_i64, -1_i64, 0_i64]);
-}
-
-#[simd_test]
-fn as_array_mask64x8<S: Simd>(simd: S) {
-    let a = mask64x8::from_slice(
-        simd,
-        &[-1_i64, 0_i64, -1_i64, 0_i64, -1_i64, 0_i64, -1_i64, 0_i64],
-    );
-    assert_eq!(
-        simd.as_array_mask64x8(a),
-        [-1_i64, 0_i64, -1_i64, 0_i64, -1_i64, 0_i64, -1_i64, 0_i64]
     );
 }
 
@@ -84,229 +60,166 @@ fn as_array_mask64x8<S: Simd>(simd: S) {
 fn as_array_i8x16<S: Simd>(simd: S) {
     let values: [i8; 16] = core::array::from_fn(|i| (i % 23) as i8 + 10_i8);
     let a = i8x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_i8x16(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_u8x16<S: Simd>(simd: S) {
     let values: [u8; 16] = core::array::from_fn(|i| (i % 23) as u8 + 10_u8);
     let a = u8x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_u8x16(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_i8x32<S: Simd>(simd: S) {
     let values: [i8; 32] = core::array::from_fn(|i| (i % 23) as i8 + 10_i8);
     let a = i8x32::from_slice(simd, &values);
-    assert_eq!(simd.as_array_i8x32(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_u8x32<S: Simd>(simd: S) {
     let values: [u8; 32] = core::array::from_fn(|i| (i % 23) as u8 + 10_u8);
     let a = u8x32::from_slice(simd, &values);
-    assert_eq!(simd.as_array_u8x32(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_i8x64<S: Simd>(simd: S) {
     let values: [i8; 64] = core::array::from_fn(|i| (i % 23) as i8 + 10_i8);
     let a = i8x64::from_slice(simd, &values);
-    assert_eq!(simd.as_array_i8x64(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_u8x64<S: Simd>(simd: S) {
     let values: [u8; 64] = core::array::from_fn(|i| (i % 23) as u8 + 10_u8);
     let a = u8x64::from_slice(simd, &values);
-    assert_eq!(simd.as_array_u8x64(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_i16x8<S: Simd>(simd: S) {
     let values: [i16; 8] = core::array::from_fn(|i| (i % 23) as i16 + 10_i16);
     let a = i16x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_i16x8(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_u16x8<S: Simd>(simd: S) {
     let values: [u16; 8] = core::array::from_fn(|i| (i % 23) as u16 + 10_u16);
     let a = u16x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_u16x8(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_i16x16<S: Simd>(simd: S) {
     let values: [i16; 16] = core::array::from_fn(|i| (i % 23) as i16 + 10_i16);
     let a = i16x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_i16x16(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_u16x16<S: Simd>(simd: S) {
     let values: [u16; 16] = core::array::from_fn(|i| (i % 23) as u16 + 10_u16);
     let a = u16x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_u16x16(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_i16x32<S: Simd>(simd: S) {
     let values: [i16; 32] = core::array::from_fn(|i| (i % 23) as i16 + 10_i16);
     let a = i16x32::from_slice(simd, &values);
-    assert_eq!(simd.as_array_i16x32(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_u16x32<S: Simd>(simd: S) {
     let values: [u16; 32] = core::array::from_fn(|i| (i % 23) as u16 + 10_u16);
     let a = u16x32::from_slice(simd, &values);
-    assert_eq!(simd.as_array_u16x32(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_f32x4<S: Simd>(simd: S) {
     let values: [f32; 4] = core::array::from_fn(|i| i as f32 + 1.25_f32);
     let a = f32x4::from_slice(simd, &values);
-    assert_eq!(simd.as_array_f32x4(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_i32x4<S: Simd>(simd: S) {
     let values: [i32; 4] = core::array::from_fn(|i| (i % 23) as i32 + 10_i32);
     let a = i32x4::from_slice(simd, &values);
-    assert_eq!(simd.as_array_i32x4(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_u32x4<S: Simd>(simd: S) {
     let values: [u32; 4] = core::array::from_fn(|i| (i % 23) as u32 + 10_u32);
     let a = u32x4::from_slice(simd, &values);
-    assert_eq!(simd.as_array_u32x4(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_f32x8<S: Simd>(simd: S) {
     let values: [f32; 8] = core::array::from_fn(|i| i as f32 + 1.25_f32);
     let a = f32x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_f32x8(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_i32x8<S: Simd>(simd: S) {
     let values: [i32; 8] = core::array::from_fn(|i| (i % 23) as i32 + 10_i32);
     let a = i32x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_i32x8(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_u32x8<S: Simd>(simd: S) {
     let values: [u32; 8] = core::array::from_fn(|i| (i % 23) as u32 + 10_u32);
     let a = u32x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_u32x8(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_f32x16<S: Simd>(simd: S) {
     let values: [f32; 16] = core::array::from_fn(|i| i as f32 + 1.25_f32);
     let a = f32x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_f32x16(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_i32x16<S: Simd>(simd: S) {
     let values: [i32; 16] = core::array::from_fn(|i| (i % 23) as i32 + 10_i32);
     let a = i32x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_i32x16(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_u32x16<S: Simd>(simd: S) {
     let values: [u32; 16] = core::array::from_fn(|i| (i % 23) as u32 + 10_u32);
     let a = u32x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_u32x16(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_f64x2<S: Simd>(simd: S) {
     let values: [f64; 2] = core::array::from_fn(|i| i as f64 + 1.25_f64);
     let a = f64x2::from_slice(simd, &values);
-    assert_eq!(simd.as_array_f64x2(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_f64x4<S: Simd>(simd: S) {
     let values: [f64; 4] = core::array::from_fn(|i| i as f64 + 1.25_f64);
     let a = f64x4::from_slice(simd, &values);
-    assert_eq!(simd.as_array_f64x4(a), values);
+    assert_eq!(a.as_array(), values);
 }
 
 #[simd_test]
 fn as_array_f64x8<S: Simd>(simd: S) {
     let values: [f64; 8] = core::array::from_fn(|i| i as f64 + 1.25_f64);
     let a = f64x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_f64x8(a), values);
-}
-
-#[simd_test]
-fn as_array_mask8x16<S: Simd>(simd: S) {
-    let values: [i8; 16] = core::array::from_fn(|i| if i % 2 == 0 { -1_i8 } else { 0_i8 });
-    let a = mask8x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_mask8x16(a), values);
-}
-
-#[simd_test]
-fn as_array_mask8x32<S: Simd>(simd: S) {
-    let values: [i8; 32] = core::array::from_fn(|i| if i % 2 == 0 { -1_i8 } else { 0_i8 });
-    let a = mask8x32::from_slice(simd, &values);
-    assert_eq!(simd.as_array_mask8x32(a), values);
-}
-
-#[simd_test]
-fn as_array_mask8x64<S: Simd>(simd: S) {
-    let values: [i8; 64] = core::array::from_fn(|i| if i % 2 == 0 { -1_i8 } else { 0_i8 });
-    let a = mask8x64::from_slice(simd, &values);
-    assert_eq!(simd.as_array_mask8x64(a), values);
-}
-
-#[simd_test]
-fn as_array_mask16x8<S: Simd>(simd: S) {
-    let values: [i16; 8] = core::array::from_fn(|i| if i % 2 == 0 { -1_i16 } else { 0_i16 });
-    let a = mask16x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_mask16x8(a), values);
-}
-
-#[simd_test]
-fn as_array_mask16x16<S: Simd>(simd: S) {
-    let values: [i16; 16] = core::array::from_fn(|i| if i % 2 == 0 { -1_i16 } else { 0_i16 });
-    let a = mask16x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_mask16x16(a), values);
-}
-
-#[simd_test]
-fn as_array_mask16x32<S: Simd>(simd: S) {
-    let values: [i16; 32] = core::array::from_fn(|i| if i % 2 == 0 { -1_i16 } else { 0_i16 });
-    let a = mask16x32::from_slice(simd, &values);
-    assert_eq!(simd.as_array_mask16x32(a), values);
-}
-
-#[simd_test]
-fn as_array_mask32x4<S: Simd>(simd: S) {
-    let values: [i32; 4] = core::array::from_fn(|i| if i % 2 == 0 { -1_i32 } else { 0_i32 });
-    let a = mask32x4::from_slice(simd, &values);
-    assert_eq!(simd.as_array_mask32x4(a), values);
-}
-
-#[simd_test]
-fn as_array_mask32x8<S: Simd>(simd: S) {
-    let values: [i32; 8] = core::array::from_fn(|i| if i % 2 == 0 { -1_i32 } else { 0_i32 });
-    let a = mask32x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_mask32x8(a), values);
-}
-
-#[simd_test]
-fn as_array_mask32x16<S: Simd>(simd: S) {
-    let values: [i32; 16] = core::array::from_fn(|i| if i % 2 == 0 { -1_i32 } else { 0_i32 });
-    let a = mask32x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_mask32x16(a), values);
+    assert_eq!(a.as_array(), values);
 }

--- a/fearless_simd_tests/tests/harness/ops/as_array_mut.rs
+++ b/fearless_simd_tests/tests/harness/ops/as_array_mut.rs
@@ -9,14 +9,14 @@ use fearless_simd_dev_macros::simd_test;
 #[simd_test]
 fn as_array_mut_i64x2<S: Simd>(simd: S) {
     let mut a = i64x2::from_slice(simd, &[1_i64, -2_i64]);
-    simd.as_array_mut_i64x2(&mut a)[0] = -2_i64;
+    a.as_array_mut()[0] = -2_i64;
     assert_eq!(*a, [-2_i64, -2_i64]);
 }
 
 #[simd_test]
 fn as_array_mut_i64x4<S: Simd>(simd: S) {
     let mut a = i64x4::from_slice(simd, &[1_i64, -2_i64, 3_i64, -4_i64]);
-    simd.as_array_mut_i64x4(&mut a)[0] = -2_i64;
+    a.as_array_mut()[0] = -2_i64;
     assert_eq!(*a, [-2_i64, -2_i64, 3_i64, -4_i64]);
 }
 
@@ -26,7 +26,7 @@ fn as_array_mut_i64x8<S: Simd>(simd: S) {
         simd,
         &[1_i64, -2_i64, 3_i64, -4_i64, 5_i64, -6_i64, 7_i64, -8_i64],
     );
-    simd.as_array_mut_i64x8(&mut a)[0] = -2_i64;
+    a.as_array_mut()[0] = -2_i64;
     assert_eq!(
         *a,
         [-2_i64, -2_i64, 3_i64, -4_i64, 5_i64, -6_i64, 7_i64, -8_i64]
@@ -36,14 +36,14 @@ fn as_array_mut_i64x8<S: Simd>(simd: S) {
 #[simd_test]
 fn as_array_mut_u64x2<S: Simd>(simd: S) {
     let mut a = u64x2::from_slice(simd, &[1_u64, 2_u64]);
-    simd.as_array_mut_u64x2(&mut a)[0] = 2_u64;
+    a.as_array_mut()[0] = 2_u64;
     assert_eq!(*a, [2_u64, 2_u64]);
 }
 
 #[simd_test]
 fn as_array_mut_u64x4<S: Simd>(simd: S) {
     let mut a = u64x4::from_slice(simd, &[1_u64, 2_u64, 3_u64, 4_u64]);
-    simd.as_array_mut_u64x4(&mut a)[0] = 2_u64;
+    a.as_array_mut()[0] = 2_u64;
     assert_eq!(*a, [2_u64, 2_u64, 3_u64, 4_u64]);
 }
 
@@ -53,7 +53,7 @@ fn as_array_mut_u64x8<S: Simd>(simd: S) {
         simd,
         &[1_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64],
     );
-    simd.as_array_mut_u64x8(&mut a)[0] = 2_u64;
+    a.as_array_mut()[0] = 2_u64;
     assert_eq!(*a, [2_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64]);
 }
 
@@ -65,7 +65,7 @@ fn as_array_mut_i8x16<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_i8;
     let mut a = i8x16::from_slice(simd, &values);
-    simd.as_array_mut_i8x16(&mut a)[0] = 42_i8;
+    a.as_array_mut()[0] = 42_i8;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -75,7 +75,7 @@ fn as_array_mut_u8x16<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_u8;
     let mut a = u8x16::from_slice(simd, &values);
-    simd.as_array_mut_u8x16(&mut a)[0] = 42_u8;
+    a.as_array_mut()[0] = 42_u8;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -85,7 +85,7 @@ fn as_array_mut_i8x32<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_i8;
     let mut a = i8x32::from_slice(simd, &values);
-    simd.as_array_mut_i8x32(&mut a)[0] = 42_i8;
+    a.as_array_mut()[0] = 42_i8;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -95,7 +95,7 @@ fn as_array_mut_u8x32<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_u8;
     let mut a = u8x32::from_slice(simd, &values);
-    simd.as_array_mut_u8x32(&mut a)[0] = 42_u8;
+    a.as_array_mut()[0] = 42_u8;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -105,7 +105,7 @@ fn as_array_mut_i8x64<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_i8;
     let mut a = i8x64::from_slice(simd, &values);
-    simd.as_array_mut_i8x64(&mut a)[0] = 42_i8;
+    a.as_array_mut()[0] = 42_i8;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -115,7 +115,7 @@ fn as_array_mut_u8x64<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_u8;
     let mut a = u8x64::from_slice(simd, &values);
-    simd.as_array_mut_u8x64(&mut a)[0] = 42_u8;
+    a.as_array_mut()[0] = 42_u8;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -125,7 +125,7 @@ fn as_array_mut_i16x8<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_i16;
     let mut a = i16x8::from_slice(simd, &values);
-    simd.as_array_mut_i16x8(&mut a)[0] = 42_i16;
+    a.as_array_mut()[0] = 42_i16;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -135,7 +135,7 @@ fn as_array_mut_u16x8<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_u16;
     let mut a = u16x8::from_slice(simd, &values);
-    simd.as_array_mut_u16x8(&mut a)[0] = 42_u16;
+    a.as_array_mut()[0] = 42_u16;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -145,7 +145,7 @@ fn as_array_mut_i16x16<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_i16;
     let mut a = i16x16::from_slice(simd, &values);
-    simd.as_array_mut_i16x16(&mut a)[0] = 42_i16;
+    a.as_array_mut()[0] = 42_i16;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -155,7 +155,7 @@ fn as_array_mut_u16x16<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_u16;
     let mut a = u16x16::from_slice(simd, &values);
-    simd.as_array_mut_u16x16(&mut a)[0] = 42_u16;
+    a.as_array_mut()[0] = 42_u16;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -165,7 +165,7 @@ fn as_array_mut_i16x32<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_i16;
     let mut a = i16x32::from_slice(simd, &values);
-    simd.as_array_mut_i16x32(&mut a)[0] = 42_i16;
+    a.as_array_mut()[0] = 42_i16;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -175,7 +175,7 @@ fn as_array_mut_u16x32<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_u16;
     let mut a = u16x32::from_slice(simd, &values);
-    simd.as_array_mut_u16x32(&mut a)[0] = 42_u16;
+    a.as_array_mut()[0] = 42_u16;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -185,7 +185,7 @@ fn as_array_mut_f32x4<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42.5_f32;
     let mut a = f32x4::from_slice(simd, &values);
-    simd.as_array_mut_f32x4(&mut a)[0] = 42.5_f32;
+    a.as_array_mut()[0] = 42.5_f32;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -195,7 +195,7 @@ fn as_array_mut_i32x4<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_i32;
     let mut a = i32x4::from_slice(simd, &values);
-    simd.as_array_mut_i32x4(&mut a)[0] = 42_i32;
+    a.as_array_mut()[0] = 42_i32;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -205,7 +205,7 @@ fn as_array_mut_u32x4<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_u32;
     let mut a = u32x4::from_slice(simd, &values);
-    simd.as_array_mut_u32x4(&mut a)[0] = 42_u32;
+    a.as_array_mut()[0] = 42_u32;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -215,7 +215,7 @@ fn as_array_mut_f32x8<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42.5_f32;
     let mut a = f32x8::from_slice(simd, &values);
-    simd.as_array_mut_f32x8(&mut a)[0] = 42.5_f32;
+    a.as_array_mut()[0] = 42.5_f32;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -225,7 +225,7 @@ fn as_array_mut_i32x8<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_i32;
     let mut a = i32x8::from_slice(simd, &values);
-    simd.as_array_mut_i32x8(&mut a)[0] = 42_i32;
+    a.as_array_mut()[0] = 42_i32;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -235,7 +235,7 @@ fn as_array_mut_u32x8<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_u32;
     let mut a = u32x8::from_slice(simd, &values);
-    simd.as_array_mut_u32x8(&mut a)[0] = 42_u32;
+    a.as_array_mut()[0] = 42_u32;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -245,7 +245,7 @@ fn as_array_mut_f32x16<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42.5_f32;
     let mut a = f32x16::from_slice(simd, &values);
-    simd.as_array_mut_f32x16(&mut a)[0] = 42.5_f32;
+    a.as_array_mut()[0] = 42.5_f32;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -255,7 +255,7 @@ fn as_array_mut_i32x16<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_i32;
     let mut a = i32x16::from_slice(simd, &values);
-    simd.as_array_mut_i32x16(&mut a)[0] = 42_i32;
+    a.as_array_mut()[0] = 42_i32;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -265,7 +265,7 @@ fn as_array_mut_u32x16<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42_u32;
     let mut a = u32x16::from_slice(simd, &values);
-    simd.as_array_mut_u32x16(&mut a)[0] = 42_u32;
+    a.as_array_mut()[0] = 42_u32;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -275,7 +275,7 @@ fn as_array_mut_f64x2<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42.5_f64;
     let mut a = f64x2::from_slice(simd, &values);
-    simd.as_array_mut_f64x2(&mut a)[0] = 42.5_f64;
+    a.as_array_mut()[0] = 42.5_f64;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -285,7 +285,7 @@ fn as_array_mut_f64x4<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42.5_f64;
     let mut a = f64x4::from_slice(simd, &values);
-    simd.as_array_mut_f64x4(&mut a)[0] = 42.5_f64;
+    a.as_array_mut()[0] = 42.5_f64;
     assert_eq!(a.as_slice(), expected.as_slice());
 }
 
@@ -295,6 +295,6 @@ fn as_array_mut_f64x8<S: Simd>(simd: S) {
     let mut expected = values;
     expected[0] = 42.5_f64;
     let mut a = f64x8::from_slice(simd, &values);
-    simd.as_array_mut_f64x8(&mut a)[0] = 42.5_f64;
+    a.as_array_mut()[0] = 42.5_f64;
     assert_eq!(a.as_slice(), expected.as_slice());
 }

--- a/fearless_simd_tests/tests/harness/ops/as_array_ref.rs
+++ b/fearless_simd_tests/tests/harness/ops/as_array_ref.rs
@@ -9,13 +9,13 @@ use fearless_simd_dev_macros::simd_test;
 #[simd_test]
 fn as_array_ref_i64x2<S: Simd>(simd: S) {
     let a = i64x2::from_slice(simd, &[1_i64, -2_i64]);
-    assert_eq!(simd.as_array_ref_i64x2(&a), &[1_i64, -2_i64]);
+    assert_eq!(a.as_array_ref(), &[1_i64, -2_i64]);
 }
 
 #[simd_test]
 fn as_array_ref_i64x4<S: Simd>(simd: S) {
     let a = i64x4::from_slice(simd, &[1_i64, -2_i64, 3_i64, -4_i64]);
-    assert_eq!(simd.as_array_ref_i64x4(&a), &[1_i64, -2_i64, 3_i64, -4_i64]);
+    assert_eq!(a.as_array_ref(), &[1_i64, -2_i64, 3_i64, -4_i64]);
 }
 
 #[simd_test]
@@ -25,7 +25,7 @@ fn as_array_ref_i64x8<S: Simd>(simd: S) {
         &[1_i64, -2_i64, 3_i64, -4_i64, 5_i64, -6_i64, 7_i64, -8_i64],
     );
     assert_eq!(
-        simd.as_array_ref_i64x8(&a),
+        a.as_array_ref(),
         &[1_i64, -2_i64, 3_i64, -4_i64, 5_i64, -6_i64, 7_i64, -8_i64]
     );
 }
@@ -33,13 +33,13 @@ fn as_array_ref_i64x8<S: Simd>(simd: S) {
 #[simd_test]
 fn as_array_ref_u64x2<S: Simd>(simd: S) {
     let a = u64x2::from_slice(simd, &[1_u64, 2_u64]);
-    assert_eq!(simd.as_array_ref_u64x2(&a), &[1_u64, 2_u64]);
+    assert_eq!(a.as_array_ref(), &[1_u64, 2_u64]);
 }
 
 #[simd_test]
 fn as_array_ref_u64x4<S: Simd>(simd: S) {
     let a = u64x4::from_slice(simd, &[1_u64, 2_u64, 3_u64, 4_u64]);
-    assert_eq!(simd.as_array_ref_u64x4(&a), &[1_u64, 2_u64, 3_u64, 4_u64]);
+    assert_eq!(a.as_array_ref(), &[1_u64, 2_u64, 3_u64, 4_u64]);
 }
 
 #[simd_test]
@@ -49,7 +49,7 @@ fn as_array_ref_u64x8<S: Simd>(simd: S) {
         &[1_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64],
     );
     assert_eq!(
-        simd.as_array_ref_u64x8(&a),
+        a.as_array_ref(),
         &[1_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64]
     );
 }
@@ -60,166 +60,166 @@ fn as_array_ref_u64x8<S: Simd>(simd: S) {
 fn as_array_ref_i8x16<S: Simd>(simd: S) {
     let values: [i8; 16] = core::array::from_fn(|i| (i % 23) as i8 + 10_i8);
     let a = i8x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_i8x16(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_u8x16<S: Simd>(simd: S) {
     let values: [u8; 16] = core::array::from_fn(|i| (i % 23) as u8 + 10_u8);
     let a = u8x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_u8x16(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_i8x32<S: Simd>(simd: S) {
     let values: [i8; 32] = core::array::from_fn(|i| (i % 23) as i8 + 10_i8);
     let a = i8x32::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_i8x32(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_u8x32<S: Simd>(simd: S) {
     let values: [u8; 32] = core::array::from_fn(|i| (i % 23) as u8 + 10_u8);
     let a = u8x32::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_u8x32(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_i8x64<S: Simd>(simd: S) {
     let values: [i8; 64] = core::array::from_fn(|i| (i % 23) as i8 + 10_i8);
     let a = i8x64::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_i8x64(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_u8x64<S: Simd>(simd: S) {
     let values: [u8; 64] = core::array::from_fn(|i| (i % 23) as u8 + 10_u8);
     let a = u8x64::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_u8x64(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_i16x8<S: Simd>(simd: S) {
     let values: [i16; 8] = core::array::from_fn(|i| (i % 23) as i16 + 10_i16);
     let a = i16x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_i16x8(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_u16x8<S: Simd>(simd: S) {
     let values: [u16; 8] = core::array::from_fn(|i| (i % 23) as u16 + 10_u16);
     let a = u16x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_u16x8(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_i16x16<S: Simd>(simd: S) {
     let values: [i16; 16] = core::array::from_fn(|i| (i % 23) as i16 + 10_i16);
     let a = i16x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_i16x16(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_u16x16<S: Simd>(simd: S) {
     let values: [u16; 16] = core::array::from_fn(|i| (i % 23) as u16 + 10_u16);
     let a = u16x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_u16x16(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_i16x32<S: Simd>(simd: S) {
     let values: [i16; 32] = core::array::from_fn(|i| (i % 23) as i16 + 10_i16);
     let a = i16x32::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_i16x32(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_u16x32<S: Simd>(simd: S) {
     let values: [u16; 32] = core::array::from_fn(|i| (i % 23) as u16 + 10_u16);
     let a = u16x32::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_u16x32(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_f32x4<S: Simd>(simd: S) {
     let values: [f32; 4] = core::array::from_fn(|i| i as f32 + 1.25_f32);
     let a = f32x4::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_f32x4(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_i32x4<S: Simd>(simd: S) {
     let values: [i32; 4] = core::array::from_fn(|i| (i % 23) as i32 + 10_i32);
     let a = i32x4::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_i32x4(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_u32x4<S: Simd>(simd: S) {
     let values: [u32; 4] = core::array::from_fn(|i| (i % 23) as u32 + 10_u32);
     let a = u32x4::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_u32x4(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_f32x8<S: Simd>(simd: S) {
     let values: [f32; 8] = core::array::from_fn(|i| i as f32 + 1.25_f32);
     let a = f32x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_f32x8(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_i32x8<S: Simd>(simd: S) {
     let values: [i32; 8] = core::array::from_fn(|i| (i % 23) as i32 + 10_i32);
     let a = i32x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_i32x8(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_u32x8<S: Simd>(simd: S) {
     let values: [u32; 8] = core::array::from_fn(|i| (i % 23) as u32 + 10_u32);
     let a = u32x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_u32x8(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_f32x16<S: Simd>(simd: S) {
     let values: [f32; 16] = core::array::from_fn(|i| i as f32 + 1.25_f32);
     let a = f32x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_f32x16(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_i32x16<S: Simd>(simd: S) {
     let values: [i32; 16] = core::array::from_fn(|i| (i % 23) as i32 + 10_i32);
     let a = i32x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_i32x16(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_u32x16<S: Simd>(simd: S) {
     let values: [u32; 16] = core::array::from_fn(|i| (i % 23) as u32 + 10_u32);
     let a = u32x16::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_u32x16(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_f64x2<S: Simd>(simd: S) {
     let values: [f64; 2] = core::array::from_fn(|i| i as f64 + 1.25_f64);
     let a = f64x2::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_f64x2(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_f64x4<S: Simd>(simd: S) {
     let values: [f64; 4] = core::array::from_fn(|i| i as f64 + 1.25_f64);
     let a = f64x4::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_f64x4(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }
 
 #[simd_test]
 fn as_array_ref_f64x8<S: Simd>(simd: S) {
     let values: [f64; 8] = core::array::from_fn(|i| i as f64 + 1.25_f64);
     let a = f64x8::from_slice(simd, &values);
-    assert_eq!(simd.as_array_ref_f64x8(&a), &values);
+    assert_eq!(a.as_array_ref(), &values);
 }

--- a/fearless_simd_tests/tests/harness/ops/load_array.rs
+++ b/fearless_simd_tests/tests/harness/ops/load_array.rs
@@ -8,19 +8,22 @@ use fearless_simd_dev_macros::simd_test;
 
 #[simd_test]
 fn load_array_i64x2<S: Simd>(simd: S) {
-    let a = simd.load_array_i64x2([1_i64, -2_i64]);
+    let a = i64x2::load_array(simd, [1_i64, -2_i64]);
     assert_eq!(*a, [1_i64, -2_i64]);
 }
 
 #[simd_test]
 fn load_array_i64x4<S: Simd>(simd: S) {
-    let a = simd.load_array_i64x4([1_i64, -2_i64, 3_i64, -4_i64]);
+    let a = i64x4::load_array(simd, [1_i64, -2_i64, 3_i64, -4_i64]);
     assert_eq!(*a, [1_i64, -2_i64, 3_i64, -4_i64]);
 }
 
 #[simd_test]
 fn load_array_i64x8<S: Simd>(simd: S) {
-    let a = simd.load_array_i64x8([1_i64, -2_i64, 3_i64, -4_i64, 5_i64, -6_i64, 7_i64, -8_i64]);
+    let a = i64x8::load_array(
+        simd,
+        [1_i64, -2_i64, 3_i64, -4_i64, 5_i64, -6_i64, 7_i64, -8_i64],
+    );
     assert_eq!(
         *a,
         [1_i64, -2_i64, 3_i64, -4_i64, 5_i64, -6_i64, 7_i64, -8_i64]
@@ -29,41 +32,23 @@ fn load_array_i64x8<S: Simd>(simd: S) {
 
 #[simd_test]
 fn load_array_u64x2<S: Simd>(simd: S) {
-    let a = simd.load_array_u64x2([1_u64, 2_u64]);
+    let a = u64x2::load_array(simd, [1_u64, 2_u64]);
     assert_eq!(*a, [1_u64, 2_u64]);
 }
 
 #[simd_test]
 fn load_array_u64x4<S: Simd>(simd: S) {
-    let a = simd.load_array_u64x4([1_u64, 2_u64, 3_u64, 4_u64]);
+    let a = u64x4::load_array(simd, [1_u64, 2_u64, 3_u64, 4_u64]);
     assert_eq!(*a, [1_u64, 2_u64, 3_u64, 4_u64]);
 }
 
 #[simd_test]
 fn load_array_u64x8<S: Simd>(simd: S) {
-    let a = simd.load_array_u64x8([1_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64]);
-    assert_eq!(*a, [1_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64]);
-}
-
-#[simd_test]
-fn load_array_mask64x2<S: Simd>(simd: S) {
-    let a = simd.load_array_mask64x2([-1_i64, 0_i64]);
-    assert_eq!(<[i64; 2]>::from(a), [-1_i64, 0_i64]);
-}
-
-#[simd_test]
-fn load_array_mask64x4<S: Simd>(simd: S) {
-    let a = simd.load_array_mask64x4([-1_i64, 0_i64, -1_i64, 0_i64]);
-    assert_eq!(<[i64; 4]>::from(a), [-1_i64, 0_i64, -1_i64, 0_i64]);
-}
-
-#[simd_test]
-fn load_array_mask64x8<S: Simd>(simd: S) {
-    let a = simd.load_array_mask64x8([-1_i64, 0_i64, -1_i64, 0_i64, -1_i64, 0_i64, -1_i64, 0_i64]);
-    assert_eq!(
-        <[i64; 8]>::from(a),
-        [-1_i64, 0_i64, -1_i64, 0_i64, -1_i64, 0_i64, -1_i64, 0_i64]
+    let a = u64x8::load_array(
+        simd,
+        [1_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64],
     );
+    assert_eq!(*a, [1_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64]);
 }
 
 // Generated gap-fill coverage rows.
@@ -71,230 +56,167 @@ fn load_array_mask64x8<S: Simd>(simd: S) {
 #[simd_test]
 fn load_array_i8x16<S: Simd>(simd: S) {
     let values: [i8; 16] = core::array::from_fn(|i| (i % 23) as i8 + 10_i8);
-    let result = simd.load_array_i8x16(values);
+    let result = i8x16::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_u8x16<S: Simd>(simd: S) {
     let values: [u8; 16] = core::array::from_fn(|i| (i % 23) as u8 + 10_u8);
-    let result = simd.load_array_u8x16(values);
+    let result = u8x16::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_i8x32<S: Simd>(simd: S) {
     let values: [i8; 32] = core::array::from_fn(|i| (i % 23) as i8 + 10_i8);
-    let result = simd.load_array_i8x32(values);
+    let result = i8x32::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_u8x32<S: Simd>(simd: S) {
     let values: [u8; 32] = core::array::from_fn(|i| (i % 23) as u8 + 10_u8);
-    let result = simd.load_array_u8x32(values);
+    let result = u8x32::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_i8x64<S: Simd>(simd: S) {
     let values: [i8; 64] = core::array::from_fn(|i| (i % 23) as i8 + 10_i8);
-    let result = simd.load_array_i8x64(values);
+    let result = i8x64::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_u8x64<S: Simd>(simd: S) {
     let values: [u8; 64] = core::array::from_fn(|i| (i % 23) as u8 + 10_u8);
-    let result = simd.load_array_u8x64(values);
+    let result = u8x64::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_i16x8<S: Simd>(simd: S) {
     let values: [i16; 8] = core::array::from_fn(|i| (i % 23) as i16 + 10_i16);
-    let result = simd.load_array_i16x8(values);
+    let result = i16x8::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_u16x8<S: Simd>(simd: S) {
     let values: [u16; 8] = core::array::from_fn(|i| (i % 23) as u16 + 10_u16);
-    let result = simd.load_array_u16x8(values);
+    let result = u16x8::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_i16x16<S: Simd>(simd: S) {
     let values: [i16; 16] = core::array::from_fn(|i| (i % 23) as i16 + 10_i16);
-    let result = simd.load_array_i16x16(values);
+    let result = i16x16::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_u16x16<S: Simd>(simd: S) {
     let values: [u16; 16] = core::array::from_fn(|i| (i % 23) as u16 + 10_u16);
-    let result = simd.load_array_u16x16(values);
+    let result = u16x16::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_i16x32<S: Simd>(simd: S) {
     let values: [i16; 32] = core::array::from_fn(|i| (i % 23) as i16 + 10_i16);
-    let result = simd.load_array_i16x32(values);
+    let result = i16x32::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_u16x32<S: Simd>(simd: S) {
     let values: [u16; 32] = core::array::from_fn(|i| (i % 23) as u16 + 10_u16);
-    let result = simd.load_array_u16x32(values);
+    let result = u16x32::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_f32x4<S: Simd>(simd: S) {
     let values: [f32; 4] = core::array::from_fn(|i| i as f32 + 1.25_f32);
-    let result = simd.load_array_f32x4(values);
+    let result = f32x4::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_i32x4<S: Simd>(simd: S) {
     let values: [i32; 4] = core::array::from_fn(|i| (i % 23) as i32 + 10_i32);
-    let result = simd.load_array_i32x4(values);
+    let result = i32x4::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_u32x4<S: Simd>(simd: S) {
     let values: [u32; 4] = core::array::from_fn(|i| (i % 23) as u32 + 10_u32);
-    let result = simd.load_array_u32x4(values);
+    let result = u32x4::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_f32x8<S: Simd>(simd: S) {
     let values: [f32; 8] = core::array::from_fn(|i| i as f32 + 1.25_f32);
-    let result = simd.load_array_f32x8(values);
+    let result = f32x8::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_i32x8<S: Simd>(simd: S) {
     let values: [i32; 8] = core::array::from_fn(|i| (i % 23) as i32 + 10_i32);
-    let result = simd.load_array_i32x8(values);
+    let result = i32x8::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_u32x8<S: Simd>(simd: S) {
     let values: [u32; 8] = core::array::from_fn(|i| (i % 23) as u32 + 10_u32);
-    let result = simd.load_array_u32x8(values);
+    let result = u32x8::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_f32x16<S: Simd>(simd: S) {
     let values: [f32; 16] = core::array::from_fn(|i| i as f32 + 1.25_f32);
-    let result = simd.load_array_f32x16(values);
+    let result = f32x16::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_i32x16<S: Simd>(simd: S) {
     let values: [i32; 16] = core::array::from_fn(|i| (i % 23) as i32 + 10_i32);
-    let result = simd.load_array_i32x16(values);
+    let result = i32x16::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_u32x16<S: Simd>(simd: S) {
     let values: [u32; 16] = core::array::from_fn(|i| (i % 23) as u32 + 10_u32);
-    let result = simd.load_array_u32x16(values);
+    let result = u32x16::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_f64x2<S: Simd>(simd: S) {
     let values: [f64; 2] = core::array::from_fn(|i| i as f64 + 1.25_f64);
-    let result = simd.load_array_f64x2(values);
+    let result = f64x2::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_f64x4<S: Simd>(simd: S) {
     let values: [f64; 4] = core::array::from_fn(|i| i as f64 + 1.25_f64);
-    let result = simd.load_array_f64x4(values);
+    let result = f64x4::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_f64x8<S: Simd>(simd: S) {
     let values: [f64; 8] = core::array::from_fn(|i| i as f64 + 1.25_f64);
-    let result = simd.load_array_f64x8(values);
+    let result = f64x8::load_array(simd, values);
     assert_eq!(result.as_slice(), values.as_slice());
-}
-
-#[simd_test]
-fn load_array_mask8x16<S: Simd>(simd: S) {
-    let values: [i8; 16] = core::array::from_fn(|i| if i % 2 == 0 { -1_i8 } else { 0_i8 });
-    let result = simd.load_array_mask8x16(values);
-    assert_eq!(<[i8; 16]>::from(result), values);
-}
-
-#[simd_test]
-fn load_array_mask8x32<S: Simd>(simd: S) {
-    let values: [i8; 32] = core::array::from_fn(|i| if i % 2 == 0 { -1_i8 } else { 0_i8 });
-    let result = simd.load_array_mask8x32(values);
-    assert_eq!(<[i8; 32]>::from(result), values);
-}
-
-#[simd_test]
-fn load_array_mask8x64<S: Simd>(simd: S) {
-    let values: [i8; 64] = core::array::from_fn(|i| if i % 2 == 0 { -1_i8 } else { 0_i8 });
-    let result = simd.load_array_mask8x64(values);
-    assert_eq!(<[i8; 64]>::from(result), values);
-}
-
-#[simd_test]
-fn load_array_mask16x8<S: Simd>(simd: S) {
-    let values: [i16; 8] = core::array::from_fn(|i| if i % 2 == 0 { -1_i16 } else { 0_i16 });
-    let result = simd.load_array_mask16x8(values);
-    assert_eq!(<[i16; 8]>::from(result), values);
-}
-
-#[simd_test]
-fn load_array_mask16x16<S: Simd>(simd: S) {
-    let values: [i16; 16] = core::array::from_fn(|i| if i % 2 == 0 { -1_i16 } else { 0_i16 });
-    let result = simd.load_array_mask16x16(values);
-    assert_eq!(<[i16; 16]>::from(result), values);
-}
-
-#[simd_test]
-fn load_array_mask16x32<S: Simd>(simd: S) {
-    let values: [i16; 32] = core::array::from_fn(|i| if i % 2 == 0 { -1_i16 } else { 0_i16 });
-    let result = simd.load_array_mask16x32(values);
-    assert_eq!(<[i16; 32]>::from(result), values);
-}
-
-#[simd_test]
-fn load_array_mask32x4<S: Simd>(simd: S) {
-    let values: [i32; 4] = core::array::from_fn(|i| if i % 2 == 0 { -1_i32 } else { 0_i32 });
-    let result = simd.load_array_mask32x4(values);
-    assert_eq!(<[i32; 4]>::from(result), values);
-}
-
-#[simd_test]
-fn load_array_mask32x8<S: Simd>(simd: S) {
-    let values: [i32; 8] = core::array::from_fn(|i| if i % 2 == 0 { -1_i32 } else { 0_i32 });
-    let result = simd.load_array_mask32x8(values);
-    assert_eq!(<[i32; 8]>::from(result), values);
-}
-
-#[simd_test]
-fn load_array_mask32x16<S: Simd>(simd: S) {
-    let values: [i32; 16] = core::array::from_fn(|i| if i % 2 == 0 { -1_i32 } else { 0_i32 });
-    let result = simd.load_array_mask32x16(values);
-    assert_eq!(<[i32; 16]>::from(result), values);
 }

--- a/fearless_simd_tests/tests/harness/ops/load_array_ref.rs
+++ b/fearless_simd_tests/tests/harness/ops/load_array_ref.rs
@@ -9,42 +9,42 @@ use fearless_simd_dev_macros::simd_test;
 #[simd_test]
 fn load_array_ref_i64x2<S: Simd>(simd: S) {
     let values = [1_i64, -2_i64];
-    let a = simd.load_array_ref_i64x2(&values);
+    let a = i64x2::load_array_ref(simd, &values);
     assert_eq!(*a, values);
 }
 
 #[simd_test]
 fn load_array_ref_i64x4<S: Simd>(simd: S) {
     let values = [1_i64, -2_i64, 3_i64, -4_i64];
-    let a = simd.load_array_ref_i64x4(&values);
+    let a = i64x4::load_array_ref(simd, &values);
     assert_eq!(*a, values);
 }
 
 #[simd_test]
 fn load_array_ref_i64x8<S: Simd>(simd: S) {
     let values = [1_i64, -2_i64, 3_i64, -4_i64, 5_i64, -6_i64, 7_i64, -8_i64];
-    let a = simd.load_array_ref_i64x8(&values);
+    let a = i64x8::load_array_ref(simd, &values);
     assert_eq!(*a, values);
 }
 
 #[simd_test]
 fn load_array_ref_u64x2<S: Simd>(simd: S) {
     let values = [1_u64, 2_u64];
-    let a = simd.load_array_ref_u64x2(&values);
+    let a = u64x2::load_array_ref(simd, &values);
     assert_eq!(*a, values);
 }
 
 #[simd_test]
 fn load_array_ref_u64x4<S: Simd>(simd: S) {
     let values = [1_u64, 2_u64, 3_u64, 4_u64];
-    let a = simd.load_array_ref_u64x4(&values);
+    let a = u64x4::load_array_ref(simd, &values);
     assert_eq!(*a, values);
 }
 
 #[simd_test]
 fn load_array_ref_u64x8<S: Simd>(simd: S) {
     let values = [1_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64];
-    let a = simd.load_array_ref_u64x8(&values);
+    let a = u64x8::load_array_ref(simd, &values);
     assert_eq!(*a, values);
 }
 
@@ -53,167 +53,167 @@ fn load_array_ref_u64x8<S: Simd>(simd: S) {
 #[simd_test]
 fn load_array_ref_i8x16<S: Simd>(simd: S) {
     let values: [i8; 16] = core::array::from_fn(|i| (i % 23) as i8 + 10_i8);
-    let result = simd.load_array_ref_i8x16(&values);
+    let result = i8x16::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_u8x16<S: Simd>(simd: S) {
     let values: [u8; 16] = core::array::from_fn(|i| (i % 23) as u8 + 10_u8);
-    let result = simd.load_array_ref_u8x16(&values);
+    let result = u8x16::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_i8x32<S: Simd>(simd: S) {
     let values: [i8; 32] = core::array::from_fn(|i| (i % 23) as i8 + 10_i8);
-    let result = simd.load_array_ref_i8x32(&values);
+    let result = i8x32::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_u8x32<S: Simd>(simd: S) {
     let values: [u8; 32] = core::array::from_fn(|i| (i % 23) as u8 + 10_u8);
-    let result = simd.load_array_ref_u8x32(&values);
+    let result = u8x32::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_i8x64<S: Simd>(simd: S) {
     let values: [i8; 64] = core::array::from_fn(|i| (i % 23) as i8 + 10_i8);
-    let result = simd.load_array_ref_i8x64(&values);
+    let result = i8x64::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_u8x64<S: Simd>(simd: S) {
     let values: [u8; 64] = core::array::from_fn(|i| (i % 23) as u8 + 10_u8);
-    let result = simd.load_array_ref_u8x64(&values);
+    let result = u8x64::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_i16x8<S: Simd>(simd: S) {
     let values: [i16; 8] = core::array::from_fn(|i| (i % 23) as i16 + 10_i16);
-    let result = simd.load_array_ref_i16x8(&values);
+    let result = i16x8::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_u16x8<S: Simd>(simd: S) {
     let values: [u16; 8] = core::array::from_fn(|i| (i % 23) as u16 + 10_u16);
-    let result = simd.load_array_ref_u16x8(&values);
+    let result = u16x8::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_i16x16<S: Simd>(simd: S) {
     let values: [i16; 16] = core::array::from_fn(|i| (i % 23) as i16 + 10_i16);
-    let result = simd.load_array_ref_i16x16(&values);
+    let result = i16x16::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_u16x16<S: Simd>(simd: S) {
     let values: [u16; 16] = core::array::from_fn(|i| (i % 23) as u16 + 10_u16);
-    let result = simd.load_array_ref_u16x16(&values);
+    let result = u16x16::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_i16x32<S: Simd>(simd: S) {
     let values: [i16; 32] = core::array::from_fn(|i| (i % 23) as i16 + 10_i16);
-    let result = simd.load_array_ref_i16x32(&values);
+    let result = i16x32::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_u16x32<S: Simd>(simd: S) {
     let values: [u16; 32] = core::array::from_fn(|i| (i % 23) as u16 + 10_u16);
-    let result = simd.load_array_ref_u16x32(&values);
+    let result = u16x32::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_f32x4<S: Simd>(simd: S) {
     let values: [f32; 4] = core::array::from_fn(|i| i as f32 + 1.25_f32);
-    let result = simd.load_array_ref_f32x4(&values);
+    let result = f32x4::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_i32x4<S: Simd>(simd: S) {
     let values: [i32; 4] = core::array::from_fn(|i| (i % 23) as i32 + 10_i32);
-    let result = simd.load_array_ref_i32x4(&values);
+    let result = i32x4::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_u32x4<S: Simd>(simd: S) {
     let values: [u32; 4] = core::array::from_fn(|i| (i % 23) as u32 + 10_u32);
-    let result = simd.load_array_ref_u32x4(&values);
+    let result = u32x4::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_f32x8<S: Simd>(simd: S) {
     let values: [f32; 8] = core::array::from_fn(|i| i as f32 + 1.25_f32);
-    let result = simd.load_array_ref_f32x8(&values);
+    let result = f32x8::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_i32x8<S: Simd>(simd: S) {
     let values: [i32; 8] = core::array::from_fn(|i| (i % 23) as i32 + 10_i32);
-    let result = simd.load_array_ref_i32x8(&values);
+    let result = i32x8::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_u32x8<S: Simd>(simd: S) {
     let values: [u32; 8] = core::array::from_fn(|i| (i % 23) as u32 + 10_u32);
-    let result = simd.load_array_ref_u32x8(&values);
+    let result = u32x8::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_f32x16<S: Simd>(simd: S) {
     let values: [f32; 16] = core::array::from_fn(|i| i as f32 + 1.25_f32);
-    let result = simd.load_array_ref_f32x16(&values);
+    let result = f32x16::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_i32x16<S: Simd>(simd: S) {
     let values: [i32; 16] = core::array::from_fn(|i| (i % 23) as i32 + 10_i32);
-    let result = simd.load_array_ref_i32x16(&values);
+    let result = i32x16::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_u32x16<S: Simd>(simd: S) {
     let values: [u32; 16] = core::array::from_fn(|i| (i % 23) as u32 + 10_u32);
-    let result = simd.load_array_ref_u32x16(&values);
+    let result = u32x16::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_f64x2<S: Simd>(simd: S) {
     let values: [f64; 2] = core::array::from_fn(|i| i as f64 + 1.25_f64);
-    let result = simd.load_array_ref_f64x2(&values);
+    let result = f64x2::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_f64x4<S: Simd>(simd: S) {
     let values: [f64; 4] = core::array::from_fn(|i| i as f64 + 1.25_f64);
-    let result = simd.load_array_ref_f64x4(&values);
+    let result = f64x4::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }
 
 #[simd_test]
 fn load_array_ref_f64x8<S: Simd>(simd: S) {
     let values: [f64; 8] = core::array::from_fn(|i| i as f64 + 1.25_f64);
-    let result = simd.load_array_ref_f64x8(&values);
+    let result = f64x8::load_array_ref(simd, &values);
     assert_eq!(result.as_slice(), values.as_slice());
 }

--- a/fearless_simd_tests/tests/harness/ops/store_array.rs
+++ b/fearless_simd_tests/tests/harness/ops/store_array.rs
@@ -10,7 +10,7 @@ use fearless_simd_dev_macros::simd_test;
 fn store_array_f32x4<S: Simd>(simd: S) {
     let a = f32x4::from_slice(simd, &[1.0, 2.0, 3.0, 4.0]);
     let mut dest = [0.0_f32; 4];
-    simd.store_array_f32x4(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, [1.0, 2.0, 3.0, 4.0]);
 }
 
@@ -18,7 +18,7 @@ fn store_array_f32x4<S: Simd>(simd: S) {
 fn store_array_f32x8<S: Simd>(simd: S) {
     let a = f32x8::from_slice(simd, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
     let mut dest = [0.0_f32; 8];
-    simd.store_array_f32x8(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
 }
 
@@ -26,7 +26,7 @@ fn store_array_f32x8<S: Simd>(simd: S) {
 fn store_array_f64x2<S: Simd>(simd: S) {
     let a = f64x2::from_slice(simd, &[1.5, 2.5]);
     let mut dest = [0.0_f64; 2];
-    simd.store_array_f64x2(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, [1.5, 2.5]);
 }
 
@@ -34,7 +34,7 @@ fn store_array_f64x2<S: Simd>(simd: S) {
 fn store_array_f64x4<S: Simd>(simd: S) {
     let a = f64x4::from_slice(simd, &[1.5, 2.5, 3.5, 4.5]);
     let mut dest = [0.0_f64; 4];
-    simd.store_array_f64x4(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, [1.5, 2.5, 3.5, 4.5]);
 }
 
@@ -45,7 +45,7 @@ fn store_array_i8x16<S: Simd>(simd: S) {
         &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
     );
     let mut dest = [0_i8; 16];
-    simd.store_array_i8x16(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(
         dest,
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
@@ -56,7 +56,7 @@ fn store_array_i8x16<S: Simd>(simd: S) {
 fn store_array_i16x8<S: Simd>(simd: S) {
     let a = i16x8::from_slice(simd, &[1, 2, 3, 4, 5, 6, 7, 8]);
     let mut dest = [0_i16; 8];
-    simd.store_array_i16x8(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, [1, 2, 3, 4, 5, 6, 7, 8]);
 }
 
@@ -64,7 +64,7 @@ fn store_array_i16x8<S: Simd>(simd: S) {
 fn store_array_i32x4<S: Simd>(simd: S) {
     let a = i32x4::from_slice(simd, &[1, 2, 3, 4]);
     let mut dest = [0_i32; 4];
-    simd.store_array_i32x4(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, [1, 2, 3, 4]);
 }
 
@@ -75,7 +75,7 @@ fn store_array_u8x16<S: Simd>(simd: S) {
         &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
     );
     let mut dest = [0_u8; 16];
-    simd.store_array_u8x16(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(
         dest,
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
@@ -86,7 +86,7 @@ fn store_array_u8x16<S: Simd>(simd: S) {
 fn store_array_u16x8<S: Simd>(simd: S) {
     let a = u16x8::from_slice(simd, &[1, 2, 3, 4, 5, 6, 7, 8]);
     let mut dest = [0_u16; 8];
-    simd.store_array_u16x8(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, [1, 2, 3, 4, 5, 6, 7, 8]);
 }
 
@@ -94,7 +94,7 @@ fn store_array_u16x8<S: Simd>(simd: S) {
 fn store_array_u32x4<S: Simd>(simd: S) {
     let a = u32x4::from_slice(simd, &[1, 2, 3, 4]);
     let mut dest = [0_u32; 4];
-    simd.store_array_u32x4(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, [1, 2, 3, 4]);
 }
 
@@ -102,7 +102,7 @@ fn store_array_u32x4<S: Simd>(simd: S) {
 fn store_array_i32x8<S: Simd>(simd: S) {
     let a = i32x8::from_slice(simd, &[1, 2, 3, 4, 5, 6, 7, 8]);
     let mut dest = [0_i32; 8];
-    simd.store_array_i32x8(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, [1, 2, 3, 4, 5, 6, 7, 8]);
 }
 
@@ -110,7 +110,7 @@ fn store_array_i32x8<S: Simd>(simd: S) {
 fn store_array_u32x8<S: Simd>(simd: S) {
     let a = u32x8::from_slice(simd, &[1, 2, 3, 4, 5, 6, 7, 8]);
     let mut dest = [0_u32; 8];
-    simd.store_array_u32x8(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, [1, 2, 3, 4, 5, 6, 7, 8]);
 }
 
@@ -119,7 +119,7 @@ fn store_array_f32x16<S: Simd>(simd: S) {
     let data: [f32; 16] = core::array::from_fn(|i| i as f32);
     let a = f32x16::from_slice(simd, &data);
     let mut dest = [0.0_f32; 16];
-    simd.store_array_f32x16(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, data);
 }
 
@@ -128,7 +128,7 @@ fn store_array_f64x8<S: Simd>(simd: S) {
     let data: [f64; 8] = core::array::from_fn(|i| i as f64);
     let a = f64x8::from_slice(simd, &data);
     let mut dest = [0.0_f64; 8];
-    simd.store_array_f64x8(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, data);
 }
 
@@ -137,7 +137,7 @@ fn store_array_i8x32<S: Simd>(simd: S) {
     let data: [i8; 32] = core::array::from_fn(|i| i8::try_from(i).unwrap());
     let a = i8x32::from_slice(simd, &data);
     let mut dest = [0_i8; 32];
-    simd.store_array_i8x32(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, data);
 }
 
@@ -146,7 +146,7 @@ fn store_array_i8x64<S: Simd>(simd: S) {
     let data: [i8; 64] = core::array::from_fn(|i| i8::try_from(i).unwrap());
     let a = i8x64::from_slice(simd, &data);
     let mut dest = [0_i8; 64];
-    simd.store_array_i8x64(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, data);
 }
 
@@ -155,7 +155,7 @@ fn store_array_i16x16<S: Simd>(simd: S) {
     let data: [i16; 16] = core::array::from_fn(|i| i16::try_from(i).unwrap());
     let a = i16x16::from_slice(simd, &data);
     let mut dest = [0_i16; 16];
-    simd.store_array_i16x16(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, data);
 }
 
@@ -164,7 +164,7 @@ fn store_array_i16x32<S: Simd>(simd: S) {
     let data: [i16; 32] = core::array::from_fn(|i| i16::try_from(i).unwrap());
     let a = i16x32::from_slice(simd, &data);
     let mut dest = [0_i16; 32];
-    simd.store_array_i16x32(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, data);
 }
 
@@ -173,7 +173,7 @@ fn store_array_i32x16<S: Simd>(simd: S) {
     let data: [i32; 16] = core::array::from_fn(|i| i32::try_from(i).unwrap());
     let a = i32x16::from_slice(simd, &data);
     let mut dest = [0_i32; 16];
-    simd.store_array_i32x16(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, data);
 }
 
@@ -182,7 +182,7 @@ fn store_array_u8x32<S: Simd>(simd: S) {
     let data: [u8; 32] = core::array::from_fn(|i| u8::try_from(i).unwrap());
     let a = u8x32::from_slice(simd, &data);
     let mut dest = [0_u8; 32];
-    simd.store_array_u8x32(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, data);
 }
 
@@ -191,7 +191,7 @@ fn store_array_u8x64<S: Simd>(simd: S) {
     let data: [u8; 64] = core::array::from_fn(|i| u8::try_from(i).unwrap());
     let a = u8x64::from_slice(simd, &data);
     let mut dest = [0_u8; 64];
-    simd.store_array_u8x64(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, data);
 }
 
@@ -200,7 +200,7 @@ fn store_array_u16x16<S: Simd>(simd: S) {
     let data: [u16; 16] = core::array::from_fn(|i| u16::try_from(i).unwrap());
     let a = u16x16::from_slice(simd, &data);
     let mut dest = [0_u16; 16];
-    simd.store_array_u16x16(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, data);
 }
 
@@ -209,7 +209,7 @@ fn store_array_u16x32<S: Simd>(simd: S) {
     let data: [u16; 32] = core::array::from_fn(|i| u16::try_from(i).unwrap());
     let a = u16x32::from_slice(simd, &data);
     let mut dest = [0_u16; 32];
-    simd.store_array_u16x32(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, data);
 }
 
@@ -218,7 +218,7 @@ fn store_array_u32x16<S: Simd>(simd: S) {
     let data: [u32; 16] = core::array::from_fn(|i| u32::try_from(i).unwrap());
     let a = u32x16::from_slice(simd, &data);
     let mut dest = [0_u32; 16];
-    simd.store_array_u32x16(a, &mut dest);
+    a.store_array(&mut dest);
     assert_eq!(dest, data);
 }
 
@@ -228,7 +228,7 @@ fn store_array_u32x16<S: Simd>(simd: S) {
 fn store_array_i64x2<S: Simd>(simd: S) {
     let a = i64x2::from_slice(simd, &[1_i64, -2_i64]);
     let mut out = [0_i64; 2];
-    simd.store_array_i64x2(a, &mut out);
+    a.store_array(&mut out);
     assert_eq!(out, [1_i64, -2_i64]);
 }
 
@@ -236,7 +236,7 @@ fn store_array_i64x2<S: Simd>(simd: S) {
 fn store_array_i64x4<S: Simd>(simd: S) {
     let a = i64x4::from_slice(simd, &[1_i64, -2_i64, 3_i64, -4_i64]);
     let mut out = [0_i64; 4];
-    simd.store_array_i64x4(a, &mut out);
+    a.store_array(&mut out);
     assert_eq!(out, [1_i64, -2_i64, 3_i64, -4_i64]);
 }
 
@@ -247,7 +247,7 @@ fn store_array_i64x8<S: Simd>(simd: S) {
         &[1_i64, -2_i64, 3_i64, -4_i64, 5_i64, -6_i64, 7_i64, -8_i64],
     );
     let mut out = [0_i64; 8];
-    simd.store_array_i64x8(a, &mut out);
+    a.store_array(&mut out);
     assert_eq!(
         out,
         [1_i64, -2_i64, 3_i64, -4_i64, 5_i64, -6_i64, 7_i64, -8_i64]
@@ -258,7 +258,7 @@ fn store_array_i64x8<S: Simd>(simd: S) {
 fn store_array_u64x2<S: Simd>(simd: S) {
     let a = u64x2::from_slice(simd, &[1_u64, 2_u64]);
     let mut out = [0_u64; 2];
-    simd.store_array_u64x2(a, &mut out);
+    a.store_array(&mut out);
     assert_eq!(out, [1_u64, 2_u64]);
 }
 
@@ -266,7 +266,7 @@ fn store_array_u64x2<S: Simd>(simd: S) {
 fn store_array_u64x4<S: Simd>(simd: S) {
     let a = u64x4::from_slice(simd, &[1_u64, 2_u64, 3_u64, 4_u64]);
     let mut out = [0_u64; 4];
-    simd.store_array_u64x4(a, &mut out);
+    a.store_array(&mut out);
     assert_eq!(out, [1_u64, 2_u64, 3_u64, 4_u64]);
 }
 
@@ -277,7 +277,7 @@ fn store_array_u64x8<S: Simd>(simd: S) {
         &[1_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64],
     );
     let mut out = [0_u64; 8];
-    simd.store_array_u64x8(a, &mut out);
+    a.store_array(&mut out);
     assert_eq!(
         out,
         [1_u64, 2_u64, 3_u64, 4_u64, 5_u64, 6_u64, 7_u64, 8_u64]


### PR DESCRIPTION
A different take on #286: reduce duplicate code and allow all the same generic programming perks, without creating extra traits and disrupting the existing trait hierarchy.

This is a draft. I am going to port Vello to this to see how it feels in practice before committing to the design.