### PR TITLE
Add mul_add_precise() which guarantees single-rounding precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can find its changes [documented below](#060-2026-07-10).
 ### Added
 
 - Added `mul_add_precise` for floating-point vectors. It guarantees the infinite-precision product-plus-add rounded once, including on SIMD levels without hardware fused multiply-add instructions.
+- Added `mul_sub_precise` for floating-point vectors. It guarantees the infinite-precision product-minus-subtrahend rounded once.
 - Added an `Sse2` level. This is the new baseline for i686-* and x86_64-* targets, replacing `Fallback`. ([#270][] by [@Shnatsel][])
 - Added full-vector `swizzle_dyn` and `swizzle_dyn_precise` byte swizzles. `swizzle_dyn` permits implementation-defined results for out-of-range indices, while `swizzle_dyn_precise` always returns zero for them.
 - Added trait bounds on `SimdElement`, and introduced the `SimdIntElement` and `SimdFloatElement` subtraits. These allow generic code to access many math and utility operations on the elements of SIMD vector types. ([#302][] by [@danderson][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can find its changes [documented below](#060-2026-07-10).
 
 ### Added
 
+- Added `mul_add_precise` for floating-point vectors. It guarantees the infinite-precision product-plus-add rounded once, including on SIMD levels without hardware fused multiply-add instructions.
 - Added an `Sse2` level. This is the new baseline for i686-* and x86_64-* targets, replacing `Fallback`. ([#270][] by [@Shnatsel][])
 - Added full-vector `swizzle_dyn` and `swizzle_dyn_precise` byte swizzles. `swizzle_dyn` permits implementation-defined results for out-of-range indices, while `swizzle_dyn_precise` always returns zero for them.
 - Added trait bounds on `SimdElement`, and introduced the `SimdIntElement` and `SimdFloatElement` subtraits. These allow generic code to access many math and utility operations on the elements of SIMD vector types. ([#302][] by [@danderson][])

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -380,6 +380,10 @@ impl Simd for Avx2 {
         kernel(self, a, b, c)
     }
     #[inline(always)]
+    fn mul_sub_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        self.mul_sub_f32x4(a, b, c)
+    }
+    #[inline(always)]
     fn floor_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3906,6 +3910,10 @@ impl Simd for Avx2 {
         kernel(self, a, b, c)
     }
     #[inline(always)]
+    fn mul_sub_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        self.mul_sub_f64x2(a, b, c)
+    }
+    #[inline(always)]
     fn floor_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5296,6 +5304,10 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, a, b, c)
+    }
+    #[inline(always)]
+    fn mul_sub_precise_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
+        self.mul_sub_f32x8(a, b, c)
     }
     #[inline(always)]
     fn floor_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
@@ -8982,6 +8994,10 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, a, b, c)
+    }
+    #[inline(always)]
+    fn mul_sub_precise_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {
+        self.mul_sub_f64x4(a, b, c)
     }
     #[inline(always)]
     fn floor_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -366,6 +366,10 @@ impl Simd for Avx2 {
         kernel(self, a, b, c)
     }
     #[inline(always)]
+    fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        self.mul_add_f32x4(a, b, c)
+    }
+    #[inline(always)]
     fn mul_sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3888,6 +3892,10 @@ impl Simd for Avx2 {
         kernel(self, a, b, c)
     }
     #[inline(always)]
+    fn mul_add_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        self.mul_add_f64x2(a, b, c)
+    }
+    #[inline(always)]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5274,6 +5282,10 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, a, b, c)
+    }
+    #[inline(always)]
+    fn mul_add_precise_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
+        self.mul_add_f32x8(a, b, c)
     }
     #[inline(always)]
     fn mul_sub_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
@@ -8956,6 +8968,10 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, a, b, c)
+    }
+    #[inline(always)]
+    fn mul_add_precise_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {
+        self.mul_add_f64x4(a, b, c)
     }
     #[inline(always)]
     fn mul_sub_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -669,6 +669,10 @@ impl Simd for Avx512 {
         kernel(self, a, b, c)
     }
     #[inline(always)]
+    fn mul_sub_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        self.mul_sub_f32x4(a, b, c)
+    }
+    #[inline(always)]
     fn floor_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3941,6 +3945,10 @@ impl Simd for Avx512 {
         kernel(self, a, b, c)
     }
     #[inline(always)]
+    fn mul_sub_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        self.mul_sub_f64x2(a, b, c)
+    }
+    #[inline(always)]
     fn floor_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5358,6 +5366,10 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, a, b, c)
+    }
+    #[inline(always)]
+    fn mul_sub_precise_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
+        self.mul_sub_f32x8(a, b, c)
     }
     #[inline(always)]
     fn floor_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
@@ -8968,6 +8980,10 @@ impl Simd for Avx512 {
         kernel(self, a, b, c)
     }
     #[inline(always)]
+    fn mul_sub_precise_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {
+        self.mul_sub_f64x4(a, b, c)
+    }
+    #[inline(always)]
     fn floor_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -10447,6 +10463,15 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, a, b, c)
+    }
+    #[inline(always)]
+    fn mul_sub_precise_f32x16(
+        self,
+        a: f32x16<Self>,
+        b: f32x16<Self>,
+        c: f32x16<Self>,
+    ) -> f32x16<Self> {
+        self.mul_sub_f32x16(a, b, c)
     }
     #[inline(always)]
     fn floor_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
@@ -14106,6 +14131,10 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, a, b, c)
+    }
+    #[inline(always)]
+    fn mul_sub_precise_f64x8(self, a: f64x8<Self>, b: f64x8<Self>, c: f64x8<Self>) -> f64x8<Self> {
+        self.mul_sub_f64x8(a, b, c)
     }
     #[inline(always)]
     fn floor_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -650,6 +650,10 @@ impl Simd for Avx512 {
         kernel(self, a, b, c)
     }
     #[inline(always)]
+    fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        self.mul_add_f32x4(a, b, c)
+    }
+    #[inline(always)]
     fn mul_sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3918,6 +3922,10 @@ impl Simd for Avx512 {
         kernel(self, a, b, c)
     }
     #[inline(always)]
+    fn mul_add_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        self.mul_add_f64x2(a, b, c)
+    }
+    #[inline(always)]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5331,6 +5339,10 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, a, b, c)
+    }
+    #[inline(always)]
+    fn mul_add_precise_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
+        self.mul_add_f32x8(a, b, c)
     }
     #[inline(always)]
     fn mul_sub_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
@@ -8937,6 +8949,10 @@ impl Simd for Avx512 {
         kernel(self, a, b, c)
     }
     #[inline(always)]
+    fn mul_add_precise_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {
+        self.mul_add_f64x4(a, b, c)
+    }
+    #[inline(always)]
     fn mul_sub_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -10407,6 +10423,15 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, a, b, c)
+    }
+    #[inline(always)]
+    fn mul_add_precise_f32x16(
+        self,
+        a: f32x16<Self>,
+        b: f32x16<Self>,
+        c: f32x16<Self>,
+    ) -> f32x16<Self> {
+        self.mul_add_f32x16(a, b, c)
     }
     #[inline(always)]
     fn mul_sub_f32x16(self, a: f32x16<Self>, b: f32x16<Self>, c: f32x16<Self>) -> f32x16<Self> {
@@ -14062,6 +14087,10 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, a, b, c)
+    }
+    #[inline(always)]
+    fn mul_add_precise_f64x8(self, a: f64x8<Self>, b: f64x8<Self>, c: f64x8<Self>) -> f64x8<Self> {
+        self.mul_add_f64x8(a, b, c)
     }
     #[inline(always)]
     fn mul_sub_f64x8(self, a: f64x8<Self>, b: f64x8<Self>, c: f64x8<Self>) -> f64x8<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -11,6 +11,30 @@ use crate::{
     u16x8, u16x16, u16x32, u32x4, u32x8, u32x16, u64x2, u64x4, u64x8,
 };
 use core::ops::*;
+#[inline(always)]
+#[allow(
+    dead_code,
+    reason = "Generated backends use different subsets of these helpers"
+)]
+fn scalar_mul_add_precise_f32(a: f32, b: f32, c: f32) -> f32 {
+    let product = (a as f64) * (b as f64);
+    let c = c as f64;
+    let mut sum = product + c;
+    if sum.is_finite() {
+        let virtual_sum = sum - product;
+        let residual = (product - (sum - virtual_sum)) + (c - virtual_sum);
+        let sum_bits = sum.to_bits();
+        if residual != 0.0 && sum_bits & 1 == 0 {
+            let corrected_bits = if sum.is_sign_negative() == residual.is_sign_negative() {
+                sum_bits.wrapping_add(1)
+            } else {
+                sum_bits.wrapping_sub(1)
+            };
+            sum = f64::from_bits(corrected_bits);
+        }
+    }
+    sum as f32
+}
 #[cfg(all(feature = "libm", not(feature = "std")))]
 #[allow(
     dead_code,
@@ -373,10 +397,10 @@ impl Simd for Fallback {
     #[inline(always)]
     fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
         [
-            f32::mul_add(a[0usize], b[0usize], c[0usize]),
-            f32::mul_add(a[1usize], b[1usize], c[1usize]),
-            f32::mul_add(a[2usize], b[2usize], c[2usize]),
-            f32::mul_add(a[3usize], b[3usize], c[3usize]),
+            scalar_mul_add_precise_f32(a[0usize], b[0usize], c[0usize]),
+            scalar_mul_add_precise_f32(a[1usize], b[1usize], c[1usize]),
+            scalar_mul_add_precise_f32(a[2usize], b[2usize], c[2usize]),
+            scalar_mul_add_precise_f32(a[3usize], b[3usize], c[3usize]),
         ]
         .simd_into(self)
     }

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -23,6 +23,7 @@ trait FloatExt {
     fn fract(self) -> Self;
     fn sqrt(self) -> Self;
     fn trunc(self) -> Self;
+    fn mul_add(self, a: Self, b: Self) -> Self;
 }
 #[cfg(all(feature = "libm", not(feature = "std")))]
 impl FloatExt for f32 {
@@ -50,6 +51,10 @@ impl FloatExt for f32 {
     fn trunc(self) -> f32 {
         libm::truncf(self)
     }
+    #[inline(always)]
+    fn mul_add(self, a: f32, b: f32) -> f32 {
+        libm::fmaf(self, a, b)
+    }
 }
 #[cfg(all(feature = "libm", not(feature = "std")))]
 impl FloatExt for f64 {
@@ -76,6 +81,10 @@ impl FloatExt for f64 {
     #[inline(always)]
     fn trunc(self) -> f64 {
         libm::trunc(self)
+    }
+    #[inline(always)]
+    fn mul_add(self, a: f64, b: f64) -> f64 {
+        libm::fma(self, a, b)
     }
 }
 #[doc = "A token for scalar fallback SIMD, representing the \"fallback\" level."]
@@ -360,6 +369,16 @@ impl Simd for Fallback {
     #[inline(always)]
     fn mul_add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
         a.mul(b).add(c)
+    }
+    #[inline(always)]
+    fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        [
+            f32::mul_add(a[0usize], b[0usize], c[0usize]),
+            f32::mul_add(a[1usize], b[1usize], c[1usize]),
+            f32::mul_add(a[2usize], b[2usize], c[2usize]),
+            f32::mul_add(a[3usize], b[3usize], c[3usize]),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn mul_sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
@@ -4485,6 +4504,14 @@ impl Simd for Fallback {
     #[inline(always)]
     fn mul_add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
         a.mul(b).add(c)
+    }
+    #[inline(always)]
+    fn mul_add_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        [
+            f64::mul_add(a[0usize], b[0usize], c[0usize]),
+            f64::mul_add(a[1usize], b[1usize], c[1usize]),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -12,10 +12,6 @@ use crate::{
 };
 use core::ops::*;
 #[inline(always)]
-#[allow(
-    dead_code,
-    reason = "Generated backends use different subsets of these helpers"
-)]
 fn scalar_mul_add_precise_f32(a: f32, b: f32, c: f32) -> f32 {
     let product = (a as f64) * (b as f64);
     let c = c as f64;

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -385,6 +385,10 @@ impl Simd for Fallback {
         a.mul(b).sub(c)
     }
     #[inline(always)]
+    fn mul_sub_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        self.mul_add_precise_f32x4(a, b, -c)
+    }
+    #[inline(always)]
     fn floor_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
         [
             f32::floor(a[0usize]),
@@ -4516,6 +4520,10 @@ impl Simd for Fallback {
     #[inline(always)]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
         a.mul(b).sub(c)
+    }
+    #[inline(always)]
+    fn mul_sub_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        self.mul_add_precise_f64x2(a, b, -c)
     }
     #[inline(always)]
     fn floor_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -362,6 +362,10 @@ impl Simd for Neon {
         kernel(self, a, b, c)
     }
     #[inline(always)]
+    fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        self.mul_add_f32x4(a, b, c)
+    }
+    #[inline(always)]
     fn mul_sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3285,6 +3289,10 @@ impl Simd for Neon {
             }
         );
         kernel(self, a, b, c)
+    }
+    #[inline(always)]
+    fn mul_add_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        self.mul_add_f64x2(a, b, c)
     }
     #[inline(always)]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -367,13 +367,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn mul_sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Neon, a: f32x4<Neon>, b: f32x4<Neon>, c: f32x4<Neon>) -> f32x4<Neon> {
-                vnegq_f32(vfmsq_f32(c.into(), b.into(), a.into())).simd_into(token)
-            }
-        );
-        kernel(self, a, b, c)
+        self.mul_add_f32x4(a, b, -c)
+    }
+    #[inline(always)]
+    fn mul_sub_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        self.mul_sub_f32x4(a, b, c)
     }
     #[inline(always)]
     fn floor_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
@@ -3296,13 +3294,11 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
-        crate::kernel!(
-            #[inline(always)]
-            fn kernel(token: Neon, a: f64x2<Neon>, b: f64x2<Neon>, c: f64x2<Neon>) -> f64x2<Neon> {
-                vnegq_f64(vfmsq_f64(c.into(), b.into(), a.into())).simd_into(token)
-            }
-        );
-        kernel(self, a, b, c)
+        self.mul_add_f64x2(a, b, -c)
+    }
+    #[inline(always)]
+    fn mul_sub_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        self.mul_sub_f64x2(a, b, c)
     }
     #[inline(always)]
     fn floor_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -297,11 +297,11 @@ pub trait Simd:
     fn deinterleave_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> (f32x4<Self>, f32x4<Self>);
     #[doc = "Compute `(a * b) + c` (fused multiply-add) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by an add, which will result in two rounding errors."]
     fn mul_add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
-    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
     fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Compute `(a * b) - c` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     fn mul_sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
-    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
     fn mul_sub_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
     fn floor_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
@@ -1139,11 +1139,11 @@ pub trait Simd:
     fn deinterleave_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> (f64x2<Self>, f64x2<Self>);
     #[doc = "Compute `(a * b) + c` (fused multiply-add) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by an add, which will result in two rounding errors."]
     fn mul_add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
-    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
     fn mul_add_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Compute `(a * b) - c` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
-    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
     fn mul_sub_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
     fn floor_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
