### PR TITLE
Move ops shared between SimdInt and SimdFloat to SimdBase

### DIFF
--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -3611,6 +3611,28 @@ pub trait SimdBase<S: Simd>:
     fn swizzle_dyn_within_blocks(self, indices: impl SimdInto<Self::Bytes, S>) -> Self;
     #[doc = "Dynamically swizzle this vector's bytes across the whole vector.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the vector's byte length select the corresponding byte from the input vector. Out-of-range indices produce zero bytes."]
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self;
+    #[doc = "Compare two vectors element-wise for equality.\n\nReturns a mask where each logical lane is true if the corresponding elements are equal, and false if not."]
+    fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
+    #[doc = "Compare two vectors element-wise for less than.\n\nReturns a mask where each logical lane is true if `self` is less than `rhs`, and false if not."]
+    fn simd_lt(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
+    #[doc = "Compare two vectors element-wise for less than or equal.\n\nReturns a mask where each logical lane is true if `self` is less than or equal to `rhs`, and false if not."]
+    fn simd_le(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
+    #[doc = "Compare two vectors element-wise for greater than or equal.\n\nReturns a mask where each logical lane is true if `self` is greater than or equal to `rhs`, and false if not."]
+    fn simd_ge(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
+    #[doc = "Compare two vectors element-wise for greater than.\n\nReturns a mask where each logical lane is true if `self` is greater than `rhs`, and false if not."]
+    fn simd_gt(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
+    #[doc = "Interleave the lower half elements of two vectors.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a0, b0, a1, b1]`.\n\n**Note:** This operation is only useful if you need to discard elements `a2, a3, b2, b3`.\n        For fully interleaving two vectors prefer `interleave`,\n        which is faster than `zip_low` followed by `zip_high` on some platforms."]
+    fn zip_low(self, rhs: impl SimdInto<Self, S>) -> Self;
+    #[doc = "Interleave the upper half elements of two vectors.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a2, b2, a3, b3]`.\n\n**Note:** This operation is only useful if you need to discard elements `a0, a1, b0, b1`.For fully interleaving two vectors prefer `interleave`,\n        which is faster than `zip_low` followed by `zip_high` on some platforms."]
+    fn zip_high(self, rhs: impl SimdInto<Self, S>) -> Self;
+    #[doc = "Extract even-indexed elements from two vectors.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a0, a2, b0, b2]`.\n\n**Note:** This operation is only useful if you need to discard elements `a1, a3, b1, b3`.For fully deinterleaving two vectors prefer `deinterleave`,\n        which is faster than `unzip_low` followed by `unzip_high` on some platforms."]
+    fn unzip_low(self, rhs: impl SimdInto<Self, S>) -> Self;
+    #[doc = "Extract odd-indexed elements from two vectors.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a1, a3, b1, b3]`.\n\n**Note:** This operation is only useful if you need to discard elements `a0, a2, b0, b2`.For fully deinterleaving two vectors prefer `deinterleave`,\n        which is faster than `unzip_low` followed by `unzip_high` on some platforms."]
+    fn unzip_high(self, rhs: impl SimdInto<Self, S>) -> Self;
+    #[doc = "Interleave two vectors.\n\nThe resulting vectors contain elements taken alternately from `self` and `rhs`, first filling the first result, and then the second.\n\nThe reverse of this operation is `deinterleave`.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `([a0, b0, a1, b1], [a2, b2, a3, b3])`."]
+    fn interleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self);
+    #[doc = "Deinterleave two vectors.\n\nThe first result contains all even-indexed elements from `self` followed by all even-indexed elements from `rhs`. The second result contains all odd-indexed elements from `self` followed by all odd-indexed elements from `rhs`.\n\nThe reverse of this operation is `interleave`.\n\nFor vectors `[a0, b0, a1, b1]` and `[a2, b2, a3, b3]`, returns `([a0, a1, a2, a3], [b0, b1, b2, b3])`."]
+    fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self);
 }
 #[doc = r" Functionality implemented by floating-point SIMD vectors."]
 pub trait SimdFloat<S: Simd>:
@@ -3664,28 +3686,6 @@ pub trait SimdFloat<S: Simd>:
     fn approximate_recip(self) -> Self;
     #[doc = "Return a vector with the magnitude of `self` and the sign of `rhs` for each element.\n\nThis operation copies the sign bit, so if an input element is NaN, the output element will be a NaN with the same payload and a copied sign bit."]
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Compare two vectors element-wise for equality.\n\nReturns a mask where each logical lane is true if the corresponding elements are equal, and false if not."]
-    fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
-    #[doc = "Compare two vectors element-wise for less than.\n\nReturns a mask where each logical lane is true if `self` is less than `rhs`, and false if not."]
-    fn simd_lt(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
-    #[doc = "Compare two vectors element-wise for less than or equal.\n\nReturns a mask where each logical lane is true if `self` is less than or equal to `rhs`, and false if not."]
-    fn simd_le(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
-    #[doc = "Compare two vectors element-wise for greater than or equal.\n\nReturns a mask where each logical lane is true if `self` is greater than or equal to `rhs`, and false if not."]
-    fn simd_ge(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
-    #[doc = "Compare two vectors element-wise for greater than.\n\nReturns a mask where each logical lane is true if `self` is greater than `rhs`, and false if not."]
-    fn simd_gt(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
-    #[doc = "Interleave the lower half elements of two vectors.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a0, b0, a1, b1]`.\n\n**Note:** This operation is only useful if you need to discard elements `a2, a3, b2, b3`.\n        For fully interleaving two vectors prefer `interleave`,\n        which is faster than `zip_low` followed by `zip_high` on some platforms."]
-    fn zip_low(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Interleave the upper half elements of two vectors.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a2, b2, a3, b3]`.\n\n**Note:** This operation is only useful if you need to discard elements `a0, a1, b0, b1`.For fully interleaving two vectors prefer `interleave`,\n        which is faster than `zip_low` followed by `zip_high` on some platforms."]
-    fn zip_high(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Extract even-indexed elements from two vectors.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a0, a2, b0, b2]`.\n\n**Note:** This operation is only useful if you need to discard elements `a1, a3, b1, b3`.For fully deinterleaving two vectors prefer `deinterleave`,\n        which is faster than `unzip_low` followed by `unzip_high` on some platforms."]
-    fn unzip_low(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Extract odd-indexed elements from two vectors.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a1, a3, b1, b3]`.\n\n**Note:** This operation is only useful if you need to discard elements `a0, a2, b0, b2`.For fully deinterleaving two vectors prefer `deinterleave`,\n        which is faster than `unzip_low` followed by `unzip_high` on some platforms."]
-    fn unzip_high(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Interleave two vectors.\n\nThe resulting vectors contain elements taken alternately from `self` and `rhs`, first filling the first result, and then the second.\n\nThe reverse of this operation is `deinterleave`.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `([a0, b0, a1, b1], [a2, b2, a3, b3])`."]
-    fn interleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self);
-    #[doc = "Deinterleave two vectors.\n\nThe first result contains all even-indexed elements from `self` followed by all even-indexed elements from `rhs`. The second result contains all odd-indexed elements from `self` followed by all odd-indexed elements from `rhs`.\n\nThe reverse of this operation is `interleave`.\n\nFor vectors `[a0, b0, a1, b1]` and `[a2, b2, a3, b3]`, returns `([a0, a1, a2, a3], [b0, b1, b2, b3])`."]
-    fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self);
     #[doc = "Return the element-wise maximum of two vectors.\n\nIf either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Return the element-wise minimum of two vectors.\n\nIf either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `min_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
@@ -3754,28 +3754,6 @@ pub trait SimdInt<S: Simd>:
     fn to_float<T: SimdCvtFloat<Self>>(self) -> T {
         T::float_from(self)
     }
-    #[doc = "Compare two vectors element-wise for equality.\n\nReturns a mask where each logical lane is true if the corresponding elements are equal, and false if not."]
-    fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
-    #[doc = "Compare two vectors element-wise for less than.\n\nReturns a mask where each logical lane is true if `self` is less than `rhs`, and false if not."]
-    fn simd_lt(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
-    #[doc = "Compare two vectors element-wise for less than or equal.\n\nReturns a mask where each logical lane is true if `self` is less than or equal to `rhs`, and false if not."]
-    fn simd_le(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
-    #[doc = "Compare two vectors element-wise for greater than or equal.\n\nReturns a mask where each logical lane is true if `self` is greater than or equal to `rhs`, and false if not."]
-    fn simd_ge(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
-    #[doc = "Compare two vectors element-wise for greater than.\n\nReturns a mask where each logical lane is true if `self` is greater than `rhs`, and false if not."]
-    fn simd_gt(self, rhs: impl SimdInto<Self, S>) -> Self::Mask;
-    #[doc = "Interleave the lower half elements of two vectors.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a0, b0, a1, b1]`.\n\n**Note:** This operation is only useful if you need to discard elements `a2, a3, b2, b3`.\n        For fully interleaving two vectors prefer `interleave`,\n        which is faster than `zip_low` followed by `zip_high` on some platforms."]
-    fn zip_low(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Interleave the upper half elements of two vectors.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a2, b2, a3, b3]`.\n\n**Note:** This operation is only useful if you need to discard elements `a0, a1, b0, b1`.For fully interleaving two vectors prefer `interleave`,\n        which is faster than `zip_low` followed by `zip_high` on some platforms."]
-    fn zip_high(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Extract even-indexed elements from two vectors.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a0, a2, b0, b2]`.\n\n**Note:** This operation is only useful if you need to discard elements `a1, a3, b1, b3`.For fully deinterleaving two vectors prefer `deinterleave`,\n        which is faster than `unzip_low` followed by `unzip_high` on some platforms."]
-    fn unzip_low(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Extract odd-indexed elements from two vectors.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a1, a3, b1, b3]`.\n\n**Note:** This operation is only useful if you need to discard elements `a0, a2, b0, b2`.For fully deinterleaving two vectors prefer `deinterleave`,\n        which is faster than `unzip_low` followed by `unzip_high` on some platforms."]
-    fn unzip_high(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Interleave two vectors.\n\nThe resulting vectors contain elements taken alternately from `self` and `rhs`, first filling the first result, and then the second.\n\nThe reverse of this operation is `deinterleave`.\n\nFor vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `([a0, b0, a1, b1], [a2, b2, a3, b3])`."]
-    fn interleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self);
-    #[doc = "Deinterleave two vectors.\n\nThe first result contains all even-indexed elements from `self` followed by all even-indexed elements from `rhs`. The second result contains all odd-indexed elements from `self` followed by all odd-indexed elements from `rhs`.\n\nThe reverse of this operation is `interleave`.\n\nFor vectors `[a0, b0, a1, b1]` and `[a2, b2, a3, b3]`, returns `([a0, a1, a2, a3], [b0, b1, b2, b3])`."]
-    fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self);
     #[doc = "Return the element-wise minimum of two vectors."]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Return the element-wise maximum of two vectors."]

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -3511,6 +3511,18 @@ pub trait SimdBase<S: Simd>:
     + core::ops::IndexMut<usize, Output = Self::Element>
     + core::ops::Deref<Target = Self::Array>
     + core::ops::DerefMut<Target = Self::Array>
+    + core::ops::Add<Output = Self>
+    + core::ops::AddAssign
+    + core::ops::Add<Self::Element, Output = Self>
+    + core::ops::AddAssign<Self::Element>
+    + core::ops::Sub<Output = Self>
+    + core::ops::SubAssign
+    + core::ops::Sub<Self::Element, Output = Self>
+    + core::ops::SubAssign<Self::Element>
+    + core::ops::Mul<Output = Self>
+    + core::ops::MulAssign
+    + core::ops::Mul<Self::Element, Output = Self>
+    + core::ops::MulAssign<Self::Element>
 {
     #[doc = r" The type of this vector's elements."]
     type Element: SimdElement;
@@ -3639,18 +3651,6 @@ pub trait SimdFloat<S: Simd>:
     SimdBase<S>
     + Seal
     + core::ops::Neg<Output = Self>
-    + core::ops::Add<Output = Self>
-    + core::ops::AddAssign
-    + core::ops::Add<Self::Element, Output = Self>
-    + core::ops::AddAssign<Self::Element>
-    + core::ops::Sub<Output = Self>
-    + core::ops::SubAssign
-    + core::ops::Sub<Self::Element, Output = Self>
-    + core::ops::SubAssign<Self::Element>
-    + core::ops::Mul<Output = Self>
-    + core::ops::MulAssign
-    + core::ops::Mul<Self::Element, Output = Self>
-    + core::ops::MulAssign<Self::Element>
     + core::ops::Div<Output = Self>
     + core::ops::DivAssign
     + core::ops::Div<Self::Element, Output = Self>
@@ -3713,18 +3713,6 @@ pub trait SimdFloat<S: Simd>:
 pub trait SimdInt<S: Simd>:
     SimdBase<S>
     + Seal
-    + core::ops::Add<Output = Self>
-    + core::ops::AddAssign
-    + core::ops::Add<Self::Element, Output = Self>
-    + core::ops::AddAssign<Self::Element>
-    + core::ops::Sub<Output = Self>
-    + core::ops::SubAssign
-    + core::ops::Sub<Self::Element, Output = Self>
-    + core::ops::SubAssign<Self::Element>
-    + core::ops::Mul<Output = Self>
-    + core::ops::MulAssign
-    + core::ops::Mul<Self::Element, Output = Self>
-    + core::ops::MulAssign<Self::Element>
     + core::ops::BitAnd<Output = Self>
     + core::ops::BitAndAssign
     + core::ops::BitAnd<Self::Element, Output = Self>

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -166,24 +166,6 @@ impl<S: Simd> SimdBase<S> for f32x4<S> {
         self.simd
             .swizzle_dyn_precise_f32x4(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdFloat<S> for f32x4<S> {
-    #[inline(always)]
-    fn abs(self) -> Self {
-        self.simd.abs_f32x4(self)
-    }
-    #[inline(always)]
-    fn sqrt(self) -> Self {
-        self.simd.sqrt_f32x4(self)
-    }
-    #[inline(always)]
-    fn approximate_recip(self) -> Self {
-        self.simd.approximate_recip_f32x4(self)
-    }
-    #[inline(always)]
-    fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
-        self.simd.copysign_f32x4(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_f32x4(self, rhs.simd_into(self.simd))
@@ -227,6 +209,24 @@ impl<S: Simd> crate::SimdFloat<S> for f32x4<S> {
     #[inline(always)]
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_f32x4(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> crate::SimdFloat<S> for f32x4<S> {
+    #[inline(always)]
+    fn abs(self) -> Self {
+        self.simd.abs_f32x4(self)
+    }
+    #[inline(always)]
+    fn sqrt(self) -> Self {
+        self.simd.sqrt_f32x4(self)
+    }
+    #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f32x4(self)
+    }
+    #[inline(always)]
+    fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd.copysign_f32x4(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -475,8 +475,6 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
         self.simd
             .swizzle_dyn_precise_i8x16(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for i8x16<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_i8x16(self, rhs.simd_into(self.simd))
@@ -521,6 +519,8 @@ impl<S: Simd> crate::SimdInt<S> for i8x16<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_i8x16(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for i8x16<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_i8x16(self, rhs.simd_into(self.simd))
@@ -716,8 +716,6 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
         self.simd
             .swizzle_dyn_precise_u8x16(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for u8x16<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_u8x16(self, rhs.simd_into(self.simd))
@@ -762,6 +760,8 @@ impl<S: Simd> crate::SimdInt<S> for u8x16<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_u8x16(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for u8x16<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_u8x16(self, rhs.simd_into(self.simd))
@@ -1043,8 +1043,6 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
         self.simd
             .swizzle_dyn_precise_i16x8(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for i16x8<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_i16x8(self, rhs.simd_into(self.simd))
@@ -1089,6 +1087,8 @@ impl<S: Simd> crate::SimdInt<S> for i16x8<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_i16x8(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for i16x8<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_i16x8(self, rhs.simd_into(self.simd))
@@ -1276,8 +1276,6 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
         self.simd
             .swizzle_dyn_precise_u16x8(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for u16x8<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_u16x8(self, rhs.simd_into(self.simd))
@@ -1322,6 +1320,8 @@ impl<S: Simd> crate::SimdInt<S> for u16x8<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_u16x8(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for u16x8<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_u16x8(self, rhs.simd_into(self.simd))
@@ -1591,8 +1591,6 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
         self.simd
             .swizzle_dyn_precise_i32x4(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for i32x4<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_i32x4(self, rhs.simd_into(self.simd))
@@ -1637,6 +1635,8 @@ impl<S: Simd> crate::SimdInt<S> for i32x4<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_i32x4(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for i32x4<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_i32x4(self, rhs.simd_into(self.simd))
@@ -1824,8 +1824,6 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
         self.simd
             .swizzle_dyn_precise_u32x4(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for u32x4<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_u32x4(self, rhs.simd_into(self.simd))
@@ -1870,6 +1868,8 @@ impl<S: Simd> crate::SimdInt<S> for u32x4<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_u32x4(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for u32x4<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_u32x4(self, rhs.simd_into(self.simd))
@@ -2151,24 +2151,6 @@ impl<S: Simd> SimdBase<S> for f64x2<S> {
         self.simd
             .swizzle_dyn_precise_f64x2(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdFloat<S> for f64x2<S> {
-    #[inline(always)]
-    fn abs(self) -> Self {
-        self.simd.abs_f64x2(self)
-    }
-    #[inline(always)]
-    fn sqrt(self) -> Self {
-        self.simd.sqrt_f64x2(self)
-    }
-    #[inline(always)]
-    fn approximate_recip(self) -> Self {
-        self.simd.approximate_recip_f64x2(self)
-    }
-    #[inline(always)]
-    fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
-        self.simd.copysign_f64x2(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_f64x2(self, rhs.simd_into(self.simd))
@@ -2212,6 +2194,24 @@ impl<S: Simd> crate::SimdFloat<S> for f64x2<S> {
     #[inline(always)]
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_f64x2(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> crate::SimdFloat<S> for f64x2<S> {
+    #[inline(always)]
+    fn abs(self) -> Self {
+        self.simd.abs_f64x2(self)
+    }
+    #[inline(always)]
+    fn sqrt(self) -> Self {
+        self.simd.sqrt_f64x2(self)
+    }
+    #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f64x2(self)
+    }
+    #[inline(always)]
+    fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd.copysign_f64x2(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -2426,8 +2426,6 @@ impl<S: Simd> SimdBase<S> for i64x2<S> {
         self.simd
             .swizzle_dyn_precise_i64x2(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for i64x2<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_i64x2(self, rhs.simd_into(self.simd))
@@ -2472,6 +2470,8 @@ impl<S: Simd> crate::SimdInt<S> for i64x2<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_i64x2(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for i64x2<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_i64x2(self, rhs.simd_into(self.simd))
@@ -2647,8 +2647,6 @@ impl<S: Simd> SimdBase<S> for u64x2<S> {
         self.simd
             .swizzle_dyn_precise_u64x2(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for u64x2<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_u64x2(self, rhs.simd_into(self.simd))
@@ -2693,6 +2691,8 @@ impl<S: Simd> crate::SimdInt<S> for u64x2<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_u64x2(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for u64x2<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_u64x2(self, rhs.simd_into(self.simd))
@@ -2974,24 +2974,6 @@ impl<S: Simd> SimdBase<S> for f32x8<S> {
         self.simd
             .swizzle_dyn_precise_f32x8(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdFloat<S> for f32x8<S> {
-    #[inline(always)]
-    fn abs(self) -> Self {
-        self.simd.abs_f32x8(self)
-    }
-    #[inline(always)]
-    fn sqrt(self) -> Self {
-        self.simd.sqrt_f32x8(self)
-    }
-    #[inline(always)]
-    fn approximate_recip(self) -> Self {
-        self.simd.approximate_recip_f32x8(self)
-    }
-    #[inline(always)]
-    fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
-        self.simd.copysign_f32x8(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_f32x8(self, rhs.simd_into(self.simd))
@@ -3035,6 +3017,24 @@ impl<S: Simd> crate::SimdFloat<S> for f32x8<S> {
     #[inline(always)]
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_f32x8(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> crate::SimdFloat<S> for f32x8<S> {
+    #[inline(always)]
+    fn abs(self) -> Self {
+        self.simd.abs_f32x8(self)
+    }
+    #[inline(always)]
+    fn sqrt(self) -> Self {
+        self.simd.sqrt_f32x8(self)
+    }
+    #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f32x8(self)
+    }
+    #[inline(always)]
+    fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd.copysign_f32x8(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -3306,8 +3306,6 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
         self.simd
             .swizzle_dyn_precise_i8x32(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for i8x32<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_i8x32(self, rhs.simd_into(self.simd))
@@ -3352,6 +3350,8 @@ impl<S: Simd> crate::SimdInt<S> for i8x32<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_i8x32(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for i8x32<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_i8x32(self, rhs.simd_into(self.simd))
@@ -3570,8 +3570,6 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
         self.simd
             .swizzle_dyn_precise_u8x32(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for u8x32<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_u8x32(self, rhs.simd_into(self.simd))
@@ -3616,6 +3614,8 @@ impl<S: Simd> crate::SimdInt<S> for u8x32<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_u8x32(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for u8x32<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_u8x32(self, rhs.simd_into(self.simd))
@@ -3913,8 +3913,6 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
         self.simd
             .swizzle_dyn_precise_i16x16(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for i16x16<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_i16x16(self, rhs.simd_into(self.simd))
@@ -3960,6 +3958,8 @@ impl<S: Simd> crate::SimdInt<S> for i16x16<S> {
         self.simd
             .deinterleave_i16x16(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for i16x16<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_i16x16(self, rhs.simd_into(self.simd))
@@ -4163,8 +4163,6 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
         self.simd
             .swizzle_dyn_precise_u16x16(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for u16x16<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_u16x16(self, rhs.simd_into(self.simd))
@@ -4210,6 +4208,8 @@ impl<S: Simd> crate::SimdInt<S> for u16x16<S> {
         self.simd
             .deinterleave_u16x16(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for u16x16<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_u16x16(self, rhs.simd_into(self.simd))
@@ -4498,8 +4498,6 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
         self.simd
             .swizzle_dyn_precise_i32x8(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for i32x8<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_i32x8(self, rhs.simd_into(self.simd))
@@ -4544,6 +4542,8 @@ impl<S: Simd> crate::SimdInt<S> for i32x8<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_i32x8(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for i32x8<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_i32x8(self, rhs.simd_into(self.simd))
@@ -4750,8 +4750,6 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
         self.simd
             .swizzle_dyn_precise_u32x8(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for u32x8<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_u32x8(self, rhs.simd_into(self.simd))
@@ -4796,6 +4794,8 @@ impl<S: Simd> crate::SimdInt<S> for u32x8<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_u32x8(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for u32x8<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_u32x8(self, rhs.simd_into(self.simd))
@@ -5084,24 +5084,6 @@ impl<S: Simd> SimdBase<S> for f64x4<S> {
         self.simd
             .swizzle_dyn_precise_f64x4(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdFloat<S> for f64x4<S> {
-    #[inline(always)]
-    fn abs(self) -> Self {
-        self.simd.abs_f64x4(self)
-    }
-    #[inline(always)]
-    fn sqrt(self) -> Self {
-        self.simd.sqrt_f64x4(self)
-    }
-    #[inline(always)]
-    fn approximate_recip(self) -> Self {
-        self.simd.approximate_recip_f64x4(self)
-    }
-    #[inline(always)]
-    fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
-        self.simd.copysign_f64x4(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_f64x4(self, rhs.simd_into(self.simd))
@@ -5145,6 +5127,24 @@ impl<S: Simd> crate::SimdFloat<S> for f64x4<S> {
     #[inline(always)]
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_f64x4(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> crate::SimdFloat<S> for f64x4<S> {
+    #[inline(always)]
+    fn abs(self) -> Self {
+        self.simd.abs_f64x4(self)
+    }
+    #[inline(always)]
+    fn sqrt(self) -> Self {
+        self.simd.sqrt_f64x4(self)
+    }
+    #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f64x4(self)
+    }
+    #[inline(always)]
+    fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd.copysign_f64x4(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -5366,8 +5366,6 @@ impl<S: Simd> SimdBase<S> for i64x4<S> {
         self.simd
             .swizzle_dyn_precise_i64x4(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for i64x4<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_i64x4(self, rhs.simd_into(self.simd))
@@ -5412,6 +5410,8 @@ impl<S: Simd> crate::SimdInt<S> for i64x4<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_i64x4(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for i64x4<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_i64x4(self, rhs.simd_into(self.simd))
@@ -5594,8 +5594,6 @@ impl<S: Simd> SimdBase<S> for u64x4<S> {
         self.simd
             .swizzle_dyn_precise_u64x4(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for u64x4<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_u64x4(self, rhs.simd_into(self.simd))
@@ -5640,6 +5638,8 @@ impl<S: Simd> crate::SimdInt<S> for u64x4<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_u64x4(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for u64x4<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_u64x4(self, rhs.simd_into(self.simd))
@@ -5938,24 +5938,6 @@ impl<S: Simd> SimdBase<S> for f32x16<S> {
         self.simd
             .swizzle_dyn_precise_f32x16(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdFloat<S> for f32x16<S> {
-    #[inline(always)]
-    fn abs(self) -> Self {
-        self.simd.abs_f32x16(self)
-    }
-    #[inline(always)]
-    fn sqrt(self) -> Self {
-        self.simd.sqrt_f32x16(self)
-    }
-    #[inline(always)]
-    fn approximate_recip(self) -> Self {
-        self.simd.approximate_recip_f32x16(self)
-    }
-    #[inline(always)]
-    fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
-        self.simd.copysign_f32x16(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_f32x16(self, rhs.simd_into(self.simd))
@@ -6000,6 +5982,24 @@ impl<S: Simd> crate::SimdFloat<S> for f32x16<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd
             .deinterleave_f32x16(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> crate::SimdFloat<S> for f32x16<S> {
+    #[inline(always)]
+    fn abs(self) -> Self {
+        self.simd.abs_f32x16(self)
+    }
+    #[inline(always)]
+    fn sqrt(self) -> Self {
+        self.simd.sqrt_f32x16(self)
+    }
+    #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f32x16(self)
+    }
+    #[inline(always)]
+    fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd.copysign_f32x16(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -6297,8 +6297,6 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
         self.simd
             .swizzle_dyn_precise_i8x64(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for i8x64<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_i8x64(self, rhs.simd_into(self.simd))
@@ -6343,6 +6341,8 @@ impl<S: Simd> crate::SimdInt<S> for i8x64<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_i8x64(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for i8x64<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_i8x64(self, rhs.simd_into(self.simd))
@@ -6587,8 +6587,6 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
         self.simd
             .swizzle_dyn_precise_u8x64(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for u8x64<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_u8x64(self, rhs.simd_into(self.simd))
@@ -6633,6 +6631,8 @@ impl<S: Simd> crate::SimdInt<S> for u8x64<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_u8x64(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for u8x64<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_u8x64(self, rhs.simd_into(self.simd))
@@ -6940,8 +6940,6 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
         self.simd
             .swizzle_dyn_precise_i16x32(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for i16x32<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_i16x32(self, rhs.simd_into(self.simd))
@@ -6987,6 +6985,8 @@ impl<S: Simd> crate::SimdInt<S> for i16x32<S> {
         self.simd
             .deinterleave_i16x32(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for i16x32<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_i16x32(self, rhs.simd_into(self.simd))
@@ -7200,8 +7200,6 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
         self.simd
             .swizzle_dyn_precise_u16x32(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for u16x32<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_u16x32(self, rhs.simd_into(self.simd))
@@ -7247,6 +7245,8 @@ impl<S: Simd> crate::SimdInt<S> for u16x32<S> {
         self.simd
             .deinterleave_u16x32(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for u16x32<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_u16x32(self, rhs.simd_into(self.simd))
@@ -7538,8 +7538,6 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
         self.simd
             .swizzle_dyn_precise_i32x16(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for i32x16<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_i32x16(self, rhs.simd_into(self.simd))
@@ -7585,6 +7583,8 @@ impl<S: Simd> crate::SimdInt<S> for i32x16<S> {
         self.simd
             .deinterleave_i32x16(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for i32x16<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_i32x16(self, rhs.simd_into(self.simd))
@@ -7794,8 +7794,6 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
         self.simd
             .swizzle_dyn_precise_u32x16(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for u32x16<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_u32x16(self, rhs.simd_into(self.simd))
@@ -7841,6 +7839,8 @@ impl<S: Simd> crate::SimdInt<S> for u32x16<S> {
         self.simd
             .deinterleave_u32x16(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for u32x16<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_u32x16(self, rhs.simd_into(self.simd))
@@ -8135,24 +8135,6 @@ impl<S: Simd> SimdBase<S> for f64x8<S> {
         self.simd
             .swizzle_dyn_precise_f64x8(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdFloat<S> for f64x8<S> {
-    #[inline(always)]
-    fn abs(self) -> Self {
-        self.simd.abs_f64x8(self)
-    }
-    #[inline(always)]
-    fn sqrt(self) -> Self {
-        self.simd.sqrt_f64x8(self)
-    }
-    #[inline(always)]
-    fn approximate_recip(self) -> Self {
-        self.simd.approximate_recip_f64x8(self)
-    }
-    #[inline(always)]
-    fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
-        self.simd.copysign_f64x8(self, rhs.simd_into(self.simd))
-    }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_f64x8(self, rhs.simd_into(self.simd))
@@ -8196,6 +8178,24 @@ impl<S: Simd> crate::SimdFloat<S> for f64x8<S> {
     #[inline(always)]
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_f64x8(self, rhs.simd_into(self.simd))
+    }
+}
+impl<S: Simd> crate::SimdFloat<S> for f64x8<S> {
+    #[inline(always)]
+    fn abs(self) -> Self {
+        self.simd.abs_f64x8(self)
+    }
+    #[inline(always)]
+    fn sqrt(self) -> Self {
+        self.simd.sqrt_f64x8(self)
+    }
+    #[inline(always)]
+    fn approximate_recip(self) -> Self {
+        self.simd.approximate_recip_f64x8(self)
+    }
+    #[inline(always)]
+    fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd.copysign_f64x8(self, rhs.simd_into(self.simd))
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -8423,8 +8423,6 @@ impl<S: Simd> SimdBase<S> for i64x8<S> {
         self.simd
             .swizzle_dyn_precise_i64x8(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for i64x8<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_i64x8(self, rhs.simd_into(self.simd))
@@ -8469,6 +8467,8 @@ impl<S: Simd> crate::SimdInt<S> for i64x8<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_i64x8(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for i64x8<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_i64x8(self, rhs.simd_into(self.simd))
@@ -8657,8 +8657,6 @@ impl<S: Simd> SimdBase<S> for u64x8<S> {
         self.simd
             .swizzle_dyn_precise_u64x8(self, indices.simd_into(self.simd))
     }
-}
-impl<S: Simd> crate::SimdInt<S> for u64x8<S> {
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self::Mask {
         self.simd.simd_eq_u64x8(self, rhs.simd_into(self.simd))
@@ -8703,6 +8701,8 @@ impl<S: Simd> crate::SimdInt<S> for u64x8<S> {
     fn deinterleave(self, rhs: impl SimdInto<Self, S>) -> (Self, Self) {
         self.simd.deinterleave_u64x8(self, rhs.simd_into(self.simd))
     }
+}
+impl<S: Simd> crate::SimdInt<S> for u64x8<S> {
     #[inline(always)]
     fn min(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.min_u64x8(self, rhs.simd_into(self.simd))

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -172,6 +172,10 @@ fn mk_simd_base() -> TokenStream {
             });
         }
     }
+    let overloaded_ops = [CoreOpTrait::Add, CoreOpTrait::Sub, CoreOpTrait::Mul];
+    let op_traits = overloaded_ops
+        .iter()
+        .flat_map(|core_op| core_op.trait_bounds());
 
     quote! {
         /// Base functionality implemented by all SIMD vectors.
@@ -181,6 +185,7 @@ fn mk_simd_base() -> TokenStream {
             + Bytes<Bytes = Self::ByteVector> + SimdFrom<Self::Element, S> + SimdFrom<Self::Array, S>
             + core::ops::Index<usize, Output = Self::Element> + core::ops::IndexMut<usize, Output = Self::Element>
             + core::ops::Deref<Target = Self::Array>+ core::ops::DerefMut<Target = Self::Array>
+            #(+ #op_traits)*
         {
             /// The type of this vector's elements.
             type Element: SimdElement;
@@ -278,6 +283,7 @@ fn mk_simd_float() -> TokenStream {
             OpKind::Overloaded(core_op) => Some(core_op),
             _ => None,
         })
+        .filter(|core_op| !is_base_arithmetic(core_op))
         .flat_map(|core_op| core_op.trait_bounds());
     quote! {
         /// Functionality implemented by floating-point SIMD vectors.
@@ -318,6 +324,7 @@ fn mk_simd_int() -> TokenStream {
             OpKind::Overloaded(core_op) => Some(core_op),
             _ => None,
         })
+        .filter(|core_op| !is_base_arithmetic(core_op))
         .flat_map(|core_op| core_op.trait_bounds());
     quote! {
         /// Functionality implemented by (signed and unsigned) integer SIMD vectors.
@@ -333,6 +340,13 @@ fn mk_simd_int() -> TokenStream {
             #( #methods )*
         }
     }
+}
+
+fn is_base_arithmetic(core_op: &CoreOpTrait) -> bool {
+    matches!(
+        core_op,
+        CoreOpTrait::Add | CoreOpTrait::Sub | CoreOpTrait::Mul
+    )
 }
 
 fn mk_simd_mask() -> TokenStream {

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -8,7 +8,7 @@ use crate::{
     generic::{generic_op_name, unrolled_array},
     ops::{
         F32_TO_I32, F32_TO_I32_PRECISE, F32_TO_U32, F32_TO_U32_PRECISE, I32_TO_F32, Op, OpSig,
-        TyFlavor, U32_TO_F32, vec_trait_ops_for,
+        TyFlavor, U32_TO_F32, base_trait_ops, vec_trait_ops_for,
     },
     types::{SIMD_TYPES, ScalarType, VecType},
 };
@@ -395,6 +395,26 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
     };
     let vec_trait_id = Ident::new(vec_trait, Span::call_site());
     let splat = generic_op_name("splat", ty);
+    let mut base_methods = vec![];
+    for op in base_trait_ops() {
+        let Op { sig, method, .. } = op;
+        if matches!(sig, OpSig::Splat) {
+            continue;
+        }
+        let Some(call_args) = sig.forwarding_call_args() else {
+            continue;
+        };
+        let trait_method = generic_op_name(method, ty);
+        let method_sig = op
+            .vec_trait_method_sig()
+            .expect("base trait operation must have a vector method signature");
+        base_methods.push(quote! {
+            #[inline(always)]
+            #method_sig {
+                self.simd.#trait_method(#call_args)
+            }
+        });
+    }
     let mut methods = vec![];
     for op in vec_trait_ops_for(ty.scalar) {
         let Op { sig, method, .. } = op;
@@ -532,6 +552,8 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
             fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
                 self.simd.#swizzle_dyn_precise_op(self, indices.simd_into(self.simd))
             }
+
+            #( #base_methods )*
         }
         impl<S: Simd> crate::#vec_trait_id<S> for #name<S> {
             #( #methods )*

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -558,6 +558,104 @@ const BASE_OPS: &[Op] = &[
     ),
 ];
 
+const COMMON_BASE_OPS: &[Op] = &[
+    Op::new(
+        "simd_eq",
+        OpKind::BaseTraitMethod,
+        OpSig::Compare,
+        "Compare two vectors element-wise for equality.\n\n\
+        Returns a mask where each logical lane is true if the corresponding elements are equal, and false if not.",
+    ),
+    Op::new(
+        "simd_lt",
+        OpKind::BaseTraitMethod,
+        OpSig::Compare,
+        "Compare two vectors element-wise for less than.\n\n\
+        Returns a mask where each logical lane is true if `{arg0}` is less than `{arg1}`, and false if not.",
+    ),
+    Op::new(
+        "simd_le",
+        OpKind::BaseTraitMethod,
+        OpSig::Compare,
+        "Compare two vectors element-wise for less than or equal.\n\n\
+        Returns a mask where each logical lane is true if `{arg0}` is less than or equal to `{arg1}`, and false if not.",
+    ),
+    Op::new(
+        "simd_ge",
+        OpKind::BaseTraitMethod,
+        OpSig::Compare,
+        "Compare two vectors element-wise for greater than or equal.\n\n\
+        Returns a mask where each logical lane is true if `{arg0}` is greater than or equal to `{arg1}`, and false if not.",
+    ),
+    Op::new(
+        "simd_gt",
+        OpKind::BaseTraitMethod,
+        OpSig::Compare,
+        "Compare two vectors element-wise for greater than.\n\n\
+        Returns a mask where each logical lane is true if `{arg0}` is greater than `{arg1}`, and false if not.",
+    ),
+    Op::new(
+        "zip_low",
+        OpKind::BaseTraitMethod,
+        OpSig::Zip { select_low: true },
+        "Interleave the lower half elements of two vectors.\n\n\
+        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a0, b0, a1, b1]`.\n\n\
+        **Note:** This operation is only useful if you need to discard elements `a2, a3, b2, b3`.
+        For fully interleaving two vectors prefer `interleave`,
+        which is faster than `zip_low` followed by `zip_high` on some platforms.",
+    ),
+    Op::new(
+        "zip_high",
+        OpKind::BaseTraitMethod,
+        OpSig::Zip { select_low: false },
+        "Interleave the upper half elements of two vectors.\n\n\
+        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a2, b2, a3, b3]`.\n\n\
+        **Note:** This operation is only useful if you need to discard elements `a0, a1, b0, b1`.\
+        For fully interleaving two vectors prefer `interleave`,
+        which is faster than `zip_low` followed by `zip_high` on some platforms.",
+    ),
+    Op::new(
+        "unzip_low",
+        OpKind::BaseTraitMethod,
+        OpSig::Unzip { select_even: true },
+        "Extract even-indexed elements from two vectors.\n\n\
+        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a0, a2, b0, b2]`.\n\n\
+        **Note:** This operation is only useful if you need to discard elements `a1, a3, b1, b3`.\
+        For fully deinterleaving two vectors prefer `deinterleave`,
+        which is faster than `unzip_low` followed by `unzip_high` on some platforms.",
+    ),
+    Op::new(
+        "unzip_high",
+        OpKind::BaseTraitMethod,
+        OpSig::Unzip { select_even: false },
+        "Extract odd-indexed elements from two vectors.\n\n\
+        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a1, a3, b1, b3]`.\n\n\
+        **Note:** This operation is only useful if you need to discard elements `a0, a2, b0, b2`.\
+        For fully deinterleaving two vectors prefer `deinterleave`,
+        which is faster than `unzip_low` followed by `unzip_high` on some platforms.",
+    ),
+    Op::new(
+        "interleave",
+        OpKind::BaseTraitMethod,
+        OpSig::Interleave,
+        "Interleave two vectors.\n\n\
+        The resulting vectors contain elements taken alternately from `{arg0}` and `{arg1}`, \
+        first filling the first result, and then the second.\n\n\
+        The reverse of this operation is `deinterleave`.\n\n\
+        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `([a0, b0, a1, b1], [a2, b2, a3, b3])`.",
+    ),
+    Op::new(
+        "deinterleave",
+        OpKind::BaseTraitMethod,
+        OpSig::Deinterleave,
+        "Deinterleave two vectors.\n\n\
+        The first result contains all even-indexed elements from `{arg0}` followed by all even-indexed elements from `{arg1}`. \
+        The second result contains all odd-indexed elements from `{arg0}` followed by all odd-indexed elements from `{arg1}`.\n\n\
+        The reverse of this operation is `interleave`.\n\n\
+        For vectors `[a0, b0, a1, b1]` and `[a2, b2, a3, b3]`, returns `([a0, a1, a2, a3], [b0, b1, b2, b3])`.",
+    ),
+];
+
 const MASK_REPRESENTATION_OPS: &[Op] = &[
     Op::new(
         "splat",
@@ -645,101 +743,6 @@ const FLOAT_OPS: &[Op] = &[
         OpSig::Binary,
         "Return a vector with the magnitude of `{arg0}` and the sign of `{arg1}` for each element.\n\n\
         This operation copies the sign bit, so if an input element is NaN, the output element will be a NaN with the same payload and a copied sign bit.",
-    ),
-    Op::new(
-        "simd_eq",
-        OpKind::VecTraitMethod,
-        OpSig::Compare,
-        "Compare two vectors element-wise for equality.\n\n\
-        Returns a mask where each logical lane is true if the corresponding elements are equal, and false if not.",
-    ),
-    Op::new(
-        "simd_lt",
-        OpKind::VecTraitMethod,
-        OpSig::Compare,
-        "Compare two vectors element-wise for less than.\n\n\
-        Returns a mask where each logical lane is true if `{arg0}` is less than `{arg1}`, and false if not.",
-    ),
-    Op::new(
-        "simd_le",
-        OpKind::VecTraitMethod,
-        OpSig::Compare,
-        "Compare two vectors element-wise for less than or equal.\n\n\
-        Returns a mask where each logical lane is true if `{arg0}` is less than or equal to `{arg1}`, and false if not.",
-    ),
-    Op::new(
-        "simd_ge",
-        OpKind::VecTraitMethod,
-        OpSig::Compare,
-        "Compare two vectors element-wise for greater than or equal.\n\n\
-        Returns a mask where each logical lane is true if `{arg0}` is greater than or equal to `{arg1}`, and false if not.",
-    ),
-    Op::new(
-        "simd_gt",
-        OpKind::VecTraitMethod,
-        OpSig::Compare,
-        "Compare two vectors element-wise for greater than.\n\n\
-        Returns a mask where each logical lane is true if `{arg0}` is greater than `{arg1}`, and false if not.",
-    ),
-    Op::new(
-        "zip_low",
-        OpKind::VecTraitMethod,
-        OpSig::Zip { select_low: true },
-        "Interleave the lower half elements of two vectors.\n\n\
-        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a0, b0, a1, b1]`.\n\n\
-        **Note:** This operation is only useful if you need to discard elements `a2, a3, b2, b3`.
-        For fully interleaving two vectors prefer `interleave`,
-        which is faster than `zip_low` followed by `zip_high` on some platforms.",
-    ),
-    Op::new(
-        "zip_high",
-        OpKind::VecTraitMethod,
-        OpSig::Zip { select_low: false },
-        "Interleave the upper half elements of two vectors.\n\n\
-        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a2, b2, a3, b3]`.\n\n\
-        **Note:** This operation is only useful if you need to discard elements `a0, a1, b0, b1`.\
-        For fully interleaving two vectors prefer `interleave`,
-        which is faster than `zip_low` followed by `zip_high` on some platforms.",
-    ),
-    Op::new(
-        "unzip_low",
-        OpKind::VecTraitMethod,
-        OpSig::Unzip { select_even: true },
-        "Extract even-indexed elements from two vectors.\n\n\
-        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a0, a2, b0, b2]`.\n\n\
-        **Note:** This operation is only useful if you need to discard elements `a1, a3, b1, b3`.\
-        For fully deinterleaving two vectors prefer `deinterleave`,
-        which is faster than `unzip_low` followed by `unzip_high` on some platforms.",
-    ),
-    Op::new(
-        "unzip_high",
-        OpKind::VecTraitMethod,
-        OpSig::Unzip { select_even: false },
-        "Extract odd-indexed elements from two vectors.\n\n\
-        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a1, a3, b1, b3]`.\n\n\
-        **Note:** This operation is only useful if you need to discard elements `a0, a2, b0, b2`.\
-        For fully deinterleaving two vectors prefer `deinterleave`,
-        which is faster than `unzip_low` followed by `unzip_high` on some platforms.",
-    ),
-    Op::new(
-        "interleave",
-        OpKind::VecTraitMethod,
-        OpSig::Interleave,
-        "Interleave two vectors.\n\n\
-        The resulting vectors contain elements taken alternately from `{arg0}` and `{arg1}`, \
-        first filling the first result, and then the second.\n\n\
-        The reverse of this operation is `deinterleave`.\n\n\
-        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `([a0, b0, a1, b1], [a2, b2, a3, b3])`.",
-    ),
-    Op::new(
-        "deinterleave",
-        OpKind::VecTraitMethod,
-        OpSig::Deinterleave,
-        "Deinterleave two vectors.\n\n\
-        The first result contains all even-indexed elements from `{arg0}` followed by all even-indexed elements from `{arg1}`. \
-        The second result contains all odd-indexed elements from `{arg0}` followed by all odd-indexed elements from `{arg1}`.\n\n\
-        The reverse of this operation is `interleave`.\n\n\
-        For vectors `[a0, b0, a1, b1]` and `[a2, b2, a3, b3]`, returns `([a0, a1, a2, a3], [b0, b1, b2, b3])`.",
     ),
     Op::new(
         "max",
@@ -909,101 +912,6 @@ const INT_OPS: &[Op] = &[
         This operation is not implemented in hardware on all platforms. On WebAssembly, and on x86 platforms without AVX2, this will use a fallback scalar implementation.",
     ),
     Op::new(
-        "simd_eq",
-        OpKind::VecTraitMethod,
-        OpSig::Compare,
-        "Compare two vectors element-wise for equality.\n\n\
-        Returns a mask where each logical lane is true if the corresponding elements are equal, and false if not.",
-    ),
-    Op::new(
-        "simd_lt",
-        OpKind::VecTraitMethod,
-        OpSig::Compare,
-        "Compare two vectors element-wise for less than.\n\n\
-        Returns a mask where each logical lane is true if `{arg0}` is less than `{arg1}`, and false if not.",
-    ),
-    Op::new(
-        "simd_le",
-        OpKind::VecTraitMethod,
-        OpSig::Compare,
-        "Compare two vectors element-wise for less than or equal.\n\n\
-        Returns a mask where each logical lane is true if `{arg0}` is less than or equal to `{arg1}`, and false if not.",
-    ),
-    Op::new(
-        "simd_ge",
-        OpKind::VecTraitMethod,
-        OpSig::Compare,
-        "Compare two vectors element-wise for greater than or equal.\n\n\
-        Returns a mask where each logical lane is true if `{arg0}` is greater than or equal to `{arg1}`, and false if not.",
-    ),
-    Op::new(
-        "simd_gt",
-        OpKind::VecTraitMethod,
-        OpSig::Compare,
-        "Compare two vectors element-wise for greater than.\n\n\
-        Returns a mask where each logical lane is true if `{arg0}` is greater than `{arg1}`, and false if not.",
-    ),
-    Op::new(
-        "zip_low",
-        OpKind::VecTraitMethod,
-        OpSig::Zip { select_low: true },
-        "Interleave the lower half elements of two vectors.\n\n\
-        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a0, b0, a1, b1]`.\n\n\
-        **Note:** This operation is only useful if you need to discard elements `a2, a3, b2, b3`.
-        For fully interleaving two vectors prefer `interleave`,
-        which is faster than `zip_low` followed by `zip_high` on some platforms.",
-    ),
-    Op::new(
-        "zip_high",
-        OpKind::VecTraitMethod,
-        OpSig::Zip { select_low: false },
-        "Interleave the upper half elements of two vectors.\n\n\
-        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a2, b2, a3, b3]`.\n\n\
-        **Note:** This operation is only useful if you need to discard elements `a0, a1, b0, b1`.\
-        For fully interleaving two vectors prefer `interleave`,
-        which is faster than `zip_low` followed by `zip_high` on some platforms.",
-    ),
-    Op::new(
-        "unzip_low",
-        OpKind::VecTraitMethod,
-        OpSig::Unzip { select_even: true },
-        "Extract even-indexed elements from two vectors.\n\n\
-        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a0, a2, b0, b2]`.\n\n\
-        **Note:** This operation is only useful if you need to discard elements `a1, a3, b1, b3`.\
-        For fully deinterleaving two vectors prefer `deinterleave`,
-        which is faster than `unzip_low` followed by `unzip_high` on some platforms.",
-    ),
-    Op::new(
-        "unzip_high",
-        OpKind::VecTraitMethod,
-        OpSig::Unzip { select_even: false },
-        "Extract odd-indexed elements from two vectors.\n\n\
-        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `[a1, a3, b1, b3]`.\n\n\
-        **Note:** This operation is only useful if you need to discard elements `a0, a2, b0, b2`.\
-        For fully deinterleaving two vectors prefer `deinterleave`,
-        which is faster than `unzip_low` followed by `unzip_high` on some platforms.",
-    ),
-    Op::new(
-        "interleave",
-        OpKind::VecTraitMethod,
-        OpSig::Interleave,
-        "Interleave two vectors.\n\n\
-        The resulting vectors contain elements taken alternately from `{arg0}` and `{arg1}`, \
-        first filling the first result, and then the second.\n\n\
-        The reverse of this operation is `deinterleave`.\n\n\
-        For vectors `[a0, a1, a2, a3]` and `[b0, b1, b2, b3]`, returns `([a0, b0, a1, b1], [a2, b2, a3, b3])`.",
-    ),
-    Op::new(
-        "deinterleave",
-        OpKind::VecTraitMethod,
-        OpSig::Deinterleave,
-        "Deinterleave two vectors.\n\n\
-        The first result contains all even-indexed elements from `{arg0}` followed by all even-indexed elements from `{arg1}`. \
-        The second result contains all odd-indexed elements from `{arg0}` followed by all odd-indexed elements from `{arg1}`.\n\n\
-        The reverse of this operation is `interleave`.\n\n\
-        For vectors `[a0, b0, a1, b1]` and `[a2, b2, a3, b3]`, returns `([a0, a1, a2, a3], [b0, b1, b2, b3])`.",
-    ),
-    Op::new(
         "select",
         OpKind::OwnTrait,
         OpSig::Select,
@@ -1129,6 +1037,7 @@ const MASK_OPS: &[Op] = &[
 pub(crate) fn base_trait_ops() -> Vec<Op> {
     BASE_OPS
         .iter()
+        .chain(COMMON_BASE_OPS.iter())
         .filter(|op| matches!(op.kind, OpKind::BaseTraitMethod))
         .copied()
         .collect()
@@ -1249,11 +1158,18 @@ pub(crate) fn ops_for_type(ty: &VecType) -> Vec<Op> {
         ScalarType::Mask => MASK_REPRESENTATION_OPS,
         _ => BASE_OPS,
     };
-    let mut ops: Vec<Op> = representation_ops
-        .iter()
-        .chain(base.iter())
-        .copied()
-        .collect();
+    let mut ops: Vec<Op> = representation_ops.iter().copied().collect();
+    for op in base {
+        ops.push(*op);
+        let common_ops_follow = match ty.scalar {
+            ScalarType::Float => op.method == "copysign",
+            ScalarType::Int | ScalarType::Unsigned => op.method == "shrv",
+            ScalarType::Mask => false,
+        };
+        if common_ops_follow {
+            ops.extend_from_slice(COMMON_BASE_OPS);
+        }
+    }
 
     if let Some(combined_ty) = ty.combine_operand() {
         ops.push(Op::new(

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -1158,7 +1158,7 @@ pub(crate) fn ops_for_type(ty: &VecType) -> Vec<Op> {
         ScalarType::Mask => MASK_REPRESENTATION_OPS,
         _ => BASE_OPS,
     };
-    let mut ops: Vec<Op> = representation_ops.iter().copied().collect();
+    let mut ops: Vec<Op> = representation_ops.to_vec();
     for op in base {
         ops.push(*op);
         let common_ops_follow = match ty.scalar {


### PR DESCRIPTION
Closes #301

Not part of this PR, but could be: min/max, min_precise/max_precise. Also we have no generic numeric conversions between ints and floats, only dedicated to_int/to_float, not sure if those are useful.