### PR TITLE
Add TryFrom bounds for all integer primitive types to SimdIntElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ You can find its changes [documented below](#070-2026-08-11).
 
 ### Added
 
- - - Added `mul_add_precise` and `mul_sub_precise` for floating-point vectors. They guarantee the infinite-precision product-plus-add rounded once, including on SIMD levels without hardware fused multiply-add instructions. They are not susceptible to the [bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library, `std::simd` and musl libc that causes incorrect rounding for subnormal results. SSE4.2 gets SIMD emulation of these operations for better performance. ([#323][], [#324][] by [@Shnatsel][])
+- - Added `mul_add_precise` and `mul_sub_precise` for floating-point vectors. They guarantee the infinite-precision product-plus-add rounded once, including on SIMD levels without hardware fused multiply-add instructions. They are not susceptible to the [bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library, `std::simd` and musl libc that causes incorrect rounding for subnormal results. SSE4.2 gets SIMD emulation of these operations for better performance. ([#323][], [#324][] by [@Shnatsel][])
+- Added `TryFrom` bounds to `SimdIntElement`, allowing attempted conversion from all primitive integer types.
 
 ## [0.7.0][] (2026-08-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You can find its changes [documented below](#070-2026-08-11).
 - Added lane-wise `count_ones` and `count_zeros` operations for all integer vector types and backends.
 - Added `mul_add_precise` and `mul_sub_precise` for floating-point vectors. They guarantee the infinite-precision product-plus-add rounded once, including on SIMD levels without hardware fused multiply-add instructions. They are not susceptible to the [bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library, `std::simd` and musl libc that causes incorrect rounding for subnormal results. SSE4.2 gets SIMD emulation of these operations for better performance. ([#323][], [#324][] by [@Shnatsel][])
 - Documented the storage representation of the SIMD vector types. The documented representation will not change without a semver major version change.
+- Added `TryFrom` bounds to `SimdIntElement`, allowing attempted conversion from all primitive integer types.
 
 ### Changed
 

--- a/fearless_simd/src/traits.rs
+++ b/fearless_simd/src/traits.rs
@@ -220,18 +220,18 @@ pub trait SimdIntElement:
     + BitOrAssign<Self>
     + BitXor<Self, Output = Self>
     + BitXorAssign<Self>
-    + TryFrom<u8, Error: Copy + Clone + Error + Eq + PartialEq>
-    + TryFrom<u16, Error: Copy + Clone + Error + Eq + PartialEq>
-    + TryFrom<u32, Error: Copy + Clone + Error + Eq + PartialEq>
-    + TryFrom<u64, Error: Copy + Clone + Error + Eq + PartialEq>
-    + TryFrom<u128, Error: Copy + Clone + Error + Eq + PartialEq>
-    + TryFrom<usize, Error: Copy + Clone + Error + Eq + PartialEq>
-    + TryFrom<i8, Error: Copy + Clone + Error + Eq + PartialEq>
-    + TryFrom<i16, Error: Copy + Clone + Error + Eq + PartialEq>
-    + TryFrom<i32, Error: Copy + Clone + Error + Eq + PartialEq>
-    + TryFrom<i64, Error: Copy + Clone + Error + Eq + PartialEq>
-    + TryFrom<i128, Error: Copy + Clone + Error + Eq + PartialEq>
-    + TryFrom<isize, Error: Copy + Clone + Error + Eq + PartialEq>
+    + TryFrom<u8, Error: Copy + Error + Eq>
+    + TryFrom<u16, Error: Copy + Error + Eq>
+    + TryFrom<u32, Error: Copy + Error + Eq>
+    + TryFrom<u64, Error: Copy + Error + Eq>
+    + TryFrom<u128, Error: Copy + Error + Eq>
+    + TryFrom<usize, Error: Copy + Error + Eq>
+    + TryFrom<i8, Error: Copy + Error + Eq>
+    + TryFrom<i16, Error: Copy + Error + Eq>
+    + TryFrom<i32, Error: Copy + Error + Eq>
+    + TryFrom<i64, Error: Copy + Error + Eq>
+    + TryFrom<i128, Error: Copy + Error + Eq>
+    + TryFrom<isize, Error: Copy + Error + Eq>
     + for<'a> Shl<&'a usize, Output = Self>
     + for<'a> ShlAssign<&'a usize>
     + for<'a> Shr<&'a usize, Output = Self>

--- a/fearless_simd/src/traits.rs
+++ b/fearless_simd/src/traits.rs
@@ -6,6 +6,7 @@
     reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
 )]
 use crate::{Simd, SimdBase, seal::Seal};
+use core::error::Error;
 use core::fmt::{Binary, Debug, Display, LowerExp, UpperExp};
 use core::iter::{Product, Sum};
 use core::ops::{
@@ -219,6 +220,18 @@ pub trait SimdIntElement:
     + BitOrAssign<Self>
     + BitXor<Self, Output = Self>
     + BitXorAssign<Self>
+    + TryFrom<u8, Error: Copy + Clone + Error + Eq + PartialEq>
+    + TryFrom<u16, Error: Copy + Clone + Error + Eq + PartialEq>
+    + TryFrom<u32, Error: Copy + Clone + Error + Eq + PartialEq>
+    + TryFrom<u64, Error: Copy + Clone + Error + Eq + PartialEq>
+    + TryFrom<u128, Error: Copy + Clone + Error + Eq + PartialEq>
+    + TryFrom<usize, Error: Copy + Clone + Error + Eq + PartialEq>
+    + TryFrom<i8, Error: Copy + Clone + Error + Eq + PartialEq>
+    + TryFrom<i16, Error: Copy + Clone + Error + Eq + PartialEq>
+    + TryFrom<i32, Error: Copy + Clone + Error + Eq + PartialEq>
+    + TryFrom<i64, Error: Copy + Clone + Error + Eq + PartialEq>
+    + TryFrom<i128, Error: Copy + Clone + Error + Eq + PartialEq>
+    + TryFrom<isize, Error: Copy + Clone + Error + Eq + PartialEq>
     + for<'a> Shl<&'a usize, Output = Self>
     + for<'a> ShlAssign<&'a usize>
     + for<'a> Shr<&'a usize, Output = Self>


### PR DESCRIPTION
I skipped these in #302 because conditional conversion didn't seem great for typically performance sensitive simd code. However, it turns out that these conversions are very useful in tests especially, and even in regular code LLVM can often rule out failure and elide the branch.

Still no `From` impls other than `bool`, because that's the lowest common denominator across signed/unsigned and all the different sizes.

No change to `SimdFloatElement`: unfortunately they don't implement TryFrom for integers, so without num-traits's cast trait (which provides the equivalent of `as` conversion) we're stuck with the existing lowest common denominator.