### PR TITLE
Docs: Show where #[inline] goes in kernel!()

### DIFF
--- a/fearless_simd/src/kernel_macros.rs
+++ b/fearless_simd/src/kernel_macros.rs
@@ -27,6 +27,7 @@
 /// use std::arch::x86_64::{__m256i, _mm256_add_epi32};
 ///
 /// fearless_simd::kernel!(
+///     #[inline]
 ///     fn add_i32x8(avx2: Avx2, a: __m256i, b: __m256i) -> __m256i {
 ///         _mm256_add_epi32(a, b)
 ///     }


### PR DESCRIPTION
I wanted to look it up recently but it wasn't in the doc comment.