### PR TITLE
Fix dangling `libm` link when building docs without the libm feature

### DIFF
--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -193,6 +193,8 @@
 //! It benefited from conversations with Luca Versari, though he is not responsible for any of the mistakes or bad decisions.
 //!
 //! [`pulp`]: https://crates.io/crates/pulp
+#![cfg_attr(feature = "libm", doc = "[libm]: libm")]
+#![cfg_attr(not(feature = "libm"), doc = "[libm]: https://crates.io/crates/libm")]
 // LINEBENDER LINT SET - lib.rs - v3
 // See https://linebender.org/wiki/canonical-lints/
 // These lints shouldn't apply to examples or tests.


### PR DESCRIPTION
Checked that `cargo doc` with and without the libm feature builds without warnings.

The README.md didn't change when regenerated by `cargo rdme`, which surprised me slightly. But looking at the readme, it has a block of explicit links outside of the generated section that fixes up libm references already, so no change needed there.

(extracted from #330 after feedback from @DJMcNab, thank you!)