@@ -1659,7 +1659,7 @@ pub trait Simd:
             self.mul_add_f32x4(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
     #[inline(always)]
     fn mul_add_precise_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
@@ -1681,7 +1681,7 @@ pub trait Simd:
             self.mul_sub_f32x4(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
     #[inline(always)]
     fn mul_sub_precise_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
@@ -3846,7 +3846,7 @@ pub trait Simd:
             self.mul_add_f64x2(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
     #[inline(always)]
     fn mul_add_precise_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f64x4(a);
@@ -3868,7 +3868,7 @@ pub trait Simd:
             self.mul_sub_f64x2(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
     #[inline(always)]
     fn mul_sub_precise_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f64x4(a);
@@ -4837,7 +4837,7 @@ pub trait Simd:
             self.mul_add_f32x8(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
     #[inline(always)]
     fn mul_add_precise_f32x16(
         self,
@@ -4864,7 +4864,7 @@ pub trait Simd:
             self.mul_sub_f32x8(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
     #[inline(always)]
     fn mul_sub_precise_f32x16(
         self,
@@ -7037,7 +7037,7 @@ pub trait Simd:
             self.mul_add_f64x4(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
     #[inline(always)]
     fn mul_add_precise_f64x8(self, a: f64x8<Self>, b: f64x8<Self>, c: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
@@ -7059,7 +7059,7 @@ pub trait Simd:
             self.mul_sub_f64x4(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
     #[inline(always)]
     fn mul_sub_precise_f64x8(self, a: f64x8<Self>, b: f64x8<Self>, c: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
@@ -8423,11 +8423,11 @@ pub trait SimdFloat<S: Simd>:
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Compute `(self * op1) + op2` (fused multiply-add) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by an add, which will result in two rounding errors."]
     fn mul_add(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Compute `(self * op1) + op2` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(self * op1) + op2` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
     fn mul_add_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
     #[doc = "Compute `(self * op1) - op2` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Compute `(self * op1) - op2` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[doc = "Compute `(self * op1) - op2` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
     fn mul_sub_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
     fn floor(self) -> Self;

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -297,6 +297,8 @@ pub trait Simd:
     fn deinterleave_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> (f32x4<Self>, f32x4<Self>);
     #[doc = "Compute `(a * b) + c` (fused multiply-add) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by an add, which will result in two rounding errors."]
     fn mul_add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Compute `(a * b) - c` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     fn mul_sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
@@ -1135,6 +1137,8 @@ pub trait Simd:
     fn deinterleave_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> (f64x2<Self>, f64x2<Self>);
     #[doc = "Compute `(a * b) + c` (fused multiply-add) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by an add, which will result in two rounding errors."]
     fn mul_add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    fn mul_add_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Compute `(a * b) - c` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
@@ -1649,6 +1653,17 @@ pub trait Simd:
         self.combine_f32x4(
             self.mul_add_f32x4(a0, b0, c0),
             self.mul_add_f32x4(a1, b1, c1),
+        )
+    }
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[inline(always)]
+    fn mul_add_precise_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        let (c0, c1) = self.split_f32x8(c);
+        self.combine_f32x4(
+            self.mul_add_precise_f32x4(a0, b0, c0),
+            self.mul_add_precise_f32x4(a1, b1, c1),
         )
     }
     #[doc = "Compute `(a * b) - c` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
@@ -3816,6 +3831,17 @@ pub trait Simd:
             self.mul_add_f64x2(a1, b1, c1),
         )
     }
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[inline(always)]
+    fn mul_add_precise_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        let (b0, b1) = self.split_f64x4(b);
+        let (c0, c1) = self.split_f64x4(c);
+        self.combine_f64x2(
+            self.mul_add_precise_f64x2(a0, b0, c0),
+            self.mul_add_precise_f64x2(a1, b1, c1),
+        )
+    }
     #[doc = "Compute `(a * b) - c` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     #[inline(always)]
     fn mul_sub_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {
@@ -4783,6 +4809,22 @@ pub trait Simd:
         self.combine_f32x8(
             self.mul_add_f32x8(a0, b0, c0),
             self.mul_add_f32x8(a1, b1, c1),
+        )
+    }
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[inline(always)]
+    fn mul_add_precise_f32x16(
+        self,
+        a: f32x16<Self>,
+        b: f32x16<Self>,
+        c: f32x16<Self>,
+    ) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        let (b0, b1) = self.split_f32x16(b);
+        let (c0, c1) = self.split_f32x16(c);
+        self.combine_f32x8(
+            self.mul_add_precise_f32x8(a0, b0, c0),
+            self.mul_add_precise_f32x8(a1, b1, c1),
         )
     }
     #[doc = "Compute `(a * b) - c` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
@@ -6953,6 +6995,17 @@ pub trait Simd:
             self.mul_add_f64x4(a1, b1, c1),
         )
     }
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[inline(always)]
+    fn mul_add_precise_f64x8(self, a: f64x8<Self>, b: f64x8<Self>, c: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        let (b0, b1) = self.split_f64x8(b);
+        let (c0, c1) = self.split_f64x8(c);
+        self.combine_f64x4(
+            self.mul_add_precise_f64x4(a0, b0, c0),
+            self.mul_add_precise_f64x4(a1, b1, c1),
+        )
+    }
     #[doc = "Compute `(a * b) - c` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     #[inline(always)]
     fn mul_sub_f64x8(self, a: f64x8<Self>, b: f64x8<Self>, c: f64x8<Self>) -> f64x8<Self> {
@@ -8317,6 +8370,8 @@ pub trait SimdFloat<S: Simd>:
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Compute `(self * op1) + op2` (fused multiply-add) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by an add, which will result in two rounding errors."]
     fn mul_add(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
+    #[doc = "Compute `(self * op1) + op2` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    fn mul_add_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
     #[doc = "Compute `(self * op1) - op2` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -301,6 +301,8 @@ pub trait Simd:
     fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Compute `(a * b) - c` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     fn mul_sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    fn mul_sub_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
     fn floor_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Return the smallest integer greater than or equal to each element, that is, round towards positive infinity."]
@@ -1141,6 +1143,8 @@ pub trait Simd:
     fn mul_add_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Compute `(a * b) - c` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    fn mul_sub_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
     fn floor_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Return the smallest integer greater than or equal to each element, that is, round towards positive infinity."]
@@ -1675,6 +1679,17 @@ pub trait Simd:
         self.combine_f32x4(
             self.mul_sub_f32x4(a0, b0, c0),
             self.mul_sub_f32x4(a1, b1, c1),
+        )
+    }
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[inline(always)]
+    fn mul_sub_precise_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        let (c0, c1) = self.split_f32x8(c);
+        self.combine_f32x4(
+            self.mul_sub_precise_f32x4(a0, b0, c0),
+            self.mul_sub_precise_f32x4(a1, b1, c1),
         )
     }
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
@@ -3853,6 +3868,17 @@ pub trait Simd:
             self.mul_sub_f64x2(a1, b1, c1),
         )
     }
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[inline(always)]
+    fn mul_sub_precise_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        let (b0, b1) = self.split_f64x4(b);
+        let (c0, c1) = self.split_f64x4(c);
+        self.combine_f64x2(
+            self.mul_sub_precise_f64x2(a0, b0, c0),
+            self.mul_sub_precise_f64x2(a1, b1, c1),
+        )
+    }
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
     #[inline(always)]
     fn floor_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
@@ -4836,6 +4862,22 @@ pub trait Simd:
         self.combine_f32x8(
             self.mul_sub_f32x8(a0, b0, c0),
             self.mul_sub_f32x8(a1, b1, c1),
+        )
+    }
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[inline(always)]
+    fn mul_sub_precise_f32x16(
+        self,
+        a: f32x16<Self>,
+        b: f32x16<Self>,
+        c: f32x16<Self>,
+    ) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        let (b0, b1) = self.split_f32x16(b);
+        let (c0, c1) = self.split_f32x16(c);
+        self.combine_f32x8(
+            self.mul_sub_precise_f32x8(a0, b0, c0),
+            self.mul_sub_precise_f32x8(a1, b1, c1),
         )
     }
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
@@ -7017,6 +7059,17 @@ pub trait Simd:
             self.mul_sub_f64x4(a1, b1, c1),
         )
     }
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    #[inline(always)]
+    fn mul_sub_precise_f64x8(self, a: f64x8<Self>, b: f64x8<Self>, c: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        let (b0, b1) = self.split_f64x8(b);
+        let (c0, c1) = self.split_f64x8(c);
+        self.combine_f64x4(
+            self.mul_sub_precise_f64x4(a0, b0, c0),
+            self.mul_sub_precise_f64x4(a1, b1, c1),
+        )
+    }
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
     #[inline(always)]
     fn floor_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
@@ -8374,6 +8427,8 @@ pub trait SimdFloat<S: Simd>:
     fn mul_add_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
     #[doc = "Compute `(self * op1) - op2` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
+    #[doc = "Compute `(self * op1) - op2` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\nFloating-point exception flags and NaN payload selection are not guaranteed."]
+    fn mul_sub_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
     fn floor(self) -> Self;
     #[doc = "Return the smallest integer greater than or equal to each element, that is, round towards positive infinity."]

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -297,11 +297,11 @@ pub trait Simd:
     fn deinterleave_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> (f32x4<Self>, f32x4<Self>);
     #[doc = "Compute `(a * b) + c` (fused multiply-add) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by an add, which will result in two rounding errors."]
     fn mul_add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
-    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\n# Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Compute `(a * b) - c` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     fn mul_sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
-    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n        # Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     fn mul_sub_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
     fn floor_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
@@ -1139,11 +1139,11 @@ pub trait Simd:
     fn deinterleave_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> (f64x2<Self>, f64x2<Self>);
     #[doc = "Compute `(a * b) + c` (fused multiply-add) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by an add, which will result in two rounding errors."]
     fn mul_add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
-    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\n# Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     fn mul_add_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Compute `(a * b) - c` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
-    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n        # Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     fn mul_sub_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
     fn floor_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
@@ -1659,7 +1659,7 @@ pub trait Simd:
             self.mul_add_f32x4(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\n# Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     #[inline(always)]
     fn mul_add_precise_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
@@ -1681,7 +1681,7 @@ pub trait Simd:
             self.mul_sub_f32x4(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n        # Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     #[inline(always)]
     fn mul_sub_precise_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
         let (a0, a1) = self.split_f32x8(a);
@@ -3846,7 +3846,7 @@ pub trait Simd:
             self.mul_add_f64x2(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\n# Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     #[inline(always)]
     fn mul_add_precise_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f64x4(a);
@@ -3868,7 +3868,7 @@ pub trait Simd:
             self.mul_sub_f64x2(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n        # Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     #[inline(always)]
     fn mul_sub_precise_f64x4(self, a: f64x4<Self>, b: f64x4<Self>, c: f64x4<Self>) -> f64x4<Self> {
         let (a0, a1) = self.split_f64x4(a);
@@ -4837,7 +4837,7 @@ pub trait Simd:
             self.mul_add_f32x8(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\n# Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     #[inline(always)]
     fn mul_add_precise_f32x16(
         self,
@@ -4864,7 +4864,7 @@ pub trait Simd:
             self.mul_sub_f32x8(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n        # Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     #[inline(always)]
     fn mul_sub_precise_f32x16(
         self,
@@ -7037,7 +7037,7 @@ pub trait Simd:
             self.mul_add_f64x4(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(a * b) + c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\n# Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     #[inline(always)]
     fn mul_add_precise_f64x8(self, a: f64x8<Self>, b: f64x8<Self>, c: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
@@ -7059,7 +7059,7 @@ pub trait Simd:
             self.mul_sub_f64x4(a1, b1, c1),
         )
     }
-    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(a * b) - c` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n        # Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     #[inline(always)]
     fn mul_sub_precise_f64x8(self, a: f64x8<Self>, b: f64x8<Self>, c: f64x8<Self>) -> f64x8<Self> {
         let (a0, a1) = self.split_f64x8(a);
@@ -8423,11 +8423,11 @@ pub trait SimdFloat<S: Simd>:
     fn copysign(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Compute `(self * op1) + op2` (fused multiply-add) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by an add, which will result in two rounding errors."]
     fn mul_add(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Compute `(self * op1) + op2` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(self * op1) + op2` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\n# Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     fn mul_add_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
     #[doc = "Compute `(self * op1) - op2` (fused multiply-subtract) for each element.\n\nDepending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors."]
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Compute `(self * op1) - op2` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions."]
+    #[doc = "Compute `(self * op1) - op2` for each element, with a single rounding at the end.\n\nThe result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n        # Precision guarantees\n\nThis function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\nOn the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\nOn WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\nThe exact `NaN` payloads as well as signaling `NaN`s are not preserved."]
     fn mul_sub_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self;
     #[doc = "Return the largest integer less than or equal to each element, that is, round towards negative infinity."]
     fn floor(self) -> Self;

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -248,6 +248,11 @@ impl<S: Simd> crate::SimdFloat<S> for f32x4<S> {
             .mul_sub_f32x4(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
     }
     #[inline(always)]
+    fn mul_sub_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .mul_sub_precise_f32x4(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
+    }
+    #[inline(always)]
     fn floor(self) -> Self {
         self.simd.floor_f32x4(self)
     }
@@ -2389,6 +2394,11 @@ impl<S: Simd> crate::SimdFloat<S> for f64x2<S> {
             .mul_sub_f64x2(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
     }
     #[inline(always)]
+    fn mul_sub_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .mul_sub_precise_f64x2(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
+    }
+    #[inline(always)]
     fn floor(self) -> Self {
         self.simd.floor_f64x2(self)
     }
@@ -3312,6 +3322,11 @@ impl<S: Simd> crate::SimdFloat<S> for f32x8<S> {
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
         self.simd
             .mul_sub_f32x8(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn mul_sub_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .mul_sub_precise_f32x8(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
     }
     #[inline(always)]
     fn floor(self) -> Self {
@@ -5494,6 +5509,11 @@ impl<S: Simd> crate::SimdFloat<S> for f64x4<S> {
             .mul_sub_f64x4(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
     }
     #[inline(always)]
+    fn mul_sub_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .mul_sub_precise_f64x4(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
+    }
+    #[inline(always)]
     fn floor(self) -> Self {
         self.simd.floor_f64x4(self)
     }
@@ -6412,6 +6432,11 @@ impl<S: Simd> crate::SimdFloat<S> for f32x16<S> {
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
         self.simd
             .mul_sub_f32x16(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn mul_sub_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .mul_sub_precise_f32x16(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
     }
     #[inline(always)]
     fn floor(self) -> Self {
@@ -8676,6 +8701,11 @@ impl<S: Simd> crate::SimdFloat<S> for f64x8<S> {
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
         self.simd
             .mul_sub_f64x8(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn mul_sub_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .mul_sub_precise_f64x8(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
     }
     #[inline(always)]
     fn floor(self) -> Self {

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -238,6 +238,11 @@ impl<S: Simd> crate::SimdFloat<S> for f32x4<S> {
             .mul_add_f32x4(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
     }
     #[inline(always)]
+    fn mul_add_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .mul_add_precise_f32x4(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
+    }
+    #[inline(always)]
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
         self.simd
             .mul_sub_f32x4(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
@@ -2374,6 +2379,11 @@ impl<S: Simd> crate::SimdFloat<S> for f64x2<S> {
             .mul_add_f64x2(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
     }
     #[inline(always)]
+    fn mul_add_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .mul_add_precise_f64x2(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
+    }
+    #[inline(always)]
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
         self.simd
             .mul_sub_f64x2(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
@@ -3292,6 +3302,11 @@ impl<S: Simd> crate::SimdFloat<S> for f32x8<S> {
     fn mul_add(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
         self.simd
             .mul_add_f32x8(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn mul_add_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .mul_add_precise_f32x8(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
     }
     #[inline(always)]
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
@@ -5469,6 +5484,11 @@ impl<S: Simd> crate::SimdFloat<S> for f64x4<S> {
             .mul_add_f64x4(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
     }
     #[inline(always)]
+    fn mul_add_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .mul_add_precise_f64x4(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
+    }
+    #[inline(always)]
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
         self.simd
             .mul_sub_f64x4(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
@@ -6382,6 +6402,11 @@ impl<S: Simd> crate::SimdFloat<S> for f32x16<S> {
     fn mul_add(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
         self.simd
             .mul_add_f32x16(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn mul_add_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .mul_add_precise_f32x16(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
     }
     #[inline(always)]
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
@@ -8641,6 +8666,11 @@ impl<S: Simd> crate::SimdFloat<S> for f64x8<S> {
     fn mul_add(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
         self.simd
             .mul_add_f64x8(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn mul_add_precise(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .mul_add_precise_f64x8(self, op1.simd_into(self.simd), op2.simd_into(self.simd))
     }
     #[inline(always)]
     fn mul_sub(self, op1: impl SimdInto<Self, S>, op2: impl SimdInto<Self, S>) -> Self {

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -460,6 +460,10 @@ impl Simd for Sse2 {
         a * b - c
     }
     #[inline(always)]
+    fn mul_sub_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        self.mul_add_precise_f32x4(a, b, -c)
+    }
+    #[inline(always)]
     fn floor_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
         [
             f32::floor(a[0usize]),
@@ -4211,6 +4215,10 @@ impl Simd for Sse2 {
     #[inline(always)]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
         a * b - c
+    }
+    #[inline(always)]
+    fn mul_sub_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        self.mul_add_precise_f64x2(a, b, -c)
     }
     #[inline(always)]
     fn floor_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -15,30 +15,32 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 use core::ops::*;
-#[inline(always)]
-#[allow(
-    dead_code,
-    reason = "Generated backends use different subsets of these helpers"
-)]
-fn scalar_mul_add_precise_f32(a: f32, b: f32, c: f32) -> f32 {
-    let product = (a as f64) * (b as f64);
-    let c = c as f64;
-    let mut sum = product + c;
-    if sum.is_finite() {
-        let virtual_sum = sum - product;
-        let residual = (product - (sum - virtual_sum)) + (c - virtual_sum);
-        let sum_bits = sum.to_bits();
-        if residual != 0.0 && sum_bits & 1 == 0 {
-            let corrected_bits = if sum.is_sign_negative() == residual.is_sign_negative() {
-                sum_bits.wrapping_add(1)
-            } else {
-                sum_bits.wrapping_sub(1)
-            };
-            sum = f64::from_bits(corrected_bits);
+crate::kernel!(
+    #[inline(always)]
+    #[allow(
+        dead_code,
+        reason = "Generated backends use different subsets of these helpers"
+    )]
+    fn scalar_mul_add_precise_f32(_token: Sse2, a: f32, b: f32, c: f32) -> f32 {
+        let product = (a as f64) * (b as f64);
+        let c = c as f64;
+        let mut sum = product + c;
+        if sum.is_finite() {
+            let virtual_sum = sum - product;
+            let residual = (product - (sum - virtual_sum)) + (c - virtual_sum);
+            let sum_bits = sum.to_bits();
+            if residual != 0.0 && sum_bits & 1 == 0 {
+                let corrected_bits = if sum.is_sign_negative() == residual.is_sign_negative() {
+                    sum_bits.wrapping_add(1)
+                } else {
+                    sum_bits.wrapping_sub(1)
+                };
+                sum = f64::from_bits(corrected_bits);
+            }
         }
+        sum as f32
     }
-    sum as f32
-}
+);
 #[cfg(all(feature = "libm", not(feature = "std")))]
 #[allow(
     dead_code,
@@ -472,10 +474,10 @@ impl Simd for Sse2 {
     #[inline(always)]
     fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
         [
-            scalar_mul_add_precise_f32(a[0usize], b[0usize], c[0usize]),
-            scalar_mul_add_precise_f32(a[1usize], b[1usize], c[1usize]),
-            scalar_mul_add_precise_f32(a[2usize], b[2usize], c[2usize]),
-            scalar_mul_add_precise_f32(a[3usize], b[3usize], c[3usize]),
+            scalar_mul_add_precise_f32(self, a[0usize], b[0usize], c[0usize]),
+            scalar_mul_add_precise_f32(self, a[1usize], b[1usize], c[1usize]),
+            scalar_mul_add_precise_f32(self, a[2usize], b[2usize], c[2usize]),
+            scalar_mul_add_precise_f32(self, a[3usize], b[3usize], c[3usize]),
         ]
         .simd_into(self)
     }

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -17,10 +17,6 @@ use core::arch::x86_64::*;
 use core::ops::*;
 crate::kernel!(
     #[inline(always)]
-    #[allow(
-        dead_code,
-        reason = "Generated backends use different subsets of these helpers"
-    )]
     fn scalar_mul_add_precise_f32(_token: Sse2, a: f32, b: f32, c: f32) -> f32 {
         let product = (a as f64) * (b as f64);
         let c = c as f64;

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -15,6 +15,30 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 use core::ops::*;
+#[inline(always)]
+#[allow(
+    dead_code,
+    reason = "Generated backends use different subsets of these helpers"
+)]
+fn scalar_mul_add_precise_f32(a: f32, b: f32, c: f32) -> f32 {
+    let product = (a as f64) * (b as f64);
+    let c = c as f64;
+    let mut sum = product + c;
+    if sum.is_finite() {
+        let virtual_sum = sum - product;
+        let residual = (product - (sum - virtual_sum)) + (c - virtual_sum);
+        let sum_bits = sum.to_bits();
+        if residual != 0.0 && sum_bits & 1 == 0 {
+            let corrected_bits = if sum.is_sign_negative() == residual.is_sign_negative() {
+                sum_bits.wrapping_add(1)
+            } else {
+                sum_bits.wrapping_sub(1)
+            };
+            sum = f64::from_bits(corrected_bits);
+        }
+    }
+    sum as f32
+}
 #[cfg(all(feature = "libm", not(feature = "std")))]
 #[allow(
     dead_code,
@@ -448,10 +472,10 @@ impl Simd for Sse2 {
     #[inline(always)]
     fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
         [
-            f32::mul_add(a[0usize], b[0usize], c[0usize]),
-            f32::mul_add(a[1usize], b[1usize], c[1usize]),
-            f32::mul_add(a[2usize], b[2usize], c[2usize]),
-            f32::mul_add(a[3usize], b[3usize], c[3usize]),
+            scalar_mul_add_precise_f32(a[0usize], b[0usize], c[0usize]),
+            scalar_mul_add_precise_f32(a[1usize], b[1usize], c[1usize]),
+            scalar_mul_add_precise_f32(a[2usize], b[2usize], c[2usize]),
+            scalar_mul_add_precise_f32(a[3usize], b[3usize], c[3usize]),
         ]
         .simd_into(self)
     }

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -27,6 +27,7 @@ trait FloatExt {
     fn fract(self) -> Self;
     fn sqrt(self) -> Self;
     fn trunc(self) -> Self;
+    fn mul_add(self, a: Self, b: Self) -> Self;
 }
 #[cfg(all(feature = "libm", not(feature = "std")))]
 impl FloatExt for f32 {
@@ -54,6 +55,10 @@ impl FloatExt for f32 {
     fn trunc(self) -> f32 {
         libm::truncf(self)
     }
+    #[inline(always)]
+    fn mul_add(self, a: f32, b: f32) -> f32 {
+        libm::fmaf(self, a, b)
+    }
 }
 #[cfg(all(feature = "libm", not(feature = "std")))]
 impl FloatExt for f64 {
@@ -80,6 +85,10 @@ impl FloatExt for f64 {
     #[inline(always)]
     fn trunc(self) -> f64 {
         libm::trunc(self)
+    }
+    #[inline(always)]
+    fn mul_add(self, a: f64, b: f64) -> f64 {
+        libm::fma(self, a, b)
     }
 }
 #[doc = "A token for SSE2 intrinsics on `x86` and `x86_64`, representing the x86-64 baseline."]
@@ -435,6 +444,16 @@ impl Simd for Sse2 {
     #[inline(always)]
     fn mul_add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
         a * b + c
+    }
+    #[inline(always)]
+    fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        [
+            f32::mul_add(a[0usize], b[0usize], c[0usize]),
+            f32::mul_add(a[1usize], b[1usize], c[1usize]),
+            f32::mul_add(a[2usize], b[2usize], c[2usize]),
+            f32::mul_add(a[3usize], b[3usize], c[3usize]),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn mul_sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
@@ -4180,6 +4199,14 @@ impl Simd for Sse2 {
     #[inline(always)]
     fn mul_add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
         a * b + c
+    }
+    #[inline(always)]
+    fn mul_add_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        [
+            f64::mul_add(a[0usize], b[0usize], c[0usize]),
+            f64::mul_add(a[1usize], b[1usize], c[1usize]),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -490,19 +490,22 @@ impl Simd for Sse4_2 {
                     let one = _mm_set1_epi64x(1);
                     let sum_low_bits = _mm_castpd_si128(sum_low);
                     let residual_low_bits = _mm_castpd_si128(residual_low);
-                    let different_sign_low =
-                        _mm_srli_epi64::<63>(_mm_xor_si128(sum_low_bits, residual_low_bits));
-                    let direction_low = _mm_sub_epi64(one, _mm_slli_epi64::<1>(different_sign_low));
+                    let different_sign_low = _mm_cmpgt_epi64(
+                        _mm_setzero_si128(),
+                        _mm_xor_si128(sum_low_bits, residual_low_bits),
+                    );
+                    let direction_low = _mm_or_si128(different_sign_low, one);
                     sum_low = _mm_castsi128_pd(_mm_add_epi64(
                         sum_low_bits,
                         _mm_and_si128(direction_low, correction_low),
                     ));
                     let sum_high_bits = _mm_castpd_si128(sum_high);
                     let residual_high_bits = _mm_castpd_si128(residual_high);
-                    let different_sign_high =
-                        _mm_srli_epi64::<63>(_mm_xor_si128(sum_high_bits, residual_high_bits));
-                    let direction_high =
-                        _mm_sub_epi64(one, _mm_slli_epi64::<1>(different_sign_high));
+                    let different_sign_high = _mm_cmpgt_epi64(
+                        _mm_setzero_si128(),
+                        _mm_xor_si128(sum_high_bits, residual_high_bits),
+                    );
+                    let direction_high = _mm_or_si128(different_sign_high, one);
                     sum_high = _mm_castsi128_pd(_mm_add_epi64(
                         sum_high_bits,
                         _mm_and_si128(direction_high, correction_high),

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -15,6 +15,82 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 use core::ops::*;
+#[cfg(all(feature = "libm", not(feature = "std")))]
+#[allow(
+    dead_code,
+    reason = "Generated backends use different subsets of these helpers"
+)]
+trait FloatExt {
+    fn floor(self) -> Self;
+    fn ceil(self) -> Self;
+    fn round_ties_even(self) -> Self;
+    fn fract(self) -> Self;
+    fn sqrt(self) -> Self;
+    fn trunc(self) -> Self;
+    fn mul_add(self, a: Self, b: Self) -> Self;
+}
+#[cfg(all(feature = "libm", not(feature = "std")))]
+impl FloatExt for f32 {
+    #[inline(always)]
+    fn floor(self) -> f32 {
+        libm::floorf(self)
+    }
+    #[inline(always)]
+    fn ceil(self) -> f32 {
+        libm::ceilf(self)
+    }
+    #[inline(always)]
+    fn round_ties_even(self) -> f32 {
+        libm::rintf(self)
+    }
+    #[inline(always)]
+    fn sqrt(self) -> f32 {
+        libm::sqrtf(self)
+    }
+    #[inline(always)]
+    fn fract(self) -> f32 {
+        self - self.trunc()
+    }
+    #[inline(always)]
+    fn trunc(self) -> f32 {
+        libm::truncf(self)
+    }
+    #[inline(always)]
+    fn mul_add(self, a: f32, b: f32) -> f32 {
+        libm::fmaf(self, a, b)
+    }
+}
+#[cfg(all(feature = "libm", not(feature = "std")))]
+impl FloatExt for f64 {
+    #[inline(always)]
+    fn floor(self) -> f64 {
+        libm::floor(self)
+    }
+    #[inline(always)]
+    fn ceil(self) -> f64 {
+        libm::ceil(self)
+    }
+    #[inline(always)]
+    fn round_ties_even(self) -> f64 {
+        libm::rint(self)
+    }
+    #[inline(always)]
+    fn sqrt(self) -> f64 {
+        libm::sqrt(self)
+    }
+    #[inline(always)]
+    fn fract(self) -> f64 {
+        self - self.trunc()
+    }
+    #[inline(always)]
+    fn trunc(self) -> f64 {
+        libm::trunc(self)
+    }
+    #[inline(always)]
+    fn mul_add(self, a: f64, b: f64) -> f64 {
+        libm::fma(self, a, b)
+    }
+}
 #[doc = "A token for SSE4.2 intrinsics on `x86` and `x86_64`, representing the x86-64-v2 level."]
 #[doc = "# Browsing the documentation"]
 #[doc = "The method list on this struct is very verbose."]
@@ -356,6 +432,88 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn mul_add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
         a * b + c
+    }
+    #[inline(always)]
+    fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Sse4_2,
+                a: f32x4<Sse4_2>,
+                b: f32x4<Sse4_2>,
+                c: f32x4<Sse4_2>,
+            ) -> f32x4<Sse4_2> {
+                let a: __m128 = a.into();
+                let b: __m128 = b.into();
+                let c: __m128 = c.into();
+                let a_low = _mm_cvtps_pd(a);
+                let a_high = _mm_cvtps_pd(_mm_movehl_ps(a, a));
+                let b_low = _mm_cvtps_pd(b);
+                let b_high = _mm_cvtps_pd(_mm_movehl_ps(b, b));
+                let c_low = _mm_cvtps_pd(c);
+                let c_high = _mm_cvtps_pd(_mm_movehl_ps(c, c));
+                let product_low = _mm_mul_pd(a_low, b_low);
+                let product_high = _mm_mul_pd(a_high, b_high);
+                let mut sum_low = _mm_add_pd(product_low, c_low);
+                let mut sum_high = _mm_add_pd(product_high, c_high);
+                let midpoint_fraction_mask = _mm_set1_epi64x(0x1fff_ffff);
+                let midpoint_fraction = _mm_set1_epi64x(0x1000_0000);
+                let midpoint_low = _mm_cmpeq_epi64(
+                    _mm_and_si128(_mm_castpd_si128(sum_low), midpoint_fraction_mask),
+                    midpoint_fraction,
+                );
+                let midpoint_high = _mm_cmpeq_epi64(
+                    _mm_and_si128(_mm_castpd_si128(sum_high), midpoint_fraction_mask),
+                    midpoint_fraction,
+                );
+                let any_midpoint = _mm_or_si128(midpoint_low, midpoint_high);
+                if _mm_testz_si128(any_midpoint, any_midpoint) == 0 {
+                    let virtual_low = _mm_sub_pd(sum_low, product_low);
+                    let residual_low = _mm_add_pd(
+                        _mm_sub_pd(product_low, _mm_sub_pd(sum_low, virtual_low)),
+                        _mm_sub_pd(c_low, virtual_low),
+                    );
+                    let virtual_high = _mm_sub_pd(sum_high, product_high);
+                    let residual_high = _mm_add_pd(
+                        _mm_sub_pd(product_high, _mm_sub_pd(sum_high, virtual_high)),
+                        _mm_sub_pd(c_high, virtual_high),
+                    );
+                    let zero = _mm_setzero_pd();
+                    let correction_low = _mm_and_si128(
+                        midpoint_low,
+                        _mm_castpd_si128(_mm_cmpneq_pd(residual_low, zero)),
+                    );
+                    let correction_high = _mm_and_si128(
+                        midpoint_high,
+                        _mm_castpd_si128(_mm_cmpneq_pd(residual_high, zero)),
+                    );
+                    let one = _mm_set1_epi64x(1);
+                    let sum_low_bits = _mm_castpd_si128(sum_low);
+                    let residual_low_bits = _mm_castpd_si128(residual_low);
+                    let different_sign_low =
+                        _mm_srli_epi64::<63>(_mm_xor_si128(sum_low_bits, residual_low_bits));
+                    let direction_low = _mm_sub_epi64(one, _mm_slli_epi64::<1>(different_sign_low));
+                    sum_low = _mm_castsi128_pd(_mm_add_epi64(
+                        sum_low_bits,
+                        _mm_and_si128(direction_low, correction_low),
+                    ));
+                    let sum_high_bits = _mm_castpd_si128(sum_high);
+                    let residual_high_bits = _mm_castpd_si128(residual_high);
+                    let different_sign_high =
+                        _mm_srli_epi64::<63>(_mm_xor_si128(sum_high_bits, residual_high_bits));
+                    let direction_high =
+                        _mm_sub_epi64(one, _mm_slli_epi64::<1>(different_sign_high));
+                    sum_high = _mm_castsi128_pd(_mm_add_epi64(
+                        sum_high_bits,
+                        _mm_and_si128(direction_high, correction_high),
+                    ));
+                }
+                let low = _mm_cvtpd_ps(sum_low);
+                let high = _mm_cvtpd_ps(sum_high);
+                _mm_movelh_ps(low, high).simd_into(token)
+            }
+        );
+        kernel(self, a, b, c)
     }
     #[inline(always)]
     fn mul_sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
@@ -3844,6 +4002,14 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn mul_add_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
         a * b + c
+    }
+    #[inline(always)]
+    fn mul_add_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        [
+            f64::mul_add(a[0usize], b[0usize], c[0usize]),
+            f64::mul_add(a[1usize], b[1usize], c[1usize]),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -520,6 +520,10 @@ impl Simd for Sse4_2 {
         a * b - c
     }
     #[inline(always)]
+    fn mul_sub_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        self.mul_add_precise_f32x4(a, b, -c)
+    }
+    #[inline(always)]
     fn floor_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -4014,6 +4018,10 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
         a * b - c
+    }
+    #[inline(always)]
+    fn mul_sub_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        self.mul_add_precise_f64x2(a, b, -c)
     }
     #[inline(always)]
     fn floor_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -15,6 +15,30 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 use core::ops::*;
+#[inline(always)]
+#[allow(
+    dead_code,
+    reason = "Generated backends use different subsets of these helpers"
+)]
+fn scalar_mul_add_precise_f32(a: f32, b: f32, c: f32) -> f32 {
+    let product = (a as f64) * (b as f64);
+    let c = c as f64;
+    let mut sum = product + c;
+    if sum.is_finite() {
+        let virtual_sum = sum - product;
+        let residual = (product - (sum - virtual_sum)) + (c - virtual_sum);
+        let sum_bits = sum.to_bits();
+        if residual != 0.0 && sum_bits & 1 == 0 {
+            let corrected_bits = if sum.is_sign_negative() == residual.is_sign_negative() {
+                sum_bits.wrapping_add(1)
+            } else {
+                sum_bits.wrapping_sub(1)
+            };
+            sum = f64::from_bits(corrected_bits);
+        }
+    }
+    sum as f32
+}
 #[cfg(all(feature = "libm", not(feature = "std")))]
 #[allow(
     dead_code,

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -15,30 +15,6 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 use core::ops::*;
-#[inline(always)]
-#[allow(
-    dead_code,
-    reason = "Generated backends use different subsets of these helpers"
-)]
-fn scalar_mul_add_precise_f32(a: f32, b: f32, c: f32) -> f32 {
-    let product = (a as f64) * (b as f64);
-    let c = c as f64;
-    let mut sum = product + c;
-    if sum.is_finite() {
-        let virtual_sum = sum - product;
-        let residual = (product - (sum - virtual_sum)) + (c - virtual_sum);
-        let sum_bits = sum.to_bits();
-        if residual != 0.0 && sum_bits & 1 == 0 {
-            let corrected_bits = if sum.is_sign_negative() == residual.is_sign_negative() {
-                sum_bits.wrapping_add(1)
-            } else {
-                sum_bits.wrapping_sub(1)
-            };
-            sum = f64::from_bits(corrected_bits);
-        }
-    }
-    sum as f32
-}
 #[cfg(all(feature = "libm", not(feature = "std")))]
 #[allow(
     dead_code,

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -15,6 +15,30 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 use core::ops::*;
+#[inline(always)]
+#[allow(
+    dead_code,
+    reason = "Generated backends use different subsets of these helpers"
+)]
+fn scalar_mul_add_precise_f32(a: f32, b: f32, c: f32) -> f32 {
+    let product = (a as f64) * (b as f64);
+    let c = c as f64;
+    let mut sum = product + c;
+    if sum.is_finite() {
+        let virtual_sum = sum - product;
+        let residual = (product - (sum - virtual_sum)) + (c - virtual_sum);
+        let sum_bits = sum.to_bits();
+        if residual != 0.0 && sum_bits & 1 == 0 {
+            let corrected_bits = if sum.is_sign_negative() == residual.is_sign_negative() {
+                sum_bits.wrapping_add(1)
+            } else {
+                sum_bits.wrapping_sub(1)
+            };
+            sum = f64::from_bits(corrected_bits);
+        }
+    }
+    sum as f32
+}
 #[cfg(all(feature = "libm", not(feature = "std")))]
 #[allow(
     dead_code,
@@ -466,8 +490,19 @@ impl Simd for Sse4_2 {
                     _mm_and_si128(_mm_castpd_si128(sum_high), midpoint_fraction_mask),
                     midpoint_fraction,
                 );
-                let any_midpoint = _mm_or_si128(midpoint_low, midpoint_high);
-                if _mm_testz_si128(any_midpoint, any_midpoint) == 0 {
+                let mut low = _mm_cvtpd_ps(sum_low);
+                let mut high = _mm_cvtpd_ps(sum_high);
+                let provisional = _mm_movelh_ps(low, high);
+                let abs_provisional_bits =
+                    _mm_and_si128(_mm_castps_si128(provisional), _mm_set1_epi32(0x7fff_ffff));
+                let at_most_min_normal =
+                    _mm_cmpgt_epi32(_mm_set1_epi32(0x0080_0001), abs_provisional_bits);
+                let subnormal_low = _mm_unpacklo_epi32(at_most_min_normal, at_most_min_normal);
+                let subnormal_high = _mm_unpackhi_epi32(at_most_min_normal, at_most_min_normal);
+                let round_to_odd_low = _mm_or_si128(midpoint_low, subnormal_low);
+                let round_to_odd_high = _mm_or_si128(midpoint_high, subnormal_high);
+                let any_round_to_odd = _mm_or_si128(round_to_odd_low, round_to_odd_high);
+                if _mm_testz_si128(any_round_to_odd, any_round_to_odd) == 0 {
                     let virtual_low = _mm_sub_pd(sum_low, product_low);
                     let residual_low = _mm_add_pd(
                         _mm_sub_pd(product_low, _mm_sub_pd(sum_low, virtual_low)),
@@ -478,22 +513,18 @@ impl Simd for Sse4_2 {
                         _mm_sub_pd(product_high, _mm_sub_pd(sum_high, virtual_high)),
                         _mm_sub_pd(c_high, virtual_high),
                     );
-                    let zero = _mm_setzero_pd();
-                    let correction_low = _mm_and_si128(
-                        midpoint_low,
-                        _mm_castpd_si128(_mm_cmpneq_pd(residual_low, zero)),
-                    );
-                    let correction_high = _mm_and_si128(
-                        midpoint_high,
-                        _mm_castpd_si128(_mm_cmpneq_pd(residual_high, zero)),
-                    );
                     let one = _mm_set1_epi64x(1);
+                    let zero_si128 = _mm_setzero_si128();
+                    let zero = _mm_setzero_pd();
                     let sum_low_bits = _mm_castpd_si128(sum_low);
                     let residual_low_bits = _mm_castpd_si128(residual_low);
-                    let different_sign_low = _mm_cmpgt_epi64(
-                        _mm_setzero_si128(),
-                        _mm_xor_si128(sum_low_bits, residual_low_bits),
+                    let even_low = _mm_cmpeq_epi64(_mm_and_si128(sum_low_bits, one), zero_si128);
+                    let correction_low = _mm_and_si128(
+                        _mm_and_si128(round_to_odd_low, even_low),
+                        _mm_castpd_si128(_mm_cmpneq_pd(residual_low, zero)),
                     );
+                    let different_sign_low =
+                        _mm_cmpgt_epi64(zero_si128, _mm_xor_si128(sum_low_bits, residual_low_bits));
                     let direction_low = _mm_or_si128(different_sign_low, one);
                     sum_low = _mm_castsi128_pd(_mm_add_epi64(
                         sum_low_bits,
@@ -501,8 +532,13 @@ impl Simd for Sse4_2 {
                     ));
                     let sum_high_bits = _mm_castpd_si128(sum_high);
                     let residual_high_bits = _mm_castpd_si128(residual_high);
+                    let even_high = _mm_cmpeq_epi64(_mm_and_si128(sum_high_bits, one), zero_si128);
+                    let correction_high = _mm_and_si128(
+                        _mm_and_si128(round_to_odd_high, even_high),
+                        _mm_castpd_si128(_mm_cmpneq_pd(residual_high, zero)),
+                    );
                     let different_sign_high = _mm_cmpgt_epi64(
-                        _mm_setzero_si128(),
+                        zero_si128,
                         _mm_xor_si128(sum_high_bits, residual_high_bits),
                     );
                     let direction_high = _mm_or_si128(different_sign_high, one);
@@ -510,9 +546,9 @@ impl Simd for Sse4_2 {
                         sum_high_bits,
                         _mm_and_si128(direction_high, correction_high),
                     ));
+                    low = _mm_cvtpd_ps(sum_low);
+                    high = _mm_cvtpd_ps(sum_high);
                 }
-                let low = _mm_cvtpd_ps(sum_low);
-                let high = _mm_cvtpd_ps(sum_high);
                 _mm_movelh_ps(low, high).simd_into(token)
             }
         );

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -480,12 +480,12 @@ impl Simd for Sse4_2 {
                 let any_round_to_odd = _mm_or_si128(round_to_odd_low, round_to_odd_high);
                 if _mm_testz_si128(any_round_to_odd, any_round_to_odd) == 0 {
                     let virtual_low = _mm_sub_pd(sum_low, product_low);
-                    let residual_low = _mm_add_pd(
+                    let error_low = _mm_add_pd(
                         _mm_sub_pd(product_low, _mm_sub_pd(sum_low, virtual_low)),
                         _mm_sub_pd(c_low, virtual_low),
                     );
                     let virtual_high = _mm_sub_pd(sum_high, product_high);
-                    let residual_high = _mm_add_pd(
+                    let error_high = _mm_add_pd(
                         _mm_sub_pd(product_high, _mm_sub_pd(sum_high, virtual_high)),
                         _mm_sub_pd(c_high, virtual_high),
                     );
@@ -493,30 +493,28 @@ impl Simd for Sse4_2 {
                     let zero_si128 = _mm_setzero_si128();
                     let zero = _mm_setzero_pd();
                     let sum_low_bits = _mm_castpd_si128(sum_low);
-                    let residual_low_bits = _mm_castpd_si128(residual_low);
+                    let error_low_bits = _mm_castpd_si128(error_low);
                     let even_low = _mm_cmpeq_epi64(_mm_and_si128(sum_low_bits, one), zero_si128);
                     let correction_low = _mm_and_si128(
                         _mm_and_si128(round_to_odd_low, even_low),
-                        _mm_castpd_si128(_mm_cmpneq_pd(residual_low, zero)),
+                        _mm_castpd_si128(_mm_cmpneq_pd(error_low, zero)),
                     );
                     let different_sign_low =
-                        _mm_cmpgt_epi64(zero_si128, _mm_xor_si128(sum_low_bits, residual_low_bits));
+                        _mm_cmpgt_epi64(zero_si128, _mm_xor_si128(sum_low_bits, error_low_bits));
                     let direction_low = _mm_or_si128(different_sign_low, one);
                     sum_low = _mm_castsi128_pd(_mm_add_epi64(
                         sum_low_bits,
                         _mm_and_si128(direction_low, correction_low),
                     ));
                     let sum_high_bits = _mm_castpd_si128(sum_high);
-                    let residual_high_bits = _mm_castpd_si128(residual_high);
+                    let error_high_bits = _mm_castpd_si128(error_high);
                     let even_high = _mm_cmpeq_epi64(_mm_and_si128(sum_high_bits, one), zero_si128);
                     let correction_high = _mm_and_si128(
                         _mm_and_si128(round_to_odd_high, even_high),
-                        _mm_castpd_si128(_mm_cmpneq_pd(residual_high, zero)),
+                        _mm_castpd_si128(_mm_cmpneq_pd(error_high, zero)),
                     );
-                    let different_sign_high = _mm_cmpgt_epi64(
-                        zero_si128,
-                        _mm_xor_si128(sum_high_bits, residual_high_bits),
-                    );
+                    let different_sign_high =
+                        _mm_cmpgt_epi64(zero_si128, _mm_xor_si128(sum_high_bits, error_high_bits));
                     let direction_high = _mm_or_si128(different_sign_high, one);
                     sum_high = _mm_castsi128_pd(_mm_add_epi64(
                         sum_high_bits,

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -12,6 +12,30 @@ use crate::{
 };
 use core::arch::wasm32::*;
 use core::ops::*;
+#[inline(always)]
+#[allow(
+    dead_code,
+    reason = "Generated backends use different subsets of these helpers"
+)]
+fn scalar_mul_add_precise_f32(a: f32, b: f32, c: f32) -> f32 {
+    let product = (a as f64) * (b as f64);
+    let c = c as f64;
+    let mut sum = product + c;
+    if sum.is_finite() {
+        let virtual_sum = sum - product;
+        let residual = (product - (sum - virtual_sum)) + (c - virtual_sum);
+        let sum_bits = sum.to_bits();
+        if residual != 0.0 && sum_bits & 1 == 0 {
+            let corrected_bits = if sum.is_sign_negative() == residual.is_sign_negative() {
+                sum_bits.wrapping_add(1)
+            } else {
+                sum_bits.wrapping_sub(1)
+            };
+            sum = f64::from_bits(corrected_bits);
+        }
+    }
+    sum as f32
+}
 #[cfg(all(feature = "libm", not(feature = "std")))]
 #[allow(
     dead_code,
@@ -321,10 +345,10 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
         [
-            f32::mul_add(a[0usize], b[0usize], c[0usize]),
-            f32::mul_add(a[1usize], b[1usize], c[1usize]),
-            f32::mul_add(a[2usize], b[2usize], c[2usize]),
-            f32::mul_add(a[3usize], b[3usize], c[3usize]),
+            scalar_mul_add_precise_f32(a[0usize], b[0usize], c[0usize]),
+            scalar_mul_add_precise_f32(a[1usize], b[1usize], c[1usize]),
+            scalar_mul_add_precise_f32(a[2usize], b[2usize], c[2usize]),
+            scalar_mul_add_precise_f32(a[3usize], b[3usize], c[3usize]),
         ]
         .simd_into(self)
     }

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -340,6 +340,10 @@ impl Simd for WasmSimd128 {
         }
     }
     #[inline(always)]
+    fn mul_sub_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        self.mul_add_precise_f32x4(a, b, -c)
+    }
+    #[inline(always)]
     fn floor_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
         f32x4_floor(a.into()).simd_into(self)
     }
@@ -2304,6 +2308,10 @@ impl Simd for WasmSimd128 {
         {
             self.sub_f64x2(self.mul_f64x2(a, b), c)
         }
+    }
+    #[inline(always)]
+    fn mul_sub_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        self.mul_add_precise_f64x2(a, b, -c)
     }
     #[inline(always)]
     fn floor_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -12,6 +12,82 @@ use crate::{
 };
 use core::arch::wasm32::*;
 use core::ops::*;
+#[cfg(all(feature = "libm", not(feature = "std")))]
+#[allow(
+    dead_code,
+    reason = "Generated backends use different subsets of these helpers"
+)]
+trait FloatExt {
+    fn floor(self) -> Self;
+    fn ceil(self) -> Self;
+    fn round_ties_even(self) -> Self;
+    fn fract(self) -> Self;
+    fn sqrt(self) -> Self;
+    fn trunc(self) -> Self;
+    fn mul_add(self, a: Self, b: Self) -> Self;
+}
+#[cfg(all(feature = "libm", not(feature = "std")))]
+impl FloatExt for f32 {
+    #[inline(always)]
+    fn floor(self) -> f32 {
+        libm::floorf(self)
+    }
+    #[inline(always)]
+    fn ceil(self) -> f32 {
+        libm::ceilf(self)
+    }
+    #[inline(always)]
+    fn round_ties_even(self) -> f32 {
+        libm::rintf(self)
+    }
+    #[inline(always)]
+    fn sqrt(self) -> f32 {
+        libm::sqrtf(self)
+    }
+    #[inline(always)]
+    fn fract(self) -> f32 {
+        self - self.trunc()
+    }
+    #[inline(always)]
+    fn trunc(self) -> f32 {
+        libm::truncf(self)
+    }
+    #[inline(always)]
+    fn mul_add(self, a: f32, b: f32) -> f32 {
+        libm::fmaf(self, a, b)
+    }
+}
+#[cfg(all(feature = "libm", not(feature = "std")))]
+impl FloatExt for f64 {
+    #[inline(always)]
+    fn floor(self) -> f64 {
+        libm::floor(self)
+    }
+    #[inline(always)]
+    fn ceil(self) -> f64 {
+        libm::ceil(self)
+    }
+    #[inline(always)]
+    fn round_ties_even(self) -> f64 {
+        libm::rint(self)
+    }
+    #[inline(always)]
+    fn sqrt(self) -> f64 {
+        libm::sqrt(self)
+    }
+    #[inline(always)]
+    fn fract(self) -> f64 {
+        self - self.trunc()
+    }
+    #[inline(always)]
+    fn trunc(self) -> f64 {
+        libm::trunc(self)
+    }
+    #[inline(always)]
+    fn mul_add(self, a: f64, b: f64) -> f64 {
+        libm::fma(self, a, b)
+    }
+}
 #[doc = "A token for WASM SIMD128, representing the \"wasm128\" level."]
 #[doc = "# Browsing the documentation"]
 #[doc = "The method list on this struct is very verbose."]
@@ -241,6 +317,16 @@ impl Simd for WasmSimd128 {
         {
             self.add_f32x4(self.mul_f32x4(a, b), c)
         }
+    }
+    #[inline(always)]
+    fn mul_add_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        [
+            f32::mul_add(a[0usize], b[0usize], c[0usize]),
+            f32::mul_add(a[1usize], b[1usize], c[1usize]),
+            f32::mul_add(a[2usize], b[2usize], c[2usize]),
+            f32::mul_add(a[3usize], b[3usize], c[3usize]),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn mul_sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
@@ -2199,6 +2285,14 @@ impl Simd for WasmSimd128 {
         {
             self.add_f64x2(self.mul_f64x2(a, b), c)
         }
+    }
+    #[inline(always)]
+    fn mul_add_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
+        [
+            f64::mul_add(a[0usize], b[0usize], c[0usize]),
+            f64::mul_add(a[1usize], b[1usize], c[1usize]),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -13,10 +13,6 @@ use crate::{
 use core::arch::wasm32::*;
 use core::ops::*;
 #[inline(always)]
-#[allow(
-    dead_code,
-    reason = "Generated backends use different subsets of these helpers"
-)]
 fn scalar_mul_add_precise_f32(a: f32, b: f32, c: f32) -> f32 {
     let product = (a as f64) * (b as f64);
     let c = c as f64;

--- a/fearless_simd_gen/src/arch/fallback.rs
+++ b/fearless_simd_gen/src/arch/fallback.rs
@@ -59,6 +59,7 @@ pub(crate) fn translate_op(op: &str, is_float: bool) -> Option<&'static str> {
         "min" => "min",
         "max_precise" => "max",
         "min_precise" => "min",
+        "mul_add_precise" => "mul_add",
         _ => return None,
     })
 }

--- a/fearless_simd_gen/src/arch/neon.rs
+++ b/fearless_simd_gen/src/arch/neon.rs
@@ -36,7 +36,6 @@ fn translate_op(op: &str) -> Option<&'static str> {
         "max_precise" => "vmaxnm",
         "min_precise" => "vminnm",
         "mul_add" => "vfma",
-        "mul_sub" => "vfms",
         _ => return None,
     })
 }

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -26,6 +26,7 @@ pub(crate) fn float_ext_prelude() -> TokenStream {
             fn fract(self) -> Self;
             fn sqrt(self) -> Self;
             fn trunc(self) -> Self;
+            fn mul_add(self, a: Self, b: Self) -> Self;
         }
         #[cfg(all(feature = "libm", not(feature = "std")))]
         impl FloatExt for f32 {
@@ -52,6 +53,10 @@ pub(crate) fn float_ext_prelude() -> TokenStream {
             #[inline(always)]
             fn trunc(self) -> f32 {
                 libm::truncf(self)
+            }
+            #[inline(always)]
+            fn mul_add(self, a: f32, b: f32) -> f32 {
+                libm::fmaf(self, a, b)
             }
         }
 
@@ -80,6 +85,10 @@ pub(crate) fn float_ext_prelude() -> TokenStream {
             #[inline(always)]
             fn trunc(self) -> f64 {
                 libm::trunc(self)
+            }
+            #[inline(always)]
+            fn mul_add(self, a: f64, b: f64) -> f64 {
+                libm::fma(self, a, b)
             }
         }
     }
@@ -301,16 +310,21 @@ impl Level for Fallback {
                         }
                     }
                 } else {
-                    let args = [
-                        quote! { a.into() },
-                        quote! { b.into() },
-                        quote! { c.into() },
-                    ];
-
-                    let expr = fallback::expr(method, vec_ty, &args);
+                    let items = make_list(
+                        (0..vec_ty.len)
+                            .map(|idx| {
+                                let args = [
+                                    lane(quote! { a }, vec_ty, idx),
+                                    lane(quote! { b }, vec_ty, idx),
+                                    lane(quote! { c }, vec_ty, idx),
+                                ];
+                                fallback::expr(method, vec_ty, &args)
+                            })
+                            .collect::<Vec<_>>(),
+                    );
                     quote! {
                         #method_sig {
-                            #expr.simd_into(self)
+                            #items.simd_into(self)
                         }
                     }
                 }

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -17,6 +17,39 @@ pub(crate) struct Fallback;
 
 pub(crate) fn float_ext_prelude() -> TokenStream {
     quote! {
+        #[inline(always)]
+        #[allow(dead_code, reason = "Generated backends use different subsets of these helpers")]
+        fn scalar_mul_add_precise_f32(a: f32, b: f32, c: f32) -> f32 {
+            // Every finite f32 product is exactly representable as f64. Recover the exact error
+            // of the widened addition with TwoSum, then turn the rounded f64 sum into a
+            // round-to-odd value before narrowing. Boldo and Melquiond prove that this final
+            // narrowing is equivalent to rounding the exact product-plus-add once to f32:
+            // https://guillaume.melquiond.fr/doc/08-tc.pdf
+            let product = (a as f64) * (b as f64);
+            let c = c as f64;
+            let mut sum = product + c;
+
+            if sum.is_finite() {
+                let virtual_sum = sum - product;
+                let residual =
+                    (product - (sum - virtual_sum)) + (c - virtual_sum);
+                let sum_bits = sum.to_bits();
+
+                if residual != 0.0 && sum_bits & 1 == 0 {
+                    let corrected_bits = if sum.is_sign_negative()
+                        == residual.is_sign_negative()
+                    {
+                        sum_bits.wrapping_add(1)
+                    } else {
+                        sum_bits.wrapping_sub(1)
+                    };
+                    sum = f64::from_bits(corrected_bits);
+                }
+            }
+
+            sum as f32
+        }
+
         #[cfg(all(feature = "libm", not(feature = "std")))]
         #[allow(dead_code, reason = "Generated backends use different subsets of these helpers")]
         trait FloatExt {
@@ -314,6 +347,25 @@ impl Level for Fallback {
                     quote! {
                         #method_sig {
                             self.#mul_add_precise(a, b, -c)
+                        }
+                    }
+                } else if method == "mul_add_precise"
+                    && vec_ty.scalar == ScalarType::Float
+                    && vec_ty.scalar_bits == 32
+                {
+                    let items = make_list(
+                        (0..vec_ty.len)
+                            .map(|idx| {
+                                let a = lane(quote! { a }, vec_ty, idx);
+                                let b = lane(quote! { b }, vec_ty, idx);
+                                let c = lane(quote! { c }, vec_ty, idx);
+                                quote! { scalar_mul_add_precise_f32(#a, #b, #c) }
+                            })
+                            .collect::<Vec<_>>(),
+                    );
+                    quote! {
+                        #method_sig {
+                            #items.simd_into(self)
                         }
                     }
                 } else {

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -309,6 +309,13 @@ impl Level for Fallback {
                             a.mul(b).sub(c)
                         }
                     }
+                } else if method == "mul_sub_precise" {
+                    let mul_add_precise = generic_op_name("mul_add_precise", vec_ty);
+                    quote! {
+                        #method_sig {
+                            self.#mul_add_precise(a, b, -c)
+                        }
+                    }
                 } else {
                     let items = make_list(
                         (0..vec_ty.len)

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -19,14 +19,18 @@ pub(crate) fn scalar_mul_add_precise_f32_body() -> TokenStream {
     quote! {
         // Every finite f32 product is exactly representable as f64. Recover the exact error
         // of the widened addition with TwoSum, then turn the rounded f64 sum into a
-        // round-to-odd value before narrowing. Boldo and Melquiond prove that this final
-        // narrowing is equivalent to rounding the exact product-plus-add once to f32:
+        // round-to-odd value before narrowing. This is the p=24, k=29 specialization of
+        // Boldo and Melquiond's Theorem 3, which proves that this final narrowing is
+        // equivalent to rounding the exact product-plus-add once to f32:
         // https://guillaume.melquiond.fr/doc/08-tc.pdf
+        // The theorem's exponent-range condition also holds: every finite exact result is
+        // a multiple of 2^-298 with magnitude below 2^256, well inside binary64's normal range.
         let product = (a as f64) * (b as f64);
         let c = c as f64;
         let mut sum = product + c;
 
         if sum.is_finite() {
+            // Knuth's unconditional TwoSum; each arithmetic operation must round to binary64.
             let virtual_sum = sum - product;
             let residual =
                 (product - (sum - virtual_sum)) + (c - virtual_sum);

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -15,7 +15,7 @@ use quote::quote;
 #[derive(Clone, Copy)]
 pub(crate) struct Fallback;
 
-fn scalar_mul_add_precise_f32_body() -> TokenStream {
+pub(crate) fn scalar_mul_add_precise_f32_body() -> TokenStream {
     quote! {
         // Every finite f32 product is exactly representable as f64. Recover the exact error
         // of the widened addition with TwoSum, then turn the rounded f64 sum into a
@@ -52,22 +52,9 @@ pub(crate) fn scalar_mul_add_precise_f32_helper() -> TokenStream {
     let body = scalar_mul_add_precise_f32_body();
     quote! {
         #[inline(always)]
-        #[allow(dead_code, reason = "Generated backends use different subsets of these helpers")]
         fn scalar_mul_add_precise_f32(a: f32, b: f32, c: f32) -> f32 {
             #body
         }
-    }
-}
-
-pub(crate) fn sse2_scalar_mul_add_precise_f32_helper() -> TokenStream {
-    let body = scalar_mul_add_precise_f32_body();
-    quote! {
-        crate::kernel!(
-            #[inline(always)]
-            fn scalar_mul_add_precise_f32(_token: Sse2, a: f32, b: f32, c: f32) -> f32 {
-                #body
-            }
-        );
     }
 }
 

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -64,7 +64,6 @@ pub(crate) fn sse2_scalar_mul_add_precise_f32_helper() -> TokenStream {
     quote! {
         crate::kernel!(
             #[inline(always)]
-            #[allow(dead_code, reason = "Generated backends use different subsets of these helpers")]
             fn scalar_mul_add_precise_f32(_token: Sse2, a: f32, b: f32, c: f32) -> f32 {
                 #body
             }

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -15,41 +15,65 @@ use quote::quote;
 #[derive(Clone, Copy)]
 pub(crate) struct Fallback;
 
-pub(crate) fn float_ext_prelude() -> TokenStream {
+fn scalar_mul_add_precise_f32_body() -> TokenStream {
+    quote! {
+        // Every finite f32 product is exactly representable as f64. Recover the exact error
+        // of the widened addition with TwoSum, then turn the rounded f64 sum into a
+        // round-to-odd value before narrowing. Boldo and Melquiond prove that this final
+        // narrowing is equivalent to rounding the exact product-plus-add once to f32:
+        // https://guillaume.melquiond.fr/doc/08-tc.pdf
+        let product = (a as f64) * (b as f64);
+        let c = c as f64;
+        let mut sum = product + c;
+
+        if sum.is_finite() {
+            let virtual_sum = sum - product;
+            let residual =
+                (product - (sum - virtual_sum)) + (c - virtual_sum);
+            let sum_bits = sum.to_bits();
+
+            if residual != 0.0 && sum_bits & 1 == 0 {
+                let corrected_bits = if sum.is_sign_negative()
+                    == residual.is_sign_negative()
+                {
+                    sum_bits.wrapping_add(1)
+                } else {
+                    sum_bits.wrapping_sub(1)
+                };
+                sum = f64::from_bits(corrected_bits);
+            }
+        }
+
+        sum as f32
+    }
+}
+
+pub(crate) fn scalar_mul_add_precise_f32_helper() -> TokenStream {
+    let body = scalar_mul_add_precise_f32_body();
     quote! {
         #[inline(always)]
         #[allow(dead_code, reason = "Generated backends use different subsets of these helpers")]
         fn scalar_mul_add_precise_f32(a: f32, b: f32, c: f32) -> f32 {
-            // Every finite f32 product is exactly representable as f64. Recover the exact error
-            // of the widened addition with TwoSum, then turn the rounded f64 sum into a
-            // round-to-odd value before narrowing. Boldo and Melquiond prove that this final
-            // narrowing is equivalent to rounding the exact product-plus-add once to f32:
-            // https://guillaume.melquiond.fr/doc/08-tc.pdf
-            let product = (a as f64) * (b as f64);
-            let c = c as f64;
-            let mut sum = product + c;
-
-            if sum.is_finite() {
-                let virtual_sum = sum - product;
-                let residual =
-                    (product - (sum - virtual_sum)) + (c - virtual_sum);
-                let sum_bits = sum.to_bits();
-
-                if residual != 0.0 && sum_bits & 1 == 0 {
-                    let corrected_bits = if sum.is_sign_negative()
-                        == residual.is_sign_negative()
-                    {
-                        sum_bits.wrapping_add(1)
-                    } else {
-                        sum_bits.wrapping_sub(1)
-                    };
-                    sum = f64::from_bits(corrected_bits);
-                }
-            }
-
-            sum as f32
+            #body
         }
+    }
+}
 
+pub(crate) fn sse2_scalar_mul_add_precise_f32_helper() -> TokenStream {
+    let body = scalar_mul_add_precise_f32_body();
+    quote! {
+        crate::kernel!(
+            #[inline(always)]
+            #[allow(dead_code, reason = "Generated backends use different subsets of these helpers")]
+            fn scalar_mul_add_precise_f32(_token: Sse2, a: f32, b: f32, c: f32) -> f32 {
+                #body
+            }
+        );
+    }
+}
+
+pub(crate) fn float_ext_prelude() -> TokenStream {
+    quote! {
         #[cfg(all(feature = "libm", not(feature = "std")))]
         #[allow(dead_code, reason = "Generated backends use different subsets of these helpers")]
         trait FloatExt {
@@ -156,10 +180,12 @@ impl Level for Fallback {
 
     fn make_module_prelude(&self) -> TokenStream {
         let float_ext = float_ext_prelude();
+        let scalar_mul_add_precise_f32 = scalar_mul_add_precise_f32_helper();
 
         quote! {
             use core::ops::*;
 
+            #scalar_mul_add_precise_f32
             #float_ext
         }
     }

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -318,6 +318,15 @@ impl Level for Neon {
                 })
             }
             OpSig::Ternary => {
+                if method == "mul_add_precise" {
+                    let mul_add = generic_op_name("mul_add", vec_ty);
+                    return quote! {
+                        #method_sig {
+                            self.#mul_add(a, b, c)
+                        }
+                    };
+                }
+
                 let args = match method {
                     "mul_add" | "mul_sub" => [
                         quote! { c.into() },

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -326,26 +326,29 @@ impl Level for Neon {
                         }
                     };
                 }
-
-                let args = match method {
-                    "mul_add" | "mul_sub" => [
-                        quote! { c.into() },
-                        quote! { b.into() },
-                        quote! { a.into() },
-                    ],
-                    _ => [
-                        quote! { a.into() },
-                        quote! { b.into() },
-                        quote! { c.into() },
-                    ],
-                };
-
-                let mut expr = neon::expr(method, vec_ty, &args);
                 if method == "mul_sub" {
-                    // -(c - a * b) = (a * b - c)
-                    let neg = simple_intrinsic("vneg", vec_ty);
-                    expr = quote! { #neg(#expr) };
+                    let mul_add = generic_op_name("mul_add", vec_ty);
+                    return quote! {
+                        #method_sig {
+                            self.#mul_add(a, b, -c)
+                        }
+                    };
                 }
+                if method == "mul_sub_precise" {
+                    let mul_sub = generic_op_name("mul_sub", vec_ty);
+                    return quote! {
+                        #method_sig {
+                            self.#mul_sub(a, b, c)
+                        }
+                    };
+                }
+
+                let args = [
+                    quote! { c.into() },
+                    quote! { b.into() },
+                    quote! { a.into() },
+                ];
+                let expr = neon::expr(method, vec_ty, &args);
                 self.kernel_method(op, vec_ty, |token| {
                     quote! { #expr.simd_into(#token) }
                 })

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -421,6 +421,13 @@ impl Level for WasmSimd128 {
             OpSig::Ternary => {
                 if method == "mul_add_precise" {
                     fallback_method(op, vec_ty)
+                } else if method == "mul_sub_precise" {
+                    let mul_add_precise = generic_op_name("mul_add_precise", vec_ty);
+                    quote! {
+                        #method_sig {
+                            self.#mul_add_precise(a, b, -c)
+                        }
+                    }
                 } else if matches!(method, "mul_add" | "mul_sub") {
                     let add_sub =
                         generic_op_name(if method == "mul_add" { "add" } else { "sub" }, vec_ty);

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -118,9 +118,11 @@ impl Level for WasmSimd128 {
 
     fn make_module_prelude(&self) -> TokenStream {
         let float_ext = crate::mk_fallback::float_ext_prelude();
+        let scalar_mul_add_precise_f32 = crate::mk_fallback::scalar_mul_add_precise_f32_helper();
         quote! {
             use core::arch::wasm32::*;
             use core::ops::*;
+            #scalar_mul_add_precise_f32
             #float_ext
         }
     }

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -117,9 +117,11 @@ impl Level for WasmSimd128 {
     }
 
     fn make_module_prelude(&self) -> TokenStream {
+        let float_ext = crate::mk_fallback::float_ext_prelude();
         quote! {
             use core::arch::wasm32::*;
             use core::ops::*;
+            #float_ext
         }
     }
 
@@ -417,7 +419,9 @@ impl Level for WasmSimd128 {
                 }
             }
             OpSig::Ternary => {
-                if matches!(method, "mul_add" | "mul_sub") {
+                if method == "mul_add_precise" {
+                    fallback_method(op, vec_ty)
+                } else if matches!(method, "mul_add" | "mul_sub") {
                     let add_sub =
                         generic_op_name(if method == "mul_add" { "add" } else { "sub" }, vec_ty);
                     let mul = generic_op_name("mul", vec_ty);

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2440,6 +2440,22 @@ impl X86 {
                 }
             }
             "mul_add_precise" => fallback_method(op, vec_ty),
+            "mul_sub_precise" if matches!(self, Self::Avx2 | Self::Avx512) => {
+                let mul_sub = generic_op_name("mul_sub", vec_ty);
+                quote! {
+                    #method_sig {
+                        self.#mul_sub(a, b, c)
+                    }
+                }
+            }
+            "mul_sub_precise" => {
+                let mul_add_precise = generic_op_name("mul_add_precise", vec_ty);
+                quote! {
+                    #method_sig {
+                        self.#mul_add_precise(a, b, -c)
+                    }
+                }
+            }
             "mul_add" if matches!(self, Self::Avx2 | Self::Avx512) => {
                 let intrinsic = simple_intrinsic("fmadd", vec_ty);
                 self.kernel_method(

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -121,7 +121,7 @@ impl Level for X86 {
     }
 
     fn make_module_prelude(&self) -> TokenStream {
-        let float_ext = if *self == Self::Sse2 {
+        let float_ext = if matches!(self, Self::Sse2 | Self::Sse4_2) {
             crate::mk_fallback::float_ext_prelude()
         } else {
             TokenStream::new()
@@ -2292,6 +2292,134 @@ impl X86 {
         }
     }
 
+    fn precise_mul_add_f32x4(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+        assert!(
+            *self == Self::Sse4_2,
+            "precise f32 multiply-add emulation is specific to SSE4.2"
+        );
+        assert_eq!(
+            vec_ty.scalar,
+            ScalarType::Float,
+            "precise f32 multiply-add requires a floating-point vector"
+        );
+        assert_eq!(
+            vec_ty.scalar_bits, 32,
+            "precise f32 multiply-add requires 32-bit lanes"
+        );
+        assert_eq!(
+            vec_ty.n_bits(),
+            128,
+            "SSE4.2 precise f32 multiply-add requires one native vector"
+        );
+
+        // The basic idea behind the algorithm: turn f32x4 into two f64x2 vectors,
+        // compute `a * b + c`` there, then round back into f32.
+        // We need round-to-odd to correctly round to f32 in this case.
+        // Paper for the algorithm, with a formal proof in Coq:
+        // https://guillaume.melquiond.fr/doc/08-tc.pdf
+        self.kernel_method(op, vec_ty, |token| {
+            quote! {
+                let a: __m128 = a.into();
+                let b: __m128 = b.into();
+                let c: __m128 = c.into();
+
+                let a_low = _mm_cvtps_pd(a);
+                let a_high = _mm_cvtps_pd(_mm_movehl_ps(a, a));
+                let b_low = _mm_cvtps_pd(b);
+                let b_high = _mm_cvtps_pd(_mm_movehl_ps(b, b));
+                let c_low = _mm_cvtps_pd(c);
+                let c_high = _mm_cvtps_pd(_mm_movehl_ps(c, c));
+
+                // Every finite f32 product is exactly representable as f64. Usually the f64 sum
+                // can therefore be narrowed directly. The only possible double-rounding error is
+                // when that sum is exactly halfway between two adjacent f32 values.
+                let product_low = _mm_mul_pd(a_low, b_low);
+                let product_high = _mm_mul_pd(a_high, b_high);
+                let mut sum_low = _mm_add_pd(product_low, c_low);
+                let mut sum_high = _mm_add_pd(product_high, c_high);
+
+                let midpoint_fraction_mask = _mm_set1_epi64x(0x1fff_ffff);
+                let midpoint_fraction = _mm_set1_epi64x(0x1000_0000);
+                let midpoint_low = _mm_cmpeq_epi64(
+                    _mm_and_si128(_mm_castpd_si128(sum_low), midpoint_fraction_mask),
+                    midpoint_fraction,
+                );
+                let midpoint_high = _mm_cmpeq_epi64(
+                    _mm_and_si128(_mm_castpd_si128(sum_high), midpoint_fraction_mask),
+                    midpoint_fraction,
+                );
+                let any_midpoint = _mm_or_si128(midpoint_low, midpoint_high);
+
+                // Optimization notes:
+                // On uniform numeric values over the entire range, this branch only fires once per 685k calls,
+                // and on uniform nuimber values in [-1, 1) it fires once in 17k calls (empirically).
+                // So it is worth putting under an `if` despite the branch misprediction penalty.
+                // Outlining this into a #[cold] function regresses performance on both fast and slow paths.
+                // TODO: try using std::hint::cold_path() once MSRV is >= 1.95 and see if that does anything
+                if _mm_testz_si128(any_midpoint, any_midpoint) == 0 {
+                    // TwoSum recovers the exact residual of each widened addition. If a midpoint
+                    // addition was inexact, shift the rounded f64 value by one ULP toward the
+                    // residual before narrowing. This is a round-to-odd intermediate result.
+                    let virtual_low = _mm_sub_pd(sum_low, product_low);
+                    let residual_low = _mm_add_pd(
+                        _mm_sub_pd(product_low, _mm_sub_pd(sum_low, virtual_low)),
+                        _mm_sub_pd(c_low, virtual_low),
+                    );
+                    let virtual_high = _mm_sub_pd(sum_high, product_high);
+                    let residual_high = _mm_add_pd(
+                        _mm_sub_pd(product_high, _mm_sub_pd(sum_high, virtual_high)),
+                        _mm_sub_pd(c_high, virtual_high),
+                    );
+
+                    let zero = _mm_setzero_pd();
+                    let correction_low = _mm_and_si128(
+                        midpoint_low,
+                        _mm_castpd_si128(_mm_cmpneq_pd(residual_low, zero)),
+                    );
+                    let correction_high = _mm_and_si128(
+                        midpoint_high,
+                        _mm_castpd_si128(_mm_cmpneq_pd(residual_high, zero)),
+                    );
+
+                    let one = _mm_set1_epi64x(1);
+                    let sum_low_bits = _mm_castpd_si128(sum_low);
+                    let residual_low_bits = _mm_castpd_si128(residual_low);
+                    let different_sign_low = _mm_srli_epi64::<63>(_mm_xor_si128(
+                        sum_low_bits,
+                        residual_low_bits,
+                    ));
+                    let direction_low = _mm_sub_epi64(
+                        one,
+                        _mm_slli_epi64::<1>(different_sign_low),
+                    );
+                    sum_low = _mm_castsi128_pd(_mm_add_epi64(
+                        sum_low_bits,
+                        _mm_and_si128(direction_low, correction_low),
+                    ));
+
+                    let sum_high_bits = _mm_castpd_si128(sum_high);
+                    let residual_high_bits = _mm_castpd_si128(residual_high);
+                    let different_sign_high = _mm_srli_epi64::<63>(_mm_xor_si128(
+                        sum_high_bits,
+                        residual_high_bits,
+                    ));
+                    let direction_high = _mm_sub_epi64(
+                        one,
+                        _mm_slli_epi64::<1>(different_sign_high),
+                    );
+                    sum_high = _mm_castsi128_pd(_mm_add_epi64(
+                        sum_high_bits,
+                        _mm_and_si128(direction_high, correction_high),
+                    ));
+                }
+
+                let low = _mm_cvtpd_ps(sum_low);
+                let high = _mm_cvtpd_ps(sum_high);
+                _mm_movelh_ps(low, high).simd_into(#token)
+            }
+        })
+    }
+
     pub(crate) fn handle_ternary(
         &self,
         op: Op,
@@ -2300,6 +2428,18 @@ impl X86 {
         vec_ty: &VecType,
     ) -> TokenStream {
         match method {
+            "mul_add_precise" if *self == Self::Sse4_2 && vec_ty.scalar_bits == 32 => {
+                self.precise_mul_add_f32x4(op, vec_ty)
+            }
+            "mul_add_precise" if matches!(self, Self::Avx2 | Self::Avx512) => {
+                let mul_add = generic_op_name("mul_add", vec_ty);
+                quote! {
+                    #method_sig {
+                        self.#mul_add(a, b, c)
+                    }
+                }
+            }
+            "mul_add_precise" => fallback_method(op, vec_ty),
             "mul_add" if matches!(self, Self::Avx2 | Self::Avx512) => {
                 let intrinsic = simple_intrinsic("fmadd", vec_ty);
                 self.kernel_method(

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2348,18 +2348,44 @@ impl X86 {
                     _mm_and_si128(_mm_castpd_si128(sum_high), midpoint_fraction_mask),
                     midpoint_fraction,
                 );
-                let any_midpoint = _mm_or_si128(midpoint_low, midpoint_high);
+                // Subnormal f32 values have fewer than 24 significant bits, so their midpoint
+                // position within the f64 significand varies with the result's exponent. Use a
+                // provisional narrowing to identify every result whose rounding interval touches
+                // the subnormal range, including zero and the smallest normal value. Those rare
+                // lanes take the general round-to-odd path below.
+                let mut low = _mm_cvtpd_ps(sum_low);
+                let mut high = _mm_cvtpd_ps(sum_high);
+                let provisional = _mm_movelh_ps(low, high);
+                let abs_provisional_bits = _mm_and_si128(
+                    _mm_castps_si128(provisional),
+                    _mm_set1_epi32(0x7fff_ffff),
+                );
+                let at_most_min_normal = _mm_cmpgt_epi32(
+                    _mm_set1_epi32(0x0080_0001),
+                    abs_provisional_bits,
+                );
+                let subnormal_low = _mm_unpacklo_epi32(
+                    at_most_min_normal,
+                    at_most_min_normal,
+                );
+                let subnormal_high = _mm_unpackhi_epi32(
+                    at_most_min_normal,
+                    at_most_min_normal,
+                );
+                let round_to_odd_low = _mm_or_si128(midpoint_low, subnormal_low);
+                let round_to_odd_high = _mm_or_si128(midpoint_high, subnormal_high);
+                let any_round_to_odd = _mm_or_si128(round_to_odd_low, round_to_odd_high);
 
                 // Optimization notes:
                 // On uniform numeric values over the entire range, this branch only fires once per 685k calls,
-                // and on uniform nuimber values in [-1, 1) it fires once in 17k calls (empirically).
+                // and on uniform numeric values in [-1, 1) it fires once in 17k calls (empirically).
                 // So it is worth putting under an `if` despite the branch misprediction penalty.
                 // Outlining this into a #[cold] function regresses performance on both fast and slow paths.
                 // TODO: try using std::hint::cold_path() once MSRV is >= 1.95 and see if that does anything
-                if _mm_testz_si128(any_midpoint, any_midpoint) == 0 {
-                    // TwoSum recovers the exact residual of each widened addition. If a midpoint
-                    // addition was inexact, shift the rounded f64 value by one ULP toward the
-                    // residual before narrowing. This is a round-to-odd intermediate result.
+                if _mm_testz_si128(any_round_to_odd, any_round_to_odd) == 0 {
+                    // TwoSum recovers the exact residual of each widened addition. If a candidate
+                    // addition was inexact and its rounded f64 significand is even, shift it by one
+                    // ULP toward the residual. This produces a round-to-odd intermediate result.
                     let virtual_low = _mm_sub_pd(sum_low, product_low);
                     let residual_low = _mm_add_pd(
                         _mm_sub_pd(product_low, _mm_sub_pd(sum_low, virtual_low)),
@@ -2371,24 +2397,24 @@ impl X86 {
                         _mm_sub_pd(c_high, virtual_high),
                     );
 
-                    let zero = _mm_setzero_pd();
-                    let correction_low = _mm_and_si128(
-                        midpoint_low,
-                        _mm_castpd_si128(_mm_cmpneq_pd(residual_low, zero)),
-                    );
-                    let correction_high = _mm_and_si128(
-                        midpoint_high,
-                        _mm_castpd_si128(_mm_cmpneq_pd(residual_high, zero)),
-                    );
-
                     let one = _mm_set1_epi64x(1);
+                    let zero_si128 = _mm_setzero_si128();
+                    let zero = _mm_setzero_pd();
                     let sum_low_bits = _mm_castpd_si128(sum_low);
                     let residual_low_bits = _mm_castpd_si128(residual_low);
+                    let even_low = _mm_cmpeq_epi64(
+                        _mm_and_si128(sum_low_bits, one),
+                        zero_si128,
+                    );
+                    let correction_low = _mm_and_si128(
+                        _mm_and_si128(round_to_odd_low, even_low),
+                        _mm_castpd_si128(_mm_cmpneq_pd(residual_low, zero)),
+                    );
                     // The XOR is negative as a signed qword exactly when the signs differ.
                     // Its zero-greater-than mask is therefore -1 for a downward correction
                     // and zero otherwise; OR with one turns those into the desired -1/+1.
                     let different_sign_low = _mm_cmpgt_epi64(
-                        _mm_setzero_si128(),
+                        zero_si128,
                         _mm_xor_si128(sum_low_bits, residual_low_bits),
                     );
                     let direction_low = _mm_or_si128(different_sign_low, one);
@@ -2399,8 +2425,16 @@ impl X86 {
 
                     let sum_high_bits = _mm_castpd_si128(sum_high);
                     let residual_high_bits = _mm_castpd_si128(residual_high);
+                    let even_high = _mm_cmpeq_epi64(
+                        _mm_and_si128(sum_high_bits, one),
+                        zero_si128,
+                    );
+                    let correction_high = _mm_and_si128(
+                        _mm_and_si128(round_to_odd_high, even_high),
+                        _mm_castpd_si128(_mm_cmpneq_pd(residual_high, zero)),
+                    );
                     let different_sign_high = _mm_cmpgt_epi64(
-                        _mm_setzero_si128(),
+                        zero_si128,
                         _mm_xor_si128(sum_high_bits, residual_high_bits),
                     );
                     let direction_high = _mm_or_si128(different_sign_high, one);
@@ -2408,10 +2442,11 @@ impl X86 {
                         sum_high_bits,
                         _mm_and_si128(direction_high, correction_high),
                     ));
+
+                    low = _mm_cvtpd_ps(sum_low);
+                    high = _mm_cvtpd_ps(sum_high);
                 }
 
-                let low = _mm_cvtpd_ps(sum_low);
-                let high = _mm_cvtpd_ps(sum_high);
                 _mm_movelh_ps(low, high).simd_into(#token)
             }
         })

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2384,14 +2384,14 @@ impl X86 {
                     let one = _mm_set1_epi64x(1);
                     let sum_low_bits = _mm_castpd_si128(sum_low);
                     let residual_low_bits = _mm_castpd_si128(residual_low);
-                    let different_sign_low = _mm_srli_epi64::<63>(_mm_xor_si128(
-                        sum_low_bits,
-                        residual_low_bits,
-                    ));
-                    let direction_low = _mm_sub_epi64(
-                        one,
-                        _mm_slli_epi64::<1>(different_sign_low),
+                    // The XOR is negative as a signed qword exactly when the signs differ.
+                    // Its zero-greater-than mask is therefore -1 for a downward correction
+                    // and zero otherwise; OR with one turns those into the desired -1/+1.
+                    let different_sign_low = _mm_cmpgt_epi64(
+                        _mm_setzero_si128(),
+                        _mm_xor_si128(sum_low_bits, residual_low_bits),
                     );
+                    let direction_low = _mm_or_si128(different_sign_low, one);
                     sum_low = _mm_castsi128_pd(_mm_add_epi64(
                         sum_low_bits,
                         _mm_and_si128(direction_low, correction_low),
@@ -2399,14 +2399,11 @@ impl X86 {
 
                     let sum_high_bits = _mm_castpd_si128(sum_high);
                     let residual_high_bits = _mm_castpd_si128(residual_high);
-                    let different_sign_high = _mm_srli_epi64::<63>(_mm_xor_si128(
-                        sum_high_bits,
-                        residual_high_bits,
-                    ));
-                    let direction_high = _mm_sub_epi64(
-                        one,
-                        _mm_slli_epi64::<1>(different_sign_high),
+                    let different_sign_high = _mm_cmpgt_epi64(
+                        _mm_setzero_si128(),
+                        _mm_xor_si128(sum_high_bits, residual_high_bits),
                     );
+                    let direction_high = _mm_or_si128(different_sign_high, one);
                     sum_high = _mm_castsi128_pd(_mm_add_epi64(
                         sum_high_bits,
                         _mm_and_si128(direction_high, correction_high),

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -37,6 +37,18 @@ pub(crate) const AVX2_FEATURES: &str =
     "avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,fxsr,lzcnt,movbe,popcnt,xsave";
 pub(crate) const AVX512_FEATURES: &str = "adx,aes,avx512bitalg,avx512bw,avx512cd,avx512dq,avx512f,avx512ifma,avx512vbmi,avx512vbmi2,avx512vl,avx512vnni,avx512vpopcntdq,bmi1,bmi2,cmpxchg16b,fma,fxsr,gfni,lzcnt,movbe,pclmulqdq,popcnt,rdrand,rdseed,sha,vaes,vpclmulqdq,xsave,xsavec,xsaveopt,xsaves";
 
+fn sse2_scalar_mul_add_precise_f32_helper() -> TokenStream {
+    let body = crate::mk_fallback::scalar_mul_add_precise_f32_body();
+    quote! {
+        crate::kernel!(
+            #[inline(always)]
+            fn scalar_mul_add_precise_f32(_token: Sse2, a: f32, b: f32, c: f32) -> f32 {
+                #body
+            }
+        );
+    }
+}
+
 impl Level for X86 {
     fn name(&self) -> &'static str {
         match self {
@@ -127,7 +139,7 @@ impl Level for X86 {
             TokenStream::new()
         };
         let scalar_mul_add_precise_f32 = if *self == Self::Sse2 {
-            crate::mk_fallback::sse2_scalar_mul_add_precise_f32_helper()
+            sse2_scalar_mul_add_precise_f32_helper()
         } else {
             TokenStream::new()
         };

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2330,10 +2330,12 @@ impl X86 {
             "SSE4.2 precise f32 multiply-add requires one native vector"
         );
 
-        // The basic idea behind the algorithm: turn f32x4 into two f64x2 vectors,
-        // compute `a * b + c`` there, then round back into f32.
-        // We need round-to-odd to correctly round to f32 in this case.
-        // Paper for the algorithm, with a formal proof in Coq:
+        // Apply Boldo and Melquiond's Theorem 3: turn f32x4 into two f64x2 vectors,
+        // conceptually compute a binary64 round-to-odd value of `a * b + c`, then round it
+        // to f32. The fast path below skips the round-to-odd correction only where narrowing
+        // the binary64 sum cannot suffer a double-rounding error.
+        // Its parameters are p=24, k=29, Ew=149, and Ee=1074, satisfying k >= 2 and
+        // Ee >= Ew + 2. The theorem, including gradual-underflow cases, is proved in Coq:
         // https://guillaume.melquiond.fr/doc/08-tc.pdf
         self.kernel_method(op, vec_ty, |token| {
             quote! {
@@ -2348,9 +2350,12 @@ impl X86 {
                 let c_low = _mm_cvtps_pd(c);
                 let c_high = _mm_cvtps_pd(_mm_movehl_ps(c, c));
 
-                // Every finite f32 product is exactly representable as f64. Usually the f64 sum
-                // can therefore be narrowed directly. The only possible double-rounding error is
-                // when that sum is exactly halfway between two adjacent f32 values.
+                // Every finite f32 product is exactly representable as f64. Every exact finite
+                // product-plus-add is a multiple of 2^-298 with magnitude below 2^256, so none of
+                // these operations underflow or overflow in f64. Usually the f64 sum can be
+                // narrowed directly. For a normal f32 result, the only possible double-rounding
+                // error is when that sum is exactly halfway between two adjacent f32 values. This
+                // also recognizes the f32 finite/infinity overflow threshold.
                 let product_low = _mm_mul_pd(a_low, b_low);
                 let product_high = _mm_mul_pd(a_high, b_high);
                 let mut sum_low = _mm_add_pd(product_low, c_low);
@@ -2401,9 +2406,10 @@ impl X86 {
                 // Outlining this into a #[cold] function regresses performance on both fast and slow paths.
                 // TODO: try using std::hint::cold_path() once MSRV is >= 1.95 and see if that does anything
                 if _mm_testz_si128(any_round_to_odd, any_round_to_odd) == 0 {
-                    // TwoSum recovers the exact residual of each widened addition. If a candidate
-                    // addition was inexact and its rounded f64 significand is even, shift it by one
-                    // ULP toward the residual. This produces a round-to-odd intermediate result.
+                    // Knuth's unconditional TwoSum establishes
+                    // `sum + residual == product + c` exactly. If a candidate addition was
+                    // inexact and its rounded f64 significand is even, shift it by one ULP toward
+                    // the residual. This produces the round-to-odd intermediate from Theorem 3.
                     let virtual_low = _mm_sub_pd(sum_low, product_low);
                     let residual_low = _mm_add_pd(
                         _mm_sub_pd(product_low, _mm_sub_pd(sum_low, virtual_low)),

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2407,16 +2407,16 @@ impl X86 {
                 // TODO: try using std::hint::cold_path() once MSRV is >= 1.95 and see if that does anything
                 if _mm_testz_si128(any_round_to_odd, any_round_to_odd) == 0 {
                     // Knuth's unconditional TwoSum establishes
-                    // `sum + residual == product + c` exactly. If a candidate addition was
+                    // `sum + error == product + c` exactly. If a candidate addition was
                     // inexact and its rounded f64 significand is even, shift it by one ULP toward
-                    // the residual. This produces the round-to-odd intermediate from Theorem 3.
+                    // the error. This produces the round-to-odd intermediate from Theorem 3.
                     let virtual_low = _mm_sub_pd(sum_low, product_low);
-                    let residual_low = _mm_add_pd(
+                    let error_low = _mm_add_pd(
                         _mm_sub_pd(product_low, _mm_sub_pd(sum_low, virtual_low)),
                         _mm_sub_pd(c_low, virtual_low),
                     );
                     let virtual_high = _mm_sub_pd(sum_high, product_high);
-                    let residual_high = _mm_add_pd(
+                    let error_high = _mm_add_pd(
                         _mm_sub_pd(product_high, _mm_sub_pd(sum_high, virtual_high)),
                         _mm_sub_pd(c_high, virtual_high),
                     );
@@ -2425,21 +2425,21 @@ impl X86 {
                     let zero_si128 = _mm_setzero_si128();
                     let zero = _mm_setzero_pd();
                     let sum_low_bits = _mm_castpd_si128(sum_low);
-                    let residual_low_bits = _mm_castpd_si128(residual_low);
+                    let error_low_bits = _mm_castpd_si128(error_low);
                     let even_low = _mm_cmpeq_epi64(
                         _mm_and_si128(sum_low_bits, one),
                         zero_si128,
                     );
                     let correction_low = _mm_and_si128(
                         _mm_and_si128(round_to_odd_low, even_low),
-                        _mm_castpd_si128(_mm_cmpneq_pd(residual_low, zero)),
+                        _mm_castpd_si128(_mm_cmpneq_pd(error_low, zero)),
                     );
                     // The XOR is negative as a signed qword exactly when the signs differ.
                     // Its zero-greater-than mask is therefore -1 for a downward correction
                     // and zero otherwise; OR with one turns those into the desired -1/+1.
                     let different_sign_low = _mm_cmpgt_epi64(
                         zero_si128,
-                        _mm_xor_si128(sum_low_bits, residual_low_bits),
+                        _mm_xor_si128(sum_low_bits, error_low_bits),
                     );
                     let direction_low = _mm_or_si128(different_sign_low, one);
                     sum_low = _mm_castsi128_pd(_mm_add_epi64(
@@ -2448,18 +2448,18 @@ impl X86 {
                     ));
 
                     let sum_high_bits = _mm_castpd_si128(sum_high);
-                    let residual_high_bits = _mm_castpd_si128(residual_high);
+                    let error_high_bits = _mm_castpd_si128(error_high);
                     let even_high = _mm_cmpeq_epi64(
                         _mm_and_si128(sum_high_bits, one),
                         zero_si128,
                     );
                     let correction_high = _mm_and_si128(
                         _mm_and_si128(round_to_odd_high, even_high),
-                        _mm_castpd_si128(_mm_cmpneq_pd(residual_high, zero)),
+                        _mm_castpd_si128(_mm_cmpneq_pd(error_high, zero)),
                     );
                     let different_sign_high = _mm_cmpgt_epi64(
                         zero_si128,
-                        _mm_xor_si128(sum_high_bits, residual_high_bits),
+                        _mm_xor_si128(sum_high_bits, error_high_bits),
                     );
                     let direction_high = _mm_or_si128(different_sign_high, one);
                     sum_high = _mm_castsi128_pd(_mm_add_epi64(

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -126,6 +126,11 @@ impl Level for X86 {
         } else {
             TokenStream::new()
         };
+        let scalar_mul_add_precise_f32 = if *self == Self::Sse2 {
+            crate::mk_fallback::sse2_scalar_mul_add_precise_f32_helper()
+        } else {
+            TokenStream::new()
+        };
 
         quote! {
             #[cfg(target_arch = "x86")]
@@ -133,6 +138,7 @@ impl Level for X86 {
             #[cfg(target_arch = "x86_64")]
             use core::arch::x86_64::*;
             use core::ops::*;
+            #scalar_mul_add_precise_f32
             #float_ext
         }
     }
@@ -2460,6 +2466,22 @@ impl X86 {
         vec_ty: &VecType,
     ) -> TokenStream {
         match method {
+            "mul_add_precise"
+                if *self == Self::Sse2
+                    && vec_ty.scalar == ScalarType::Float
+                    && vec_ty.scalar_bits == 32 =>
+            {
+                let calls = (0..vec_ty.len).map(|idx| {
+                    quote! {
+                        scalar_mul_add_precise_f32(self, a[#idx], b[#idx], c[#idx])
+                    }
+                });
+                quote! {
+                    #method_sig {
+                        [#(#calls),*].simd_into(self)
+                    }
+                }
+            }
             "mul_add_precise" if *self == Self::Sse4_2 && vec_ty.scalar_bits == 32 => {
                 self.precise_mul_add_f32x4(op, vec_ty)
             }

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -822,6 +822,14 @@ const FLOAT_OPS: &[Op] = &[
         Depending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by a subtract, which will result in two rounding errors.",
     ),
     Op::new(
+        "mul_sub_precise",
+        OpKind::VecTraitMethod,
+        OpSig::Ternary,
+        "Compute `({arg0} * {arg1}) - {arg2}` for each element, with a single rounding at the end.\n\n\
+        The result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\n\
+        Floating-point exception flags and NaN payload selection are not guaranteed.",
+    ),
+    Op::new(
         "floor",
         OpKind::VecTraitMethod,
         OpSig::Unary,

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -811,7 +811,13 @@ const FLOAT_OPS: &[Op] = &[
         OpKind::VecTraitMethod,
         OpSig::Ternary,
         "Compute `({arg0} * {arg1}) + {arg2}` for each element, with a single rounding at the end.\n\n\
-        The result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.",
+        The result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\n\
+        # Precision guarantees\n\n\
+        This function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library \
+        and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\n\
+        On the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\n\
+        On WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\n\
+        The exact `NaN` payloads as well as signaling `NaN`s are not preserved.",
     ),
     Op::new(
         "mul_sub",
@@ -825,7 +831,13 @@ const FLOAT_OPS: &[Op] = &[
         OpKind::VecTraitMethod,
         OpSig::Ternary,
         "Compute `({arg0} * {arg1}) - {arg2}` for each element, with a single rounding at the end.\n\n\
-        The result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.",
+        The result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.
+        # Precision guarantees\n\n\
+        This function is **not** susceptible to [the bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library \
+        and in musl libc that causes incorrect rounding for near-zero values on CPUs without hardware support for this operation.\n\n\
+        On the tier-2 i586-* targets, this function is correct if and only if SSE2 is available on the CPU.\n\n\
+        On WebAssembly this uses the host implementation of precise multiply-add via the `madd` intrinsic.\n\n\
+        The exact `NaN` payloads as well as signaling `NaN`s are not preserved.",
     ),
     Op::new(
         "floor",

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -811,8 +811,7 @@ const FLOAT_OPS: &[Op] = &[
         OpKind::VecTraitMethod,
         OpSig::Ternary,
         "Compute `({arg0} * {arg1}) + {arg2}` for each element, with a single rounding at the end.\n\n\
-        The result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\n\
-        Floating-point exception flags and NaN payload selection are not guaranteed.",
+        The result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.",
     ),
     Op::new(
         "mul_sub",
@@ -826,8 +825,7 @@ const FLOAT_OPS: &[Op] = &[
         OpKind::VecTraitMethod,
         OpSig::Ternary,
         "Compute `({arg0} * {arg1}) - {arg2}` for each element, with a single rounding at the end.\n\n\
-        The result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.\n\n\
-        Floating-point exception flags and NaN payload selection are not guaranteed.",
+        The result is the infinite-precision product-minus-subtrahend rounded once to the element type. This may be substantially slower than `mul_sub` on hardware without fused multiply-add instructions.",
     ),
     Op::new(
         "floor",

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -807,6 +807,14 @@ const FLOAT_OPS: &[Op] = &[
         Depending on hardware support, the result may be computed with only one rounding error, or may be implemented as a regular multiply followed by an add, which will result in two rounding errors.",
     ),
     Op::new(
+        "mul_add_precise",
+        OpKind::VecTraitMethod,
+        OpSig::Ternary,
+        "Compute `({arg0} * {arg1}) + {arg2}` for each element, with a single rounding at the end.\n\n\
+        The result is the infinite-precision product-plus-add rounded once to the element type. This may be substantially slower than `mul_add` on hardware without fused multiply-add instructions.\n\n\
+        Floating-point exception flags and NaN payload selection are not guaranteed.",
+    ),
+    Op::new(
         "mul_sub",
         OpKind::VecTraitMethod,
         OpSig::Ternary,
@@ -1592,6 +1600,7 @@ impl OpSig {
             Self::StoreInterleaved { .. } => &["vectors", "dest"],
         }
     }
+
     fn vec_trait_arg_names(&self) -> &'static [&'static str] {
         match self {
             Self::Splat => &["simd", "val"],

--- a/fearless_simd_tests/tests/harness/ops/mod.rs
+++ b/fearless_simd_tests/tests/harness/ops/mod.rs
@@ -48,6 +48,7 @@ mod min;
 mod min_precise;
 mod mul;
 mod mul_add;
+mod mul_add_precise;
 mod mul_sub;
 mod narrow;
 mod native_width;

--- a/fearless_simd_tests/tests/harness/ops/mod.rs
+++ b/fearless_simd_tests/tests/harness/ops/mod.rs
@@ -50,6 +50,7 @@ mod mul;
 mod mul_add;
 mod mul_add_precise;
 mod mul_sub;
+mod mul_sub_precise;
 mod narrow;
 mod native_width;
 mod neg;

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -4,6 +4,10 @@
 use fearless_simd::*;
 use fearless_simd_dev_macros::simd_test;
 
+// This file has a lot of coverage for 128-bit vectors specifically.
+// That's because we have complex, error-prone emulation of precise FMA
+// on SSE4.2 and need to test it in great depth.
+
 #[simd_test]
 #[ignore = "exhaustively checks all non-NaN f32 bit patterns"]
 fn mul_add_precise_f32x4_exhaustive<S: Simd>(simd: S) {
@@ -45,6 +49,49 @@ fn mul_add_precise_f32x4_exhaustive<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+#[ignore = "randomly checks independent f32 bit patterns"]
+// Run with: cargo test --release mul_add_precise_f32x4_random_independent -- --ignored
+fn mul_add_precise_f32x4_random_independent_bit_patterns<S: Simd>(simd: S) {
+    let mut rng = fastrand::Rng::with_seed(0xd1b5_4a32_d192_ed03);
+
+    for iteration in 0..1_000_000_000 {
+        let a_bits: [u32; 4] = core::array::from_fn(|_| rng.u32(..));
+        let b_bits: [u32; 4] = core::array::from_fn(|_| rng.u32(..));
+        let c_bits: [u32; 4] = core::array::from_fn(|_| rng.u32(..));
+        let a_values = a_bits.map(f32::from_bits);
+        let b_values = b_bits.map(f32::from_bits);
+        let c_values = c_bits.map(f32::from_bits);
+        let actual = f32x4::from_slice(simd, &a_values).mul_add_precise(
+            f32x4::from_slice(simd, &b_values),
+            f32x4::from_slice(simd, &c_values),
+        );
+
+        for lane in 0..4 {
+            let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
+            if expected.is_nan() {
+                assert!(
+                    actual[lane].is_nan(),
+                    "iteration {iteration}, lane {lane}: mul_add_precise(a={:#010x}, b={:#010x}, c={:#010x}) returned {:#010x}, expected NaN",
+                    a_bits[lane],
+                    b_bits[lane],
+                    c_bits[lane],
+                    actual[lane].to_bits(),
+                );
+            } else {
+                assert_eq!(
+                    actual[lane].to_bits(),
+                    expected.to_bits(),
+                    "iteration {iteration}, lane {lane}: mul_add_precise inputs a={:#010x}, b={:#010x}, c={:#010x}",
+                    a_bits[lane],
+                    b_bits[lane],
+                    c_bits[lane],
+                );
+            }
+        }
+    }
+}
+
+#[simd_test]
 fn mul_add_precise_f32x4<S: Simd>(simd: S) {
     let midpoint_a = f32::from_bits(0x3f80_1000); // 1 + 2^-11
     let midpoint_b = f32::from_bits(0x3f7f_f800); // 1 - 2^-13
@@ -70,6 +117,215 @@ fn mul_add_precise_f32x4<S: Simd>(simd: S) {
         expected[2],
         ((midpoint_a as f64) * (midpoint_b as f64) - (tiny as f64)) as f32
     );
+}
+
+#[simd_test]
+fn mul_add_precise_f32x4_subnormal_rounding_regression<S: Simd>(simd: S) {
+    // Each product is slightly more than half of the smallest f32 subnormal. The exact sum must
+    // therefore round to the subnormal adjacent to c, even when a widened f64 addition rounds to
+    // the midpoint between c and that adjacent value.
+    // Regression test for https://github.com/linebender/fearless_simd/pull/323#issuecomment-5233682925
+    let cases: [(u32, u32, u32, u32); 26] = [
+        (0x9700_0800, 0x1cff_f001, 0x0001_0002, 0x0001_0001),
+        (0x9700_0800, 0x1cff_f001, 0x0001_0002, 0x0001_0001),
+        (0x9700_0800, 0x1cff_f001, 0x0020_0002, 0x0020_0001),
+        (0x19ff_e002, 0x1a00_1001, 0x0000_0040, 0x0000_0041),
+        (0x99ff_e002, 0x1a00_1001, 0x8000_0040, 0x8000_0041),
+        (0x19ff_e002, 0x1a00_1001, 0x0000_0400, 0x0000_0401),
+        (0x99ff_e002, 0x1a00_1001, 0x8000_0400, 0x8000_0401),
+        (0x19ff_e002, 0x1a00_1001, 0x0001_0000, 0x0001_0001),
+        (0x99ff_e002, 0x1a00_1001, 0x8001_0000, 0x8001_0001),
+        (0x19ff_e002, 0x1a00_1001, 0x0020_0000, 0x0020_0001),
+        (0x99ff_e002, 0x1a00_1001, 0x8020_0000, 0x8020_0001),
+        (0x19ff_e002, 0x1a00_1001, 0x0040_0000, 0x0040_0001),
+        (0x99ff_e002, 0x1a00_1001, 0x8040_0000, 0x8040_0001),
+        (0x99ff_e002, 0x1a00_1001, 0x0000_0042, 0x0000_0041),
+        (0x19ff_e002, 0x1a00_1001, 0x8000_0042, 0x8000_0041),
+        (0x99ff_e002, 0x1a00_1001, 0x0000_0402, 0x0000_0401),
+        (0x19ff_e002, 0x1a00_1001, 0x8000_0402, 0x8000_0401),
+        (0x99ff_e002, 0x1a00_1001, 0x0001_0002, 0x0001_0001),
+        (0x19ff_e002, 0x1a00_1001, 0x8001_0002, 0x8001_0001),
+        (0x99ff_e002, 0x1a00_1001, 0x0020_0002, 0x0020_0001),
+        (0x19ff_e002, 0x1a00_1001, 0x8020_0002, 0x8020_0001),
+        (0x1700_0800, 0x1cff_f001, 0x0001_0000, 0x0001_0001),
+        (0x1700_0800, 0x1cff_f001, 0x0004_0000, 0x0004_0001),
+        (0x1700_0800, 0x1cff_f001, 0x0020_0000, 0x0020_0001),
+        (0x9700_0800, 0x1cff_f001, 0x0001_0002, 0x0001_0001),
+        (0x9700_0800, 0x1cff_f001, 0x0020_0002, 0x0020_0001),
+    ];
+
+    for (a_bits, b_bits, c_bits, expected_bits) in cases {
+        let a = f32x4::splat(simd, f32::from_bits(a_bits));
+        let b = f32x4::splat(simd, f32::from_bits(b_bits));
+        let c = f32x4::splat(simd, f32::from_bits(c_bits));
+        let actual = a.mul_add_precise(b, c);
+        let actual_bits = [
+            actual[0].to_bits(),
+            actual[1].to_bits(),
+            actual[2].to_bits(),
+            actual[3].to_bits(),
+        ];
+
+        assert_eq!(
+            actual_bits, [expected_bits; 4],
+            "mul_add_precise inputs: a={a_bits:#010x}, b={b_bits:#010x}, c={c_bits:#010x}",
+        );
+    }
+}
+
+#[simd_test]
+#[ignore = "randomly stress-tests subnormal results"]
+// Run with: cargo test --release mul_add_precise_f32x4_random -- --ignored
+fn mul_add_precise_f32x4_random_reported_product_patterns<S: Simd>(simd: S) {
+    let mut rng = fastrand::Rng::with_seed(0x8b7d_3a21_19c4_e605);
+    let significand_pairs = [(0x00ff_e002, 0x0080_1001), (0x0080_0800, 0x00ff_f001)];
+
+    for iteration in 0..1_000_000 {
+        let mut a_bits = [0_u32; 4];
+        let mut b_bits = [0_u32; 4];
+        let mut c_bits = [0_u32; 4];
+
+        for lane in 0..4 {
+            let mut significands = significand_pairs[rng.usize(..significand_pairs.len())];
+            if rng.bool() {
+                significands = (significands.1, significands.0);
+            }
+
+            // The unbiased exponents sum to -151. Both significand products are just above 2^47,
+            // so the resulting product is just above half of the smallest f32 subnormal.
+            let a_exponent = rng.i32(-126..-24);
+            let b_exponent = -151 - a_exponent;
+            let a_negative = rng.bool();
+            let product_negative = rng.bool();
+            let b_negative = a_negative ^ product_negative;
+            a_bits[lane] = ((a_negative as u32) << 31)
+                | (((a_exponent + 127) as u32) << 23)
+                | (significands.0 & 0x007f_ffff);
+            b_bits[lane] = ((b_negative as u32) << 31)
+                | (((b_exponent + 127) as u32) << 23)
+                | (significands.1 & 0x007f_ffff);
+
+            let magnitude = match lane {
+                0 => rng.u32(1..0x0080_0000),
+                1 => {
+                    let highest_bit = rng.u32(0..23);
+                    let lower_bits = if highest_bit == 0 {
+                        0
+                    } else {
+                        rng.u32(0..1 << highest_bit)
+                    };
+                    (1 << highest_bit) | lower_bits
+                }
+                2 => 0x007f_ffff - rng.u32(0..1024),
+                3 => rng.u32(0..512),
+                _ => unreachable!(),
+            };
+            c_bits[lane] = ((rng.bool() as u32) << 31) | magnitude;
+        }
+
+        let a_values = a_bits.map(f32::from_bits);
+        let b_values = b_bits.map(f32::from_bits);
+        let c_values = c_bits.map(f32::from_bits);
+        let expected_bits: [u32; 4] = core::array::from_fn(|lane| {
+            a_values[lane]
+                .mul_add(b_values[lane], c_values[lane])
+                .to_bits()
+        });
+        let actual = f32x4::from_slice(simd, &a_values).mul_add_precise(
+            f32x4::from_slice(simd, &b_values),
+            f32x4::from_slice(simd, &c_values),
+        );
+        let actual_bits = [
+            actual[0].to_bits(),
+            actual[1].to_bits(),
+            actual[2].to_bits(),
+            actual[3].to_bits(),
+        ];
+
+        assert_eq!(
+            actual_bits, expected_bits,
+            "iteration {iteration}: a={a_bits:x?}, b={b_bits:x?}, c={c_bits:x?}",
+        );
+    }
+}
+
+#[simd_test]
+#[ignore = "randomly stress-tests subnormal results"]
+fn mul_add_precise_f32x4_random_half_subnormal_products<S: Simd>(simd: S) {
+    let mut rng = fastrand::Rng::with_seed(0x31f2_b984_7d06_ca5e);
+
+    for iteration in 0..1_000_000 {
+        let mut a_bits = [0_u32; 4];
+        let mut b_bits = [0_u32; 4];
+        let mut c_bits = [0_u32; 4];
+
+        for lane in 0..4 {
+            // Construct random 24-bit significands whose product is the closest representable
+            // integer product above or below 2^47. With exponents summing to -151, this places the
+            // floating-point product immediately around half of the smallest f32 subnormal.
+            let offset = rng.u32(1..0x0080_0000) as u64;
+            let low_significand = 1_u64 << 23;
+            let high_significand = 1_u64 << 24;
+            let b_significand = low_significand + offset;
+            let numerator = high_significand * offset;
+            let quotient = numerator / b_significand;
+            let remainder = numerator % b_significand;
+            let distance_from_high = if rng.bool() || remainder == 0 {
+                quotient
+            } else {
+                quotient + 1
+            };
+            let mut significands = (high_significand - distance_from_high, b_significand);
+            if rng.bool() {
+                significands = (significands.1, significands.0);
+            }
+
+            let a_exponent = rng.i32(-126..-24);
+            let b_exponent = -151 - a_exponent;
+            let a_negative = rng.bool();
+            let product_negative = rng.bool();
+            let b_negative = a_negative ^ product_negative;
+            a_bits[lane] = ((a_negative as u32) << 31)
+                | (((a_exponent + 127) as u32) << 23)
+                | (significands.0 as u32 & 0x007f_ffff);
+            b_bits[lane] = ((b_negative as u32) << 31)
+                | (((b_exponent + 127) as u32) << 23)
+                | (significands.1 as u32 & 0x007f_ffff);
+
+            let highest_bit = rng.u32(0..23);
+            let lower_bits = if highest_bit == 0 {
+                0
+            } else {
+                rng.u32(0..1 << highest_bit)
+            };
+            let magnitude = (1 << highest_bit) | lower_bits;
+            c_bits[lane] = ((rng.bool() as u32) << 31) | magnitude;
+        }
+
+        let a_values = a_bits.map(f32::from_bits);
+        let b_values = b_bits.map(f32::from_bits);
+        let c_values = c_bits.map(f32::from_bits);
+        let expected_bits: [u32; 4] = core::array::from_fn(|lane| {
+            a_values[lane]
+                .mul_add(b_values[lane], c_values[lane])
+                .to_bits()
+        });
+        let actual = f32x4::from_slice(simd, &a_values).mul_add_precise(
+            f32x4::from_slice(simd, &b_values),
+            f32x4::from_slice(simd, &c_values),
+        );
+        let actual_bits = [
+            actual[0].to_bits(),
+            actual[1].to_bits(),
+            actual[2].to_bits(),
+            actual[3].to_bits(),
+        ];
+
+        assert_eq!(
+            actual_bits, expected_bits,
+            "iteration {iteration}: a={a_bits:x?}, b={b_bits:x?}, c={c_bits:x?}",
+        );
+    }
 }
 
 #[simd_test]

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -1,7 +1,6 @@
 // Copyright 2026 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use core::any::TypeId;
 use fearless_simd::*;
 use fearless_simd_dev_macros::simd_test;
 
@@ -10,18 +9,16 @@ use fearless_simd_dev_macros::simd_test;
 // on SSE4.2 and need to test it in great depth.
 
 #[inline(always)]
-fn reference_fma_f32<S: Simd>(_: S, x: f32, y: f32, z: f32) -> f32 {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    if TypeId::of::<S>() == TypeId::of::<Avx2>() || TypeId::of::<S>() == TypeId::of::<Avx512>() {
-        return x.mul_add(y, z);
+fn reference_fma_f32<S: Simd>(simd: S, x: f32, y: f32, z: f32) -> f32 {
+    // Targets with hardware FMA use it; other use our own software emulation
+    use Level::*;
+    match simd.level() {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        Avx2(_) | Avx512(_) => x.mul_add(y, z),
+        #[cfg(target_arch = "aarch64")]
+        Neon(_) => x.mul_add(y, z),
+        _ => soft_fma(x, y, z),
     }
-
-    #[cfg(target_arch = "aarch64")]
-    if TypeId::of::<S>() == TypeId::of::<Neon>() {
-        return x.mul_add(y, z);
-    }
-
-    soft_fma(x, y, z)
 }
 
 // Rust std and even musl libc have buggy software FMA:

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -8,140 +8,6 @@ use fearless_simd_dev_macros::simd_test;
 // That's because we have complex, error-prone emulation of precise FMA
 // on SSE4.2 and need to test it in great depth.
 
-#[inline(always)]
-fn reference_fma_f32<S: Simd>(simd: S, x: f32, y: f32, z: f32) -> f32 {
-    // Targets with hardware FMA use it; other use our own software emulation
-    match simd.level() {
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        Level::Avx2(_) | Level::Avx512(_) => x.mul_add(y, z),
-        #[cfg(target_arch = "aarch64")]
-        Level::Neon(_) => x.mul_add(y, z),
-        _ => soft_fma(x, y, z),
-    }
-}
-
-// Rust std and even musl libc have buggy software FMA:
-// https://github.com/rust-lang/compiler-builtins/issues/1262
-// We're using a formally verified algorithm in prod,
-// but comparing an algorithm against itself is silly,
-// so we need something else for verification, and this is the
-// "something else", sourced from
-// https://github.com/linebender/fearless_simd/pull/323#issuecomment-5234072329
-#[inline]
-fn soft_fma(x: f32, y: f32, z: f32) -> f32 {
-    let xy = f64::from(x) * f64::from(y);
-    let z = f64::from(z);
-    let result = xy + z;
-    let mut u = result.to_bits();
-    if u & 0x0fff_ffff != 0 {
-        return result as f32;
-    }
-
-    if u & 0x1000_0000 == 0 && (u >> 52) & 0x7ff > 1023 - 126 {
-        return result as f32;
-    }
-
-    if result - xy == z && result - z == xy {
-        return result as f32;
-    }
-
-    let neg = u >> 63 != 0;
-    let err = if neg == (z > xy) {
-        xy - result + z
-    } else {
-        z - result + xy
-    };
-    if neg == (err < 0.0) {
-        u += 1;
-    } else {
-        u -= 1;
-    }
-    f64::from_bits(u) as f32
-}
-
-#[simd_test]
-#[ignore = "exhaustively checks all non-NaN f32 bit patterns"]
-fn mul_add_precise_f32x4_exhaustive<S: Simd>(simd: S) {
-    // Using each value for all three operands exercises every non-NaN bit pattern in every input
-    // position while keeping the exhaustive domain tractable.
-    simd.vectorize(
-        #[inline(always)]
-        || {
-            for base in (0..u32::MAX).step_by(4) {
-                let values = f32x4::from_fn(simd, |lane| f32::from_bits(base + lane as u32));
-                let actual = values.mul_add_precise(values, values);
-
-                for lane in 0..4 {
-                    let value = values[lane];
-                    if value.is_nan() {
-                        continue;
-                    }
-
-                    let expected = value.mul_add(value, value);
-                    if expected.is_nan() {
-                        assert!(
-                            actual[lane].is_nan(),
-                            "mul_add_precise({value:?}, {value:?}, {value:?}) returned {:?}, expected NaN (input bits: {:#010x})",
-                            actual[lane],
-                            value.to_bits(),
-                        );
-                    } else {
-                        assert_eq!(
-                            actual[lane].to_bits(),
-                            expected.to_bits(),
-                            "mul_add_precise({value:?}, {value:?}, {value:?}) differs from scalar mul_add (input bits: {:#010x})",
-                            value.to_bits(),
-                        );
-                    }
-                }
-            }
-        },
-    );
-}
-
-#[simd_test]
-#[ignore = "randomly checks independent f32 bit patterns"]
-// Run with: cargo test --release mul_add_precise_f32x4_random_independent -- --ignored
-fn mul_add_precise_f32x4_random_independent_bit_patterns<S: Simd>(simd: S) {
-    let mut rng = fastrand::Rng::with_seed(0xd1b5_4a32_d192_ed03);
-
-    for iteration in 0..1_000_000_000 {
-        let a_bits: [u32; 4] = core::array::from_fn(|_| rng.u32(..));
-        let b_bits: [u32; 4] = core::array::from_fn(|_| rng.u32(..));
-        let c_bits: [u32; 4] = core::array::from_fn(|_| rng.u32(..));
-        let a_values = a_bits.map(f32::from_bits);
-        let b_values = b_bits.map(f32::from_bits);
-        let c_values = c_bits.map(f32::from_bits);
-        let actual = f32x4::from_slice(simd, &a_values).mul_add_precise(
-            f32x4::from_slice(simd, &b_values),
-            f32x4::from_slice(simd, &c_values),
-        );
-
-        for lane in 0..4 {
-            let expected = reference_fma_f32(simd, a_values[lane], b_values[lane], c_values[lane]);
-            if expected.is_nan() {
-                assert!(
-                    actual[lane].is_nan(),
-                    "iteration {iteration}, lane {lane}: mul_add_precise(a={:#010x}, b={:#010x}, c={:#010x}) returned {:#010x}, expected NaN",
-                    a_bits[lane],
-                    b_bits[lane],
-                    c_bits[lane],
-                    actual[lane].to_bits(),
-                );
-            } else {
-                assert_eq!(
-                    actual[lane].to_bits(),
-                    expected.to_bits(),
-                    "iteration {iteration}, lane {lane}: mul_add_precise inputs a={:#010x}, b={:#010x}, c={:#010x}",
-                    a_bits[lane],
-                    b_bits[lane],
-                    c_bits[lane],
-                );
-            }
-        }
-    }
-}
-
 #[simd_test]
 fn mul_add_precise_f32x4<S: Simd>(simd: S) {
     let midpoint_a = f32::from_bits(0x3f80_1000); // 1 + 2^-11
@@ -168,211 +34,6 @@ fn mul_add_precise_f32x4<S: Simd>(simd: S) {
         expected[2],
         ((midpoint_a as f64) * (midpoint_b as f64) - (tiny as f64)) as f32
     );
-}
-
-#[simd_test]
-fn mul_add_precise_f32x4_subnormal_rounding_regression<S: Simd>(simd: S) {
-    // Each product is slightly more than half of the smallest f32 subnormal. The exact sum must
-    // therefore round to the subnormal adjacent to c, even when a widened f64 addition rounds to
-    // the midpoint between c and that adjacent value.
-    // Regression test for https://github.com/linebender/fearless_simd/pull/323#issuecomment-5233682925
-    let cases: [(u32, u32, u32, u32); 26] = [
-        (0x9700_0800, 0x1cff_f001, 0x0001_0002, 0x0001_0001),
-        (0x9700_0800, 0x1cff_f001, 0x0001_0002, 0x0001_0001),
-        (0x9700_0800, 0x1cff_f001, 0x0020_0002, 0x0020_0001),
-        (0x19ff_e002, 0x1a00_1001, 0x0000_0040, 0x0000_0041),
-        (0x99ff_e002, 0x1a00_1001, 0x8000_0040, 0x8000_0041),
-        (0x19ff_e002, 0x1a00_1001, 0x0000_0400, 0x0000_0401),
-        (0x99ff_e002, 0x1a00_1001, 0x8000_0400, 0x8000_0401),
-        (0x19ff_e002, 0x1a00_1001, 0x0001_0000, 0x0001_0001),
-        (0x99ff_e002, 0x1a00_1001, 0x8001_0000, 0x8001_0001),
-        (0x19ff_e002, 0x1a00_1001, 0x0020_0000, 0x0020_0001),
-        (0x99ff_e002, 0x1a00_1001, 0x8020_0000, 0x8020_0001),
-        (0x19ff_e002, 0x1a00_1001, 0x0040_0000, 0x0040_0001),
-        (0x99ff_e002, 0x1a00_1001, 0x8040_0000, 0x8040_0001),
-        (0x99ff_e002, 0x1a00_1001, 0x0000_0042, 0x0000_0041),
-        (0x19ff_e002, 0x1a00_1001, 0x8000_0042, 0x8000_0041),
-        (0x99ff_e002, 0x1a00_1001, 0x0000_0402, 0x0000_0401),
-        (0x19ff_e002, 0x1a00_1001, 0x8000_0402, 0x8000_0401),
-        (0x99ff_e002, 0x1a00_1001, 0x0001_0002, 0x0001_0001),
-        (0x19ff_e002, 0x1a00_1001, 0x8001_0002, 0x8001_0001),
-        (0x99ff_e002, 0x1a00_1001, 0x0020_0002, 0x0020_0001),
-        (0x19ff_e002, 0x1a00_1001, 0x8020_0002, 0x8020_0001),
-        (0x1700_0800, 0x1cff_f001, 0x0001_0000, 0x0001_0001),
-        (0x1700_0800, 0x1cff_f001, 0x0004_0000, 0x0004_0001),
-        (0x1700_0800, 0x1cff_f001, 0x0020_0000, 0x0020_0001),
-        (0x9700_0800, 0x1cff_f001, 0x0001_0002, 0x0001_0001),
-        (0x9700_0800, 0x1cff_f001, 0x0020_0002, 0x0020_0001),
-    ];
-
-    for (a_bits, b_bits, c_bits, expected_bits) in cases {
-        let a = f32x4::splat(simd, f32::from_bits(a_bits));
-        let b = f32x4::splat(simd, f32::from_bits(b_bits));
-        let c = f32x4::splat(simd, f32::from_bits(c_bits));
-        let actual = a.mul_add_precise(b, c);
-        let actual_bits = [
-            actual[0].to_bits(),
-            actual[1].to_bits(),
-            actual[2].to_bits(),
-            actual[3].to_bits(),
-        ];
-
-        assert_eq!(
-            actual_bits, [expected_bits; 4],
-            "mul_add_precise inputs: a={a_bits:#010x}, b={b_bits:#010x}, c={c_bits:#010x}",
-        );
-    }
-}
-
-#[simd_test]
-#[ignore = "randomly stress-tests subnormal results"]
-// Run with: cargo test --release mul_add_precise_f32x4_random -- --ignored
-fn mul_add_precise_f32x4_random_reported_product_patterns<S: Simd>(simd: S) {
-    let mut rng = fastrand::Rng::with_seed(0x8b7d_3a21_19c4_e605);
-    let significand_pairs = [(0x00ff_e002, 0x0080_1001), (0x0080_0800, 0x00ff_f001)];
-
-    for iteration in 0..1_000_000 {
-        let mut a_bits = [0_u32; 4];
-        let mut b_bits = [0_u32; 4];
-        let mut c_bits = [0_u32; 4];
-
-        for lane in 0..4 {
-            let mut significands = significand_pairs[rng.usize(..significand_pairs.len())];
-            if rng.bool() {
-                significands = (significands.1, significands.0);
-            }
-
-            // The unbiased exponents sum to -151. Both significand products are just above 2^47,
-            // so the resulting product is just above half of the smallest f32 subnormal.
-            let a_exponent = rng.i32(-126..-24);
-            let b_exponent = -151 - a_exponent;
-            let a_negative = rng.bool();
-            let product_negative = rng.bool();
-            let b_negative = a_negative ^ product_negative;
-            a_bits[lane] = ((a_negative as u32) << 31)
-                | (((a_exponent + 127) as u32) << 23)
-                | (significands.0 & 0x007f_ffff);
-            b_bits[lane] = ((b_negative as u32) << 31)
-                | (((b_exponent + 127) as u32) << 23)
-                | (significands.1 & 0x007f_ffff);
-
-            let magnitude = match lane {
-                0 => rng.u32(1..0x0080_0000),
-                1 => {
-                    let highest_bit = rng.u32(0..23);
-                    let lower_bits = if highest_bit == 0 {
-                        0
-                    } else {
-                        rng.u32(0..1 << highest_bit)
-                    };
-                    (1 << highest_bit) | lower_bits
-                }
-                2 => 0x007f_ffff - rng.u32(0..1024),
-                3 => rng.u32(0..512),
-                _ => unreachable!(),
-            };
-            c_bits[lane] = ((rng.bool() as u32) << 31) | magnitude;
-        }
-
-        let a_values = a_bits.map(f32::from_bits);
-        let b_values = b_bits.map(f32::from_bits);
-        let c_values = c_bits.map(f32::from_bits);
-        let expected_bits: [u32; 4] = core::array::from_fn(|lane| {
-            reference_fma_f32(simd, a_values[lane], b_values[lane], c_values[lane]).to_bits()
-        });
-        let actual = f32x4::from_slice(simd, &a_values).mul_add_precise(
-            f32x4::from_slice(simd, &b_values),
-            f32x4::from_slice(simd, &c_values),
-        );
-        let actual_bits = [
-            actual[0].to_bits(),
-            actual[1].to_bits(),
-            actual[2].to_bits(),
-            actual[3].to_bits(),
-        ];
-
-        assert_eq!(
-            actual_bits, expected_bits,
-            "iteration {iteration}: a={a_bits:x?}, b={b_bits:x?}, c={c_bits:x?}",
-        );
-    }
-}
-
-#[simd_test]
-#[ignore = "randomly stress-tests subnormal results"]
-fn mul_add_precise_f32x4_random_half_subnormal_products<S: Simd>(simd: S) {
-    let mut rng = fastrand::Rng::with_seed(0x31f2_b984_7d06_ca5e);
-
-    for iteration in 0..1_000_000 {
-        let mut a_bits = [0_u32; 4];
-        let mut b_bits = [0_u32; 4];
-        let mut c_bits = [0_u32; 4];
-
-        for lane in 0..4 {
-            // Construct random 24-bit significands whose product is the closest representable
-            // integer product above or below 2^47. With exponents summing to -151, this places the
-            // floating-point product immediately around half of the smallest f32 subnormal.
-            let offset = rng.u32(1..0x0080_0000) as u64;
-            let low_significand = 1_u64 << 23;
-            let high_significand = 1_u64 << 24;
-            let b_significand = low_significand + offset;
-            let numerator = high_significand * offset;
-            let quotient = numerator / b_significand;
-            let remainder = numerator % b_significand;
-            let distance_from_high = if rng.bool() || remainder == 0 {
-                quotient
-            } else {
-                quotient + 1
-            };
-            let mut significands = (high_significand - distance_from_high, b_significand);
-            if rng.bool() {
-                significands = (significands.1, significands.0);
-            }
-
-            let a_exponent = rng.i32(-126..-24);
-            let b_exponent = -151 - a_exponent;
-            let a_negative = rng.bool();
-            let product_negative = rng.bool();
-            let b_negative = a_negative ^ product_negative;
-            a_bits[lane] = ((a_negative as u32) << 31)
-                | (((a_exponent + 127) as u32) << 23)
-                | (significands.0 as u32 & 0x007f_ffff);
-            b_bits[lane] = ((b_negative as u32) << 31)
-                | (((b_exponent + 127) as u32) << 23)
-                | (significands.1 as u32 & 0x007f_ffff);
-
-            let highest_bit = rng.u32(0..23);
-            let lower_bits = if highest_bit == 0 {
-                0
-            } else {
-                rng.u32(0..1 << highest_bit)
-            };
-            let magnitude = (1 << highest_bit) | lower_bits;
-            c_bits[lane] = ((rng.bool() as u32) << 31) | magnitude;
-        }
-
-        let a_values = a_bits.map(f32::from_bits);
-        let b_values = b_bits.map(f32::from_bits);
-        let c_values = c_bits.map(f32::from_bits);
-        let expected_bits: [u32; 4] = core::array::from_fn(|lane| {
-            reference_fma_f32(simd, a_values[lane], b_values[lane], c_values[lane]).to_bits()
-        });
-        let actual = f32x4::from_slice(simd, &a_values).mul_add_precise(
-            f32x4::from_slice(simd, &b_values),
-            f32x4::from_slice(simd, &c_values),
-        );
-        let actual_bits = [
-            actual[0].to_bits(),
-            actual[1].to_bits(),
-            actual[2].to_bits(),
-            actual[3].to_bits(),
-        ];
-
-        assert_eq!(
-            actual_bits, expected_bits,
-            "iteration {iteration}: a={a_bits:x?}, b={b_bits:x?}, c={c_bits:x?}",
-        );
-    }
 }
 
 #[simd_test]
@@ -603,4 +264,343 @@ fn mul_add_precise_f64x8<S: Simd>(simd: S) {
     let b = f64x8::from_slice(simd, &b_values);
     let c = f64x8::from_slice(simd, &c_values);
     assert_eq!(*a.mul_add_precise(b, c), expected);
+}
+
+#[inline(always)]
+fn reference_fma_f32<S: Simd>(simd: S, x: f32, y: f32, z: f32) -> f32 {
+    // Targets with hardware FMA use it; other use our own software emulation
+    match simd.level() {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        Level::Avx2(_) | Level::Avx512(_) => x.mul_add(y, z),
+        #[cfg(target_arch = "aarch64")]
+        Level::Neon(_) => x.mul_add(y, z),
+        _ => soft_fma(x, y, z),
+    }
+}
+
+// Rust std and even musl libc have buggy software FMA:
+// https://github.com/rust-lang/compiler-builtins/issues/1262
+// We're using a formally verified algorithm in prod,
+// but comparing an algorithm against itself is silly,
+// so we need something else for verification, and this is the
+// "something else", sourced from
+// https://github.com/linebender/fearless_simd/pull/323#issuecomment-5234072329
+#[inline]
+fn soft_fma(x: f32, y: f32, z: f32) -> f32 {
+    let xy = f64::from(x) * f64::from(y);
+    let z = f64::from(z);
+    let result = xy + z;
+    let mut u = result.to_bits();
+    if u & 0x0fff_ffff != 0 {
+        return result as f32;
+    }
+
+    if u & 0x1000_0000 == 0 && (u >> 52) & 0x7ff > 1023 - 126 {
+        return result as f32;
+    }
+
+    if result - xy == z && result - z == xy {
+        return result as f32;
+    }
+
+    let neg = u >> 63 != 0;
+    let err = if neg == (z > xy) {
+        xy - result + z
+    } else {
+        z - result + xy
+    };
+    if neg == (err < 0.0) {
+        u += 1;
+    } else {
+        u -= 1;
+    }
+    f64::from_bits(u) as f32
+}
+
+#[simd_test]
+#[ignore = "exhaustively checks all non-NaN f32 bit patterns"]
+fn mul_add_precise_f32x4_exhaustive<S: Simd>(simd: S) {
+    // Using each value for all three operands exercises every non-NaN bit pattern in every input
+    // position while keeping the exhaustive domain tractable.
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            for base in (0..u32::MAX).step_by(4) {
+                let values = f32x4::from_fn(simd, |lane| f32::from_bits(base + lane as u32));
+                let actual = values.mul_add_precise(values, values);
+
+                for lane in 0..4 {
+                    let value = values[lane];
+                    if value.is_nan() {
+                        continue;
+                    }
+
+                    let expected = value.mul_add(value, value);
+                    if expected.is_nan() {
+                        assert!(
+                            actual[lane].is_nan(),
+                            "mul_add_precise({value:?}, {value:?}, {value:?}) returned {:?}, expected NaN (input bits: {:#010x})",
+                            actual[lane],
+                            value.to_bits(),
+                        );
+                    } else {
+                        assert_eq!(
+                            actual[lane].to_bits(),
+                            expected.to_bits(),
+                            "mul_add_precise({value:?}, {value:?}, {value:?}) differs from scalar mul_add (input bits: {:#010x})",
+                            value.to_bits(),
+                        );
+                    }
+                }
+            }
+        },
+    );
+}
+
+#[simd_test]
+#[ignore = "randomly checks independent f32 bit patterns"]
+// Run with: cargo test --release mul_add_precise_f32x4_random_independent -- --ignored
+fn mul_add_precise_f32x4_random_independent_bit_patterns<S: Simd>(simd: S) {
+    let mut rng = fastrand::Rng::with_seed(0xd1b5_4a32_d192_ed03);
+
+    for iteration in 0..1_000_000_000 {
+        let a_bits: [u32; 4] = core::array::from_fn(|_| rng.u32(..));
+        let b_bits: [u32; 4] = core::array::from_fn(|_| rng.u32(..));
+        let c_bits: [u32; 4] = core::array::from_fn(|_| rng.u32(..));
+        let a_values = a_bits.map(f32::from_bits);
+        let b_values = b_bits.map(f32::from_bits);
+        let c_values = c_bits.map(f32::from_bits);
+        let actual = f32x4::from_slice(simd, &a_values).mul_add_precise(
+            f32x4::from_slice(simd, &b_values),
+            f32x4::from_slice(simd, &c_values),
+        );
+
+        for lane in 0..4 {
+            let expected = reference_fma_f32(simd, a_values[lane], b_values[lane], c_values[lane]);
+            if expected.is_nan() {
+                assert!(
+                    actual[lane].is_nan(),
+                    "iteration {iteration}, lane {lane}: mul_add_precise(a={:#010x}, b={:#010x}, c={:#010x}) returned {:#010x}, expected NaN",
+                    a_bits[lane],
+                    b_bits[lane],
+                    c_bits[lane],
+                    actual[lane].to_bits(),
+                );
+            } else {
+                assert_eq!(
+                    actual[lane].to_bits(),
+                    expected.to_bits(),
+                    "iteration {iteration}, lane {lane}: mul_add_precise inputs a={:#010x}, b={:#010x}, c={:#010x}",
+                    a_bits[lane],
+                    b_bits[lane],
+                    c_bits[lane],
+                );
+            }
+        }
+    }
+}
+
+#[simd_test]
+fn mul_add_precise_f32x4_subnormal_rounding_regression<S: Simd>(simd: S) {
+    // Each product is slightly more than half of the smallest f32 subnormal. The exact sum must
+    // therefore round to the subnormal adjacent to c, even when a widened f64 addition rounds to
+    // the midpoint between c and that adjacent value.
+    // Regression test for https://github.com/linebender/fearless_simd/pull/323#issuecomment-5233682925
+    let cases: [(u32, u32, u32, u32); 26] = [
+        (0x9700_0800, 0x1cff_f001, 0x0001_0002, 0x0001_0001),
+        (0x9700_0800, 0x1cff_f001, 0x0001_0002, 0x0001_0001),
+        (0x9700_0800, 0x1cff_f001, 0x0020_0002, 0x0020_0001),
+        (0x19ff_e002, 0x1a00_1001, 0x0000_0040, 0x0000_0041),
+        (0x99ff_e002, 0x1a00_1001, 0x8000_0040, 0x8000_0041),
+        (0x19ff_e002, 0x1a00_1001, 0x0000_0400, 0x0000_0401),
+        (0x99ff_e002, 0x1a00_1001, 0x8000_0400, 0x8000_0401),
+        (0x19ff_e002, 0x1a00_1001, 0x0001_0000, 0x0001_0001),
+        (0x99ff_e002, 0x1a00_1001, 0x8001_0000, 0x8001_0001),
+        (0x19ff_e002, 0x1a00_1001, 0x0020_0000, 0x0020_0001),
+        (0x99ff_e002, 0x1a00_1001, 0x8020_0000, 0x8020_0001),
+        (0x19ff_e002, 0x1a00_1001, 0x0040_0000, 0x0040_0001),
+        (0x99ff_e002, 0x1a00_1001, 0x8040_0000, 0x8040_0001),
+        (0x99ff_e002, 0x1a00_1001, 0x0000_0042, 0x0000_0041),
+        (0x19ff_e002, 0x1a00_1001, 0x8000_0042, 0x8000_0041),
+        (0x99ff_e002, 0x1a00_1001, 0x0000_0402, 0x0000_0401),
+        (0x19ff_e002, 0x1a00_1001, 0x8000_0402, 0x8000_0401),
+        (0x99ff_e002, 0x1a00_1001, 0x0001_0002, 0x0001_0001),
+        (0x19ff_e002, 0x1a00_1001, 0x8001_0002, 0x8001_0001),
+        (0x99ff_e002, 0x1a00_1001, 0x0020_0002, 0x0020_0001),
+        (0x19ff_e002, 0x1a00_1001, 0x8020_0002, 0x8020_0001),
+        (0x1700_0800, 0x1cff_f001, 0x0001_0000, 0x0001_0001),
+        (0x1700_0800, 0x1cff_f001, 0x0004_0000, 0x0004_0001),
+        (0x1700_0800, 0x1cff_f001, 0x0020_0000, 0x0020_0001),
+        (0x9700_0800, 0x1cff_f001, 0x0001_0002, 0x0001_0001),
+        (0x9700_0800, 0x1cff_f001, 0x0020_0002, 0x0020_0001),
+    ];
+
+    for (a_bits, b_bits, c_bits, expected_bits) in cases {
+        let a = f32x4::splat(simd, f32::from_bits(a_bits));
+        let b = f32x4::splat(simd, f32::from_bits(b_bits));
+        let c = f32x4::splat(simd, f32::from_bits(c_bits));
+        let actual = a.mul_add_precise(b, c);
+        let actual_bits = [
+            actual[0].to_bits(),
+            actual[1].to_bits(),
+            actual[2].to_bits(),
+            actual[3].to_bits(),
+        ];
+
+        assert_eq!(
+            actual_bits, [expected_bits; 4],
+            "mul_add_precise inputs: a={a_bits:#010x}, b={b_bits:#010x}, c={c_bits:#010x}",
+        );
+    }
+}
+
+#[simd_test]
+#[ignore = "randomly stress-tests subnormal results"]
+// Run with: cargo test --release mul_add_precise_f32x4_random -- --ignored
+fn mul_add_precise_f32x4_random_reported_product_patterns<S: Simd>(simd: S) {
+    let mut rng = fastrand::Rng::with_seed(0x8b7d_3a21_19c4_e605);
+    let significand_pairs = [(0x00ff_e002, 0x0080_1001), (0x0080_0800, 0x00ff_f001)];
+
+    for iteration in 0..1_000_000 {
+        let mut a_bits = [0_u32; 4];
+        let mut b_bits = [0_u32; 4];
+        let mut c_bits = [0_u32; 4];
+
+        for lane in 0..4 {
+            let mut significands = significand_pairs[rng.usize(..significand_pairs.len())];
+            if rng.bool() {
+                significands = (significands.1, significands.0);
+            }
+
+            // The unbiased exponents sum to -151. Both significand products are just above 2^47,
+            // so the resulting product is just above half of the smallest f32 subnormal.
+            let a_exponent = rng.i32(-126..-24);
+            let b_exponent = -151 - a_exponent;
+            let a_negative = rng.bool();
+            let product_negative = rng.bool();
+            let b_negative = a_negative ^ product_negative;
+            a_bits[lane] = ((a_negative as u32) << 31)
+                | (((a_exponent + 127) as u32) << 23)
+                | (significands.0 & 0x007f_ffff);
+            b_bits[lane] = ((b_negative as u32) << 31)
+                | (((b_exponent + 127) as u32) << 23)
+                | (significands.1 & 0x007f_ffff);
+
+            let magnitude = match lane {
+                0 => rng.u32(1..0x0080_0000),
+                1 => {
+                    let highest_bit = rng.u32(0..23);
+                    let lower_bits = if highest_bit == 0 {
+                        0
+                    } else {
+                        rng.u32(0..1 << highest_bit)
+                    };
+                    (1 << highest_bit) | lower_bits
+                }
+                2 => 0x007f_ffff - rng.u32(0..1024),
+                3 => rng.u32(0..512),
+                _ => unreachable!(),
+            };
+            c_bits[lane] = ((rng.bool() as u32) << 31) | magnitude;
+        }
+
+        let a_values = a_bits.map(f32::from_bits);
+        let b_values = b_bits.map(f32::from_bits);
+        let c_values = c_bits.map(f32::from_bits);
+        let expected_bits: [u32; 4] = core::array::from_fn(|lane| {
+            reference_fma_f32(simd, a_values[lane], b_values[lane], c_values[lane]).to_bits()
+        });
+        let actual = f32x4::from_slice(simd, &a_values).mul_add_precise(
+            f32x4::from_slice(simd, &b_values),
+            f32x4::from_slice(simd, &c_values),
+        );
+        let actual_bits = [
+            actual[0].to_bits(),
+            actual[1].to_bits(),
+            actual[2].to_bits(),
+            actual[3].to_bits(),
+        ];
+
+        assert_eq!(
+            actual_bits, expected_bits,
+            "iteration {iteration}: a={a_bits:x?}, b={b_bits:x?}, c={c_bits:x?}",
+        );
+    }
+}
+
+#[simd_test]
+#[ignore = "randomly stress-tests subnormal results"]
+fn mul_add_precise_f32x4_random_half_subnormal_products<S: Simd>(simd: S) {
+    let mut rng = fastrand::Rng::with_seed(0x31f2_b984_7d06_ca5e);
+
+    for iteration in 0..1_000_000 {
+        let mut a_bits = [0_u32; 4];
+        let mut b_bits = [0_u32; 4];
+        let mut c_bits = [0_u32; 4];
+
+        for lane in 0..4 {
+            // Construct random 24-bit significands whose product is the closest representable
+            // integer product above or below 2^47. With exponents summing to -151, this places the
+            // floating-point product immediately around half of the smallest f32 subnormal.
+            let offset = rng.u32(1..0x0080_0000) as u64;
+            let low_significand = 1_u64 << 23;
+            let high_significand = 1_u64 << 24;
+            let b_significand = low_significand + offset;
+            let numerator = high_significand * offset;
+            let quotient = numerator / b_significand;
+            let remainder = numerator % b_significand;
+            let distance_from_high = if rng.bool() || remainder == 0 {
+                quotient
+            } else {
+                quotient + 1
+            };
+            let mut significands = (high_significand - distance_from_high, b_significand);
+            if rng.bool() {
+                significands = (significands.1, significands.0);
+            }
+
+            let a_exponent = rng.i32(-126..-24);
+            let b_exponent = -151 - a_exponent;
+            let a_negative = rng.bool();
+            let product_negative = rng.bool();
+            let b_negative = a_negative ^ product_negative;
+            a_bits[lane] = ((a_negative as u32) << 31)
+                | (((a_exponent + 127) as u32) << 23)
+                | (significands.0 as u32 & 0x007f_ffff);
+            b_bits[lane] = ((b_negative as u32) << 31)
+                | (((b_exponent + 127) as u32) << 23)
+                | (significands.1 as u32 & 0x007f_ffff);
+
+            let highest_bit = rng.u32(0..23);
+            let lower_bits = if highest_bit == 0 {
+                0
+            } else {
+                rng.u32(0..1 << highest_bit)
+            };
+            let magnitude = (1 << highest_bit) | lower_bits;
+            c_bits[lane] = ((rng.bool() as u32) << 31) | magnitude;
+        }
+
+        let a_values = a_bits.map(f32::from_bits);
+        let b_values = b_bits.map(f32::from_bits);
+        let c_values = c_bits.map(f32::from_bits);
+        let expected_bits: [u32; 4] = core::array::from_fn(|lane| {
+            reference_fma_f32(simd, a_values[lane], b_values[lane], c_values[lane]).to_bits()
+        });
+        let actual = f32x4::from_slice(simd, &a_values).mul_add_precise(
+            f32x4::from_slice(simd, &b_values),
+            f32x4::from_slice(simd, &c_values),
+        );
+        let actual_bits = [
+            actual[0].to_bits(),
+            actual[1].to_bits(),
+            actual[2].to_bits(),
+            actual[3].to_bits(),
+        ];
+
+        assert_eq!(
+            actual_bits, expected_bits,
+            "iteration {iteration}: a={a_bits:x?}, b={b_bits:x?}, c={c_bits:x?}",
+        );
+    }
 }

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -1,12 +1,67 @@
 // Copyright 2026 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use core::any::TypeId;
 use fearless_simd::*;
 use fearless_simd_dev_macros::simd_test;
 
 // This file has a lot of coverage for 128-bit vectors specifically.
 // That's because we have complex, error-prone emulation of precise FMA
 // on SSE4.2 and need to test it in great depth.
+
+#[inline(always)]
+fn reference_fma_f32<S: Simd>(_: S, x: f32, y: f32, z: f32) -> f32 {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if TypeId::of::<S>() == TypeId::of::<Avx2>() || TypeId::of::<S>() == TypeId::of::<Avx512>() {
+        return x.mul_add(y, z);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    if TypeId::of::<S>() == TypeId::of::<Neon>() {
+        return x.mul_add(y, z);
+    }
+
+    soft_fma(x, y, z)
+}
+
+// Rust std and even musl libc have buggy software FMA:
+// https://github.com/rust-lang/compiler-builtins/issues/1262
+// We're using a formally verified algorithm in prod,
+// but comparing an algorithm against itself is silly,
+// so we need something else for verification, and this is the
+// "something else", sourced from
+// https://github.com/linebender/fearless_simd/pull/323#issuecomment-5234072329
+#[inline]
+fn soft_fma(x: f32, y: f32, z: f32) -> f32 {
+    let xy = f64::from(x) * f64::from(y);
+    let z = f64::from(z);
+    let result = xy + z;
+    let mut u = result.to_bits();
+    if u & 0x0fff_ffff != 0 {
+        return result as f32;
+    }
+
+    if u & 0x1000_0000 == 0 && (u >> 52) & 0x7ff > 1023 - 126 {
+        return result as f32;
+    }
+
+    if result - xy == z && result - z == xy {
+        return result as f32;
+    }
+
+    let neg = u >> 63 != 0;
+    let err = if neg == (z > xy) {
+        xy - result + z
+    } else {
+        z - result + xy
+    };
+    if neg == (err < 0.0) {
+        u += 1;
+    } else {
+        u -= 1;
+    }
+    f64::from_bits(u) as f32
+}
 
 #[simd_test]
 #[ignore = "exhaustively checks all non-NaN f32 bit patterns"]
@@ -67,7 +122,7 @@ fn mul_add_precise_f32x4_random_independent_bit_patterns<S: Simd>(simd: S) {
         );
 
         for lane in 0..4 {
-            let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
+            let expected = reference_fma_f32(simd, a_values[lane], b_values[lane], c_values[lane]);
             if expected.is_nan() {
                 assert!(
                     actual[lane].is_nan(),
@@ -227,9 +282,7 @@ fn mul_add_precise_f32x4_random_reported_product_patterns<S: Simd>(simd: S) {
         let b_values = b_bits.map(f32::from_bits);
         let c_values = c_bits.map(f32::from_bits);
         let expected_bits: [u32; 4] = core::array::from_fn(|lane| {
-            a_values[lane]
-                .mul_add(b_values[lane], c_values[lane])
-                .to_bits()
+            reference_fma_f32(simd, a_values[lane], b_values[lane], c_values[lane]).to_bits()
         });
         let actual = f32x4::from_slice(simd, &a_values).mul_add_precise(
             f32x4::from_slice(simd, &b_values),
@@ -306,9 +359,7 @@ fn mul_add_precise_f32x4_random_half_subnormal_products<S: Simd>(simd: S) {
         let b_values = b_bits.map(f32::from_bits);
         let c_values = c_bits.map(f32::from_bits);
         let expected_bits: [u32; 4] = core::array::from_fn(|lane| {
-            a_values[lane]
-                .mul_add(b_values[lane], c_values[lane])
-                .to_bits()
+            reference_fma_f32(simd, a_values[lane], b_values[lane], c_values[lane]).to_bits()
         });
         let actual = f32x4::from_slice(simd, &a_values).mul_add_precise(
             f32x4::from_slice(simd, &b_values),

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -11,12 +11,11 @@ use fearless_simd_dev_macros::simd_test;
 #[inline(always)]
 fn reference_fma_f32<S: Simd>(simd: S, x: f32, y: f32, z: f32) -> f32 {
     // Targets with hardware FMA use it; other use our own software emulation
-    use Level::*;
     match simd.level() {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        Avx2(_) | Avx512(_) => x.mul_add(y, z),
+        Level::Avx2(_) | Level::Avx512(_) => x.mul_add(y, z),
         #[cfg(target_arch = "aarch64")]
-        Neon(_) => x.mul_add(y, z),
+        Level::Neon(_) => x.mul_add(y, z),
         _ => soft_fma(x, y, z),
     }
 }

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -1,0 +1,303 @@
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use fearless_simd::*;
+use fearless_simd_dev_macros::simd_test;
+
+#[simd_test]
+#[ignore = "exhaustively checks all non-NaN f32 bit patterns"]
+fn mul_add_precise_f32x4_exhaustive<S: Simd>(simd: S) {
+    // Using each value for all three operands exercises every non-NaN bit pattern in every input
+    // position while keeping the exhaustive domain tractable.
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            for base in (0..u32::MAX).step_by(4) {
+                let values = f32x4::from_fn(simd, |lane| f32::from_bits(base + lane as u32));
+                let actual = values.mul_add_precise(values, values);
+
+                for lane in 0..4 {
+                    let value = values[lane];
+                    if value.is_nan() {
+                        continue;
+                    }
+
+                    let expected = value.mul_add(value, value);
+                    if expected.is_nan() {
+                        assert!(
+                            actual[lane].is_nan(),
+                            "mul_add_precise({value:?}, {value:?}, {value:?}) returned {:?}, expected NaN (input bits: {:#010x})",
+                            actual[lane],
+                            value.to_bits(),
+                        );
+                    } else {
+                        assert_eq!(
+                            actual[lane].to_bits(),
+                            expected.to_bits(),
+                            "mul_add_precise({value:?}, {value:?}, {value:?}) differs from scalar mul_add (input bits: {:#010x})",
+                            value.to_bits(),
+                        );
+                    }
+                }
+            }
+        },
+    );
+}
+
+#[simd_test]
+fn mul_add_precise_f32x4<S: Simd>(simd: S) {
+    let midpoint_a = f32::from_bits(0x3f80_1000); // 1 + 2^-11
+    let midpoint_b = f32::from_bits(0x3f7f_f800); // 1 - 2^-13
+    let tiny = f32::from_bits(0x0d80_0000); // 2^-100
+    let a_values = [1.0 + f32::EPSILON, midpoint_a, midpoint_a, f32::MAX];
+    let b_values = [1.0 - f32::EPSILON, midpoint_b, midpoint_b, 2.0];
+    let c_values = [-1.0, tiny, -tiny, -f32::MAX];
+    let expected = [
+        a_values[0].mul_add(b_values[0], c_values[0]),
+        a_values[1].mul_add(b_values[1], c_values[1]),
+        a_values[2].mul_add(b_values[2], c_values[2]),
+        a_values[3].mul_add(b_values[3], c_values[3]),
+    ];
+
+    let a = f32x4::from_slice(simd, &a_values);
+    let b = f32x4::from_slice(simd, &b_values);
+    let c = f32x4::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_add_precise(b, c), expected);
+
+    // The negative tiny addend moves the exact result below an f32 midpoint, but is lost by a
+    // naive f64 add before narrowing.
+    assert_ne!(
+        expected[2],
+        ((midpoint_a as f64) * (midpoint_b as f64) - (tiny as f64)) as f32
+    );
+}
+
+#[simd_test]
+fn mul_add_precise_f32x4_special_values<S: Simd>(simd: S) {
+    let a_values = [-0.0, f32::MIN_POSITIVE, f32::INFINITY, f32::NAN];
+    let b_values = [2.0, 0.5, 2.0, 1.0];
+    let c_values = [-0.0, 0.0, f32::NEG_INFINITY, 1.0];
+    let a = f32x4::from_slice(simd, &a_values);
+    let b = f32x4::from_slice(simd, &b_values);
+    let c = f32x4::from_slice(simd, &c_values);
+    let result = a.mul_add_precise(b, c);
+
+    assert_eq!(
+        result[0].to_bits(),
+        a_values[0].mul_add(b_values[0], c_values[0]).to_bits()
+    );
+    assert_eq!(
+        result[1].to_bits(),
+        a_values[1].mul_add(b_values[1], c_values[1]).to_bits()
+    );
+    assert!(result[2].is_nan());
+    assert!(result[3].is_nan());
+}
+
+#[simd_test]
+fn mul_add_precise_f64x2<S: Simd>(simd: S) {
+    let a_values = [1.0 + f64::EPSILON, f64::MAX];
+    let b_values = [1.0 - f64::EPSILON, 2.0];
+    let c_values = [-1.0, -f64::MAX];
+    let expected = [
+        a_values[0].mul_add(b_values[0], c_values[0]),
+        a_values[1].mul_add(b_values[1], c_values[1]),
+    ];
+
+    let a = f64x2::from_slice(simd, &a_values);
+    let b = f64x2::from_slice(simd, &b_values);
+    let c = f64x2::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_add_precise(b, c), expected);
+}
+
+#[simd_test]
+fn mul_add_precise_f64x2_special_values<S: Simd>(simd: S) {
+    let a_values = [-0.0, f64::INFINITY];
+    let b_values = [2.0, 2.0];
+    let c_values = [-0.0, f64::NEG_INFINITY];
+    let a = f64x2::from_slice(simd, &a_values);
+    let b = f64x2::from_slice(simd, &b_values);
+    let c = f64x2::from_slice(simd, &c_values);
+    let result = a.mul_add_precise(b, c);
+
+    assert_eq!(
+        result[0].to_bits(),
+        a_values[0].mul_add(b_values[0], c_values[0]).to_bits()
+    );
+    assert!(result[1].is_nan());
+}
+
+#[simd_test]
+fn mul_add_precise_f32x8<S: Simd>(simd: S) {
+    let midpoint_a = f32::from_bits(0x3f80_1000);
+    let midpoint_b = f32::from_bits(0x3f7f_f800);
+    let tiny = f32::from_bits(0x0d80_0000);
+    let a_values = [
+        1.0 + f32::EPSILON,
+        midpoint_a,
+        midpoint_a,
+        f32::MAX,
+        -0.0,
+        f32::MIN_POSITIVE,
+        3.0,
+        -7.0,
+    ];
+    let b_values = [
+        1.0 - f32::EPSILON,
+        midpoint_b,
+        midpoint_b,
+        2.0,
+        2.0,
+        0.5,
+        4.0,
+        5.0,
+    ];
+    let c_values = [-1.0, tiny, -tiny, -f32::MAX, -0.0, 0.0, 0.5, 2.0];
+    let expected = [
+        a_values[0].mul_add(b_values[0], c_values[0]),
+        a_values[1].mul_add(b_values[1], c_values[1]),
+        a_values[2].mul_add(b_values[2], c_values[2]),
+        a_values[3].mul_add(b_values[3], c_values[3]),
+        a_values[4].mul_add(b_values[4], c_values[4]),
+        a_values[5].mul_add(b_values[5], c_values[5]),
+        a_values[6].mul_add(b_values[6], c_values[6]),
+        a_values[7].mul_add(b_values[7], c_values[7]),
+    ];
+
+    let a = f32x8::from_slice(simd, &a_values);
+    let b = f32x8::from_slice(simd, &b_values);
+    let c = f32x8::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_add_precise(b, c), expected);
+}
+
+#[simd_test]
+fn mul_add_precise_f64x4<S: Simd>(simd: S) {
+    let midpoint_a = 1.0 + 2.0_f64.powi(-27);
+    let midpoint_b = 1.0 - 2.0_f64.powi(-27);
+    let tiny = 2.0_f64.powi(-150);
+    let a_values = [1.0 + f64::EPSILON, f64::MAX, midpoint_a, midpoint_a];
+    let b_values = [1.0 - f64::EPSILON, 2.0, midpoint_b, midpoint_b];
+    let c_values = [-1.0, -f64::MAX, tiny, -tiny];
+    let expected = [
+        a_values[0].mul_add(b_values[0], c_values[0]),
+        a_values[1].mul_add(b_values[1], c_values[1]),
+        a_values[2].mul_add(b_values[2], c_values[2]),
+        a_values[3].mul_add(b_values[3], c_values[3]),
+    ];
+
+    let a = f64x4::from_slice(simd, &a_values);
+    let b = f64x4::from_slice(simd, &b_values);
+    let c = f64x4::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_add_precise(b, c), expected);
+}
+
+#[simd_test]
+fn mul_add_precise_f32x16<S: Simd>(simd: S) {
+    let midpoint_a = f32::from_bits(0x3f80_1000);
+    let midpoint_b = f32::from_bits(0x3f7f_f800);
+    let tiny = f32::from_bits(0x0d80_0000);
+    let a_values = [
+        1.0 + f32::EPSILON,
+        midpoint_a,
+        midpoint_a,
+        f32::MAX,
+        -0.0,
+        f32::MIN_POSITIVE,
+        3.0,
+        -7.0,
+        1.0 + f32::EPSILON,
+        midpoint_a,
+        midpoint_a,
+        f32::MAX,
+        -0.0,
+        f32::MIN_POSITIVE,
+        3.0,
+        -7.0,
+    ];
+    let b_values = [
+        1.0 - f32::EPSILON,
+        midpoint_b,
+        midpoint_b,
+        2.0,
+        2.0,
+        0.5,
+        4.0,
+        5.0,
+        1.0 - f32::EPSILON,
+        midpoint_b,
+        midpoint_b,
+        2.0,
+        2.0,
+        0.5,
+        4.0,
+        5.0,
+    ];
+    let c_values = [
+        -1.0,
+        tiny,
+        -tiny,
+        -f32::MAX,
+        -0.0,
+        0.0,
+        0.5,
+        2.0,
+        -1.0,
+        tiny,
+        -tiny,
+        -f32::MAX,
+        -0.0,
+        0.0,
+        0.5,
+        2.0,
+    ];
+    let expected: [f32; 16] =
+        core::array::from_fn(|i| a_values[i].mul_add(b_values[i], c_values[i]));
+
+    let a = f32x16::from_slice(simd, &a_values);
+    let b = f32x16::from_slice(simd, &b_values);
+    let c = f32x16::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_add_precise(b, c), expected);
+}
+
+#[simd_test]
+fn mul_add_precise_f64x8<S: Simd>(simd: S) {
+    let midpoint_a = 1.0 + 2.0_f64.powi(-27);
+    let midpoint_b = 1.0 - 2.0_f64.powi(-27);
+    let tiny = 2.0_f64.powi(-150);
+    let a_values = [
+        1.0 + f64::EPSILON,
+        f64::MAX,
+        midpoint_a,
+        midpoint_a,
+        -0.0,
+        f64::MIN_POSITIVE,
+        3.0,
+        -7.0,
+    ];
+    let b_values = [
+        1.0 - f64::EPSILON,
+        2.0,
+        midpoint_b,
+        midpoint_b,
+        2.0,
+        0.5,
+        4.0,
+        5.0,
+    ];
+    let c_values = [-1.0, -f64::MAX, tiny, -tiny, -0.0, 0.0, 0.5, 2.0];
+    let expected = [
+        a_values[0].mul_add(b_values[0], c_values[0]),
+        a_values[1].mul_add(b_values[1], c_values[1]),
+        a_values[2].mul_add(b_values[2], c_values[2]),
+        a_values[3].mul_add(b_values[3], c_values[3]),
+        a_values[4].mul_add(b_values[4], c_values[4]),
+        a_values[5].mul_add(b_values[5], c_values[5]),
+        a_values[6].mul_add(b_values[6], c_values[6]),
+        a_values[7].mul_add(b_values[7], c_values[7]),
+    ];
+
+    let a = f64x8::from_slice(simd, &a_values);
+    let b = f64x8::from_slice(simd, &b_values);
+    let c = f64x8::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_add_precise(b, c), expected);
+}

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -37,6 +37,35 @@ fn mul_add_precise_f32x4<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn mul_add_precise_f32x4_overflow_rounding<S: Simd>(simd: S) {
+    // a*b is exactly the overflow midpoint 2^128 - 2^103. The much smaller addend is
+    // lost by the rounded f64 addition, but decides whether the exact FMA is finite.
+    let a_value = f32::from_bits(0x5ff8_0000);
+    let b_value = f32::from_bits(0x5f04_2108);
+    let delta = f32::from_bits(0x6280_0000); // 2^70
+    let a = f32x4::from_slice(simd, &[a_value, a_value, -a_value, -a_value]);
+    let b = f32x4::splat(simd, b_value);
+    let c = f32x4::from_slice(simd, &[delta, -delta, -delta, delta]);
+    let actual = a.mul_add_precise(b, c);
+    let actual_bits = [
+        actual[0].to_bits(),
+        actual[1].to_bits(),
+        actual[2].to_bits(),
+        actual[3].to_bits(),
+    ];
+
+    assert_eq!(
+        actual_bits,
+        [
+            f32::INFINITY.to_bits(),
+            f32::MAX.to_bits(),
+            f32::NEG_INFINITY.to_bits(),
+            (-f32::MAX).to_bits(),
+        ]
+    );
+}
+
+#[simd_test]
 fn mul_add_precise_f32x4_special_values<S: Simd>(simd: S) {
     let a_values = [-0.0, f32::MIN_POSITIVE, f32::INFINITY, f32::NAN];
     let b_values = [2.0, 0.5, 2.0, 1.0];

--- a/fearless_simd_tests/tests/harness/ops/mul_sub.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_sub.rs
@@ -23,6 +23,42 @@ fn mul_sub_f64x2<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn mul_sub_f32x4_signed_zero<S: Simd>(simd: S) {
+    let a_values = [1.0_f32, -1.0, 0.0, -0.0];
+    let b_values = [1.0_f32, -1.0, 1.0, 1.0];
+    let c_values = [1.0_f32, 1.0, 0.0, 0.0];
+    let a = f32x4::from_slice(simd, &a_values);
+    let b = f32x4::from_slice(simd, &b_values);
+    let c = f32x4::from_slice(simd, &c_values);
+    let result = a.mul_sub(b, c);
+
+    for lane in 0..4 {
+        assert_eq!(
+            result[lane].to_bits(),
+            (a_values[lane] * b_values[lane] - c_values[lane]).to_bits()
+        );
+    }
+}
+
+#[simd_test]
+fn mul_sub_f64x2_signed_zero<S: Simd>(simd: S) {
+    let a_values = [1.0_f64, -0.0];
+    let b_values = [1.0_f64, 1.0];
+    let c_values = [1.0_f64, 0.0];
+    let a = f64x2::from_slice(simd, &a_values);
+    let b = f64x2::from_slice(simd, &b_values);
+    let c = f64x2::from_slice(simd, &c_values);
+    let result = a.mul_sub(b, c);
+
+    for lane in 0..2 {
+        assert_eq!(
+            result[lane].to_bits(),
+            (a_values[lane] * b_values[lane] - c_values[lane]).to_bits()
+        );
+    }
+}
+
+#[simd_test]
 fn mul_sub_f32x8<S: Simd>(simd: S) {
     let a = f32x8::from_slice(simd, &[2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
     let b = f32x8::from_slice(simd, &[10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0]);

--- a/fearless_simd_tests/tests/harness/ops/mul_sub_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_sub_precise.rs
@@ -1,0 +1,283 @@
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use fearless_simd::*;
+use fearless_simd_dev_macros::simd_test;
+
+#[simd_test]
+#[ignore = "exhaustively checks all non-NaN f32 bit patterns"]
+fn mul_sub_precise_f32x4_exhaustive<S: Simd>(simd: S) {
+    // Using each value for all three operands exercises every non-NaN bit pattern in every input
+    // position while keeping the exhaustive domain tractable.
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            for base in (0..u32::MAX).step_by(4) {
+                let values = f32x4::from_fn(simd, |lane| f32::from_bits(base + lane as u32));
+                let actual = values.mul_sub_precise(values, values);
+
+                for lane in 0..4 {
+                    let value = values[lane];
+                    if value.is_nan() {
+                        continue;
+                    }
+
+                    let expected = value.mul_add(value, -value);
+                    if expected.is_nan() {
+                        assert!(
+                            actual[lane].is_nan(),
+                            "mul_sub_precise({value:?}, {value:?}, {value:?}) returned {:?}, expected NaN (input bits: {:#010x})",
+                            actual[lane],
+                            value.to_bits(),
+                        );
+                    } else {
+                        assert_eq!(
+                            actual[lane].to_bits(),
+                            expected.to_bits(),
+                            "mul_sub_precise({value:?}, {value:?}, {value:?}) differs from scalar mul_add with a negated addend (input bits: {:#010x})",
+                            value.to_bits(),
+                        );
+                    }
+                }
+            }
+        },
+    );
+}
+
+#[simd_test]
+fn mul_sub_precise_f32x4<S: Simd>(simd: S) {
+    let midpoint_a = f32::from_bits(0x3f80_1000); // 1 + 2^-11
+    let midpoint_b = f32::from_bits(0x3f7f_f800); // 1 - 2^-13
+    let tiny = f32::from_bits(0x0d80_0000); // 2^-100
+    let a_values = [1.0 + f32::EPSILON, midpoint_a, midpoint_a, f32::MAX];
+    let b_values = [1.0 - f32::EPSILON, midpoint_b, midpoint_b, 2.0];
+    let c_values = [1.0, -tiny, tiny, f32::MAX];
+    let expected = [
+        a_values[0].mul_add(b_values[0], -c_values[0]),
+        a_values[1].mul_add(b_values[1], -c_values[1]),
+        a_values[2].mul_add(b_values[2], -c_values[2]),
+        a_values[3].mul_add(b_values[3], -c_values[3]),
+    ];
+
+    let a = f32x4::from_slice(simd, &a_values);
+    let b = f32x4::from_slice(simd, &b_values);
+    let c = f32x4::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_sub_precise(b, c), expected);
+
+    // The positive tiny subtrahend moves the exact result below an f32 midpoint, but is lost by a
+    // naive f64 subtraction before narrowing.
+    assert_ne!(
+        expected[2],
+        ((midpoint_a as f64) * (midpoint_b as f64) - (tiny as f64)) as f32
+    );
+}
+
+#[simd_test]
+fn mul_sub_precise_f32x4_special_values<S: Simd>(simd: S) {
+    let a_values = [-0.0_f32, f32::MIN_POSITIVE, f32::INFINITY, f32::NAN];
+    let b_values = [2.0_f32, 0.5, 2.0, 1.0];
+    let c_values = [0.0_f32, -0.0, f32::INFINITY, -1.0];
+    let a = f32x4::from_slice(simd, &a_values);
+    let b = f32x4::from_slice(simd, &b_values);
+    let c = f32x4::from_slice(simd, &c_values);
+    let result = a.mul_sub_precise(b, c);
+
+    assert_eq!(
+        result[0].to_bits(),
+        a_values[0].mul_add(b_values[0], -c_values[0]).to_bits()
+    );
+    assert_eq!(
+        result[1].to_bits(),
+        a_values[1].mul_add(b_values[1], -c_values[1]).to_bits()
+    );
+    assert!(result[2].is_nan());
+    assert!(result[3].is_nan());
+}
+
+#[simd_test]
+fn mul_sub_precise_f64x2<S: Simd>(simd: S) {
+    let a_values = [1.0 + f64::EPSILON, f64::MAX];
+    let b_values = [1.0 - f64::EPSILON, 2.0];
+    let c_values = [1.0, f64::MAX];
+    let expected = [
+        a_values[0].mul_add(b_values[0], -c_values[0]),
+        a_values[1].mul_add(b_values[1], -c_values[1]),
+    ];
+
+    let a = f64x2::from_slice(simd, &a_values);
+    let b = f64x2::from_slice(simd, &b_values);
+    let c = f64x2::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_sub_precise(b, c), expected);
+}
+
+#[simd_test]
+fn mul_sub_precise_f64x2_special_values<S: Simd>(simd: S) {
+    let a_values = [-0.0_f64, f64::INFINITY];
+    let b_values = [2.0_f64, 2.0];
+    let c_values = [0.0_f64, f64::INFINITY];
+    let a = f64x2::from_slice(simd, &a_values);
+    let b = f64x2::from_slice(simd, &b_values);
+    let c = f64x2::from_slice(simd, &c_values);
+    let result = a.mul_sub_precise(b, c);
+
+    assert_eq!(
+        result[0].to_bits(),
+        a_values[0].mul_add(b_values[0], -c_values[0]).to_bits()
+    );
+    assert!(result[1].is_nan());
+}
+
+#[simd_test]
+fn mul_sub_precise_f32x8<S: Simd>(simd: S) {
+    let midpoint_a = f32::from_bits(0x3f80_1000);
+    let midpoint_b = f32::from_bits(0x3f7f_f800);
+    let tiny = f32::from_bits(0x0d80_0000);
+    let a_values = [
+        1.0 + f32::EPSILON,
+        midpoint_a,
+        midpoint_a,
+        f32::MAX,
+        -0.0,
+        f32::MIN_POSITIVE,
+        3.0,
+        -7.0,
+    ];
+    let b_values = [
+        1.0 - f32::EPSILON,
+        midpoint_b,
+        midpoint_b,
+        2.0,
+        2.0,
+        0.5,
+        4.0,
+        5.0,
+    ];
+    let c_values = [1.0, -tiny, tiny, f32::MAX, 0.0, -0.0, -0.5, -2.0];
+    let expected: [f32; 8] =
+        core::array::from_fn(|i| a_values[i].mul_add(b_values[i], -c_values[i]));
+
+    let a = f32x8::from_slice(simd, &a_values);
+    let b = f32x8::from_slice(simd, &b_values);
+    let c = f32x8::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_sub_precise(b, c), expected);
+}
+
+#[simd_test]
+fn mul_sub_precise_f64x4<S: Simd>(simd: S) {
+    let midpoint_a = 1.0 + 2.0_f64.powi(-27);
+    let midpoint_b = 1.0 - 2.0_f64.powi(-27);
+    let tiny = 2.0_f64.powi(-150);
+    let a_values = [1.0 + f64::EPSILON, f64::MAX, midpoint_a, midpoint_a];
+    let b_values = [1.0 - f64::EPSILON, 2.0, midpoint_b, midpoint_b];
+    let c_values = [1.0, f64::MAX, -tiny, tiny];
+    let expected: [f64; 4] =
+        core::array::from_fn(|i| a_values[i].mul_add(b_values[i], -c_values[i]));
+
+    let a = f64x4::from_slice(simd, &a_values);
+    let b = f64x4::from_slice(simd, &b_values);
+    let c = f64x4::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_sub_precise(b, c), expected);
+}
+
+#[simd_test]
+fn mul_sub_precise_f32x16<S: Simd>(simd: S) {
+    let midpoint_a = f32::from_bits(0x3f80_1000);
+    let midpoint_b = f32::from_bits(0x3f7f_f800);
+    let tiny = f32::from_bits(0x0d80_0000);
+    let a_values = [
+        1.0 + f32::EPSILON,
+        midpoint_a,
+        midpoint_a,
+        f32::MAX,
+        -0.0,
+        f32::MIN_POSITIVE,
+        3.0,
+        -7.0,
+        1.0 + f32::EPSILON,
+        midpoint_a,
+        midpoint_a,
+        f32::MAX,
+        -0.0,
+        f32::MIN_POSITIVE,
+        3.0,
+        -7.0,
+    ];
+    let b_values = [
+        1.0 - f32::EPSILON,
+        midpoint_b,
+        midpoint_b,
+        2.0,
+        2.0,
+        0.5,
+        4.0,
+        5.0,
+        1.0 - f32::EPSILON,
+        midpoint_b,
+        midpoint_b,
+        2.0,
+        2.0,
+        0.5,
+        4.0,
+        5.0,
+    ];
+    let c_values = [
+        1.0,
+        -tiny,
+        tiny,
+        f32::MAX,
+        0.0,
+        -0.0,
+        -0.5,
+        -2.0,
+        1.0,
+        -tiny,
+        tiny,
+        f32::MAX,
+        0.0,
+        -0.0,
+        -0.5,
+        -2.0,
+    ];
+    let expected: [f32; 16] =
+        core::array::from_fn(|i| a_values[i].mul_add(b_values[i], -c_values[i]));
+
+    let a = f32x16::from_slice(simd, &a_values);
+    let b = f32x16::from_slice(simd, &b_values);
+    let c = f32x16::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_sub_precise(b, c), expected);
+}
+
+#[simd_test]
+fn mul_sub_precise_f64x8<S: Simd>(simd: S) {
+    let midpoint_a = 1.0 + 2.0_f64.powi(-27);
+    let midpoint_b = 1.0 - 2.0_f64.powi(-27);
+    let tiny = 2.0_f64.powi(-150);
+    let a_values = [
+        1.0 + f64::EPSILON,
+        f64::MAX,
+        midpoint_a,
+        midpoint_a,
+        -0.0,
+        f64::MIN_POSITIVE,
+        3.0,
+        -7.0,
+    ];
+    let b_values = [
+        1.0 - f64::EPSILON,
+        2.0,
+        midpoint_b,
+        midpoint_b,
+        2.0,
+        0.5,
+        4.0,
+        5.0,
+    ];
+    let c_values = [1.0, f64::MAX, -tiny, tiny, 0.0, -0.0, -0.5, -2.0];
+    let expected: [f64; 8] =
+        core::array::from_fn(|i| a_values[i].mul_add(b_values[i], -c_values[i]));
+
+    let a = f64x8::from_slice(simd, &a_values);
+    let b = f64x8::from_slice(simd, &b_values);
+    let c = f64x8::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_sub_precise(b, c), expected);
+}


### PR DESCRIPTION
This is useful for building algorithms with guaranteed precision. For example, most of the literature on getting accurate SIMD trigonometry requires precise fused multiply-add.

Lowers into:

- accurate FMA on WASM even with relaxed SIMD
- Custom scalar FMA based on a formally verified algorithm from a [2008 paper]( https://guillaume.melquiond.fr/doc/08-tc.pdf) to work around [a bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust libm and musl libc
- SSE4.2 f32 emulates it on f64 SIMD vectors using the same algorithm from the same paper

The paper is "Emulation of FMA and correctly-rounded sums: proved algorithms using rounding to odd" by Sylvie Boldo and Guillaume Melquiond.

The SSE4.2 version is 5x faster than the libm scalar implementation, and 2.5x faster when the rare fixup branch always needs to be taken. On branches: Nehalem misprediction recovery is 17 cycles which amounts to a 40% throughput penalty, so this should never be worse than scalar even in the worst case for branch misprediction. Tremont timings are hard to find but it gets a very beefy predictor and its throughput is awful, so it shouldn't be any worse. Zen4 benchmarks confirm that worst case misprediction is roughly in line with scalar. A branchles formulation with more work in the hot path would be possible but with misprediction being rare, it isn't worth it in practice.

Also fixes `mul_sub()` on NEON which used to produce zero with an incorrect sign when all inputs are 1s with different signs. The fixed assembly has identical performance to the previous one on llvm-mca in both throughput and latency. It's always two instructions because NEON doesn't have `mul_sub` with the semantics we need, this PR only changes which two instructions are selected.

It is unfortunately not possible to remove the dedicated mul_sub operation and just write mul_add(a, b, -c) because LLVM does not optimize it reliably enough, see https://github.com/linebender/fearless_simd/issues/18