### PR TITLE
Add BITS constant to SimdElement

### DIFF
--- a/fearless_simd/src/traits.rs
+++ b/fearless_simd/src/traits.rs
@@ -131,57 +131,47 @@ pub trait SimdElement: Copy + Seal {
     type Mask: SimdElement<Mask = Self::Mask>;
 
     /// The size of an element in bits.
-    const BITS: usize;
+    const BITS: usize = size_of::<Self>() * u8::BITS as usize;
 }
 
 impl SimdElement for f32 {
     type Mask = i32;
-    const BITS: usize = 32;
 }
 
 impl SimdElement for f64 {
     type Mask = i64;
-    const BITS: usize = 64;
 }
 
 impl SimdElement for u8 {
     type Mask = i8;
-    const BITS: usize = 8;
 }
 
 impl SimdElement for i8 {
     type Mask = Self;
-    const BITS: usize = 8;
 }
 
 impl SimdElement for u16 {
     type Mask = i16;
-    const BITS: usize = 16;
 }
 
 impl SimdElement for i16 {
     type Mask = Self;
-    const BITS: usize = 16;
 }
 
 impl SimdElement for u32 {
     type Mask = i32;
-    const BITS: usize = 32;
 }
 
 impl SimdElement for i32 {
     type Mask = Self;
-    const BITS: usize = 32;
 }
 
 impl SimdElement for u64 {
     type Mask = i64;
-    const BITS: usize = 64;
 }
 
 impl SimdElement for i64 {
     type Mask = Self;
-    const BITS: usize = 64;
 }
 
 /// Construction of integer vectors from floats by truncation

--- a/fearless_simd/src/traits.rs
+++ b/fearless_simd/src/traits.rs
@@ -129,46 +129,59 @@ impl<T, S: Simd> SimdFrom<T, S> for T {
 pub trait SimdElement: Copy + Seal {
     /// The associated mask lane type. This will be a signed integer of the same size as this type.
     type Mask: SimdElement<Mask = Self::Mask>;
+
+    /// The size of an element in bits.
+    const BITS: usize;
 }
 
 impl SimdElement for f32 {
     type Mask = i32;
+    const BITS: usize = 32;
 }
 
 impl SimdElement for f64 {
     type Mask = i64;
+    const BITS: usize = 64;
 }
 
 impl SimdElement for u8 {
     type Mask = i8;
+    const BITS: usize = 8;
 }
 
 impl SimdElement for i8 {
     type Mask = Self;
+    const BITS: usize = 8;
 }
 
 impl SimdElement for u16 {
     type Mask = i16;
+    const BITS: usize = 16;
 }
 
 impl SimdElement for i16 {
     type Mask = Self;
+    const BITS: usize = 16;
 }
 
 impl SimdElement for u32 {
     type Mask = i32;
+    const BITS: usize = 32;
 }
 
 impl SimdElement for i32 {
     type Mask = Self;
+    const BITS: usize = 32;
 }
 
 impl SimdElement for u64 {
     type Mask = i64;
+    const BITS: usize = 64;
 }
 
 impl SimdElement for i64 {
     type Mask = Self;
+    const BITS: usize = 64;
 }
 
 /// Construction of integer vectors from floats by truncation


### PR DESCRIPTION
While writing bitpacking routines, this was a blocker for defining generic helpers: given just an `impl SimdInt<S>`, afaict there's no way to find out the bit width of elements, which is necessary in bitpacking for stuff like calculating carry shifts when a packed value spans words. This PR adds a `BITS` constant to `SimdElement`, mirroring the constant of the same name that's defined on primitive types.