### PR TITLE
Run CI tests in an emulator in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,23 +260,24 @@ jobs:
       - name: build tests
         run: cargo test --no-run $CARGO_TEST_ARGS
 
-      - name: run tests on CPU with only SSE2
-        # -p4p stands for Pentium 4 Prescott, the first Intel 64-bit CPU
-        run: ${SDE_PKG}-lin/sde64 -p4p -- cargo test $CARGO_TEST_ARGS
+      - parallel:
+          - name: run tests on CPU with only SSE2
+            # -p4p stands for Pentium 4 Prescott, the first Intel 64-bit CPU
+            run: ${SDE_PKG}-lin/sde64 -p4p -- cargo test $CARGO_TEST_ARGS
 
-      - name: run tests on CPU with SSE4.2
-        # -nhm stands for Nehalem
-        run: ${SDE_PKG}-lin/sde64 -nhm -- cargo test $CARGO_TEST_ARGS
+          - name: run tests on CPU with SSE4.2
+            # -nhm stands for Nehalem
+            run: ${SDE_PKG}-lin/sde64 -nhm -- cargo test $CARGO_TEST_ARGS
 
-      - name: run tests on CPU with AVX2
-        # -hsw stands for Haswell
-        run: ${SDE_PKG}-lin/sde64 -hsw -- cargo test $CARGO_TEST_ARGS
+          - name: run tests on CPU with AVX2
+            # -hsw stands for Haswell
+            run: ${SDE_PKG}-lin/sde64 -hsw -- cargo test $CARGO_TEST_ARGS
 
-      - name: run tests on CPU with AVX-512
-        # Github Actions doesn't give us AVX-512 so this is the only way to exercise AVX-512 codepaths on CI.
-        # -icl stands for Ice Lake. Technically Skylake added AVX-512 first, but it's mostly useless there due to
-        # downclocking, so our explicit AVX-512 level targets Ice Lake.
-        run: ${SDE_PKG}-lin/sde64 -icl -- cargo test $CARGO_TEST_ARGS
+          - name: run tests on CPU with AVX-512
+            # Github Actions doesn't give us AVX-512 so this is the only way to exercise AVX-512 codepaths on CI.
+            # -icl stands for Ice Lake. Technically Skylake added AVX-512 first, but it's mostly useless there due to
+            # downclocking, so our explicit AVX-512 level targets Ice Lake.
+            run: ${SDE_PKG}-lin/sde64 -icl -- cargo test $CARGO_TEST_ARGS
 
   test-aarch64-qemu:
     # This job runs tests on an emulated CPU that only implements the baseline Aarch64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,9 @@ jobs:
     env:
       # doc tests take a long time to run in the emulator and are already tested elsewhere, so exclude them with --lib --bins --tests
       # the rest of the arguments match the native test jobs
-      CARGO_TEST_ARGS: --lib --bins --tests --workspace --locked --all-features
+      CARGO_TEST_ARGS: --release --lib --bins --tests --workspace --locked --all-features
+      # explicitly enable debug assertions because we're building tests in release mode for performance
+      CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: "true"
       # SDE package name without the platform suffix.
       SDE_PKG: sde-external-10.8.0-2026-03-15
       SDE_SHA256: 50b320cd226acef7a491f5b321fc1be3c3c7984f9e27a456e64894b5b0979dd3


### PR DESCRIPTION
This step has been taking too long and annoying me.

The tests for the four x86 SIMD levels are now run in parallel instead of in series. This maps nicely to the 4 cores in Github's runners: https://docs.github.com/en/actions/reference/runners/github-hosted-runners

This also builds tests to be run in the Intel Software Development Emulator in release mode, trading more build time for faster runtime, which is worthwhile when running in slow emulators.

The total time is now down from 7 minutes to 3 minutes, despite the cold cache; should be even faster with warm cache.

Documentation on the `parallel` directive: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel
Documentation for the Cargo debug assertions override: https://doc.rust-lang.org/cargo/reference/environment-variables.html