### PR TITLE
Use WASM relaxed_swizzle in swizzle_dyn

### DIFF
--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -662,7 +662,18 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn swizzle_dyn_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {
-        self.swizzle_dyn_precise_u8x16(a, indices)
+        #[cfg(target_feature = "relaxed-simd")]
+        {
+            let result = u8x16_relaxed_swizzle(Bytes::to_bytes(a).val.0, indices.into());
+            Bytes::from_bytes(u8x16 {
+                val: crate::support::Aligned128(result),
+                simd: self,
+            })
+        }
+        #[cfg(not(target_feature = "relaxed-simd"))]
+        {
+            self.swizzle_dyn_precise_u8x16(a, indices)
+        }
     }
     #[inline(always)]
     fn swizzle_dyn_precise_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self> {

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -643,9 +643,37 @@ impl Level for WasmSimd128 {
             }
             OpSig::SwizzleDyn => {
                 let precise = generic_op_name("swizzle_dyn_precise", vec_ty);
-                quote! {
-                    #method_sig {
-                        self.#precise(a, indices)
+
+                // Relaxed SIMD's relaxed_swizzle is only used for 128-bit vectors
+                // because the double-width swizzle path needs out-of-bounds indices
+                // to be zeroed to work efficiently
+                if vec_ty.n_bits() == 128 {
+                    let bytes_ty = vec_ty.bytes_ty();
+                    let bytes = bytes_ty.rust();
+                    let wrapper = bytes_ty.aligned_wrapper();
+
+                    quote! {
+                        #method_sig {
+                            #[cfg(target_feature = "relaxed-simd")]
+                            {
+                                let result = u8x16_relaxed_swizzle(
+                                    Bytes::to_bytes(a).val.0,
+                                    indices.into(),
+                                );
+                                Bytes::from_bytes(#bytes { val: #wrapper(result), simd: self })
+                            }
+
+                            #[cfg(not(target_feature = "relaxed-simd"))]
+                            {
+                                self.#precise(a, indices)
+                            }
+                        }
+                    }
+                } else {
+                    quote! {
+                        #method_sig {
+                            self.#precise(a, indices)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
swizzle_dyn_precise guarantees zeroing on out-of-bounds indices

swizzle_dyn matches WASM relaxed_swizzle semantics

Ref: https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md