### PR TITLE
Add SIMD emulation of `mul_add_precise` for f64 on SSE4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find its changes [documented below](#070-2026-08-11).
 
 ### Added
 
- - - Added `mul_add_precise` and `mul_sub_precise` for floating-point vectors. They guarantee the infinite-precision product-plus-add rounded once, including on SIMD levels without hardware fused multiply-add instructions. They are not susceptible to the [bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library, `std::simd` and musl libc that causes incorrect rounding for subnormal results.
+ - - Added `mul_add_precise` and `mul_sub_precise` for floating-point vectors. They guarantee the infinite-precision product-plus-add rounded once, including on SIMD levels without hardware fused multiply-add instructions. They are not susceptible to the [bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library, `std::simd` and musl libc that causes incorrect rounding for subnormal results. SSE4.2 gets SIMD emulation of these operations for better performance. ([#323][], [#324][] by [@Shnatsel][])
 
 ## [0.7.0][] (2026-08-11)
 
@@ -341,6 +341,8 @@ No changelog was kept for this release.
 [#318]: https://github.com/linebender/fearless_simd/pull/318
 [#320]: https://github.com/linebender/fearless_simd/pull/320
 [#321]: https://github.com/linebender/fearless_simd/pull/321
+[#323]: https://github.com/linebender/fearless_simd/pull/323
+[#324]: https://github.com/linebender/fearless_simd/pull/324
 
 [Unreleased]: https://github.com/linebender/fearless_simd/compare/v0.7.0...HEAD
 [0.7.0]: https://github.com/linebender/fearless_simd/compare/v0.6.0...v0.7.0

--- a/fearless_simd/Cargo.toml
+++ b/fearless_simd/Cargo.toml
@@ -42,8 +42,3 @@ workspace = true
 
 [dependencies]
 libm = { version = "0.2.15", optional = true }
-
-[dev-dependencies]
-# Keep precise-FMA benchmarks on libm's generic software implementation even on
-# x86 hosts where libm would otherwise select hardware FMA at runtime.
-libm = { version = "0.2.15", features = ["force-soft-floats"] }

--- a/fearless_simd/Cargo.toml
+++ b/fearless_simd/Cargo.toml
@@ -42,3 +42,8 @@ workspace = true
 
 [dependencies]
 libm = { version = "0.2.15", optional = true }
+
+[dev-dependencies]
+# Keep precise-FMA benchmarks on libm's generic software implementation even on
+# x86 hosts where libm would otherwise select hardware FMA at runtime.
+libm = { version = "0.2.15", features = ["force-soft-floats"] }

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -4022,11 +4022,111 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn mul_add_precise_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {
-        [
-            f64::mul_add(a[0usize], b[0usize], c[0usize]),
-            f64::mul_add(a[1usize], b[1usize], c[1usize]),
-        ]
-        .simd_into(self)
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Sse4_2,
+                a: f64x2<Sse4_2>,
+                b: f64x2<Sse4_2>,
+                c: f64x2<Sse4_2>,
+            ) -> f64x2<Sse4_2> {
+                let a_raw: __m128d = a.into();
+                let b_raw: __m128d = b.into();
+                let c_raw: __m128d = c.into();
+                let absolute_value_mask = _mm_set1_epi64x(i64::MAX);
+                let a_bits = _mm_and_si128(_mm_castpd_si128(a_raw), absolute_value_mask);
+                let b_bits = _mm_and_si128(_mm_castpd_si128(b_raw), absolute_value_mask);
+                let c_bits = _mm_and_si128(_mm_castpd_si128(c_raw), absolute_value_mask);
+                let lower_bound_minus_one = _mm_set1_epi64x((623_i64 << 52) - 1);
+                let upper_bound_plus_one = _mm_set1_epi64x((1423_i64 << 52) + 1);
+                let zero_bits = _mm_setzero_si128();
+                let all_ones = _mm_set1_epi64x(-1);
+                let a_safe = _mm_and_si128(
+                    _mm_cmpgt_epi64(a_bits, lower_bound_minus_one),
+                    _mm_cmpgt_epi64(upper_bound_plus_one, a_bits),
+                );
+                let b_safe = _mm_and_si128(
+                    _mm_cmpgt_epi64(b_bits, lower_bound_minus_one),
+                    _mm_cmpgt_epi64(upper_bound_plus_one, b_bits),
+                );
+                let c_in_range = _mm_and_si128(
+                    _mm_cmpgt_epi64(c_bits, lower_bound_minus_one),
+                    _mm_cmpgt_epi64(upper_bound_plus_one, c_bits),
+                );
+                let c_safe = _mm_or_si128(c_in_range, _mm_cmpeq_epi64(c_bits, zero_bits));
+                let all_safe = _mm_and_si128(_mm_and_si128(a_safe, b_safe), c_safe);
+                if _mm_testc_si128(all_safe, all_ones) == 0 {
+                    return [
+                        f64::mul_add(a[0], b[0], c[0]),
+                        f64::mul_add(a[1], b[1], c[1]),
+                    ]
+                    .simd_into(token);
+                }
+                let splitter = _mm_set1_pd(134_217_729.0);
+                let a_gamma = _mm_mul_pd(splitter, a_raw);
+                let a_delta = _mm_sub_pd(a_raw, a_gamma);
+                let a_high = _mm_add_pd(a_gamma, a_delta);
+                let a_low = _mm_sub_pd(a_raw, a_high);
+                let b_gamma = _mm_mul_pd(splitter, b_raw);
+                let b_delta = _mm_sub_pd(b_raw, b_gamma);
+                let b_high = _mm_add_pd(b_gamma, b_delta);
+                let b_low = _mm_sub_pd(b_raw, b_high);
+                let product_high = _mm_mul_pd(a_raw, b_raw);
+                let product_error_1 = _mm_sub_pd(_mm_mul_pd(a_high, b_high), product_high);
+                let product_error_2 = _mm_add_pd(product_error_1, _mm_mul_pd(a_high, b_low));
+                let product_error_3 = _mm_add_pd(product_error_2, _mm_mul_pd(a_low, b_high));
+                let product_low = _mm_add_pd(product_error_3, _mm_mul_pd(a_low, b_low));
+                let sum_high = _mm_add_pd(product_high, c_raw);
+                let sum_product_part = _mm_sub_pd(sum_high, c_raw);
+                let sum_low = _mm_add_pd(
+                    _mm_sub_pd(product_high, sum_product_part),
+                    _mm_sub_pd(c_raw, _mm_sub_pd(sum_high, sum_product_part)),
+                );
+                let v_high = _mm_add_pd(product_low, sum_low);
+                let v_product_part = _mm_sub_pd(v_high, sum_low);
+                let v_low = _mm_add_pd(
+                    _mm_sub_pd(product_low, v_product_part),
+                    _mm_sub_pd(sum_low, _mm_sub_pd(v_high, v_product_part)),
+                );
+                let v_high_bits = _mm_castpd_si128(v_high);
+                let v_high_abs = _mm_and_si128(v_high_bits, absolute_value_mask);
+                let fraction_mask = _mm_set1_epi64x(0x000f_ffff_ffff_ffff);
+                let top_fraction_bit = _mm_set1_epi64x(0x0008_0000_0000_0000);
+                let exponent_mask = _mm_set1_epi64x(0x7ff0_0000_0000_0000);
+                let fraction = _mm_and_si128(v_high_abs, fraction_mask);
+                let exponent = _mm_and_si128(v_high_abs, exponent_mask);
+                let special_fraction = _mm_or_si128(
+                    _mm_cmpeq_epi64(fraction, zero_bits),
+                    _mm_cmpeq_epi64(fraction, top_fraction_bit),
+                );
+                let normal_exponent = _mm_andnot_si128(
+                    _mm_cmpeq_epi64(exponent, exponent_mask),
+                    _mm_cmpgt_epi64(exponent, zero_bits),
+                );
+                let v_low_nonzero = _mm_castpd_si128(_mm_cmpneq_pd(v_low, _mm_setzero_pd()));
+                let special = _mm_and_si128(
+                    v_low_nonzero,
+                    _mm_and_si128(special_fraction, normal_exponent),
+                );
+                if _mm_testz_si128(special, special) == 0 {
+                    let different_sign_bits = _mm_slli_epi64::<63>(_mm_srli_epi64::<63>(
+                        _mm_xor_si128(v_high_bits, _mm_castpd_si128(v_low)),
+                    ));
+                    let factor = _mm_blendv_pd(
+                        _mm_set1_pd(9.0 / 8.0),
+                        _mm_set1_pd(7.0 / 8.0),
+                        _mm_castsi128_pd(different_sign_bits),
+                    );
+                    let adjusted_v_high = _mm_mul_pd(factor, v_high);
+                    let correction =
+                        _mm_blendv_pd(v_high, adjusted_v_high, _mm_castsi128_pd(special));
+                    _mm_add_pd(sum_high, correction).simd_into(token)
+                } else {
+                    _mm_add_pd(sum_high, v_high).simd_into(token)
+                }
+            }
+        );
+        kernel(self, a, b, c)
     }
     #[inline(always)]
     fn mul_sub_f64x2(self, a: f64x2<Self>, b: f64x2<Self>, c: f64x2<Self>) -> f64x2<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -4062,14 +4062,17 @@ impl Simd for Sse4_2 {
                     ]
                     .simd_into(token);
                 }
-                let splitter = _mm_set1_pd(134_217_729.0);
-                let a_gamma = _mm_mul_pd(splitter, a_raw);
-                let a_delta = _mm_sub_pd(a_raw, a_gamma);
-                let a_high = _mm_add_pd(a_gamma, a_delta);
+                let split_rounding_bit = _mm_set1_epi64x(1_i64 << 26);
+                let split_high_mask = _mm_set1_epi64x(!((1_i64 << 27) - 1));
+                let a_high = _mm_castsi128_pd(_mm_and_si128(
+                    _mm_add_epi64(_mm_castpd_si128(a_raw), split_rounding_bit),
+                    split_high_mask,
+                ));
                 let a_low = _mm_sub_pd(a_raw, a_high);
-                let b_gamma = _mm_mul_pd(splitter, b_raw);
-                let b_delta = _mm_sub_pd(b_raw, b_gamma);
-                let b_high = _mm_add_pd(b_gamma, b_delta);
+                let b_high = _mm_castsi128_pd(_mm_and_si128(
+                    _mm_add_epi64(_mm_castpd_si128(b_raw), split_rounding_bit),
+                    split_high_mask,
+                ));
                 let b_low = _mm_sub_pd(b_raw, b_high);
                 let product_high = _mm_mul_pd(a_raw, b_raw);
                 let product_error_1 = _mm_sub_pd(_mm_mul_pd(a_high, b_high), product_high);
@@ -4085,23 +4088,23 @@ impl Simd for Sse4_2 {
                 let sum_small = _mm_blendv_pd(product_high, c_raw, product_high_larger);
                 let sum_low = _mm_sub_pd(sum_small, _mm_sub_pd(sum_high, sum_large));
                 let v_high = _mm_add_pd(product_low, sum_low);
-                let product_low_abs =
-                    _mm_and_si128(_mm_castpd_si128(product_low), absolute_value_mask);
-                let sum_low_abs = _mm_and_si128(_mm_castpd_si128(sum_low), absolute_value_mask);
-                let product_low_larger = _mm_cmpgt_pd(
-                    _mm_castsi128_pd(product_low_abs),
-                    _mm_castsi128_pd(sum_low_abs),
-                );
-                let v_large = _mm_blendv_pd(sum_low, product_low, product_low_larger);
-                let v_small = _mm_blendv_pd(product_low, sum_low, product_low_larger);
-                let v_low = _mm_sub_pd(v_small, _mm_sub_pd(v_high, v_large));
                 let v_high_bits = _mm_castpd_si128(v_high);
                 let lower_fraction_mask = _mm_set1_epi64x(0x0007_ffff_ffff_ffff);
                 let special_fraction =
                     _mm_cmpeq_epi64(_mm_and_si128(v_high_bits, lower_fraction_mask), zero_bits);
-                let v_low_nonzero = _mm_castpd_si128(_mm_cmpneq_pd(v_low, _mm_setzero_pd()));
-                let special = _mm_and_si128(v_low_nonzero, special_fraction);
-                if _mm_testz_si128(special, special) == 0 {
+                if _mm_testz_si128(special_fraction, v_high_bits) == 0 {
+                    let product_low_abs =
+                        _mm_and_si128(_mm_castpd_si128(product_low), absolute_value_mask);
+                    let sum_low_abs = _mm_and_si128(_mm_castpd_si128(sum_low), absolute_value_mask);
+                    let product_low_larger = _mm_cmpgt_pd(
+                        _mm_castsi128_pd(product_low_abs),
+                        _mm_castsi128_pd(sum_low_abs),
+                    );
+                    let v_large = _mm_blendv_pd(sum_low, product_low, product_low_larger);
+                    let v_small = _mm_blendv_pd(product_low, sum_low, product_low_larger);
+                    let v_low = _mm_sub_pd(v_small, _mm_sub_pd(v_high, v_large));
+                    let v_low_nonzero = _mm_castpd_si128(_mm_cmpneq_pd(v_low, _mm_setzero_pd()));
+                    let special = _mm_and_si128(v_low_nonzero, special_fraction);
                     let different_sign_bits = _mm_slli_epi64::<63>(_mm_srli_epi64::<63>(
                         _mm_xor_si128(v_high_bits, _mm_castpd_si128(v_low)),
                     ));

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -4077,37 +4077,30 @@ impl Simd for Sse4_2 {
                 let product_error_3 = _mm_add_pd(product_error_2, _mm_mul_pd(a_low, b_high));
                 let product_low = _mm_add_pd(product_error_3, _mm_mul_pd(a_low, b_low));
                 let sum_high = _mm_add_pd(product_high, c_raw);
-                let sum_product_part = _mm_sub_pd(sum_high, c_raw);
-                let sum_low = _mm_add_pd(
-                    _mm_sub_pd(product_high, sum_product_part),
-                    _mm_sub_pd(c_raw, _mm_sub_pd(sum_high, sum_product_part)),
-                );
+                let product_high_abs =
+                    _mm_and_si128(_mm_castpd_si128(product_high), absolute_value_mask);
+                let product_high_larger =
+                    _mm_cmpgt_pd(_mm_castsi128_pd(product_high_abs), _mm_castsi128_pd(c_bits));
+                let sum_large = _mm_blendv_pd(c_raw, product_high, product_high_larger);
+                let sum_small = _mm_blendv_pd(product_high, c_raw, product_high_larger);
+                let sum_low = _mm_sub_pd(sum_small, _mm_sub_pd(sum_high, sum_large));
                 let v_high = _mm_add_pd(product_low, sum_low);
-                let v_product_part = _mm_sub_pd(v_high, sum_low);
-                let v_low = _mm_add_pd(
-                    _mm_sub_pd(product_low, v_product_part),
-                    _mm_sub_pd(sum_low, _mm_sub_pd(v_high, v_product_part)),
+                let product_low_abs =
+                    _mm_and_si128(_mm_castpd_si128(product_low), absolute_value_mask);
+                let sum_low_abs = _mm_and_si128(_mm_castpd_si128(sum_low), absolute_value_mask);
+                let product_low_larger = _mm_cmpgt_pd(
+                    _mm_castsi128_pd(product_low_abs),
+                    _mm_castsi128_pd(sum_low_abs),
                 );
+                let v_large = _mm_blendv_pd(sum_low, product_low, product_low_larger);
+                let v_small = _mm_blendv_pd(product_low, sum_low, product_low_larger);
+                let v_low = _mm_sub_pd(v_small, _mm_sub_pd(v_high, v_large));
                 let v_high_bits = _mm_castpd_si128(v_high);
-                let v_high_abs = _mm_and_si128(v_high_bits, absolute_value_mask);
-                let fraction_mask = _mm_set1_epi64x(0x000f_ffff_ffff_ffff);
-                let top_fraction_bit = _mm_set1_epi64x(0x0008_0000_0000_0000);
-                let exponent_mask = _mm_set1_epi64x(0x7ff0_0000_0000_0000);
-                let fraction = _mm_and_si128(v_high_abs, fraction_mask);
-                let exponent = _mm_and_si128(v_high_abs, exponent_mask);
-                let special_fraction = _mm_or_si128(
-                    _mm_cmpeq_epi64(fraction, zero_bits),
-                    _mm_cmpeq_epi64(fraction, top_fraction_bit),
-                );
-                let normal_exponent = _mm_andnot_si128(
-                    _mm_cmpeq_epi64(exponent, exponent_mask),
-                    _mm_cmpgt_epi64(exponent, zero_bits),
-                );
+                let lower_fraction_mask = _mm_set1_epi64x(0x0007_ffff_ffff_ffff);
+                let special_fraction =
+                    _mm_cmpeq_epi64(_mm_and_si128(v_high_bits, lower_fraction_mask), zero_bits);
                 let v_low_nonzero = _mm_castpd_si128(_mm_cmpneq_pd(v_low, _mm_setzero_pd()));
-                let special = _mm_and_si128(
-                    v_low_nonzero,
-                    _mm_and_si128(special_fraction, normal_exponent),
-                );
+                let special = _mm_and_si128(v_low_nonzero, special_fraction);
                 if _mm_testz_si128(special, special) == 0 {
                     let different_sign_bits = _mm_slli_epi64::<63>(_mm_srli_epi64::<63>(
                         _mm_xor_si128(v_high_bits, _mm_castpd_si128(v_low)),

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2476,6 +2476,162 @@ impl X86 {
         })
     }
 
+    fn precise_mul_add_f64x2(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+        assert!(
+            *self == Self::Sse4_2,
+            "precise f64 multiply-add emulation is specific to SSE4.2"
+        );
+        assert_eq!(
+            vec_ty.scalar,
+            ScalarType::Float,
+            "precise f64 multiply-add requires a floating-point vector"
+        );
+        assert_eq!(
+            vec_ty.scalar_bits, 64,
+            "precise f64 multiply-add requires 64-bit lanes"
+        );
+        assert_eq!(
+            vec_ty.n_bits(),
+            128,
+            "SSE4.2 precise f64 multiply-add requires one native vector"
+        );
+
+        // Graillat and Muller's Algorithm 9 computes an FMA from a Dekker product
+        // and their correctly rounded addition of a double-word and an FP number:
+        // https://doi.org/10.1007/s00211-025-01487-2
+        //
+        // Their proof assumes an unbounded exponent range. Restrict the packed path
+        // to a conservative range where no nonzero intermediate can underflow or
+        // overflow, and use scalar FMA for complete IEEE binary64 range coverage.
+        self.kernel_method(op, vec_ty, |token| {
+            quote! {
+                let a_raw: __m128d = a.into();
+                let b_raw: __m128d = b.into();
+                let c_raw: __m128d = c.into();
+
+                let absolute_value_mask = _mm_set1_epi64x(i64::MAX);
+                let a_bits = _mm_and_si128(_mm_castpd_si128(a_raw), absolute_value_mask);
+                let b_bits = _mm_and_si128(_mm_castpd_si128(b_raw), absolute_value_mask);
+                let c_bits = _mm_and_si128(_mm_castpd_si128(c_raw), absolute_value_mask);
+
+                // 2^-400 and 2^400 have biased exponents 623 and 1423. Inclusive
+                // comparisons are expressed using strict signed qword comparisons;
+                // absolute-value binary64 bits are always nonnegative as i64 values.
+                let lower_bound_minus_one = _mm_set1_epi64x((623_i64 << 52) - 1);
+                let upper_bound_plus_one = _mm_set1_epi64x((1423_i64 << 52) + 1);
+                let zero_bits = _mm_setzero_si128();
+                let all_ones = _mm_set1_epi64x(-1);
+                let a_safe = _mm_and_si128(
+                    _mm_cmpgt_epi64(a_bits, lower_bound_minus_one),
+                    _mm_cmpgt_epi64(upper_bound_plus_one, a_bits),
+                );
+                let b_safe = _mm_and_si128(
+                    _mm_cmpgt_epi64(b_bits, lower_bound_minus_one),
+                    _mm_cmpgt_epi64(upper_bound_plus_one, b_bits),
+                );
+                let c_in_range = _mm_and_si128(
+                    _mm_cmpgt_epi64(c_bits, lower_bound_minus_one),
+                    _mm_cmpgt_epi64(upper_bound_plus_one, c_bits),
+                );
+                let c_safe = _mm_or_si128(c_in_range, _mm_cmpeq_epi64(c_bits, zero_bits));
+                let all_safe = _mm_and_si128(_mm_and_si128(a_safe, b_safe), c_safe);
+
+                // Scalarize both lanes if either one is outside the proven exponent-safe range.
+                // This branch must precede the packed arithmetic so unsafe inactive lanes cannot
+                // overflow or underflow inside the error-free transforms.
+                if _mm_testc_si128(all_safe, all_ones) == 0 {
+                    return [
+                        f64::mul_add(a[0], b[0], c[0]),
+                        f64::mul_add(a[1], b[1], c[1]),
+                    ]
+                    .simd_into(#token);
+                }
+
+                // Veltkamp splitting for binary64, using K = 2^27 + 1.
+                let splitter = _mm_set1_pd(134_217_729.0);
+                let a_gamma = _mm_mul_pd(splitter, a_raw);
+                let a_delta = _mm_sub_pd(a_raw, a_gamma);
+                let a_high = _mm_add_pd(a_gamma, a_delta);
+                let a_low = _mm_sub_pd(a_raw, a_high);
+                let b_gamma = _mm_mul_pd(splitter, b_raw);
+                let b_delta = _mm_sub_pd(b_raw, b_gamma);
+                let b_high = _mm_add_pd(b_gamma, b_delta);
+                let b_low = _mm_sub_pd(b_raw, b_high);
+
+                // Dekker product: product_high + product_low is exactly a * b.
+                let product_high = _mm_mul_pd(a_raw, b_raw);
+                let product_error_1 =
+                    _mm_sub_pd(_mm_mul_pd(a_high, b_high), product_high);
+                let product_error_2 =
+                    _mm_add_pd(product_error_1, _mm_mul_pd(a_high, b_low));
+                let product_error_3 =
+                    _mm_add_pd(product_error_2, _mm_mul_pd(a_low, b_high));
+                let product_low =
+                    _mm_add_pd(product_error_3, _mm_mul_pd(a_low, b_low));
+
+                // TwoSum(product_high, c).
+                let sum_high = _mm_add_pd(product_high, c_raw);
+                let sum_product_part = _mm_sub_pd(sum_high, c_raw);
+                let sum_low = _mm_add_pd(
+                    _mm_sub_pd(product_high, sum_product_part),
+                    _mm_sub_pd(c_raw, _mm_sub_pd(sum_high, sum_product_part)),
+                );
+
+                // TwoSum(product_low, sum_low).
+                let v_high = _mm_add_pd(product_low, sum_low);
+                let v_product_part = _mm_sub_pd(v_high, sum_low);
+                let v_low = _mm_add_pd(
+                    _mm_sub_pd(product_low, v_product_part),
+                    _mm_sub_pd(sum_low, _mm_sub_pd(v_high, v_product_part)),
+                );
+
+                // The default sum is correctly rounded except when v_low is nonzero and
+                // |v_high| is 2^k or 3 * 2^k. Detect those significand shapes from the
+                // binary64 fraction while explicitly excluding zero and non-finite values.
+                let v_high_bits = _mm_castpd_si128(v_high);
+                let v_high_abs = _mm_and_si128(v_high_bits, absolute_value_mask);
+                let fraction_mask = _mm_set1_epi64x(0x000f_ffff_ffff_ffff);
+                let top_fraction_bit = _mm_set1_epi64x(0x0008_0000_0000_0000);
+                let exponent_mask = _mm_set1_epi64x(0x7ff0_0000_0000_0000);
+                let fraction = _mm_and_si128(v_high_abs, fraction_mask);
+                let exponent = _mm_and_si128(v_high_abs, exponent_mask);
+                let special_fraction = _mm_or_si128(
+                    _mm_cmpeq_epi64(fraction, zero_bits),
+                    _mm_cmpeq_epi64(fraction, top_fraction_bit),
+                );
+                let normal_exponent = _mm_andnot_si128(
+                    _mm_cmpeq_epi64(exponent, exponent_mask),
+                    _mm_cmpgt_epi64(exponent, zero_bits),
+                );
+                let v_low_nonzero = _mm_castpd_si128(_mm_cmpneq_pd(v_low, _mm_setzero_pd()));
+                let special = _mm_and_si128(
+                    v_low_nonzero,
+                    _mm_and_si128(special_fraction, normal_exponent),
+                );
+
+                if _mm_testz_si128(special, special) == 0 {
+                    let different_sign_bits = _mm_slli_epi64::<63>(_mm_srli_epi64::<63>(
+                        _mm_xor_si128(v_high_bits, _mm_castpd_si128(v_low)),
+                    ));
+                    let factor = _mm_blendv_pd(
+                        _mm_set1_pd(9.0 / 8.0),
+                        _mm_set1_pd(7.0 / 8.0),
+                        _mm_castsi128_pd(different_sign_bits),
+                    );
+                    let adjusted_v_high = _mm_mul_pd(factor, v_high);
+                    let correction = _mm_blendv_pd(
+                        v_high,
+                        adjusted_v_high,
+                        _mm_castsi128_pd(special),
+                    );
+                    _mm_add_pd(sum_high, correction).simd_into(#token)
+                } else {
+                    _mm_add_pd(sum_high, v_high).simd_into(#token)
+                }
+            }
+        })
+    }
+
     pub(crate) fn handle_ternary(
         &self,
         op: Op,
@@ -2502,6 +2658,9 @@ impl X86 {
             }
             "mul_add_precise" if *self == Self::Sse4_2 && vec_ty.scalar_bits == 32 => {
                 self.precise_mul_add_f32x4(op, vec_ty)
+            }
+            "mul_add_precise" if *self == Self::Sse4_2 && vec_ty.scalar_bits == 64 => {
+                self.precise_mul_add_f64x2(op, vec_ty)
             }
             "mul_add_precise" if matches!(self, Self::Avx2 | Self::Avx512) => {
                 let mul_add = generic_op_name("mul_add", vec_ty);

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2498,11 +2498,15 @@ impl X86 {
 
         // Graillat and Muller's Algorithm 9 computes an FMA from a Dekker product
         // and their correctly rounded addition of a double-word and an FP number:
+        // https://perso.lip6.fr/Stef.Graillat/papers/NM-2025.pdf
         // https://doi.org/10.1007/s00211-025-01487-2
         //
         // Their proof assumes an unbounded exponent range. Restrict the packed path
         // to a conservative range where no nonzero intermediate can underflow or
         // overflow, and use scalar FMA for complete IEEE binary64 range coverage.
+        //
+        // The vectorized path is taken for values between 2^-400 and 2^400,
+        // values outside that range are routed to the scalar fallback.
         self.kernel_method(op, vec_ty, |token| {
             quote! {
                 let a_raw: __m128d = a.into();
@@ -2569,45 +2573,53 @@ impl X86 {
                 let product_low =
                     _mm_add_pd(product_error_3, _mm_mul_pd(a_low, b_low));
 
-                // TwoSum(product_high, c).
+                // Magnitude-sort each addition so Fast2Sum can replace TwoSum.
+                // This trades packed compares and blends for a shorter floating-point
+                // dependency chain, as suggested by Graillat and Muller.
                 let sum_high = _mm_add_pd(product_high, c_raw);
-                let sum_product_part = _mm_sub_pd(sum_high, c_raw);
-                let sum_low = _mm_add_pd(
-                    _mm_sub_pd(product_high, sum_product_part),
-                    _mm_sub_pd(c_raw, _mm_sub_pd(sum_high, sum_product_part)),
+                let product_high_abs = _mm_and_si128(
+                    _mm_castpd_si128(product_high),
+                    absolute_value_mask,
                 );
+                let product_high_larger = _mm_cmpgt_pd(
+                    _mm_castsi128_pd(product_high_abs),
+                    _mm_castsi128_pd(c_bits),
+                );
+                let sum_large = _mm_blendv_pd(c_raw, product_high, product_high_larger);
+                let sum_small = _mm_blendv_pd(product_high, c_raw, product_high_larger);
+                let sum_low = _mm_sub_pd(sum_small, _mm_sub_pd(sum_high, sum_large));
 
-                // TwoSum(product_low, sum_low).
+                // Fast2Sum(product_low, sum_low), after the same magnitude sort.
                 let v_high = _mm_add_pd(product_low, sum_low);
-                let v_product_part = _mm_sub_pd(v_high, sum_low);
-                let v_low = _mm_add_pd(
-                    _mm_sub_pd(product_low, v_product_part),
-                    _mm_sub_pd(sum_low, _mm_sub_pd(v_high, v_product_part)),
+                let product_low_abs = _mm_and_si128(
+                    _mm_castpd_si128(product_low),
+                    absolute_value_mask,
                 );
+                let sum_low_abs = _mm_and_si128(
+                    _mm_castpd_si128(sum_low),
+                    absolute_value_mask,
+                );
+                let product_low_larger = _mm_cmpgt_pd(
+                    _mm_castsi128_pd(product_low_abs),
+                    _mm_castsi128_pd(sum_low_abs),
+                );
+                let v_large = _mm_blendv_pd(sum_low, product_low, product_low_larger);
+                let v_small = _mm_blendv_pd(product_low, sum_low, product_low_larger);
+                let v_low = _mm_sub_pd(v_small, _mm_sub_pd(v_high, v_large));
 
                 // The default sum is correctly rounded except when v_low is nonzero and
-                // |v_high| is 2^k or 3 * 2^k. Detect those significand shapes from the
-                // binary64 fraction while explicitly excluding zero and non-finite values.
+                // |v_high| is 2^k or 3 * 2^k. Under the exponent guard, every nonzero
+                // product or residual is a multiple of at least 2^-904, so v_low != 0
+                // implies that v_high is finite, normal, and nonzero. The two relevant
+                // significand shapes therefore differ only in their top fraction bit.
                 let v_high_bits = _mm_castpd_si128(v_high);
-                let v_high_abs = _mm_and_si128(v_high_bits, absolute_value_mask);
-                let fraction_mask = _mm_set1_epi64x(0x000f_ffff_ffff_ffff);
-                let top_fraction_bit = _mm_set1_epi64x(0x0008_0000_0000_0000);
-                let exponent_mask = _mm_set1_epi64x(0x7ff0_0000_0000_0000);
-                let fraction = _mm_and_si128(v_high_abs, fraction_mask);
-                let exponent = _mm_and_si128(v_high_abs, exponent_mask);
-                let special_fraction = _mm_or_si128(
-                    _mm_cmpeq_epi64(fraction, zero_bits),
-                    _mm_cmpeq_epi64(fraction, top_fraction_bit),
-                );
-                let normal_exponent = _mm_andnot_si128(
-                    _mm_cmpeq_epi64(exponent, exponent_mask),
-                    _mm_cmpgt_epi64(exponent, zero_bits),
+                let lower_fraction_mask = _mm_set1_epi64x(0x0007_ffff_ffff_ffff);
+                let special_fraction = _mm_cmpeq_epi64(
+                    _mm_and_si128(v_high_bits, lower_fraction_mask),
+                    zero_bits,
                 );
                 let v_low_nonzero = _mm_castpd_si128(_mm_cmpneq_pd(v_low, _mm_setzero_pd()));
-                let special = _mm_and_si128(
-                    v_low_nonzero,
-                    _mm_and_si128(special_fraction, normal_exponent),
-                );
+                let special = _mm_and_si128(v_low_nonzero, special_fraction);
 
                 if _mm_testz_si128(special, special) == 0 {
                     let different_sign_bits = _mm_slli_epi64::<63>(_mm_srli_epi64::<63>(

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2551,15 +2551,23 @@ impl X86 {
                     .simd_into(#token);
                 }
 
-                // Veltkamp splitting for binary64, using K = 2^27 + 1.
-                let splitter = _mm_set1_pd(134_217_729.0);
-                let a_gamma = _mm_mul_pd(splitter, a_raw);
-                let a_delta = _mm_sub_pd(a_raw, a_gamma);
-                let a_high = _mm_add_pd(a_gamma, a_delta);
+                // Split each normal multiplicand into nonoverlapping high and low parts.
+                // Adding half of the discarded range before clearing 27 significand bits
+                // gives the high part at most 26 significant bits and leaves the low part
+                // at most 27. The addition operates on sign-magnitude binary64 encodings,
+                // so it rounds the magnitude in the same direction for either sign. The
+                // exponent guard above prevents the integer addition from wrapping.
+                let split_rounding_bit = _mm_set1_epi64x(1_i64 << 26);
+                let split_high_mask = _mm_set1_epi64x(!((1_i64 << 27) - 1));
+                let a_high = _mm_castsi128_pd(_mm_and_si128(
+                    _mm_add_epi64(_mm_castpd_si128(a_raw), split_rounding_bit),
+                    split_high_mask,
+                ));
                 let a_low = _mm_sub_pd(a_raw, a_high);
-                let b_gamma = _mm_mul_pd(splitter, b_raw);
-                let b_delta = _mm_sub_pd(b_raw, b_gamma);
-                let b_high = _mm_add_pd(b_gamma, b_delta);
+                let b_high = _mm_castsi128_pd(_mm_and_si128(
+                    _mm_add_epi64(_mm_castpd_si128(b_raw), split_rounding_bit),
+                    split_high_mask,
+                ));
                 let b_low = _mm_sub_pd(b_raw, b_high);
 
                 // Dekker product: product_high + product_low is exactly a * b.
@@ -2589,39 +2597,47 @@ impl X86 {
                 let sum_small = _mm_blendv_pd(product_high, c_raw, product_high_larger);
                 let sum_low = _mm_sub_pd(sum_small, _mm_sub_pd(sum_high, sum_large));
 
-                // Fast2Sum(product_low, sum_low), after the same magnitude sort.
+                // Only the rounded sum of product_low and sum_low is needed on the
+                // overwhelmingly common path. Its exact residual matters only when
+                // v_high has one of the two significand shapes that can require the
+                // Graillat-Muller correction, so defer that second Fast2Sum until then.
                 let v_high = _mm_add_pd(product_low, sum_low);
-                let product_low_abs = _mm_and_si128(
-                    _mm_castpd_si128(product_low),
-                    absolute_value_mask,
-                );
-                let sum_low_abs = _mm_and_si128(
-                    _mm_castpd_si128(sum_low),
-                    absolute_value_mask,
-                );
-                let product_low_larger = _mm_cmpgt_pd(
-                    _mm_castsi128_pd(product_low_abs),
-                    _mm_castsi128_pd(sum_low_abs),
-                );
-                let v_large = _mm_blendv_pd(sum_low, product_low, product_low_larger);
-                let v_small = _mm_blendv_pd(product_low, sum_low, product_low_larger);
-                let v_low = _mm_sub_pd(v_small, _mm_sub_pd(v_high, v_large));
-
-                // The default sum is correctly rounded except when v_low is nonzero and
-                // |v_high| is 2^k or 3 * 2^k. Under the exponent guard, every nonzero
-                // product or residual is a multiple of at least 2^-904, so v_low != 0
-                // implies that v_high is finite, normal, and nonzero. The two relevant
-                // significand shapes therefore differ only in their top fraction bit.
                 let v_high_bits = _mm_castpd_si128(v_high);
                 let lower_fraction_mask = _mm_set1_epi64x(0x0007_ffff_ffff_ffff);
                 let special_fraction = _mm_cmpeq_epi64(
                     _mm_and_si128(v_high_bits, lower_fraction_mask),
                     zero_bits,
                 );
-                let v_low_nonzero = _mm_castpd_si128(_mm_cmpneq_pd(v_low, _mm_setzero_pd()));
-                let special = _mm_and_si128(v_low_nonzero, special_fraction);
 
-                if _mm_testz_si128(special, special) == 0 {
+                // A positive zero has the same fraction shape, but cannot need correction.
+                // Testing the shape mask against v_high itself excludes it without forming
+                // another packed mask. A negative zero may enter the rare path harmlessly.
+                if _mm_testz_si128(special_fraction, v_high_bits) == 0 {
+                    // Fast2Sum(product_low, sum_low), after the same magnitude sort.
+                    let product_low_abs = _mm_and_si128(
+                        _mm_castpd_si128(product_low),
+                        absolute_value_mask,
+                    );
+                    let sum_low_abs = _mm_and_si128(
+                        _mm_castpd_si128(sum_low),
+                        absolute_value_mask,
+                    );
+                    let product_low_larger = _mm_cmpgt_pd(
+                        _mm_castsi128_pd(product_low_abs),
+                        _mm_castsi128_pd(sum_low_abs),
+                    );
+                    let v_large = _mm_blendv_pd(sum_low, product_low, product_low_larger);
+                    let v_small = _mm_blendv_pd(product_low, sum_low, product_low_larger);
+                    let v_low = _mm_sub_pd(v_small, _mm_sub_pd(v_high, v_large));
+
+                    // The default sum is correctly rounded except when v_low is nonzero and
+                    // |v_high| is 2^k or 3 * 2^k. Under the exponent guard, every nonzero
+                    // product or residual is a multiple of at least 2^-904, so v_low != 0
+                    // implies that v_high is finite, normal, and nonzero. The two relevant
+                    // significand shapes therefore differ only in their top fraction bit.
+                    let v_low_nonzero =
+                        _mm_castpd_si128(_mm_cmpneq_pd(v_low, _mm_setzero_pd()));
+                    let special = _mm_and_si128(v_low_nonzero, special_fraction);
                     let different_sign_bits = _mm_slli_epi64::<63>(_mm_srli_epi64::<63>(
                         _mm_xor_si128(v_high_bits, _mm_castpd_si128(v_low)),
                     ));

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -9,7 +9,7 @@ use fearless_simd_dev_macros::simd_test;
 // on SSE4.2 and need to test it in great depth.
 
 #[simd_test]
-#[ignore = "stress-tests randomized safe-range and full-range f64 inputs"]
+#[ignore = "stress-tests 10 million randomized safe-range and full-range f64 inputs"]
 fn mul_add_precise_f64x2_random<S: Simd>(simd: S) {
     simd.vectorize(
         #[inline(always)]
@@ -17,7 +17,7 @@ fn mul_add_precise_f64x2_random<S: Simd>(simd: S) {
             let mut rng = fastrand::Rng::with_seed(0x3c6e_f372_fe94_f82b);
             let fraction_mask = (1_u64 << 52) - 1;
 
-            for iteration in 0..100_000 {
+            for iteration in 0..10_000_000 {
                 let safe_a: [f64; 2] = core::array::from_fn(|_| {
                     let exponent = rng.i32(-400..400);
                     let sign = if rng.bool() { 1_u64 << 63 } else { 0 };

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -92,6 +92,154 @@ fn mul_add_precise_f64x2_random<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+#[ignore = "stress-tests 1 billion safe-range, split-tie, and cancellation f64 inputs each"]
+fn mul_add_precise_f64x2_adversarial_random<S: Simd>(simd: S) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            const CASES_PER_DISTRIBUTION: usize = 1_000_000_000;
+            let fraction_mask = (1_u64 << 52) - 1;
+            let mut rng = fastrand::Rng::with_seed(0x4d59_5df4_d0f3_3173);
+
+            // Uniformly sample the exponent-safe packed path. Each vector supplies two cases.
+            for vector_index in 0..CASES_PER_DISTRIBUTION / 2 {
+                let a_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let b_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let c_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+                    f64x2::from_slice(simd, &b_values),
+                    f64x2::from_slice(simd, &c_values),
+                );
+
+                for lane in 0..2 {
+                    let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
+                    assert_eq!(
+                        result[lane].to_bits(),
+                        expected.to_bits(),
+                        "safe-range case {}: a={:#018x}, b={:#018x}, c={:#018x}",
+                        vector_index * 2 + lane,
+                        a_values[lane].to_bits(),
+                        b_values[lane].to_bits(),
+                        c_values[lane].to_bits(),
+                    );
+                }
+            }
+
+            // Put both multiplicands exactly halfway across the integer-mask split boundary.
+            // Random binary64 bit patterns almost never exercise this rounding case.
+            let fraction_above_split_mask = 0x000f_ffff_f800_0000_u64;
+            let split_rounding_bit = 1_u64 << 26;
+            for vector_index in 0..CASES_PER_DISTRIBUTION / 2 {
+                let a_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let fraction = (rng.u64(..) & fraction_above_split_mask) | split_rounding_bit;
+                    f64::from_bits(sign | (((exponent + 1023) as u64) << 52) | fraction)
+                });
+                let b_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let fraction = (rng.u64(..) & fraction_above_split_mask) | split_rounding_bit;
+                    f64::from_bits(sign | (((exponent + 1023) as u64) << 52) | fraction)
+                });
+                let c_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+                    f64x2::from_slice(simd, &b_values),
+                    f64x2::from_slice(simd, &c_values),
+                );
+
+                for lane in 0..2 {
+                    let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
+                    assert_eq!(
+                        result[lane].to_bits(),
+                        expected.to_bits(),
+                        "split-tie case {}: a={:#018x}, b={:#018x}, c={:#018x}",
+                        vector_index * 2 + lane,
+                        a_values[lane].to_bits(),
+                        b_values[lane].to_bits(),
+                        c_values[lane].to_bits(),
+                    );
+                }
+            }
+
+            // Cancelling the rounded product exposes any error in the reconstructed exact tail.
+            let safe_minimum_bits = 623_u64 << 52;
+            let safe_maximum_bits = 1423_u64 << 52;
+            for vector_index in 0..CASES_PER_DISTRIBUTION / 2 {
+                let mut a_values = [0.0; 2];
+                let mut b_values = [0.0; 2];
+                let mut c_values = [0.0; 2];
+                for lane in 0..2 {
+                    loop {
+                        let a_exponent = rng.i32(-400..400);
+                        let a_sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                        let a_bits = a_sign
+                            | (((a_exponent + 1023) as u64) << 52)
+                            | (rng.u64(..) & fraction_mask);
+                        let b_exponent = rng.i32(-400..400);
+                        let b_sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                        let b_bits = b_sign
+                            | (((b_exponent + 1023) as u64) << 52)
+                            | (rng.u64(..) & fraction_mask);
+                        let a = f64::from_bits(a_bits);
+                        let b = f64::from_bits(b_bits);
+                        let rounded_product = a * b;
+                        let product_bits = rounded_product.to_bits() & i64::MAX as u64;
+                        if product_bits >= safe_minimum_bits && product_bits <= safe_maximum_bits {
+                            a_values[lane] = a;
+                            b_values[lane] = b;
+                            c_values[lane] = -rounded_product;
+                            break;
+                        }
+                    }
+                }
+                let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+                    f64x2::from_slice(simd, &b_values),
+                    f64x2::from_slice(simd, &c_values),
+                );
+
+                for lane in 0..2 {
+                    let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
+                    assert_eq!(
+                        result[lane].to_bits(),
+                        expected.to_bits(),
+                        "cancellation case {}: a={:#018x}, b={:#018x}, c={:#018x}",
+                        vector_index * 2 + lane,
+                        a_values[lane].to_bits(),
+                        b_values[lane].to_bits(),
+                        c_values[lane].to_bits(),
+                    );
+                }
+            }
+        },
+    );
+}
+
+#[simd_test]
 fn mul_add_precise_f32x4<S: Simd>(simd: S) {
     let midpoint_a = f32::from_bits(0x3f80_1000); // 1 + 2^-11
     let midpoint_b = f32::from_bits(0x3f7f_f800); // 1 - 2^-13
@@ -209,6 +357,37 @@ fn mul_add_precise_f64x2_midpoint<S: Simd>(simd: S) {
         midpoint_a * midpoint_b - tiny,
         "the negative perturbation must differ from a naive multiply-add",
     );
+}
+
+#[simd_test]
+fn mul_add_precise_f64x2_split_rounding_regression<S: Simd>(simd: S) {
+    // Clearing the low split bits without first rounding them loses two ULPs of the
+    // exact product residual for this cancellation. Exercise both result signs.
+    let a_values = [
+        f64::from_bits(0xc168_bab3_2de0_0aeb),
+        f64::from_bits(0x4168_bab3_2de0_0aeb),
+    ];
+    let b_values = [
+        f64::from_bits(0x4f79_aedc_867f_cdc1),
+        f64::from_bits(0x4f79_aedc_867f_cdc1),
+    ];
+    let c_values = [
+        f64::from_bits(0x50f3_d8fd_95a0_e870),
+        f64::from_bits(0xd0f3_d8fd_95a0_e870),
+    ];
+    let expected = [
+        a_values[0].mul_add(b_values[0], c_values[0]),
+        a_values[1].mul_add(b_values[1], c_values[1]),
+    ];
+    assert_eq!(expected[0].to_bits(), 0x4d95_3ebb_2989_2baa);
+    assert_eq!(expected[1].to_bits(), 0xcd95_3ebb_2989_2baa);
+
+    let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+        f64x2::from_slice(simd, &b_values),
+        f64x2::from_slice(simd, &c_values),
+    );
+    assert_eq!(result[0].to_bits(), expected[0].to_bits());
+    assert_eq!(result[1].to_bits(), expected[1].to_bits());
 }
 
 #[simd_test]

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -240,6 +240,541 @@ fn mul_add_precise_f64x2_adversarial_random<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn mul_add_precise_f64x2_edge_patterns<S: Simd>(simd: S) {
+    let edge_bits = [
+        0x0000_0000_0000_0000,
+        0x8000_0000_0000_0000,
+        0x0000_0000_0000_0001,
+        0x8000_0000_0000_0001,
+        0x000f_ffff_ffff_ffff,
+        0x800f_ffff_ffff_ffff,
+        0x0010_0000_0000_0000,
+        0x8010_0000_0000_0000,
+        (623_u64 << 52) - 1,
+        (1_u64 << 63) | ((623_u64 << 52) - 1),
+        623_u64 << 52,
+        (1_u64 << 63) | (623_u64 << 52),
+        (623_u64 << 52) + 1,
+        (1_u64 << 63) | ((623_u64 << 52) + 1),
+        0x3fef_ffff_ffff_ffff,
+        0xbfef_ffff_ffff_ffff,
+        0x3ff0_0000_0000_0000,
+        0xbff0_0000_0000_0000,
+        0x3ff0_0000_0000_0001,
+        0xbff0_0000_0000_0001,
+        (1423_u64 << 52) - 1,
+        (1_u64 << 63) | ((1423_u64 << 52) - 1),
+        1423_u64 << 52,
+        (1_u64 << 63) | (1423_u64 << 52),
+        (1423_u64 << 52) + 1,
+        (1_u64 << 63) | ((1423_u64 << 52) + 1),
+        0x7fef_ffff_ffff_ffff,
+        0xffef_ffff_ffff_ffff,
+        0x7ff0_0000_0000_0000,
+        0xfff0_0000_0000_0000,
+        0x7ff8_0000_0000_0001,
+        0xfff8_0000_0000_1234,
+        0x7ff0_0000_0000_0001,
+        0xfff0_0000_0000_0001,
+    ];
+
+    let mut pending_a = [0.0; 2];
+    let mut pending_b = [0.0; 2];
+    let mut pending_c = [0.0; 2];
+    let mut pending_lanes = 0;
+    let mut case_index = 0;
+    for &a_bits in &edge_bits {
+        for &b_bits in &edge_bits {
+            for &c_bits in &edge_bits {
+                pending_a[pending_lanes] = f64::from_bits(a_bits);
+                pending_b[pending_lanes] = f64::from_bits(b_bits);
+                pending_c[pending_lanes] = f64::from_bits(c_bits);
+                pending_lanes += 1;
+
+                if pending_lanes == 2 {
+                    let result = f64x2::from_slice(simd, &pending_a).mul_add_precise(
+                        f64x2::from_slice(simd, &pending_b),
+                        f64x2::from_slice(simd, &pending_c),
+                    );
+                    for lane in 0..2 {
+                        let expected = pending_a[lane].mul_add(pending_b[lane], pending_c[lane]);
+                        if expected.is_nan() {
+                            // Rust does not specify the payload or signalingness of arithmetic NaNs.
+                            assert!(
+                                result[lane].is_nan(),
+                                "edge case {}, lane {lane}: a={:#018x}, b={:#018x}, c={:#018x}",
+                                case_index + lane,
+                                pending_a[lane].to_bits(),
+                                pending_b[lane].to_bits(),
+                                pending_c[lane].to_bits(),
+                            );
+                        } else {
+                            assert_eq!(
+                                result[lane].to_bits(),
+                                expected.to_bits(),
+                                "edge case {}, lane {lane}: a={:#018x}, b={:#018x}, c={:#018x}",
+                                case_index + lane,
+                                pending_a[lane].to_bits(),
+                                pending_b[lane].to_bits(),
+                                pending_c[lane].to_bits(),
+                            );
+                        }
+                    }
+                    pending_lanes = 0;
+                    case_index += 2;
+                }
+            }
+        }
+    }
+    assert_eq!(pending_lanes, 0);
+
+    // These cases exercise a carry from the retained split significand into the exponent,
+    // including the endpoints of the exponent-safe packed path.
+    let fraction_mask = (1_u64 << 52) - 1;
+    let upper_fraction_ones = fraction_mask & !((1_u64 << 27) - 1);
+    let exponent_fields = [623_u64, 624, 1022, 1023, 1024, 1422, 1423];
+    let low_split_bits = [
+        0,
+        1,
+        (1_u64 << 26) - 1,
+        1_u64 << 26,
+        (1_u64 << 26) + 1,
+        (1_u64 << 27) - 2,
+        (1_u64 << 27) - 1,
+        0x0555_5555,
+    ];
+    let multipliers = [
+        f64::from_bits(0x3ff0_0000_0000_0001),
+        f64::from_bits(0x3fef_ffff_ffff_ffff),
+        f64::from_bits(0xbff0_0000_0400_0000),
+        f64::from_bits(0x4008_0000_0000_0001),
+    ];
+
+    for exponent_field in exponent_fields {
+        for sign in [0, 1_u64 << 63] {
+            for low_bits in low_split_bits {
+                let a_value =
+                    f64::from_bits(sign | (exponent_field << 52) | upper_fraction_ones | low_bits);
+                for b_value in multipliers {
+                    let rounded_product = a_value * b_value;
+                    let c_values = [
+                        0.0,
+                        -0.0,
+                        -rounded_product,
+                        if rounded_product == f64::NEG_INFINITY {
+                            f64::MAX
+                        } else if rounded_product == 0.0 {
+                            f64::from_bits(1)
+                        } else {
+                            let bits = (-rounded_product).to_bits();
+                            f64::from_bits(if -rounded_product > 0.0 {
+                                bits + 1
+                            } else {
+                                bits - 1
+                            })
+                        },
+                        if rounded_product == f64::INFINITY {
+                            -f64::MAX
+                        } else if rounded_product == 0.0 {
+                            f64::from_bits((1_u64 << 63) | 1)
+                        } else {
+                            let bits = (-rounded_product).to_bits();
+                            f64::from_bits(if -rounded_product > 0.0 {
+                                bits - 1
+                            } else {
+                                bits + 1
+                            })
+                        },
+                    ];
+
+                    for c_value in c_values {
+                        let a_values = [a_value, -a_value];
+                        let b_values = [b_value, b_value];
+                        let c_values = [c_value, -c_value];
+                        let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+                            f64x2::from_slice(simd, &b_values),
+                            f64x2::from_slice(simd, &c_values),
+                        );
+                        for lane in 0..2 {
+                            let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
+                            if expected.is_nan() {
+                                assert!(result[lane].is_nan());
+                            } else {
+                                assert_eq!(
+                                    result[lane].to_bits(),
+                                    expected.to_bits(),
+                                    "split carry: a={:#018x}, b={:#018x}, c={:#018x}, lane {lane}",
+                                    a_values[lane].to_bits(),
+                                    b_values[lane].to_bits(),
+                                    c_values[lane].to_bits(),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Fixed cases found while auditing the integer splitter and deferred correction path.
+    // They are deliberately written as exact bits so future failures are easy to reproduce.
+    let regression_cases = [
+        (
+            0x3ff0_0000_0200_0000,
+            0x3fef_ffff_fc00_0000,
+            0xb930_0000_0000_0000,
+            0x3fef_ffff_ffff_ffff,
+        ),
+        (
+            0x3ff0_0000_0200_0000,
+            0x3fef_ffff_fc00_0000,
+            0x3930_0000_0000_0000,
+            0x3ff0_0000_0000_0000,
+        ),
+        (
+            0x58ef_ffff_fc00_0000,
+            0x26f0_0000_0400_0000,
+            0xbff0_0000_0200_0000,
+            0xbca0_0000_0000_0000,
+        ),
+        (
+            0x58ef_ffff_fc00_0000,
+            0x26f0_0000_0400_0000,
+            0xbff0_0000_01ff_ffff,
+            0x3ca0_0000_0000_0000,
+        ),
+        (
+            0x58ef_ffff_fc00_0000,
+            0x26f0_0000_0400_0000,
+            0xbff0_0000_0200_0001,
+            0xbcb8_0000_0000_0000,
+        ),
+        (
+            0x26f0_0000_0400_0000,
+            0x26f0_0000_0400_0000,
+            0x8df0_0000_0800_0001,
+            0x0000_0000_0000_0000,
+        ),
+        (
+            0x26f0_0000_0400_0000,
+            0x26f0_0000_0400_0000,
+            0x8df0_0000_0800_0000,
+            0x0ab0_0000_0000_0000,
+        ),
+        (
+            0x26f0_0000_0400_0000,
+            0x26f0_0000_0400_0000,
+            0x8df0_0000_0800_0002,
+            0x8ab0_0000_0000_0000,
+        ),
+        (
+            0x58ef_ffff_fc00_0000,
+            0x3ff0_0000_0400_0000,
+            0xd8f0_0000_0200_0000,
+            0xd5a0_0000_0000_0000,
+        ),
+        (
+            0x58ef_ffff_fc00_0000,
+            0x3ff0_0000_0400_0000,
+            0xd8f0_0000_01ff_ffff,
+            0x55a0_0000_0000_0000,
+        ),
+        (
+            0x58ef_ffff_fc00_0000,
+            0x3ff0_0000_0400_0000,
+            0xd8f0_0000_0200_0001,
+            0xd5b8_0000_0000_0000,
+        ),
+    ];
+
+    for (a_bits, b_bits, c_bits, expected_bits) in regression_cases {
+        let a_value = f64::from_bits(a_bits);
+        let b_value = f64::from_bits(b_bits);
+        let c_value = f64::from_bits(c_bits);
+        assert_eq!(a_value.mul_add(b_value, c_value).to_bits(), expected_bits);
+
+        let result = f64x2::splat(simd, a_value)
+            .mul_add_precise(f64x2::splat(simd, b_value), f64x2::splat(simd, c_value));
+        assert_eq!(result[0].to_bits(), expected_bits);
+        assert_eq!(result[1].to_bits(), expected_bits);
+    }
+}
+
+#[simd_test]
+#[ignore = "stress-tests 1 billion split-boundary and near-cancellation f64 inputs"]
+fn mul_add_precise_f64x2_random_split_boundaries<S: Simd>(simd: S) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            const CASES: usize = 1_000_000_000;
+            const FRACTION_MASK: u64 = (1_u64 << 52) - 1;
+            const LOW_SPLIT_BITS: [u64; 10] = [
+                0,
+                1,
+                (1 << 26) - 1,
+                1 << 26,
+                (1 << 26) + 1,
+                (1 << 27) - 3,
+                (1 << 27) - 2,
+                (1 << 27) - 1,
+                0x02aa_aaaa,
+                0x0555_5555,
+            ];
+            let mut rng = fastrand::Rng::with_seed(0x1319_8a2e_0370_7344);
+
+            for vector_index in 0..CASES / 2 {
+                let mode = vector_index % 5;
+                let a_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = if mode == 0 {
+                        rng.i32(-400..401)
+                    } else {
+                        rng.i32(-190..191)
+                    };
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let upper_fraction = rng.u64(..) & (FRACTION_MASK & !((1_u64 << 27) - 1));
+                    let low = LOW_SPLIT_BITS[rng.usize(..LOW_SPLIT_BITS.len())];
+                    f64::from_bits(sign | (((exponent + 1023) as u64) << 52) | upper_fraction | low)
+                });
+                let b_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = if mode == 0 {
+                        rng.i32(-400..401)
+                    } else {
+                        rng.i32(-190..191)
+                    };
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let upper_fraction = rng.u64(..) & (FRACTION_MASK & !((1_u64 << 27) - 1));
+                    let low = LOW_SPLIT_BITS[rng.usize(..LOW_SPLIT_BITS.len())];
+                    f64::from_bits(sign | (((exponent + 1023) as u64) << 52) | upper_fraction | low)
+                });
+                let rounded_products = [a_values[0] * b_values[0], a_values[1] * b_values[1]];
+                let c_values: [f64; 2] = core::array::from_fn(|lane| match mode {
+                    0 => {
+                        let exponent = rng.i32(-400..401);
+                        let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                        f64::from_bits(
+                            sign | (((exponent + 1023) as u64) << 52)
+                                | (rng.u64(..) & FRACTION_MASK),
+                        )
+                    }
+                    1 => -rounded_products[lane],
+                    2 => {
+                        let value = -rounded_products[lane];
+                        let bits = value.to_bits();
+                        f64::from_bits(if value > 0.0 { bits + 1 } else { bits - 1 })
+                    }
+                    3 => {
+                        let value = -rounded_products[lane];
+                        let bits = value.to_bits();
+                        f64::from_bits(if value > 0.0 { bits - 1 } else { bits + 1 })
+                    }
+                    4 => {
+                        let value = -rounded_products[lane];
+                        let bits = value.to_bits();
+                        if lane == 0 {
+                            f64::from_bits(if value > 0.0 { bits + 2 } else { bits - 2 })
+                        } else {
+                            f64::from_bits(if value > 0.0 { bits - 2 } else { bits + 2 })
+                        }
+                    }
+                    _ => unreachable!(),
+                });
+
+                let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+                    f64x2::from_slice(simd, &b_values),
+                    f64x2::from_slice(simd, &c_values),
+                );
+                for lane in 0..2 {
+                    let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
+                    assert_eq!(
+                        result[lane].to_bits(),
+                        expected.to_bits(),
+                        "split-boundary case {}, lane {lane}: a={:#018x}, b={:#018x}, c={:#018x}",
+                        vector_index * 2 + lane,
+                        a_values[lane].to_bits(),
+                        b_values[lane].to_bits(),
+                        c_values[lane].to_bits(),
+                    );
+                }
+            }
+        },
+    );
+}
+
+#[simd_test]
+#[ignore = "stress-tests 1 billion forced rare-correction f64 inputs"]
+fn mul_add_precise_f64x2_random_rare_correction<S: Simd>(simd: S) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            const CASES: usize = 1_000_000_000;
+            const FRACTION_MASK: u64 = (1_u64 << 52) - 1;
+            let mut rng = fastrand::Rng::with_seed(0x082e_fa98_ec4e_6c89);
+
+            for vector_index in 0..CASES / 2 {
+                // These products have exact tails of -2^-54 and -3*2^-56. They force the
+                // power-of-two and three-times-power-of-two significand shapes for which the
+                // residual of the second Fast2Sum can change the final rounding.
+                let (base_a, base_b, tiny_offset) = if vector_index % 2 == 0 {
+                    (
+                        f64::from_bits(0x3ff0_0000_0200_0000),
+                        f64::from_bits(0x3fef_ffff_fc00_0000),
+                        108,
+                    )
+                } else {
+                    (1.0 + 3.0 * 2.0_f64.powi(-28), 1.0 - 2.0_f64.powi(-28), 110)
+                };
+                let product_exponent = rng.i32(-150..151);
+                let a_exponent = rng.i32(-100..101);
+                let b_exponent = product_exponent - a_exponent;
+
+                let scale = |value: f64, exponent: i32| {
+                    let bits = value.to_bits();
+                    let exponent_field = ((bits >> 52) & 0x7ff) as i32;
+                    f64::from_bits(
+                        (((exponent_field + exponent) as u64) << 52) | (bits & FRACTION_MASK),
+                    )
+                };
+                let a_value = scale(base_a, a_exponent);
+                let b_value = scale(base_b, b_exponent);
+                let tiny = f64::from_bits(((product_exponent - tiny_offset + 1023) as u64) << 52);
+                let c_value = if rng.bool() { tiny } else { -tiny };
+                let a_values = [a_value, -a_value];
+                let b_values = [b_value, b_value];
+                let c_values = [c_value, c_value];
+                let expected = [
+                    a_values[0].mul_add(b_values[0], c_values[0]),
+                    a_values[1].mul_add(b_values[1], c_values[1]),
+                ];
+
+                if vector_index % 2 == 0 {
+                    // The power-of-two-tail cases are true midpoint corrections: one lane must
+                    // distinguish fused evaluation from a rounded multiply followed by an add.
+                    assert!(
+                        expected[0].to_bits()
+                            != (a_values[0] * b_values[0] + c_values[0]).to_bits()
+                            || expected[1].to_bits()
+                                != (a_values[1] * b_values[1] + c_values[1]).to_bits(),
+                        "case {} must distinguish fused from unfused evaluation",
+                        vector_index * 2,
+                    );
+                }
+
+                let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+                    f64x2::from_slice(simd, &b_values),
+                    f64x2::from_slice(simd, &c_values),
+                );
+                for lane in 0..2 {
+                    assert_eq!(
+                        result[lane].to_bits(),
+                        expected[lane].to_bits(),
+                        "rare-correction case {}, lane {lane}: a={:#018x}, b={:#018x}, c={:#018x}",
+                        vector_index * 2 + lane,
+                        a_values[lane].to_bits(),
+                        b_values[lane].to_bits(),
+                        c_values[lane].to_bits(),
+                    );
+                }
+            }
+        },
+    );
+}
+
+#[simd_test]
+#[ignore = "stress-tests 1 billion mixed packed-path and scalar-fallback f64 lanes"]
+fn mul_add_precise_f64x2_random_mixed_safe_and_unsafe<S: Simd>(simd: S) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            const CASES: usize = 1_000_000_000;
+            const FRACTION_MASK: u64 = (1_u64 << 52) - 1;
+            const UNSAFE_BITS: [u64; 20] = [
+                0x0000_0000_0000_0000,
+                0x8000_0000_0000_0000,
+                0x0000_0000_0000_0001,
+                0x8000_0000_0000_0001,
+                0x000f_ffff_ffff_ffff,
+                0x800f_ffff_ffff_ffff,
+                0x0010_0000_0000_0000,
+                0x8010_0000_0000_0000,
+                (623_u64 << 52) - 1,
+                (1_u64 << 63) | ((623_u64 << 52) - 1),
+                (1423_u64 << 52) + 1,
+                (1_u64 << 63) | ((1423_u64 << 52) + 1),
+                0x7fef_ffff_ffff_ffff,
+                0xffef_ffff_ffff_ffff,
+                0x7ff0_0000_0000_0000,
+                0xfff0_0000_0000_0000,
+                0x7ff8_0000_0000_0042,
+                0xfff8_0000_0000_0042,
+                0x7ff0_0000_0000_0042,
+                0xfff0_0000_0000_0042,
+            ];
+            let mut rng = fastrand::Rng::with_seed(0xbe54_66cf_34e9_0c6c);
+
+            for vector_index in 0..CASES / 2 {
+                let safe_a = {
+                    let exponent = rng.i32(-400..401);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    f64::from_bits(
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & FRACTION_MASK),
+                    )
+                };
+                let safe_b = {
+                    let exponent = rng.i32(-400..401);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    f64::from_bits(
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & FRACTION_MASK),
+                    )
+                };
+                let safe_c = {
+                    let exponent = rng.i32(-400..401);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    f64::from_bits(
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & FRACTION_MASK),
+                    )
+                };
+                let unsafe_a = f64::from_bits(UNSAFE_BITS[rng.usize(..UNSAFE_BITS.len())]);
+                let unsafe_b = f64::from_bits(UNSAFE_BITS[rng.usize(..UNSAFE_BITS.len())]);
+                let unsafe_c = f64::from_bits(UNSAFE_BITS[rng.usize(..UNSAFE_BITS.len())]);
+                let (a_values, b_values, c_values) = if vector_index % 2 == 0 {
+                    ([safe_a, unsafe_a], [safe_b, unsafe_b], [safe_c, unsafe_c])
+                } else {
+                    ([unsafe_a, safe_a], [unsafe_b, safe_b], [unsafe_c, safe_c])
+                };
+
+                let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+                    f64x2::from_slice(simd, &b_values),
+                    f64x2::from_slice(simd, &c_values),
+                );
+                for lane in 0..2 {
+                    let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
+                    if expected.is_nan() {
+                        assert!(
+                            result[lane].is_nan(),
+                            "mixed-lane case {}, lane {lane}: a={:#018x}, b={:#018x}, c={:#018x}",
+                            vector_index * 2 + lane,
+                            a_values[lane].to_bits(),
+                            b_values[lane].to_bits(),
+                            c_values[lane].to_bits(),
+                        );
+                    } else {
+                        assert_eq!(
+                            result[lane].to_bits(),
+                            expected.to_bits(),
+                            "mixed-lane case {}, lane {lane}: a={:#018x}, b={:#018x}, c={:#018x}",
+                            vector_index * 2 + lane,
+                            a_values[lane].to_bits(),
+                            b_values[lane].to_bits(),
+                            c_values[lane].to_bits(),
+                        );
+                    }
+                }
+            }
+        },
+    );
+}
+
+#[simd_test]
 fn mul_add_precise_f32x4<S: Simd>(simd: S) {
     let midpoint_a = f32::from_bits(0x3f80_1000); // 1 + 2^-11
     let midpoint_b = f32::from_bits(0x3f7f_f800); // 1 - 2^-13

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -9,7 +9,7 @@ use fearless_simd_dev_macros::simd_test;
 // on SSE4.2 and need to test it in great depth.
 
 #[simd_test]
-#[ignore = "stress-tests 10 million randomized safe-range and full-range f64 inputs"]
+#[ignore = "stress-tests 1 billion randomized safe-range and full-range f64 inputs"]
 fn mul_add_precise_f64x2_random<S: Simd>(simd: S) {
     simd.vectorize(
         #[inline(always)]
@@ -17,7 +17,7 @@ fn mul_add_precise_f64x2_random<S: Simd>(simd: S) {
             let mut rng = fastrand::Rng::with_seed(0x3c6e_f372_fe94_f82b);
             let fraction_mask = (1_u64 << 52) - 1;
 
-            for iteration in 0..10_000_000 {
+            for iteration in 0..1_000_000_000 {
                 let safe_a: [f64; 2] = core::array::from_fn(|_| {
                     let exponent = rng.i32(-400..400);
                     let sign = if rng.bool() { 1_u64 << 63 } else { 0 };

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -9,237 +9,6 @@ use fearless_simd_dev_macros::simd_test;
 // on SSE4.2 and need to test it in great depth.
 
 #[simd_test]
-#[ignore = "stress-tests 1 billion randomized safe-range and full-range f64 inputs"]
-fn mul_add_precise_f64x2_random<S: Simd>(simd: S) {
-    simd.vectorize(
-        #[inline(always)]
-        || {
-            let mut rng = fastrand::Rng::with_seed(0x3c6e_f372_fe94_f82b);
-            let fraction_mask = (1_u64 << 52) - 1;
-
-            for iteration in 0..1_000_000_000 {
-                let safe_a: [f64; 2] = core::array::from_fn(|_| {
-                    let exponent = rng.i32(-400..400);
-                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
-                    let bits =
-                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
-                    f64::from_bits(bits)
-                });
-                let safe_b: [f64; 2] = core::array::from_fn(|_| {
-                    let exponent = rng.i32(-400..400);
-                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
-                    let bits =
-                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
-                    f64::from_bits(bits)
-                });
-                let safe_c: [f64; 2] = core::array::from_fn(|lane| {
-                    if iteration % 32 == 0 && lane == 0 {
-                        return if rng.bool() { 0.0 } else { -0.0 };
-                    }
-                    let exponent = rng.i32(-400..400);
-                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
-                    let bits =
-                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
-                    f64::from_bits(bits)
-                });
-                let safe_result = f64x2::from_slice(simd, &safe_a).mul_add_precise(
-                    f64x2::from_slice(simd, &safe_b),
-                    f64x2::from_slice(simd, &safe_c),
-                );
-                for lane in 0..2 {
-                    let expected = safe_a[lane].mul_add(safe_b[lane], safe_c[lane]);
-                    if expected.is_nan() {
-                        assert!(
-                            safe_result[lane].is_nan(),
-                            "safe-range iteration {iteration}, lane {lane}: expected NaN, got {:?}",
-                            safe_result[lane],
-                        );
-                    } else {
-                        assert_eq!(
-                            safe_result[lane].to_bits(),
-                            expected.to_bits(),
-                            "safe-range iteration {iteration}, lane {lane}",
-                        );
-                    }
-                }
-
-                let arbitrary_a = [f64::from_bits(rng.u64(..)), f64::from_bits(rng.u64(..))];
-                let arbitrary_b = [f64::from_bits(rng.u64(..)), f64::from_bits(rng.u64(..))];
-                let arbitrary_c = [f64::from_bits(rng.u64(..)), f64::from_bits(rng.u64(..))];
-                let arbitrary_result = f64x2::from_slice(simd, &arbitrary_a).mul_add_precise(
-                    f64x2::from_slice(simd, &arbitrary_b),
-                    f64x2::from_slice(simd, &arbitrary_c),
-                );
-                for lane in 0..2 {
-                    let expected = arbitrary_a[lane].mul_add(arbitrary_b[lane], arbitrary_c[lane]);
-                    if expected.is_nan() {
-                        assert!(
-                            arbitrary_result[lane].is_nan(),
-                            "full-range iteration {iteration}, lane {lane}: expected NaN, got {:?}",
-                            arbitrary_result[lane],
-                        );
-                    } else {
-                        assert_eq!(
-                            arbitrary_result[lane].to_bits(),
-                            expected.to_bits(),
-                            "full-range iteration {iteration}, lane {lane}",
-                        );
-                    }
-                }
-            }
-        },
-    );
-}
-
-#[simd_test]
-#[ignore = "stress-tests 1 billion safe-range, split-tie, and cancellation f64 inputs each"]
-fn mul_add_precise_f64x2_adversarial_random<S: Simd>(simd: S) {
-    simd.vectorize(
-        #[inline(always)]
-        || {
-            const CASES_PER_DISTRIBUTION: usize = 1_000_000_000;
-            let fraction_mask = (1_u64 << 52) - 1;
-            let mut rng = fastrand::Rng::with_seed(0x4d59_5df4_d0f3_3173);
-
-            // Uniformly sample the exponent-safe packed path. Each vector supplies two cases.
-            for vector_index in 0..CASES_PER_DISTRIBUTION / 2 {
-                let a_values: [f64; 2] = core::array::from_fn(|_| {
-                    let exponent = rng.i32(-400..400);
-                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
-                    let bits =
-                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
-                    f64::from_bits(bits)
-                });
-                let b_values: [f64; 2] = core::array::from_fn(|_| {
-                    let exponent = rng.i32(-400..400);
-                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
-                    let bits =
-                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
-                    f64::from_bits(bits)
-                });
-                let c_values: [f64; 2] = core::array::from_fn(|_| {
-                    let exponent = rng.i32(-400..400);
-                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
-                    let bits =
-                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
-                    f64::from_bits(bits)
-                });
-                let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
-                    f64x2::from_slice(simd, &b_values),
-                    f64x2::from_slice(simd, &c_values),
-                );
-
-                for lane in 0..2 {
-                    let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
-                    assert_eq!(
-                        result[lane].to_bits(),
-                        expected.to_bits(),
-                        "safe-range case {}: a={:#018x}, b={:#018x}, c={:#018x}",
-                        vector_index * 2 + lane,
-                        a_values[lane].to_bits(),
-                        b_values[lane].to_bits(),
-                        c_values[lane].to_bits(),
-                    );
-                }
-            }
-
-            // Put both multiplicands exactly halfway across the integer-mask split boundary.
-            // Random binary64 bit patterns almost never exercise this rounding case.
-            let fraction_above_split_mask = 0x000f_ffff_f800_0000_u64;
-            let split_rounding_bit = 1_u64 << 26;
-            for vector_index in 0..CASES_PER_DISTRIBUTION / 2 {
-                let a_values: [f64; 2] = core::array::from_fn(|_| {
-                    let exponent = rng.i32(-400..400);
-                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
-                    let fraction = (rng.u64(..) & fraction_above_split_mask) | split_rounding_bit;
-                    f64::from_bits(sign | (((exponent + 1023) as u64) << 52) | fraction)
-                });
-                let b_values: [f64; 2] = core::array::from_fn(|_| {
-                    let exponent = rng.i32(-400..400);
-                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
-                    let fraction = (rng.u64(..) & fraction_above_split_mask) | split_rounding_bit;
-                    f64::from_bits(sign | (((exponent + 1023) as u64) << 52) | fraction)
-                });
-                let c_values: [f64; 2] = core::array::from_fn(|_| {
-                    let exponent = rng.i32(-400..400);
-                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
-                    let bits =
-                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
-                    f64::from_bits(bits)
-                });
-                let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
-                    f64x2::from_slice(simd, &b_values),
-                    f64x2::from_slice(simd, &c_values),
-                );
-
-                for lane in 0..2 {
-                    let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
-                    assert_eq!(
-                        result[lane].to_bits(),
-                        expected.to_bits(),
-                        "split-tie case {}: a={:#018x}, b={:#018x}, c={:#018x}",
-                        vector_index * 2 + lane,
-                        a_values[lane].to_bits(),
-                        b_values[lane].to_bits(),
-                        c_values[lane].to_bits(),
-                    );
-                }
-            }
-
-            // Cancelling the rounded product exposes any error in the reconstructed exact tail.
-            let safe_minimum_bits = 623_u64 << 52;
-            let safe_maximum_bits = 1423_u64 << 52;
-            for vector_index in 0..CASES_PER_DISTRIBUTION / 2 {
-                let mut a_values = [0.0; 2];
-                let mut b_values = [0.0; 2];
-                let mut c_values = [0.0; 2];
-                for lane in 0..2 {
-                    loop {
-                        let a_exponent = rng.i32(-400..400);
-                        let a_sign = if rng.bool() { 1_u64 << 63 } else { 0 };
-                        let a_bits = a_sign
-                            | (((a_exponent + 1023) as u64) << 52)
-                            | (rng.u64(..) & fraction_mask);
-                        let b_exponent = rng.i32(-400..400);
-                        let b_sign = if rng.bool() { 1_u64 << 63 } else { 0 };
-                        let b_bits = b_sign
-                            | (((b_exponent + 1023) as u64) << 52)
-                            | (rng.u64(..) & fraction_mask);
-                        let a = f64::from_bits(a_bits);
-                        let b = f64::from_bits(b_bits);
-                        let rounded_product = a * b;
-                        let product_bits = rounded_product.to_bits() & i64::MAX as u64;
-                        if product_bits >= safe_minimum_bits && product_bits <= safe_maximum_bits {
-                            a_values[lane] = a;
-                            b_values[lane] = b;
-                            c_values[lane] = -rounded_product;
-                            break;
-                        }
-                    }
-                }
-                let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
-                    f64x2::from_slice(simd, &b_values),
-                    f64x2::from_slice(simd, &c_values),
-                );
-
-                for lane in 0..2 {
-                    let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
-                    assert_eq!(
-                        result[lane].to_bits(),
-                        expected.to_bits(),
-                        "cancellation case {}: a={:#018x}, b={:#018x}, c={:#018x}",
-                        vector_index * 2 + lane,
-                        a_values[lane].to_bits(),
-                        b_values[lane].to_bits(),
-                        c_values[lane].to_bits(),
-                    );
-                }
-            }
-        },
-    );
-}
-
-#[simd_test]
 fn mul_add_precise_f64x2_edge_patterns<S: Simd>(simd: S) {
     let edge_bits = [
         0x0000_0000_0000_0000,
@@ -1544,4 +1313,235 @@ fn mul_add_precise_f32x4_random_half_subnormal_products<S: Simd>(simd: S) {
             "iteration {iteration}: a={a_bits:x?}, b={b_bits:x?}, c={c_bits:x?}",
         );
     }
+}
+
+#[simd_test]
+#[ignore = "stress-tests 1 billion randomized safe-range and full-range f64 inputs"]
+fn mul_add_precise_f64x2_random<S: Simd>(simd: S) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            let mut rng = fastrand::Rng::with_seed(0x3c6e_f372_fe94_f82b);
+            let fraction_mask = (1_u64 << 52) - 1;
+
+            for iteration in 0..1_000_000_000 {
+                let safe_a: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let safe_b: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let safe_c: [f64; 2] = core::array::from_fn(|lane| {
+                    if iteration % 32 == 0 && lane == 0 {
+                        return if rng.bool() { 0.0 } else { -0.0 };
+                    }
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let safe_result = f64x2::from_slice(simd, &safe_a).mul_add_precise(
+                    f64x2::from_slice(simd, &safe_b),
+                    f64x2::from_slice(simd, &safe_c),
+                );
+                for lane in 0..2 {
+                    let expected = safe_a[lane].mul_add(safe_b[lane], safe_c[lane]);
+                    if expected.is_nan() {
+                        assert!(
+                            safe_result[lane].is_nan(),
+                            "safe-range iteration {iteration}, lane {lane}: expected NaN, got {:?}",
+                            safe_result[lane],
+                        );
+                    } else {
+                        assert_eq!(
+                            safe_result[lane].to_bits(),
+                            expected.to_bits(),
+                            "safe-range iteration {iteration}, lane {lane}",
+                        );
+                    }
+                }
+
+                let arbitrary_a = [f64::from_bits(rng.u64(..)), f64::from_bits(rng.u64(..))];
+                let arbitrary_b = [f64::from_bits(rng.u64(..)), f64::from_bits(rng.u64(..))];
+                let arbitrary_c = [f64::from_bits(rng.u64(..)), f64::from_bits(rng.u64(..))];
+                let arbitrary_result = f64x2::from_slice(simd, &arbitrary_a).mul_add_precise(
+                    f64x2::from_slice(simd, &arbitrary_b),
+                    f64x2::from_slice(simd, &arbitrary_c),
+                );
+                for lane in 0..2 {
+                    let expected = arbitrary_a[lane].mul_add(arbitrary_b[lane], arbitrary_c[lane]);
+                    if expected.is_nan() {
+                        assert!(
+                            arbitrary_result[lane].is_nan(),
+                            "full-range iteration {iteration}, lane {lane}: expected NaN, got {:?}",
+                            arbitrary_result[lane],
+                        );
+                    } else {
+                        assert_eq!(
+                            arbitrary_result[lane].to_bits(),
+                            expected.to_bits(),
+                            "full-range iteration {iteration}, lane {lane}",
+                        );
+                    }
+                }
+            }
+        },
+    );
+}
+
+#[simd_test]
+#[ignore = "stress-tests 1 billion safe-range, split-tie, and cancellation f64 inputs each"]
+fn mul_add_precise_f64x2_adversarial_random<S: Simd>(simd: S) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            const CASES_PER_DISTRIBUTION: usize = 1_000_000_000;
+            let fraction_mask = (1_u64 << 52) - 1;
+            let mut rng = fastrand::Rng::with_seed(0x4d59_5df4_d0f3_3173);
+
+            // Uniformly sample the exponent-safe packed path. Each vector supplies two cases.
+            for vector_index in 0..CASES_PER_DISTRIBUTION / 2 {
+                let a_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let b_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let c_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+                    f64x2::from_slice(simd, &b_values),
+                    f64x2::from_slice(simd, &c_values),
+                );
+
+                for lane in 0..2 {
+                    let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
+                    assert_eq!(
+                        result[lane].to_bits(),
+                        expected.to_bits(),
+                        "safe-range case {}: a={:#018x}, b={:#018x}, c={:#018x}",
+                        vector_index * 2 + lane,
+                        a_values[lane].to_bits(),
+                        b_values[lane].to_bits(),
+                        c_values[lane].to_bits(),
+                    );
+                }
+            }
+
+            // Put both multiplicands exactly halfway across the integer-mask split boundary.
+            // Random binary64 bit patterns almost never exercise this rounding case.
+            let fraction_above_split_mask = 0x000f_ffff_f800_0000_u64;
+            let split_rounding_bit = 1_u64 << 26;
+            for vector_index in 0..CASES_PER_DISTRIBUTION / 2 {
+                let a_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let fraction = (rng.u64(..) & fraction_above_split_mask) | split_rounding_bit;
+                    f64::from_bits(sign | (((exponent + 1023) as u64) << 52) | fraction)
+                });
+                let b_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let fraction = (rng.u64(..) & fraction_above_split_mask) | split_rounding_bit;
+                    f64::from_bits(sign | (((exponent + 1023) as u64) << 52) | fraction)
+                });
+                let c_values: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+                    f64x2::from_slice(simd, &b_values),
+                    f64x2::from_slice(simd, &c_values),
+                );
+
+                for lane in 0..2 {
+                    let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
+                    assert_eq!(
+                        result[lane].to_bits(),
+                        expected.to_bits(),
+                        "split-tie case {}: a={:#018x}, b={:#018x}, c={:#018x}",
+                        vector_index * 2 + lane,
+                        a_values[lane].to_bits(),
+                        b_values[lane].to_bits(),
+                        c_values[lane].to_bits(),
+                    );
+                }
+            }
+
+            // Cancelling the rounded product exposes any error in the reconstructed exact tail.
+            let safe_minimum_bits = 623_u64 << 52;
+            let safe_maximum_bits = 1423_u64 << 52;
+            for vector_index in 0..CASES_PER_DISTRIBUTION / 2 {
+                let mut a_values = [0.0; 2];
+                let mut b_values = [0.0; 2];
+                let mut c_values = [0.0; 2];
+                for lane in 0..2 {
+                    loop {
+                        let a_exponent = rng.i32(-400..400);
+                        let a_sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                        let a_bits = a_sign
+                            | (((a_exponent + 1023) as u64) << 52)
+                            | (rng.u64(..) & fraction_mask);
+                        let b_exponent = rng.i32(-400..400);
+                        let b_sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                        let b_bits = b_sign
+                            | (((b_exponent + 1023) as u64) << 52)
+                            | (rng.u64(..) & fraction_mask);
+                        let a = f64::from_bits(a_bits);
+                        let b = f64::from_bits(b_bits);
+                        let rounded_product = a * b;
+                        let product_bits = rounded_product.to_bits() & i64::MAX as u64;
+                        if product_bits >= safe_minimum_bits && product_bits <= safe_maximum_bits {
+                            a_values[lane] = a;
+                            b_values[lane] = b;
+                            c_values[lane] = -rounded_product;
+                            break;
+                        }
+                    }
+                }
+                let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+                    f64x2::from_slice(simd, &b_values),
+                    f64x2::from_slice(simd, &c_values),
+                );
+
+                for lane in 0..2 {
+                    let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
+                    assert_eq!(
+                        result[lane].to_bits(),
+                        expected.to_bits(),
+                        "cancellation case {}: a={:#018x}, b={:#018x}, c={:#018x}",
+                        vector_index * 2 + lane,
+                        a_values[lane].to_bits(),
+                        b_values[lane].to_bits(),
+                        c_values[lane].to_bits(),
+                    );
+                }
+            }
+        },
+    );
 }

--- a/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_add_precise.rs
@@ -9,6 +9,89 @@ use fearless_simd_dev_macros::simd_test;
 // on SSE4.2 and need to test it in great depth.
 
 #[simd_test]
+#[ignore = "stress-tests randomized safe-range and full-range f64 inputs"]
+fn mul_add_precise_f64x2_random<S: Simd>(simd: S) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            let mut rng = fastrand::Rng::with_seed(0x3c6e_f372_fe94_f82b);
+            let fraction_mask = (1_u64 << 52) - 1;
+
+            for iteration in 0..100_000 {
+                let safe_a: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let safe_b: [f64; 2] = core::array::from_fn(|_| {
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let safe_c: [f64; 2] = core::array::from_fn(|lane| {
+                    if iteration % 32 == 0 && lane == 0 {
+                        return if rng.bool() { 0.0 } else { -0.0 };
+                    }
+                    let exponent = rng.i32(-400..400);
+                    let sign = if rng.bool() { 1_u64 << 63 } else { 0 };
+                    let bits =
+                        sign | (((exponent + 1023) as u64) << 52) | (rng.u64(..) & fraction_mask);
+                    f64::from_bits(bits)
+                });
+                let safe_result = f64x2::from_slice(simd, &safe_a).mul_add_precise(
+                    f64x2::from_slice(simd, &safe_b),
+                    f64x2::from_slice(simd, &safe_c),
+                );
+                for lane in 0..2 {
+                    let expected = safe_a[lane].mul_add(safe_b[lane], safe_c[lane]);
+                    if expected.is_nan() {
+                        assert!(
+                            safe_result[lane].is_nan(),
+                            "safe-range iteration {iteration}, lane {lane}: expected NaN, got {:?}",
+                            safe_result[lane],
+                        );
+                    } else {
+                        assert_eq!(
+                            safe_result[lane].to_bits(),
+                            expected.to_bits(),
+                            "safe-range iteration {iteration}, lane {lane}",
+                        );
+                    }
+                }
+
+                let arbitrary_a = [f64::from_bits(rng.u64(..)), f64::from_bits(rng.u64(..))];
+                let arbitrary_b = [f64::from_bits(rng.u64(..)), f64::from_bits(rng.u64(..))];
+                let arbitrary_c = [f64::from_bits(rng.u64(..)), f64::from_bits(rng.u64(..))];
+                let arbitrary_result = f64x2::from_slice(simd, &arbitrary_a).mul_add_precise(
+                    f64x2::from_slice(simd, &arbitrary_b),
+                    f64x2::from_slice(simd, &arbitrary_c),
+                );
+                for lane in 0..2 {
+                    let expected = arbitrary_a[lane].mul_add(arbitrary_b[lane], arbitrary_c[lane]);
+                    if expected.is_nan() {
+                        assert!(
+                            arbitrary_result[lane].is_nan(),
+                            "full-range iteration {iteration}, lane {lane}: expected NaN, got {:?}",
+                            arbitrary_result[lane],
+                        );
+                    } else {
+                        assert_eq!(
+                            arbitrary_result[lane].to_bits(),
+                            expected.to_bits(),
+                            "full-range iteration {iteration}, lane {lane}",
+                        );
+                    }
+                }
+            }
+        },
+    );
+}
+
+#[simd_test]
 fn mul_add_precise_f32x4<S: Simd>(simd: S) {
     let midpoint_a = f32::from_bits(0x3f80_1000); // 1 + 2^-11
     let midpoint_b = f32::from_bits(0x3f7f_f800); // 1 - 2^-13
@@ -104,6 +187,31 @@ fn mul_add_precise_f64x2<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn mul_add_precise_f64x2_midpoint<S: Simd>(simd: S) {
+    let midpoint_a = 1.0 + 2.0_f64.powi(-27);
+    let midpoint_b = 1.0 - 2.0_f64.powi(-27);
+    let tiny = 2.0_f64.powi(-150);
+    let a_values = [midpoint_a, midpoint_a];
+    let b_values = [midpoint_b, midpoint_b];
+    let c_values = [tiny, -tiny];
+    let expected = [
+        a_values[0].mul_add(b_values[0], c_values[0]),
+        a_values[1].mul_add(b_values[1], c_values[1]),
+    ];
+
+    let a = f64x2::from_slice(simd, &a_values);
+    let b = f64x2::from_slice(simd, &b_values);
+    let c = f64x2::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_add_precise(b, c), expected);
+
+    assert_ne!(
+        expected[1],
+        midpoint_a * midpoint_b - tiny,
+        "the negative perturbation must differ from a naive multiply-add",
+    );
+}
+
+#[simd_test]
 fn mul_add_precise_f64x2_special_values<S: Simd>(simd: S) {
     let a_values = [-0.0, f64::INFINITY];
     let b_values = [2.0, 2.0];
@@ -118,6 +226,96 @@ fn mul_add_precise_f64x2_special_values<S: Simd>(simd: S) {
         a_values[0].mul_add(b_values[0], c_values[0]).to_bits()
     );
     assert!(result[1].is_nan());
+}
+
+#[simd_test]
+fn mul_add_precise_f64x2_safe_range_boundaries<S: Simd>(simd: S) {
+    let safe_minimum = f64::from_bits(623_u64 << 52);
+    let below_safe_minimum = f64::from_bits((623_u64 << 52) - 1);
+    let safe_maximum = f64::from_bits(1423_u64 << 52);
+    let above_safe_maximum = f64::from_bits((1423_u64 << 52) + 1);
+
+    let a_values = [safe_minimum, safe_maximum];
+    let b_values = [safe_maximum, safe_minimum];
+    let c_values = [-0.0, safe_minimum];
+    let expected = [
+        a_values[0].mul_add(b_values[0], c_values[0]),
+        a_values[1].mul_add(b_values[1], c_values[1]),
+    ];
+    let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+        f64x2::from_slice(simd, &b_values),
+        f64x2::from_slice(simd, &c_values),
+    );
+    assert_eq!(result[0].to_bits(), expected[0].to_bits());
+    assert_eq!(result[1].to_bits(), expected[1].to_bits());
+
+    let a_values = [below_safe_minimum, above_safe_maximum];
+    let b_values = [1.0, 1.0];
+    let c_values = [safe_minimum, -safe_maximum];
+    let expected = [
+        a_values[0].mul_add(b_values[0], c_values[0]),
+        a_values[1].mul_add(b_values[1], c_values[1]),
+    ];
+    let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+        f64x2::from_slice(simd, &b_values),
+        f64x2::from_slice(simd, &c_values),
+    );
+    assert_eq!(result[0].to_bits(), expected[0].to_bits());
+    assert_eq!(result[1].to_bits(), expected[1].to_bits());
+}
+
+#[simd_test]
+fn mul_add_precise_f64x2_mixed_safe_and_unsafe<S: Simd>(simd: S) {
+    let midpoint_a = 1.0 + 2.0_f64.powi(-27);
+    let midpoint_b = 1.0 - 2.0_f64.powi(-27);
+    let tiny = 2.0_f64.powi(-150);
+    let a_values = [midpoint_a, f64::from_bits(1)];
+    let b_values = [midpoint_b, f64::MAX];
+    let c_values = [-tiny, -f64::MAX];
+    let expected = [
+        a_values[0].mul_add(b_values[0], c_values[0]),
+        a_values[1].mul_add(b_values[1], c_values[1]),
+    ];
+
+    let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+        f64x2::from_slice(simd, &b_values),
+        f64x2::from_slice(simd, &c_values),
+    );
+    assert_eq!(result[0].to_bits(), expected[0].to_bits());
+    assert_eq!(result[1].to_bits(), expected[1].to_bits());
+}
+
+#[simd_test]
+fn mul_add_precise_f64x2_full_range_fallback<S: Simd>(simd: S) {
+    let cases = [
+        ([0.0, -0.0], [-2.0, 2.0], [-0.0, 0.0]),
+        (
+            [f64::from_bits(1), f64::MIN_POSITIVE],
+            [0.5, 0.5],
+            [f64::from_bits(1), -f64::from_bits(1)],
+        ),
+        (
+            [f64::MAX, f64::INFINITY],
+            [2.0, 2.0],
+            [-f64::MAX, f64::NEG_INFINITY],
+        ),
+        ([f64::NAN, 1.0], [1.0, f64::NAN], [2.0, 3.0]),
+    ];
+
+    for (a_values, b_values, c_values) in cases {
+        let result = f64x2::from_slice(simd, &a_values).mul_add_precise(
+            f64x2::from_slice(simd, &b_values),
+            f64x2::from_slice(simd, &c_values),
+        );
+        for lane in 0..2 {
+            let expected = a_values[lane].mul_add(b_values[lane], c_values[lane]);
+            if expected.is_nan() {
+                assert!(result[lane].is_nan());
+            } else {
+                assert_eq!(result[lane].to_bits(), expected.to_bits());
+            }
+        }
+    }
 }
 
 #[simd_test]

--- a/fearless_simd_tests/tests/harness/ops/mul_sub_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/mul_sub_precise.rs
@@ -111,6 +111,31 @@ fn mul_sub_precise_f64x2<S: Simd>(simd: S) {
 }
 
 #[simd_test]
+fn mul_sub_precise_f64x2_midpoint<S: Simd>(simd: S) {
+    let midpoint_a = 1.0 + 2.0_f64.powi(-27);
+    let midpoint_b = 1.0 - 2.0_f64.powi(-27);
+    let tiny = 2.0_f64.powi(-150);
+    let a_values = [midpoint_a, midpoint_a];
+    let b_values = [midpoint_b, midpoint_b];
+    let c_values = [-tiny, tiny];
+    let expected = [
+        a_values[0].mul_add(b_values[0], -c_values[0]),
+        a_values[1].mul_add(b_values[1], -c_values[1]),
+    ];
+
+    let a = f64x2::from_slice(simd, &a_values);
+    let b = f64x2::from_slice(simd, &b_values);
+    let c = f64x2::from_slice(simd, &c_values);
+    assert_eq!(*a.mul_sub_precise(b, c), expected);
+
+    assert_ne!(
+        expected[1],
+        midpoint_a * midpoint_b - tiny,
+        "the positive subtrahend must differ from a naive multiply-subtract",
+    );
+}
+
+#[simd_test]
 fn mul_sub_precise_f64x2_special_values<S: Simd>(simd: S) {
     let a_values = [-0.0_f64, f64::INFINITY];
     let b_values = [2.0_f64, 2.0];


### PR DESCRIPTION
The implementation is based on a 2025 paper by Graillat and Muller, [Emulation of the FMA and the correctly-rounded sum of three numbers in rounding-to-nearest floating-point arithmetic](https://perso.lip6.fr/Stef.Graillat/papers/NM-2025.pdf). Integrating cutting edge research here!

To the best of my knowledge this doesn't fix any libm or musl bugs, so this isn't necessary for correctness, it's just an optimization. 

This is upwards of 3x faster than scalar on normal values; huge values and subnormals fall back to scalar and only get about 0.7x the usual scalar performance. It's still worth it because subnormals are rare and [slow even in hardware](https://gitlab.in2p3.fr/CTA-LAPP/COURS/GRAY_SCOTT_REVOLUTIONS/GrayScottRevolution/-/wikis/uploads/4-ComputingPrecision/Subnormal.pdf).

@awxkee I'd appreciate it if you could take a look