### PR TITLE
Allow safely creating SIMD level tokens from #[target_feature] functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can find its changes [documented below](#060-2026-07-10).
 
 ### Changed
 
+- The `new_unchecked()` function on SIMD level tokens such as `Avx2` has been renamed to `assume_supported()` and is now safe to call from contexts that already contain the appropriate `#[target_feature]` annotations. Functions without such annotations can still call `assume_supported()` with an `unsafe` block. ([#293][] by [@Shnatsel][])
 - On x86_64 targets with static SSE2 support, `Level::baseline()` now returns `Sse2` instead of `Fallback`. ([#270][] by [@Shnatsel][])
 - The `fxsr` CPU feature is now required for all x86 SIMD levels. It is present in hardware on all SIMD-capable CPUs, but it is possible to disable it in some emulators combined with a custom Rust target specification. ([#270][] by [@Shnatsel][])
 - All native-width non-mask vector types now share `u8s` as their byte representation, enabling `Bytes::bitcast` between arbitrary lane types in code generic over `Simd`. The byte representation of any `SimdBase` type is now also guaranteed to be an idempotent, same-token `u8` SIMD vector, so it can be manipulated directly in generic code.
@@ -285,6 +286,7 @@ No changelog was kept for this release.
 [#264]: https://github.com/linebender/fearless_simd/pull/264
 [#266]: https://github.com/linebender/fearless_simd/pull/266
 [#270]: https://github.com/linebender/fearless_simd/pull/270
+[#270]: https://github.com/linebender/fearless_simd/pull/293
 
 [Unreleased]: https://github.com/linebender/fearless_simd/compare/v0.6.0...HEAD
 [0.6.0]: https://github.com/linebender/fearless_simd/compare/v0.5.0...v0.6.0

--- a/fearless_simd/src/generated.rs
+++ b/fearless_simd/src/generated.rs
@@ -31,7 +31,6 @@
         all(not(target_arch = "x86_64"), not(target_arch = "wasm32"))
     ),
     expect(
-        clippy::missing_safety_doc,
         clippy::new_without_default,
         reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
     )

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -23,6 +23,8 @@ pub struct Avx2 {
 impl Avx2 {
     #[doc = "Create a SIMD token proving that the x86-64-v3 features are available."]
     #[doc = r""]
+    #[doc = r" Most users should safely obtain the token from [`Level::new`] instead of calling this function."]
+    #[doc = r""]
     #[doc = r" This function can be called without an `unsafe` block from a function"]
     #[doc = r" with all the required target features enabled via the `#[target_feature]` annotation."]
     #[doc = r""]

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -28,9 +28,9 @@ impl Avx2 {
     #[doc = r""]
     #[doc = r" # Safety"]
     #[doc = r""]
-    #[doc = "When invoking this function through an `unsafe` block, the caller must ensure that the current CPU supports `fxsr`, `avx2`, `bmi1`, `bmi2`, `cmpxchg16b`, `f16c`, `fma`, `lzcnt`, `movbe`, `popcnt`, `xsave`."]
+    #[doc = "When invoking this function through an `unsafe` block, the caller must ensure that the current CPU supports `avx2`, `bmi1`, `bmi2`, `cmpxchg16b`, `f16c`, `fma`, `fxsr`, `lzcnt`, `movbe`, `popcnt`, `xsave`."]
     #[inline]
-    #[target_feature(enable = "fxsr,avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,lzcnt,movbe,popcnt,xsave")]
+    #[target_feature(enable = "avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,fxsr,lzcnt,movbe,popcnt,xsave")]
     pub const fn new_unchecked() -> Self {
         Self { _private: () }
     }
@@ -102,7 +102,7 @@ impl Simd for Avx2 {
     #[inline]
     fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
         #[target_feature(
-            enable = "fxsr,avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,lzcnt,movbe,popcnt,xsave"
+            enable = "avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,fxsr,lzcnt,movbe,popcnt,xsave"
         )]
         fn vectorize_avx2<F: FnOnce() -> R, R>(f: F) -> R {
             f()

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -33,7 +33,7 @@ impl Avx2 {
     #[doc = "When invoking this function through an `unsafe` block, the caller must ensure that the current CPU supports `avx2`, `bmi1`, `bmi2`, `cmpxchg16b`, `f16c`, `fma`, `fxsr`, `lzcnt`, `movbe`, `popcnt`, `xsave`."]
     #[inline]
     #[target_feature(enable = "avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,fxsr,lzcnt,movbe,popcnt,xsave")]
-    pub const fn new_unchecked() -> Self {
+    pub const fn assume_supported() -> Self {
         Self { _private: () }
     }
 }

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -21,15 +21,17 @@ pub struct Avx2 {
     _private: (),
 }
 impl Avx2 {
-    #[doc = r" Create a SIMD token."]
+    #[doc = "Create a SIMD token proving that the x86-64-v3 features are available."]
+    #[doc = r""]
+    #[doc = r" This function can be called without an `unsafe` block from a function"]
+    #[doc = r" with all the required target features enabled via the `#[target_feature]` annotation."]
     #[doc = r""]
     #[doc = r" # Safety"]
     #[doc = r""]
-    #[doc = r" The `fxsr`, `avx2`, `bmi1`, `bmi2`, `cmpxchg16b`, `f16c`,"]
-    #[doc = r" `fma`, `lzcnt`, `movbe`, `popcnt`, and `xsave` CPU features"]
-    #[doc = r" must be available."]
+    #[doc = "When invoking this function through an `unsafe` block, the caller must ensure that the current CPU supports `fxsr`, `avx2`, `bmi1`, `bmi2`, `cmpxchg16b`, `f16c`, `fma`, `lzcnt`, `movbe`, `popcnt`, `xsave`."]
     #[inline]
-    pub const unsafe fn new_unchecked() -> Self {
+    #[target_feature(enable = "fxsr,avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,lzcnt,movbe,popcnt,xsave")]
+    pub const fn new_unchecked() -> Self {
         Self { _private: () }
     }
 }

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -29,14 +29,19 @@ pub struct Avx512 {
     _private: (),
 }
 impl Avx512 {
-    #[doc = r" Create a SIMD token."]
+    #[doc = "Create a SIMD token proving that the Ice Lake AVX-512 features are available."]
+    #[doc = r""]
+    #[doc = r" This function can be called without an `unsafe` block from a function"]
+    #[doc = r" with all the required target features enabled via the `#[target_feature]` annotation."]
     #[doc = r""]
     #[doc = r" # Safety"]
     #[doc = r""]
-    #[doc = r" The Ice Lake AVX-512 CPU feature set and `fxsr` must be"]
-    #[doc = r" available."]
+    #[doc = "When invoking this function through an `unsafe` block, the caller must ensure that the current CPU supports `fxsr`, `adx`, `aes`, `avx512bitalg`, `avx512bw`, `avx512cd`, `avx512dq`, `avx512f`, `avx512ifma`, `avx512vbmi`, `avx512vbmi2`, `avx512vl`, `avx512vnni`, `avx512vpopcntdq`, `bmi1`, `bmi2`, `cmpxchg16b`, `fma`, `gfni`, `lzcnt`, `movbe`, `pclmulqdq`, `popcnt`, `rdrand`, `rdseed`, `sha`, `vaes`, `vpclmulqdq`, `xsave`, `xsavec`, `xsaveopt`, `xsaves`."]
     #[inline]
-    pub const unsafe fn new_unchecked() -> Self {
+    #[target_feature(
+        enable = "fxsr,adx,aes,avx512bitalg,avx512bw,avx512cd,avx512dq,avx512f,avx512ifma,avx512vbmi,avx512vbmi2,avx512vl,avx512vnni,avx512vpopcntdq,bmi1,bmi2,cmpxchg16b,fma,gfni,lzcnt,movbe,pclmulqdq,popcnt,rdrand,rdseed,sha,vaes,vpclmulqdq,xsave,xsavec,xsaveopt,xsaves"
+    )]
+    pub const fn new_unchecked() -> Self {
         Self { _private: () }
     }
 }

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -36,10 +36,10 @@ impl Avx512 {
     #[doc = r""]
     #[doc = r" # Safety"]
     #[doc = r""]
-    #[doc = "When invoking this function through an `unsafe` block, the caller must ensure that the current CPU supports `fxsr`, `adx`, `aes`, `avx512bitalg`, `avx512bw`, `avx512cd`, `avx512dq`, `avx512f`, `avx512ifma`, `avx512vbmi`, `avx512vbmi2`, `avx512vl`, `avx512vnni`, `avx512vpopcntdq`, `bmi1`, `bmi2`, `cmpxchg16b`, `fma`, `gfni`, `lzcnt`, `movbe`, `pclmulqdq`, `popcnt`, `rdrand`, `rdseed`, `sha`, `vaes`, `vpclmulqdq`, `xsave`, `xsavec`, `xsaveopt`, `xsaves`."]
+    #[doc = "When invoking this function through an `unsafe` block, the caller must ensure that the current CPU supports `adx`, `aes`, `avx512bitalg`, `avx512bw`, `avx512cd`, `avx512dq`, `avx512f`, `avx512ifma`, `avx512vbmi`, `avx512vbmi2`, `avx512vl`, `avx512vnni`, `avx512vpopcntdq`, `bmi1`, `bmi2`, `cmpxchg16b`, `fma`, `fxsr`, `gfni`, `lzcnt`, `movbe`, `pclmulqdq`, `popcnt`, `rdrand`, `rdseed`, `sha`, `vaes`, `vpclmulqdq`, `xsave`, `xsavec`, `xsaveopt`, `xsaves`."]
     #[inline]
     #[target_feature(
-        enable = "fxsr,adx,aes,avx512bitalg,avx512bw,avx512cd,avx512dq,avx512f,avx512ifma,avx512vbmi,avx512vbmi2,avx512vl,avx512vnni,avx512vpopcntdq,bmi1,bmi2,cmpxchg16b,fma,gfni,lzcnt,movbe,pclmulqdq,popcnt,rdrand,rdseed,sha,vaes,vpclmulqdq,xsave,xsavec,xsaveopt,xsaves"
+        enable = "adx,aes,avx512bitalg,avx512bw,avx512cd,avx512dq,avx512f,avx512ifma,avx512vbmi,avx512vbmi2,avx512vl,avx512vnni,avx512vpopcntdq,bmi1,bmi2,cmpxchg16b,fma,fxsr,gfni,lzcnt,movbe,pclmulqdq,popcnt,rdrand,rdseed,sha,vaes,vpclmulqdq,xsave,xsavec,xsaveopt,xsaves"
     )]
     pub const fn new_unchecked() -> Self {
         Self { _private: () }
@@ -112,7 +112,7 @@ impl Simd for Avx512 {
     #[inline]
     fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
         #[target_feature(
-            enable = "fxsr,adx,aes,avx512bitalg,avx512bw,avx512cd,avx512dq,avx512f,avx512ifma,avx512vbmi,avx512vbmi2,avx512vl,avx512vnni,avx512vpopcntdq,bmi1,bmi2,cmpxchg16b,fma,gfni,lzcnt,movbe,pclmulqdq,popcnt,rdrand,rdseed,sha,vaes,vpclmulqdq,xsave,xsavec,xsaveopt,xsaves"
+            enable = "adx,aes,avx512bitalg,avx512bw,avx512cd,avx512dq,avx512f,avx512ifma,avx512vbmi,avx512vbmi2,avx512vl,avx512vnni,avx512vpopcntdq,bmi1,bmi2,cmpxchg16b,fma,fxsr,gfni,lzcnt,movbe,pclmulqdq,popcnt,rdrand,rdseed,sha,vaes,vpclmulqdq,xsave,xsavec,xsaveopt,xsaves"
         )]
         fn vectorize_avx512<F: FnOnce() -> R, R>(f: F) -> R {
             f()

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -31,6 +31,8 @@ pub struct Avx512 {
 impl Avx512 {
     #[doc = "Create a SIMD token proving that the Ice Lake AVX-512 features are available."]
     #[doc = r""]
+    #[doc = r" Most users should safely obtain the token from [`Level::new`] instead of calling this function."]
+    #[doc = r""]
     #[doc = r" This function can be called without an `unsafe` block from a function"]
     #[doc = r" with all the required target features enabled via the `#[target_feature]` annotation."]
     #[doc = r""]

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -43,7 +43,7 @@ impl Avx512 {
     #[target_feature(
         enable = "adx,aes,avx512bitalg,avx512bw,avx512cd,avx512dq,avx512f,avx512ifma,avx512vbmi,avx512vbmi2,avx512vl,avx512vnni,avx512vpopcntdq,bmi1,bmi2,cmpxchg16b,fma,fxsr,gfni,lzcnt,movbe,pclmulqdq,popcnt,rdrand,rdseed,sha,vaes,vpclmulqdq,xsave,xsavec,xsaveopt,xsaves"
     )]
-    pub const fn new_unchecked() -> Self {
+    pub const fn assume_supported() -> Self {
         Self { _private: () }
     }
 }

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -84,6 +84,7 @@ pub struct Fallback {
     _private: (),
 }
 impl Fallback {
+    #[doc = r" Create a scalar fallback token."]
     #[inline]
     pub const fn new() -> Self {
         Self { _private: () }

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -17,8 +17,18 @@ pub struct Neon {
     _private: (),
 }
 impl Neon {
+    #[doc = r" Create a SIMD token proving that Neon is available."]
+    #[doc = r""]
+    #[doc = r" This function can be called safely from a function with the `neon` target feature"]
+    #[doc = r" enabled."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" When invoking this function through an `unsafe` block, the caller must ensure that"]
+    #[doc = r" the current CPU supports `neon`."]
     #[inline]
-    pub const unsafe fn new_unchecked() -> Self {
+    #[target_feature(enable = "neon")]
+    pub const fn new_unchecked() -> Self {
         Neon { _private: () }
     }
 }

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -28,7 +28,7 @@ impl Neon {
     #[doc = r" the current CPU supports `neon`."]
     #[inline]
     #[target_feature(enable = "neon")]
-    pub const fn new_unchecked() -> Self {
+    pub const fn assume_supported() -> Self {
         Neon { _private: () }
     }
 }

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -90,6 +90,8 @@ pub struct Sse2 {
 impl Sse2 {
     #[doc = "Create a SIMD token proving that SSE2 is available.\n\nThis is the baseline on x86-64 and i686 targets. On i586 it needs runtime detection."]
     #[doc = r""]
+    #[doc = r" Most users should safely obtain the token from [`Level::new`] instead of calling this function."]
+    #[doc = r""]
     #[doc = r" This function can be called without an `unsafe` block from a function"]
     #[doc = r" with all the required target features enabled via the `#[target_feature]` annotation."]
     #[doc = r""]

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -100,7 +100,7 @@ impl Sse2 {
     #[doc = "When invoking this function through an `unsafe` block, the caller must ensure that the current CPU supports `fxsr`, `sse`, `sse2`."]
     #[inline]
     #[target_feature(enable = "fxsr,sse,sse2")]
-    pub const fn new_unchecked() -> Self {
+    pub const fn assume_supported() -> Self {
         Self { _private: () }
     }
 }

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -88,13 +88,18 @@ pub struct Sse2 {
     _private: (),
 }
 impl Sse2 {
-    #[doc = r" Create a SIMD token."]
+    #[doc = "Create a SIMD token proving that SSE2 is available."]
+    #[doc = "This is the baseline on x86-64 and i686 targets. On i586 it needs runtime detection."]
+    #[doc = r""]
+    #[doc = r" This function can be called without an `unsafe` block from a function"]
+    #[doc = r" with all the required target features enabled via the `#[target_feature]` annotation."]
     #[doc = r""]
     #[doc = r" # Safety"]
     #[doc = r""]
-    #[doc = r" The `fxsr`, `sse`, and `sse2` CPU features must be available."]
+    #[doc = "When invoking this function through an `unsafe` block, the caller must ensure that the current CPU supports `fxsr`, `sse`, `sse2`."]
     #[inline]
-    pub const unsafe fn new_unchecked() -> Self {
+    #[target_feature(enable = "fxsr,sse,sse2")]
+    pub const fn new_unchecked() -> Self {
         Self { _private: () }
     }
 }

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -88,8 +88,7 @@ pub struct Sse2 {
     _private: (),
 }
 impl Sse2 {
-    #[doc = "Create a SIMD token proving that SSE2 is available."]
-    #[doc = "This is the baseline on x86-64 and i686 targets. On i586 it needs runtime detection."]
+    #[doc = "Create a SIMD token proving that SSE2 is available.\n\nThis is the baseline on x86-64 and i686 targets. On i586 it needs runtime detection."]
     #[doc = r""]
     #[doc = r" This function can be called without an `unsafe` block from a function"]
     #[doc = r" with all the required target features enabled via the `#[target_feature]` annotation."]

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -33,7 +33,7 @@ impl Sse4_2 {
     #[doc = "When invoking this function through an `unsafe` block, the caller must ensure that the current CPU supports `fxsr`, `sse4.2`, `cmpxchg16b`, `popcnt`."]
     #[inline]
     #[target_feature(enable = "fxsr,sse4.2,cmpxchg16b,popcnt")]
-    pub const fn new_unchecked() -> Self {
+    pub const fn assume_supported() -> Self {
         Self { _private: () }
     }
 }

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -21,15 +21,18 @@ pub struct Sse4_2 {
     _private: (),
 }
 impl Sse4_2 {
-    #[doc = r" Create a SIMD token."]
+    #[doc = "Create a SIMD token proving that the x86-64-v2 features are available."]
+    #[doc = r""]
+    #[doc = r" This function can be called without an `unsafe` block from a function"]
+    #[doc = r" with all the required target features enabled via the `#[target_feature]` annotation."]
     #[doc = r""]
     #[doc = r" # Safety"]
     #[doc = r""]
-    #[doc = r" The `fxsr`, `sse4.2`, `cmpxchg16b`, and `popcnt` CPU"]
-    #[doc = r" features must be available."]
+    #[doc = "When invoking this function through an `unsafe` block, the caller must ensure that the current CPU supports `fxsr`, `sse4.2`, `cmpxchg16b`, `popcnt`."]
     #[inline]
-    pub const unsafe fn new_unchecked() -> Self {
-        Sse4_2 { _private: () }
+    #[target_feature(enable = "fxsr,sse4.2,cmpxchg16b,popcnt")]
+    pub const fn new_unchecked() -> Self {
+        Self { _private: () }
     }
 }
 impl Seal for Sse4_2 {}

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -23,6 +23,8 @@ pub struct Sse4_2 {
 impl Sse4_2 {
     #[doc = "Create a SIMD token proving that the x86-64-v2 features are available."]
     #[doc = r""]
+    #[doc = r" Most users should safely obtain the token from [`Level::new`] instead of calling this function."]
+    #[doc = r""]
     #[doc = r" This function can be called without an `unsafe` block from a function"]
     #[doc = r" with all the required target features enabled via the `#[target_feature]` annotation."]
     #[doc = r""]

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -24,7 +24,7 @@ impl WasmSimd128 {
     #[doc = r" available when the library is compiled with `simd128` enabled."]
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
     #[inline]
-    pub const fn new_unchecked() -> Self {
+    pub const fn assume_supported() -> Self {
         Self { _private: () }
     }
 }

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -18,6 +18,10 @@ pub struct WasmSimd128 {
     _private: (),
 }
 impl WasmSimd128 {
+    #[doc = r" Create a SIMD token proving that the WebAssembly `simd128` feature is enabled."]
+    #[doc = r""]
+    #[doc = r" WebAssembly does not support runtime feature detection, so this function is only"]
+    #[doc = r" available when the library is compiled with `simd128` enabled."]
     #[inline]
     pub const fn new_unchecked() -> Self {
         Self { _private: () }

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -22,6 +22,7 @@ impl WasmSimd128 {
     #[doc = r""]
     #[doc = r" WebAssembly does not support runtime feature detection, so this function is only"]
     #[doc = r" available when the library is compiled with `simd128` enabled."]
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
     #[inline]
     pub const fn new_unchecked() -> Self {
         Self { _private: () }

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -310,7 +310,7 @@ fn x86_detects_icelake_avx512() -> bool {
 fn detect_x86_level() -> Level {
     if x86_detects_icelake_avx512() {
         // Safety: All features required by Avx512 were detected above.
-        unsafe { Level::Avx512(Avx512::new_unchecked()) }
+        unsafe { Level::Avx512(Avx512::assume_supported()) }
     // Feature list sourced from `rustc --print=cfg --target x86_64-unknown-linux-gnu -C target-cpu=x86-64-v3`
     // However, the following features are implied by avx2 and do not need to be spelled out:
     // avx,sse,sse2,sse3,sse4.1,sse4.2,ssse3
@@ -329,7 +329,7 @@ fn detect_x86_level() -> Level {
         && std::arch::is_x86_feature_detected!("xsave")
     {
         // Safety: All features required by Avx2 were detected above.
-        unsafe { Level::Avx2(Avx2::new_unchecked()) }
+        unsafe { Level::Avx2(Avx2::assume_supported()) }
     // All x86 CPUs that ever shipped with sse4.2 also have cmpxchg16b and popcnt:
     // Intel Nehalem, AMD Bulldozer and VIA Isaiah II were the first with SSE4.2
     // and have these extensions already.
@@ -345,12 +345,12 @@ fn detect_x86_level() -> Level {
         && std::arch::is_x86_feature_detected!("popcnt")
     {
         // Safety: All features required by Sse4_2 were detected above.
-        unsafe { Level::Sse4_2(Sse4_2::new_unchecked()) }
+        unsafe { Level::Sse4_2(Sse4_2::assume_supported()) }
     } else if std::arch::is_x86_feature_detected!("sse2")
         && std::arch::is_x86_feature_detected!("fxsr")
     {
         // Safety: All features required by Sse2 were detected above.
-        unsafe { Level::Sse2(Sse2::new_unchecked()) }
+        unsafe { Level::Sse2(Sse2::assume_supported()) }
     } else {
         Level::Fallback(Fallback::new())
     }
@@ -407,7 +407,7 @@ impl Level {
     /// On x86-64, it is sometimes possible to detect the available features on `#[no_std]`
     /// by parsing the output of `cpuid` instruction, but this function
     /// [does not do that](https://github.com/linebender/fearless_simd/issues/157).
-    /// If you do this, you can create the SIMD token via [`new_unchecked`](Avx2::new_unchecked)
+    /// If you do this, you can create the SIMD token via [`assume_supported`](Avx2::assume_supported)
     /// and then get the [level](Simd::level) from it.
     ///
     /// Libraries that use SIMD on `#[no_std]` should let the user pass the appropriate SIMD level
@@ -498,7 +498,7 @@ impl Level {
 
     /// If this is a proof that SSE2 (or better) is available, access that instruction set.
     ///
-    /// See [`Sse2::new_unchecked`] for the exact list of CPU features this token enables.
+    /// See [`Sse2::assume_supported`] for the exact list of CPU features this token enables.
     ///
     /// This method should be preferred over matching against the `Sse2` variant of self,
     /// because if the CPU supports a superset of SSE2 (e.g. SSE4.2, AVX2, or AVX-512),
@@ -512,9 +512,9 @@ impl Level {
         match self {
             // Safety: Every stronger x86 SIMD level in this crate includes the `fxsr`,
             // `sse`, and `sse2` features required by Sse2.
-            Self::Avx512(_avx512) => unsafe { Some(Sse2::new_unchecked()) },
-            Self::Avx2(_avx2) => unsafe { Some(Sse2::new_unchecked()) },
-            Self::Sse4_2(_sse4_2) => unsafe { Some(Sse2::new_unchecked()) },
+            Self::Avx512(_avx512) => unsafe { Some(Sse2::assume_supported()) },
+            Self::Avx2(_avx2) => unsafe { Some(Sse2::assume_supported()) },
+            Self::Sse4_2(_sse4_2) => unsafe { Some(Sse2::assume_supported()) },
             Self::Sse2(sse2) => Some(sse2),
             #[allow(
                 unreachable_patterns,
@@ -527,7 +527,7 @@ impl Level {
     /// If this is a proof that x86-64-v2 feature set (or better) is available, access that
     /// instruction set.
     ///
-    /// See [`Sse4_2::new_unchecked`] for the exact list of CPU features this token enables.
+    /// See [`Sse4_2::assume_supported`] for the exact list of CPU features this token enables.
     ///
     /// This method should be preferred over matching against the `Sse4_2` variant of self,
     /// because if the CPU supports a superset of SSE4.2 (e.g. AVX2 or AVX-512),
@@ -541,10 +541,10 @@ impl Level {
         match self {
             // Safety: The Avx512 struct represents an Ice Lake feature set, which includes the
             // `sse4.2`, `cmpxchg16b`, and `popcnt` features required by Sse4_2.
-            Self::Avx512(_avx512) => unsafe { Some(Sse4_2::new_unchecked()) },
+            Self::Avx512(_avx512) => unsafe { Some(Sse4_2::assume_supported()) },
             // Safety: The Avx2 struct represents the x86-64-v3 feature set being enabled, which
             // includes the `sse4.2`, `cmpxchg16b`, and `popcnt` features required by Sse4_2.
-            Self::Avx2(_avx) => unsafe { Some(Sse4_2::new_unchecked()) },
+            Self::Avx2(_avx) => unsafe { Some(Sse4_2::assume_supported()) },
             Self::Sse4_2(sse42) => Some(sse42),
             _ => None,
         }
@@ -553,7 +553,7 @@ impl Level {
     /// If this is a proof that the x86-64-v3 feature set (or better) is available, access that
     /// instruction set.
     ///
-    /// See [`Avx2::new_unchecked`] for the exact list of CPU features this token enables.
+    /// See [`Avx2::assume_supported`] for the exact list of CPU features this token enables.
     ///
     /// This method should be preferred over matching against the `Avx2` variant of self,
     /// because if the CPU supports a superset of AVX2 (e.g. AVX-512),
@@ -570,7 +570,7 @@ impl Level {
         )]
         match self {
             // Safety: The Ice Lake AVX-512 feature set includes the x86-64-v3 features required by Avx2.
-            Self::Avx512(_avx512) => unsafe { Some(Avx2::new_unchecked()) },
+            Self::Avx512(_avx512) => unsafe { Some(Avx2::assume_supported()) },
             Self::Avx2(avx2) => Some(avx2),
             _ => None,
         }
@@ -579,7 +579,7 @@ impl Level {
     /// If this is a proof that the Ice Lake AVX-512 feature set is available, access that
     /// instruction set.
     ///
-    /// See [`Avx512::new_unchecked`] for the exact list of CPU features this token enables.
+    /// See [`Avx512::assume_supported`] for the exact list of CPU features this token enables.
     ///
     /// This can be used in combination with the [kernel] macro to safely access level-specific
     /// SIMD intrinsics.
@@ -629,7 +629,7 @@ impl Level {
         #[cfg(target_arch = "aarch64")]
         {
             #[cfg(target_feature = "neon")]
-            return unsafe { Self::Neon(Neon::new_unchecked()) };
+            return unsafe { Self::Neon(Neon::assume_supported()) };
             #[cfg(not(target_feature = "neon"))]
             return Self::Fallback(Fallback::new());
         }
@@ -669,7 +669,7 @@ impl Level {
                 target_feature = "xsaveopt",
                 target_feature = "xsaves"
             ))]
-            return unsafe { Self::Avx512(Avx512::new_unchecked()) };
+            return unsafe { Self::Avx512(Avx512::assume_supported()) };
             #[cfg(all(
                 target_feature = "avx2",
                 target_feature = "bmi1",
@@ -717,7 +717,7 @@ impl Level {
                     target_feature = "xsaves"
                 ))
             ))]
-            return unsafe { Self::Avx2(Avx2::new_unchecked()) };
+            return unsafe { Self::Avx2(Avx2::assume_supported()) };
             #[cfg(all(
                 all(
                     target_feature = "fxsr",
@@ -739,7 +739,7 @@ impl Level {
                     target_feature = "xsave"
                 ))
             ))]
-            return unsafe { Self::Sse4_2(Sse4_2::new_unchecked()) };
+            return unsafe { Self::Sse4_2(Sse4_2::assume_supported()) };
             #[cfg(all(
                 target_feature = "sse2",
                 target_feature = "fxsr",
@@ -750,14 +750,14 @@ impl Level {
                     target_feature = "popcnt"
                 ))
             ))]
-            return unsafe { Self::Sse2(Sse2::new_unchecked()) };
+            return unsafe { Self::Sse2(Sse2::assume_supported()) };
             #[cfg(not(all(target_feature = "sse2", target_feature = "fxsr")))]
             return Self::Fallback(Fallback::new());
         }
         #[cfg(target_arch = "wasm32")]
         {
             #[cfg(target_feature = "simd128")]
-            return Self::WasmSimd128(WasmSimd128::new_unchecked());
+            return Self::WasmSimd128(WasmSimd128::assume_supported());
             #[cfg(not(target_feature = "simd128"))]
             return Self::Fallback(Fallback::new());
         }

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -434,10 +434,10 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[allow(dead_code, reason = "Compile test")]
     fn x86_level_variants_remain_available() {
-        let _ = Level::Sse2(unsafe { crate::Sse2::new_unchecked() });
-        let _ = Level::Sse4_2(unsafe { crate::Sse4_2::new_unchecked() });
-        let _ = Level::Avx2(unsafe { crate::Avx2::new_unchecked() });
-        let _ = Level::Avx512(unsafe { crate::Avx512::new_unchecked() });
+        let _ = Level::Sse2(unsafe { crate::Sse2::assume_supported() });
+        let _ = Level::Sse4_2(unsafe { crate::Sse4_2::assume_supported() });
+        let _ = Level::Avx2(unsafe { crate::Avx2::assume_supported() });
+        let _ = Level::Avx512(unsafe { crate::Avx512::assume_supported() });
     }
 
     #[allow(dead_code, reason = "Compile test")]

--- a/fearless_simd_dev_macros/src/lib.rs
+++ b/fearless_simd_dev_macros/src/lib.rs
@@ -71,7 +71,7 @@ pub fn simd_test(_: TokenStream, item: TokenStream) -> TokenStream {
         #ignore_neon
         fn #neon_name() {
             if std::arch::is_aarch64_feature_detected!("neon") {
-                let neon = unsafe { fearless_simd::aarch64::Neon::new_unchecked() };
+                let neon = unsafe { fearless_simd::aarch64::Neon::assume_supported() };
                 #input_fn_name(neon);
             }
         }
@@ -87,7 +87,7 @@ pub fn simd_test(_: TokenStream, item: TokenStream) -> TokenStream {
                 && std::arch::is_x86_feature_detected!("cmpxchg16b")
                 && std::arch::is_x86_feature_detected!("popcnt")
             {
-                let sse4 = unsafe { fearless_simd::x86::Sse4_2::new_unchecked() };
+                let sse4 = unsafe { fearless_simd::x86::Sse4_2::assume_supported() };
                 sse4.vectorize(
                     #[inline(always)]
                     || #input_fn_name(sse4)
@@ -105,7 +105,7 @@ pub fn simd_test(_: TokenStream, item: TokenStream) -> TokenStream {
                 && std::arch::is_x86_feature_detected!("sse")
                 && std::arch::is_x86_feature_detected!("sse2")
             {
-                let sse2 = unsafe { fearless_simd::x86::Sse2::new_unchecked() };
+                let sse2 = unsafe { fearless_simd::x86::Sse2::assume_supported() };
                 sse2.vectorize(
                     #[inline(always)]
                     || #input_fn_name(sse2)
@@ -131,7 +131,7 @@ pub fn simd_test(_: TokenStream, item: TokenStream) -> TokenStream {
                 && std::arch::is_x86_feature_detected!("popcnt")
                 && std::arch::is_x86_feature_detected!("xsave")
             {
-                let avx2 = unsafe { fearless_simd::x86::Avx2::new_unchecked() };
+                let avx2 = unsafe { fearless_simd::x86::Avx2::assume_supported() };
                 avx2.vectorize(
                     #[inline(always)]
                     || #input_fn_name(avx2)
@@ -178,7 +178,7 @@ pub fn simd_test(_: TokenStream, item: TokenStream) -> TokenStream {
                 && std::arch::is_x86_feature_detected!("xsaveopt")
                 && std::arch::is_x86_feature_detected!("xsaves")
             {
-                let avx512 = unsafe { fearless_simd::x86::Avx512::new_unchecked() };
+                let avx512 = unsafe { fearless_simd::x86::Avx512::assume_supported() };
                 avx512.vectorize(
                     #[inline(always)]
                     || #input_fn_name(avx512)
@@ -192,7 +192,7 @@ pub fn simd_test(_: TokenStream, item: TokenStream) -> TokenStream {
         #[test]
         #ignore_wasm
         fn #wasm_name() {
-            let wasm = unsafe { fearless_simd::wasm32::WasmSimd128::new_unchecked() };
+            let wasm = unsafe { fearless_simd::wasm32::WasmSimd128::assume_supported() };
             #input_fn_name(wasm);
         }
     };

--- a/fearless_simd_gen/src/level.rs
+++ b/fearless_simd_gen/src/level.rs
@@ -50,7 +50,7 @@ pub(crate) trait Level {
     fn make_module_attrs(&self) -> TokenStream {
         TokenStream::new()
     }
-    /// The body of the SIMD token's inherent `impl` block. By convention, this contains a `new_unchecked`
+    /// The body of the SIMD token's inherent `impl` block. By convention, this contains an `assume_supported`
     /// method for constructing a SIMD token whose required target features are checked by the compiler or upheld by an
     /// unsafe caller, or a safe `new` method for constructing a SIMD token that is always supported.
     fn make_impl_body(&self) -> TokenStream;

--- a/fearless_simd_gen/src/level.rs
+++ b/fearless_simd_gen/src/level.rs
@@ -50,9 +50,9 @@ pub(crate) trait Level {
     fn make_module_attrs(&self) -> TokenStream {
         TokenStream::new()
     }
-    /// The body of the SIMD token's inherent `impl` block. By convention, this contains an unsafe `new_unchecked`
-    /// method for constructing a SIMD token that may not be supported on current hardware, or a safe `new` method for
-    /// constructing a SIMD token that is statically known to be supported.
+    /// The body of the SIMD token's inherent `impl` block. By convention, this contains a `new_unchecked`
+    /// method for constructing a SIMD token whose required target features are checked by the compiler or upheld by an
+    /// unsafe caller, or a safe `new` method for constructing a SIMD token that is always supported.
     fn make_impl_body(&self) -> TokenStream;
     /// Generate a single operation's method on the `Simd` implementation.
     fn make_method(&self, op: Op, vec_ty: &VecType) -> TokenStream;

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -134,6 +134,7 @@ impl Level for Fallback {
 
     fn make_impl_body(&self) -> TokenStream {
         quote! {
+            /// Create a scalar fallback token.
             #[inline]
             pub const fn new() -> Self {
                 Self { _private: () }

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -83,7 +83,7 @@ impl Level for Neon {
             /// the current CPU supports `neon`.
             #[inline]
             #[target_feature(enable = #features)]
-            pub const fn new_unchecked() -> Self {
+            pub const fn assume_supported() -> Self {
                 Neon { _private: () }
             }
         }

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -67,9 +67,23 @@ impl Level for Neon {
     }
 
     fn make_impl_body(&self) -> TokenStream {
+        let features = self
+            .enabled_target_features()
+            .expect("Neon always enables target features");
+
         quote! {
+            /// Create a SIMD token proving that Neon is available.
+            ///
+            /// This function can be called safely from a function with the `neon` target feature
+            /// enabled.
+            ///
+            /// # Safety
+            ///
+            /// When invoking this function through an `unsafe` block, the caller must ensure that
+            /// the current CPU supports `neon`.
             #[inline]
-            pub const unsafe fn new_unchecked() -> Self {
+            #[target_feature(enable = #features)]
+            pub const fn new_unchecked() -> Self {
                 Neon { _private: () }
             }
         }

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -140,7 +140,7 @@ impl Level for WasmSimd128 {
             // since the surrounding code might change in the future.
             #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
             #[inline]
-            pub const fn new_unchecked() -> Self {
+            pub const fn assume_supported() -> Self {
                 Self { _private: () }
             }
         }

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -130,6 +130,10 @@ impl Level for WasmSimd128 {
 
     fn make_impl_body(&self) -> TokenStream {
         quote! {
+            /// Create a SIMD token proving that the WebAssembly `simd128` feature is enabled.
+            ///
+            /// WebAssembly does not support runtime feature detection, so this function is only
+            /// available when the library is compiled with `simd128` enabled.
             #[inline]
             pub const fn new_unchecked() -> Self {
                 Self { _private: () }

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -134,6 +134,11 @@ impl Level for WasmSimd128 {
             ///
             /// WebAssembly does not support runtime feature detection, so this function is only
             /// available when the library is compiled with `simd128` enabled.
+            //
+            // This cfg is redundant with the gate on the containing module.
+            // Keep it here anyway to avoid relying on non-local invariants,
+            // since the surrounding code might change in the future.
+            #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
             #[inline]
             pub const fn new_unchecked() -> Self {
                 Self { _private: () }

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -235,6 +235,8 @@ impl Level for X86 {
         quote! {
             #[doc = #description_doc]
             ///
+            /// Most users should safely obtain the token from [`Level::new`] instead of calling this function.
+            ///
             /// This function can be called without an `unsafe` block from a function
             /// with all the required target features enabled via the `#[target_feature]` annotation.
             ///

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -245,7 +245,7 @@ impl Level for X86 {
             #[doc = #safety_doc]
             #[inline]
             #[target_feature(enable = #features)]
-            pub const fn new_unchecked() -> Self {
+            pub const fn assume_supported() -> Self {
                 Self { _private: () }
             }
         }

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -28,8 +28,8 @@ pub(crate) enum X86 {
 pub(crate) const SSE2_FEATURES: &str = "fxsr,sse,sse2";
 pub(crate) const SSE4_2_FEATURES: &str = "fxsr,sse4.2,cmpxchg16b,popcnt";
 pub(crate) const AVX2_FEATURES: &str =
-    "fxsr,avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,lzcnt,movbe,popcnt,xsave";
-pub(crate) const AVX512_FEATURES: &str = "fxsr,adx,aes,avx512bitalg,avx512bw,avx512cd,avx512dq,avx512f,avx512ifma,avx512vbmi,avx512vbmi2,avx512vl,avx512vnni,avx512vpopcntdq,bmi1,bmi2,cmpxchg16b,fma,gfni,lzcnt,movbe,pclmulqdq,popcnt,rdrand,rdseed,sha,vaes,vpclmulqdq,xsave,xsavec,xsaveopt,xsaves";
+    "avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,fxsr,lzcnt,movbe,popcnt,xsave";
+pub(crate) const AVX512_FEATURES: &str = "adx,aes,avx512bitalg,avx512bw,avx512cd,avx512dq,avx512f,avx512ifma,avx512vbmi,avx512vbmi2,avx512vl,avx512vnni,avx512vpopcntdq,bmi1,bmi2,cmpxchg16b,fma,fxsr,gfni,lzcnt,movbe,pclmulqdq,popcnt,rdrand,rdseed,sha,vaes,vpclmulqdq,xsave,xsavec,xsaveopt,xsaves";
 
 impl Level for X86 {
     fn name(&self) -> &'static str {
@@ -210,55 +210,51 @@ impl Level for X86 {
     }
 
     fn make_impl_body(&self) -> TokenStream {
-        match self {
-            Self::Sse2 => quote! {
-                /// Create a SIMD token.
-                ///
-                /// # Safety
-                ///
-                /// The `fxsr`, `sse`, and `sse2` CPU features must be available.
-                #[inline]
-                pub const unsafe fn new_unchecked() -> Self {
-                    Self { _private: () }
-                }
-            },
-            Self::Sse4_2 => quote! {
-                /// Create a SIMD token.
-                ///
-                /// # Safety
-                ///
-                /// The `fxsr`, `sse4.2`, `cmpxchg16b`, and `popcnt` CPU
-                /// features must be available.
-                #[inline]
-                pub const unsafe fn new_unchecked() -> Self {
-                    Sse4_2 { _private: () }
-                }
-            },
-            Self::Avx2 => quote! {
-                /// Create a SIMD token.
-                ///
-                /// # Safety
-                ///
-                /// The `fxsr`, `avx2`, `bmi1`, `bmi2`, `cmpxchg16b`, `f16c`,
-                /// `fma`, `lzcnt`, `movbe`, `popcnt`, and `xsave` CPU features
-                /// must be available.
-                #[inline]
-                pub const unsafe fn new_unchecked() -> Self {
-                    Self { _private: () }
-                }
-            },
-            Self::Avx512 => quote! {
-                /// Create a SIMD token.
-                ///
-                /// # Safety
-                ///
-                /// The Ice Lake AVX-512 CPU feature set and `fxsr` must be
-                /// available.
-                #[inline]
-                pub const unsafe fn new_unchecked() -> Self {
-                    Self { _private: () }
-                }
-            },
+        let features = self
+            .enabled_target_features()
+            .expect("x86 SIMD levels always enable target features");
+        let (summary_doc, details_doc): (&str, Option<&str>) = match self {
+            Self::Sse2 => (
+                "Create a SIMD token proving that SSE2 is available.",
+                Some(
+                    "This is the baseline on x86-64 and i686 targets. On i586 it needs runtime detection.",
+                ),
+            ),
+            Self::Sse4_2 => (
+                "Create a SIMD token proving that the x86-64-v2 features are available.",
+                None,
+            ),
+            Self::Avx2 => (
+                "Create a SIMD token proving that the x86-64-v3 features are available.",
+                None,
+            ),
+            Self::Avx512 => (
+                "Create a SIMD token proving that the Ice Lake AVX-512 features are available.",
+                None,
+            ),
+        };
+        let details_doc = details_doc.map(|doc| quote! { #[doc = #doc] });
+        let required_features = features.replace(',', "`, `");
+        let safety_doc = format!(
+            "When invoking this function through an `unsafe` block, the caller must ensure \
+             that the current CPU supports `{required_features}`."
+        );
+
+        quote! {
+            #[doc = #summary_doc]
+            #[doc = #details_doc]
+            ///
+            /// This function can be called without an `unsafe` block from a function
+            /// with all the required target features enabled via the `#[target_feature]` annotation.
+            ///
+            /// # Safety
+            ///
+            #[doc = #safety_doc]
+            #[inline]
+            #[target_feature(enable = #features)]
+            pub const fn new_unchecked() -> Self {
+                Self { _private: () }
+            }
         }
     }
 

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -213,27 +213,19 @@ impl Level for X86 {
         let features = self
             .enabled_target_features()
             .expect("x86 SIMD levels always enable target features");
-        let (summary_doc, details_doc): (&str, Option<&str>) = match self {
-            Self::Sse2 => (
-                "Create a SIMD token proving that SSE2 is available.",
-                Some(
-                    "This is the baseline on x86-64 and i686 targets. On i586 it needs runtime detection.",
-                ),
-            ),
-            Self::Sse4_2 => (
-                "Create a SIMD token proving that the x86-64-v2 features are available.",
-                None,
-            ),
-            Self::Avx2 => (
-                "Create a SIMD token proving that the x86-64-v3 features are available.",
-                None,
-            ),
-            Self::Avx512 => (
-                "Create a SIMD token proving that the Ice Lake AVX-512 features are available.",
-                None,
-            ),
+        let description_doc = match self {
+            Self::Sse2 => {
+                "Create a SIMD token proving that SSE2 is available.\n\n\
+                 This is the baseline on x86-64 and i686 targets. On i586 it needs runtime detection."
+            }
+            Self::Sse4_2 => {
+                "Create a SIMD token proving that the x86-64-v2 features are available."
+            }
+            Self::Avx2 => "Create a SIMD token proving that the x86-64-v3 features are available.",
+            Self::Avx512 => {
+                "Create a SIMD token proving that the Ice Lake AVX-512 features are available."
+            }
         };
-        let details_doc = details_doc.map(|doc| quote! { #[doc = #doc] });
         let required_features = features.replace(',', "`, `");
         let safety_doc = format!(
             "When invoking this function through an `unsafe` block, the caller must ensure \
@@ -241,8 +233,7 @@ impl Level for X86 {
         );
 
         quote! {
-            #[doc = #summary_doc]
-            #[doc = #details_doc]
+            #[doc = #description_doc]
             ///
             /// This function can be called without an `unsafe` block from a function
             /// with all the required target features enabled via the `#[target_feature]` annotation.

--- a/fearless_simd_tests/tests/mod.rs
+++ b/fearless_simd_tests/tests/mod.rs
@@ -17,6 +17,7 @@ mod generics;
 mod harness;
 #[cfg(not(miri))] // too slow
 mod soundness;
+mod token_soundness;
 
 #[allow(clippy::allow_attributes, reason = "Only needed in some cfgs.")]
 #[allow(

--- a/fearless_simd_tests/tests/token_soundness.rs
+++ b/fearless_simd_tests/tests/token_soundness.rs
@@ -3,37 +3,37 @@
 
 fearless_simd::kernel!(
     fn create_neon_token(_neon: Neon) -> fearless_simd::Neon {
-        fearless_simd::Neon::new_unchecked()
+        fearless_simd::Neon::assume_supported()
     }
 );
 
 fearless_simd::kernel!(
     fn create_wasm_simd128_token(_wasm_simd128: WasmSimd128) -> fearless_simd::WasmSimd128 {
-        fearless_simd::WasmSimd128::new_unchecked()
+        fearless_simd::WasmSimd128::assume_supported()
     }
 );
 
 fearless_simd::kernel!(
     fn create_sse2_token(_sse2: Sse2) -> fearless_simd::Sse2 {
-        fearless_simd::Sse2::new_unchecked()
+        fearless_simd::Sse2::assume_supported()
     }
 );
 
 fearless_simd::kernel!(
     fn create_sse4_2_token(_sse4_2: Sse4_2) -> fearless_simd::Sse4_2 {
-        fearless_simd::Sse4_2::new_unchecked()
+        fearless_simd::Sse4_2::assume_supported()
     }
 );
 
 fearless_simd::kernel!(
     fn create_avx2_token(_avx2: Avx2) -> fearless_simd::Avx2 {
-        fearless_simd::Avx2::new_unchecked()
+        fearless_simd::Avx2::assume_supported()
     }
 );
 
 fearless_simd::kernel!(
     fn create_avx512_token(_avx512: Avx512) -> fearless_simd::Avx512 {
-        fearless_simd::Avx512::new_unchecked()
+        fearless_simd::Avx512::assume_supported()
     }
 );
 

--- a/fearless_simd_tests/tests/token_soundness.rs
+++ b/fearless_simd_tests/tests/token_soundness.rs
@@ -1,0 +1,98 @@
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+fearless_simd::kernel!(
+    fn create_neon_token(_neon: Neon) -> fearless_simd::Neon {
+        fearless_simd::Neon::new_unchecked()
+    }
+);
+
+fearless_simd::kernel!(
+    fn create_wasm_simd128_token(_wasm_simd128: WasmSimd128) -> fearless_simd::WasmSimd128 {
+        fearless_simd::WasmSimd128::new_unchecked()
+    }
+);
+
+fearless_simd::kernel!(
+    fn create_sse2_token(_sse2: Sse2) -> fearless_simd::Sse2 {
+        fearless_simd::Sse2::new_unchecked()
+    }
+);
+
+fearless_simd::kernel!(
+    fn create_sse4_2_token(_sse4_2: Sse4_2) -> fearless_simd::Sse4_2 {
+        fearless_simd::Sse4_2::new_unchecked()
+    }
+);
+
+fearless_simd::kernel!(
+    fn create_avx2_token(_avx2: Avx2) -> fearless_simd::Avx2 {
+        fearless_simd::Avx2::new_unchecked()
+    }
+);
+
+fearless_simd::kernel!(
+    fn create_avx512_token(_avx512: Avx512) -> fearless_simd::Avx512 {
+        fearless_simd::Avx512::new_unchecked()
+    }
+);
+
+#[cfg(target_arch = "aarch64")]
+#[test]
+fn neon_kernel_features_allow_safe_token_creation() {
+    let Some(neon) = fearless_simd::Level::new().as_neon() else {
+        return;
+    };
+
+    let _ = create_neon_token(neon);
+}
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[test]
+fn wasm_simd128_kernel_allows_safe_token_creation() {
+    let wasm_simd128 = fearless_simd::Level::new()
+        .as_wasm_simd128()
+        .expect("WASM SIMD128 should be available when +simd128 is enabled");
+
+    let _ = create_wasm_simd128_token(wasm_simd128);
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[test]
+fn sse2_kernel_features_allow_safe_token_creation() {
+    let Some(sse2) = fearless_simd::Level::new().as_sse2() else {
+        return;
+    };
+
+    let _ = create_sse2_token(sse2);
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[test]
+fn sse4_2_kernel_features_allow_safe_token_creation() {
+    let Some(sse4_2) = fearless_simd::Level::new().as_sse4_2() else {
+        return;
+    };
+
+    let _ = create_sse4_2_token(sse4_2);
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[test]
+fn avx2_kernel_features_allow_safe_token_creation() {
+    let Some(avx2) = fearless_simd::Level::new().as_avx2() else {
+        return;
+    };
+
+    let _ = create_avx2_token(avx2);
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[test]
+fn avx512_kernel_features_allow_safe_token_creation() {
+    let Some(avx512) = fearless_simd::Level::new().as_avx512() else {
+        return;
+    };
+
+    let _ = create_avx512_token(avx512);
+}


### PR DESCRIPTION
An updated version of #223

Also adds tests that verify that tokens can be safely made inside `kernel!` macros to verify that the target_feature annotations match.