### PR TITLE
Add count_zeros() and count_ones() (lane-wise popcnt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can find its changes [documented below](#070-2026-08-11).
 
 ### Added
 
+- Added lane-wise `count_ones` and `count_zeros` operations for all integer vector types and backends.
 - Added `mul_add_precise` and `mul_sub_precise` for floating-point vectors. They guarantee the infinite-precision product-plus-add rounded once, including on SIMD levels without hardware fused multiply-add instructions. They are not susceptible to the [bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library, `std::simd` and musl libc that causes incorrect rounding for subnormal results. SSE4.2 gets SIMD emulation of these operations for better performance. ([#323][], [#324][] by [@Shnatsel][])
 - Documented the storage representation of the SIMD vector types. The documented representation will not change without a semver major version change.
 

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -657,6 +657,29 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i8x16<Avx2>) -> i8x16<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                byte_counts.simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        self.count_ones_i8x16(self.not_i8x16(a))
+    }
+    #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1120,6 +1143,29 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, a, indices)
+    }
+    #[inline(always)]
+    fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u8x16<Avx2>) -> u8x16<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                byte_counts.simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        self.count_ones_u8x16(self.not_u8x16(a))
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1697,6 +1743,29 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i16x8<Avx2>) -> i16x8<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                _mm_maddubs_epi16(byte_counts, _mm_set1_epi8(1)).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        self.count_ones_i16x8(self.not_i16x8(a))
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2112,6 +2181,29 @@ impl Simd for Avx2 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u16x8<Avx2>) -> u16x8<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                _mm_maddubs_epi16(byte_counts, _mm_set1_epi8(1)).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        self.count_ones_u16x8(self.not_u16x8(a))
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2696,6 +2788,33 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i32x4<Avx2>) -> i32x4<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                _mm_madd_epi16(
+                    _mm_maddubs_epi16(byte_counts, _mm_set1_epi8(1)),
+                    _mm_set1_epi16(1),
+                )
+                .simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        self.count_ones_i32x4(self.not_i32x4(a))
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3101,6 +3220,33 @@ impl Simd for Avx2 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u32x4<Avx2>) -> u32x4<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                _mm_madd_epi16(
+                    _mm_maddubs_epi16(byte_counts, _mm_set1_epi8(1)),
+                    _mm_set1_epi16(1),
+                )
+                .simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        self.count_ones_u32x4(self.not_u32x4(a))
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4114,6 +4260,29 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i64x2<Avx2>) -> i64x2<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                _mm_sad_epu8(byte_counts, _mm_setzero_si128()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        self.count_ones_i64x2(self.not_i64x2(a))
+    }
+    #[inline(always)]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -4486,6 +4655,29 @@ impl Simd for Avx2 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u64x2<Avx2>) -> u64x2<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                _mm_sad_epu8(byte_counts, _mm_setzero_si128()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        self.count_ones_u64x2(self.not_u64x2(a))
     }
     #[inline(always)]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
@@ -5532,6 +5724,32 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i8x32(self, a: i8x32<Self>) -> i8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i8x32<Avx2>) -> i8x32<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm256_set1_epi8(0x0f);
+                let lookup = _mm256_setr_epi8(
+                    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2,
+                    2, 3, 2, 3, 3, 4,
+                );
+                let low = _mm256_and_si256(value, nibble_mask);
+                let high = _mm256_and_si256(_mm256_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm256_add_epi8(
+                    _mm256_shuffle_epi8(lookup, low),
+                    _mm256_shuffle_epi8(lookup, high),
+                );
+                byte_counts.simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i8x32(self, a: i8x32<Self>) -> i8x32<Self> {
+        self.count_ones_i8x32(self.not_i8x32(a))
+    }
+    #[inline(always)]
     fn add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -6043,6 +6261,32 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, a, indices)
+    }
+    #[inline(always)]
+    fn count_ones_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u8x32<Avx2>) -> u8x32<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm256_set1_epi8(0x0f);
+                let lookup = _mm256_setr_epi8(
+                    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2,
+                    2, 3, 2, 3, 3, 4,
+                );
+                let low = _mm256_and_si256(value, nibble_mask);
+                let high = _mm256_and_si256(_mm256_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm256_add_epi8(
+                    _mm256_shuffle_epi8(lookup, low),
+                    _mm256_shuffle_epi8(lookup, high),
+                );
+                byte_counts.simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
+        self.count_ones_u8x32(self.not_u8x32(a))
     }
     #[inline(always)]
     fn add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
@@ -6670,6 +6914,32 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i16x16(self, a: i16x16<Self>) -> i16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i16x16<Avx2>) -> i16x16<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm256_set1_epi8(0x0f);
+                let lookup = _mm256_setr_epi8(
+                    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2,
+                    2, 3, 2, 3, 3, 4,
+                );
+                let low = _mm256_and_si256(value, nibble_mask);
+                let high = _mm256_and_si256(_mm256_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm256_add_epi8(
+                    _mm256_shuffle_epi8(lookup, low),
+                    _mm256_shuffle_epi8(lookup, high),
+                );
+                _mm256_maddubs_epi16(byte_counts, _mm256_set1_epi8(1)).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i16x16(self, a: i16x16<Self>) -> i16x16<Self> {
+        self.count_ones_i16x16(self.not_i16x16(a))
+    }
+    #[inline(always)]
     fn add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7112,6 +7382,32 @@ impl Simd for Avx2 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u16x16(self, a: u16x16<Self>) -> u16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u16x16<Avx2>) -> u16x16<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm256_set1_epi8(0x0f);
+                let lookup = _mm256_setr_epi8(
+                    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2,
+                    2, 3, 2, 3, 3, 4,
+                );
+                let low = _mm256_and_si256(value, nibble_mask);
+                let high = _mm256_and_si256(_mm256_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm256_add_epi8(
+                    _mm256_shuffle_epi8(lookup, low),
+                    _mm256_shuffle_epi8(lookup, high),
+                );
+                _mm256_maddubs_epi16(byte_counts, _mm256_set1_epi8(1)).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u16x16(self, a: u16x16<Self>) -> u16x16<Self> {
+        self.count_ones_u16x16(self.not_u16x16(a))
     }
     #[inline(always)]
     fn add_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -7739,6 +8035,36 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i32x8(self, a: i32x8<Self>) -> i32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i32x8<Avx2>) -> i32x8<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm256_set1_epi8(0x0f);
+                let lookup = _mm256_setr_epi8(
+                    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2,
+                    2, 3, 2, 3, 3, 4,
+                );
+                let low = _mm256_and_si256(value, nibble_mask);
+                let high = _mm256_and_si256(_mm256_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm256_add_epi8(
+                    _mm256_shuffle_epi8(lookup, low),
+                    _mm256_shuffle_epi8(lookup, high),
+                );
+                _mm256_madd_epi16(
+                    _mm256_maddubs_epi16(byte_counts, _mm256_set1_epi8(1)),
+                    _mm256_set1_epi16(1),
+                )
+                .simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i32x8(self, a: i32x8<Self>) -> i32x8<Self> {
+        self.count_ones_i32x8(self.not_i32x8(a))
+    }
+    #[inline(always)]
     fn add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -8141,6 +8467,36 @@ impl Simd for Avx2 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u32x8(self, a: u32x8<Self>) -> u32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u32x8<Avx2>) -> u32x8<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm256_set1_epi8(0x0f);
+                let lookup = _mm256_setr_epi8(
+                    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2,
+                    2, 3, 2, 3, 3, 4,
+                );
+                let low = _mm256_and_si256(value, nibble_mask);
+                let high = _mm256_and_si256(_mm256_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm256_add_epi8(
+                    _mm256_shuffle_epi8(lookup, low),
+                    _mm256_shuffle_epi8(lookup, high),
+                );
+                _mm256_madd_epi16(
+                    _mm256_maddubs_epi16(byte_counts, _mm256_set1_epi8(1)),
+                    _mm256_set1_epi16(1),
+                )
+                .simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u32x8(self, a: u32x8<Self>) -> u32x8<Self> {
+        self.count_ones_u32x8(self.not_u32x8(a))
     }
     #[inline(always)]
     fn add_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
@@ -9189,6 +9545,32 @@ impl Simd for Avx2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i64x4(self, a: i64x4<Self>) -> i64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i64x4<Avx2>) -> i64x4<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm256_set1_epi8(0x0f);
+                let lookup = _mm256_setr_epi8(
+                    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2,
+                    2, 3, 2, 3, 3, 4,
+                );
+                let low = _mm256_and_si256(value, nibble_mask);
+                let high = _mm256_and_si256(_mm256_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm256_add_epi8(
+                    _mm256_shuffle_epi8(lookup, low),
+                    _mm256_shuffle_epi8(lookup, high),
+                );
+                _mm256_sad_epu8(byte_counts, _mm256_setzero_si256()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i64x4(self, a: i64x4<Self>) -> i64x4<Self> {
+        self.count_ones_i64x4(self.not_i64x4(a))
+    }
+    #[inline(always)]
     fn add_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -9573,6 +9955,32 @@ impl Simd for Avx2 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u64x4(self, a: u64x4<Self>) -> u64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u64x4<Avx2>) -> u64x4<Avx2> {
+                let value = a.into();
+                let nibble_mask = _mm256_set1_epi8(0x0f);
+                let lookup = _mm256_setr_epi8(
+                    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2,
+                    2, 3, 2, 3, 3, 4,
+                );
+                let low = _mm256_and_si256(value, nibble_mask);
+                let high = _mm256_and_si256(_mm256_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm256_add_epi8(
+                    _mm256_shuffle_epi8(lookup, low),
+                    _mm256_shuffle_epi8(lookup, high),
+                );
+                _mm256_sad_epu8(byte_counts, _mm256_setzero_si256()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u64x4(self, a: u64x4<Self>) -> u64x4<Self> {
+        self.count_ones_u64x4(self.not_u64x4(a))
     }
     #[inline(always)]
     fn add_u64x4(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -885,6 +885,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn count_ones_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x16<Avx512>) -> i8x16<Avx512> {
+                _mm_popcnt_epi8(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        self.count_ones_i8x16(self.not_i8x16(a))
+    }
+    #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1355,6 +1369,20 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, a, indices)
+    }
+    #[inline(always)]
+    fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x16<Avx512>) -> u8x16<Avx512> {
+                _mm_popcnt_epi8(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        self.count_ones_u8x16(self.not_u8x16(a))
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1879,6 +1907,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn count_ones_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x8<Avx512>) -> i16x8<Avx512> {
+                _mm_popcnt_epi16(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        self.count_ones_i16x8(self.not_i16x8(a))
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2283,6 +2325,20 @@ impl Simd for Avx512 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x8<Avx512>) -> u16x8<Avx512> {
+                _mm_popcnt_epi16(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        self.count_ones_u16x8(self.not_u16x8(a))
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2791,6 +2847,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn count_ones_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x4<Avx512>) -> i32x4<Avx512> {
+                _mm_popcnt_epi32(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        self.count_ones_i32x4(self.not_i32x4(a))
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3189,6 +3259,20 @@ impl Simd for Avx512 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x4<Avx512>) -> u32x4<Avx512> {
+                _mm_popcnt_epi32(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        self.count_ones_u32x4(self.not_u32x4(a))
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4161,6 +4245,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn count_ones_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i64x2<Avx512>) -> i64x2<Avx512> {
+                _mm_popcnt_epi64(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        self.count_ones_i64x2(self.not_i64x2(a))
+    }
+    #[inline(always)]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -4539,6 +4637,20 @@ impl Simd for Avx512 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u64x2<Avx512>) -> u64x2<Avx512> {
+                _mm_popcnt_epi64(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        self.count_ones_u64x2(self.not_u64x2(a))
     }
     #[inline(always)]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
@@ -5583,6 +5695,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn count_ones_i8x32(self, a: i8x32<Self>) -> i8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x32<Avx512>) -> i8x32<Avx512> {
+                _mm256_popcnt_epi8(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i8x32(self, a: i8x32<Self>) -> i8x32<Self> {
+        self.count_ones_i8x32(self.not_i8x32(a))
+    }
+    #[inline(always)]
     fn add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -6106,6 +6232,20 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, a, indices)
+    }
+    #[inline(always)]
+    fn count_ones_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x32<Avx512>) -> u8x32<Avx512> {
+                _mm256_popcnt_epi8(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
+        self.count_ones_u8x32(self.not_u8x32(a))
     }
     #[inline(always)]
     fn add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
@@ -6697,6 +6837,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn count_ones_i16x16(self, a: i16x16<Self>) -> i16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x16<Avx512>) -> i16x16<Avx512> {
+                _mm256_popcnt_epi16(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i16x16(self, a: i16x16<Self>) -> i16x16<Self> {
+        self.count_ones_i16x16(self.not_i16x16(a))
+    }
+    #[inline(always)]
     fn add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7142,6 +7296,20 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u16x16(self, a: u16x16<Self>) -> u16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x16<Avx512>) -> u16x16<Avx512> {
+                _mm256_popcnt_epi16(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u16x16(self, a: u16x16<Self>) -> u16x16<Self> {
+        self.count_ones_u16x16(self.not_u16x16(a))
     }
     #[inline(always)]
     fn add_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -7705,6 +7873,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn count_ones_i32x8(self, a: i32x8<Self>) -> i32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x8<Avx512>) -> i32x8<Avx512> {
+                _mm256_popcnt_epi32(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i32x8(self, a: i32x8<Self>) -> i32x8<Self> {
+        self.count_ones_i32x8(self.not_i32x8(a))
+    }
+    #[inline(always)]
     fn add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -8138,6 +8320,20 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u32x8(self, a: u32x8<Self>) -> u32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x8<Avx512>) -> u32x8<Avx512> {
+                _mm256_popcnt_epi32(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u32x8(self, a: u32x8<Self>) -> u32x8<Self> {
+        self.count_ones_u32x8(self.not_u32x8(a))
     }
     #[inline(always)]
     fn add_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
@@ -9202,6 +9398,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn count_ones_i64x4(self, a: i64x4<Self>) -> i64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i64x4<Avx512>) -> i64x4<Avx512> {
+                _mm256_popcnt_epi64(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i64x4(self, a: i64x4<Self>) -> i64x4<Self> {
+        self.count_ones_i64x4(self.not_i64x4(a))
+    }
+    #[inline(always)]
     fn add_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -9605,6 +9815,20 @@ impl Simd for Avx512 {
             val: crate::support::Aligned256(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u64x4(self, a: u64x4<Self>) -> u64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u64x4<Avx512>) -> u64x4<Avx512> {
+                _mm256_popcnt_epi64(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u64x4(self, a: u64x4<Self>) -> u64x4<Self> {
+        self.count_ones_u64x4(self.not_u64x4(a))
     }
     #[inline(always)]
     fn add_u64x4(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
@@ -10677,6 +10901,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn count_ones_i8x64(self, a: i8x64<Self>) -> i8x64<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x64<Avx512>) -> i8x64<Avx512> {
+                _mm512_popcnt_epi8(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i8x64(self, a: i8x64<Self>) -> i8x64<Self> {
+        self.count_ones_i8x64(self.not_i8x64(a))
+    }
+    #[inline(always)]
     fn add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -11208,6 +11446,20 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, a, indices)
+    }
+    #[inline(always)]
+    fn count_ones_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x64<Avx512>) -> u8x64<Avx512> {
+                _mm512_popcnt_epi8(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
+        self.count_ones_u8x64(self.not_u8x64(a))
     }
     #[inline(always)]
     fn add_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -11799,6 +12051,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn count_ones_i16x32(self, a: i16x32<Self>) -> i16x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x32<Avx512>) -> i16x32<Avx512> {
+                _mm512_popcnt_epi16(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i16x32(self, a: i16x32<Self>) -> i16x32<Self> {
+        self.count_ones_i16x32(self.not_i16x32(a))
+    }
+    #[inline(always)]
     fn add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -12254,6 +12520,20 @@ impl Simd for Avx512 {
             val: crate::support::Aligned512(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u16x32(self, a: u16x32<Self>) -> u16x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x32<Avx512>) -> u16x32<Avx512> {
+                _mm512_popcnt_epi16(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u16x32(self, a: u16x32<Self>) -> u16x32<Self> {
+        self.count_ones_u16x32(self.not_u16x32(a))
     }
     #[inline(always)]
     fn add_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -12819,6 +13099,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn count_ones_i32x16(self, a: i32x16<Self>) -> i32x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x16<Avx512>) -> i32x16<Avx512> {
+                _mm512_popcnt_epi32(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i32x16(self, a: i32x16<Self>) -> i32x16<Self> {
+        self.count_ones_i32x16(self.not_i32x16(a))
+    }
+    #[inline(always)]
     fn add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -13266,6 +13560,20 @@ impl Simd for Avx512 {
             val: crate::support::Aligned512(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u32x16(self, a: u32x16<Self>) -> u32x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x16<Avx512>) -> u32x16<Avx512> {
+                _mm512_popcnt_epi32(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u32x16(self, a: u32x16<Self>) -> u32x16<Self> {
+        self.count_ones_u32x16(self.not_u32x16(a))
     }
     #[inline(always)]
     fn add_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -14347,6 +14655,20 @@ impl Simd for Avx512 {
         })
     }
     #[inline(always)]
+    fn count_ones_i64x8(self, a: i64x8<Self>) -> i64x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i64x8<Avx512>) -> i64x8<Avx512> {
+                _mm512_popcnt_epi64(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i64x8(self, a: i64x8<Self>) -> i64x8<Self> {
+        self.count_ones_i64x8(self.not_i64x8(a))
+    }
+    #[inline(always)]
     fn add_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -14758,6 +15080,20 @@ impl Simd for Avx512 {
             val: crate::support::Aligned512(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u64x8(self, a: u64x8<Self>) -> u64x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u64x8<Avx512>) -> u64x8<Avx512> {
+                _mm512_popcnt_epi64(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u64x8(self, a: u64x8<Self>) -> u64x8<Self> {
+        self.count_ones_u64x8(self.not_u64x8(a))
     }
     #[inline(always)]
     fn add_u64x8(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -607,7 +607,25 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
-        self.count_ones_i8x16(self.not_i8x16(a))
+        [
+            i8::try_from(a[0usize].count_zeros()).unwrap(),
+            i8::try_from(a[1usize].count_zeros()).unwrap(),
+            i8::try_from(a[2usize].count_zeros()).unwrap(),
+            i8::try_from(a[3usize].count_zeros()).unwrap(),
+            i8::try_from(a[4usize].count_zeros()).unwrap(),
+            i8::try_from(a[5usize].count_zeros()).unwrap(),
+            i8::try_from(a[6usize].count_zeros()).unwrap(),
+            i8::try_from(a[7usize].count_zeros()).unwrap(),
+            i8::try_from(a[8usize].count_zeros()).unwrap(),
+            i8::try_from(a[9usize].count_zeros()).unwrap(),
+            i8::try_from(a[10usize].count_zeros()).unwrap(),
+            i8::try_from(a[11usize].count_zeros()).unwrap(),
+            i8::try_from(a[12usize].count_zeros()).unwrap(),
+            i8::try_from(a[13usize].count_zeros()).unwrap(),
+            i8::try_from(a[14usize].count_zeros()).unwrap(),
+            i8::try_from(a[15usize].count_zeros()).unwrap(),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
@@ -1430,7 +1448,25 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
-        self.count_ones_u8x16(self.not_u8x16(a))
+        [
+            u8::try_from(a[0usize].count_zeros()).unwrap(),
+            u8::try_from(a[1usize].count_zeros()).unwrap(),
+            u8::try_from(a[2usize].count_zeros()).unwrap(),
+            u8::try_from(a[3usize].count_zeros()).unwrap(),
+            u8::try_from(a[4usize].count_zeros()).unwrap(),
+            u8::try_from(a[5usize].count_zeros()).unwrap(),
+            u8::try_from(a[6usize].count_zeros()).unwrap(),
+            u8::try_from(a[7usize].count_zeros()).unwrap(),
+            u8::try_from(a[8usize].count_zeros()).unwrap(),
+            u8::try_from(a[9usize].count_zeros()).unwrap(),
+            u8::try_from(a[10usize].count_zeros()).unwrap(),
+            u8::try_from(a[11usize].count_zeros()).unwrap(),
+            u8::try_from(a[12usize].count_zeros()).unwrap(),
+            u8::try_from(a[13usize].count_zeros()).unwrap(),
+            u8::try_from(a[14usize].count_zeros()).unwrap(),
+            u8::try_from(a[15usize].count_zeros()).unwrap(),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -2463,7 +2499,17 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
-        self.count_ones_i16x8(self.not_i16x8(a))
+        [
+            i16::try_from(a[0usize].count_zeros()).unwrap(),
+            i16::try_from(a[1usize].count_zeros()).unwrap(),
+            i16::try_from(a[2usize].count_zeros()).unwrap(),
+            i16::try_from(a[3usize].count_zeros()).unwrap(),
+            i16::try_from(a[4usize].count_zeros()).unwrap(),
+            i16::try_from(a[5usize].count_zeros()).unwrap(),
+            i16::try_from(a[6usize].count_zeros()).unwrap(),
+            i16::try_from(a[7usize].count_zeros()).unwrap(),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
@@ -2983,7 +3029,17 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
-        self.count_ones_u16x8(self.not_u16x8(a))
+        [
+            u16::try_from(a[0usize].count_zeros()).unwrap(),
+            u16::try_from(a[1usize].count_zeros()).unwrap(),
+            u16::try_from(a[2usize].count_zeros()).unwrap(),
+            u16::try_from(a[3usize].count_zeros()).unwrap(),
+            u16::try_from(a[4usize].count_zeros()).unwrap(),
+            u16::try_from(a[5usize].count_zeros()).unwrap(),
+            u16::try_from(a[6usize].count_zeros()).unwrap(),
+            u16::try_from(a[7usize].count_zeros()).unwrap(),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -3700,7 +3756,13 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
-        self.count_ones_i32x4(self.not_i32x4(a))
+        [
+            a[0usize].count_zeros().cast_signed(),
+            a[1usize].count_zeros().cast_signed(),
+            a[2usize].count_zeros().cast_signed(),
+            a[3usize].count_zeros().cast_signed(),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
@@ -4042,7 +4104,13 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
-        self.count_ones_u32x4(self.not_u32x4(a))
+        [
+            a[0usize].count_zeros(),
+            a[1usize].count_zeros(),
+            a[2usize].count_zeros(),
+            a[3usize].count_zeros(),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4795,7 +4863,11 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
-        self.count_ones_i64x2(self.not_i64x2(a))
+        [
+            i64::from(a[0usize].count_zeros()),
+            i64::from(a[1usize].count_zeros()),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
@@ -5054,7 +5126,11 @@ impl Simd for Fallback {
     }
     #[inline(always)]
     fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
-        self.count_ones_u64x2(self.not_u64x2(a))
+        [
+            u64::from(a[0usize].count_zeros()),
+            u64::from(a[1usize].count_zeros()),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -584,6 +584,32 @@ impl Simd for Fallback {
         dest.simd_into(self)
     }
     #[inline(always)]
+    fn count_ones_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        [
+            i8::try_from(a[0usize].count_ones()).unwrap(),
+            i8::try_from(a[1usize].count_ones()).unwrap(),
+            i8::try_from(a[2usize].count_ones()).unwrap(),
+            i8::try_from(a[3usize].count_ones()).unwrap(),
+            i8::try_from(a[4usize].count_ones()).unwrap(),
+            i8::try_from(a[5usize].count_ones()).unwrap(),
+            i8::try_from(a[6usize].count_ones()).unwrap(),
+            i8::try_from(a[7usize].count_ones()).unwrap(),
+            i8::try_from(a[8usize].count_ones()).unwrap(),
+            i8::try_from(a[9usize].count_ones()).unwrap(),
+            i8::try_from(a[10usize].count_ones()).unwrap(),
+            i8::try_from(a[11usize].count_ones()).unwrap(),
+            i8::try_from(a[12usize].count_ones()).unwrap(),
+            i8::try_from(a[13usize].count_ones()).unwrap(),
+            i8::try_from(a[14usize].count_ones()).unwrap(),
+            i8::try_from(a[15usize].count_ones()).unwrap(),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        self.count_ones_i8x16(self.not_i8x16(a))
+    }
+    #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         [
             i8::wrapping_add(a[0usize], b[0usize]),
@@ -1379,6 +1405,32 @@ impl Simd for Fallback {
         }
         let result: u8x16<Self> = output.simd_into(self);
         Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        [
+            u8::try_from(a[0usize].count_ones()).unwrap(),
+            u8::try_from(a[1usize].count_ones()).unwrap(),
+            u8::try_from(a[2usize].count_ones()).unwrap(),
+            u8::try_from(a[3usize].count_ones()).unwrap(),
+            u8::try_from(a[4usize].count_ones()).unwrap(),
+            u8::try_from(a[5usize].count_ones()).unwrap(),
+            u8::try_from(a[6usize].count_ones()).unwrap(),
+            u8::try_from(a[7usize].count_ones()).unwrap(),
+            u8::try_from(a[8usize].count_ones()).unwrap(),
+            u8::try_from(a[9usize].count_ones()).unwrap(),
+            u8::try_from(a[10usize].count_ones()).unwrap(),
+            u8::try_from(a[11usize].count_ones()).unwrap(),
+            u8::try_from(a[12usize].count_ones()).unwrap(),
+            u8::try_from(a[13usize].count_ones()).unwrap(),
+            u8::try_from(a[14usize].count_ones()).unwrap(),
+            u8::try_from(a[15usize].count_ones()).unwrap(),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        self.count_ones_u8x16(self.not_u8x16(a))
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -2396,6 +2448,24 @@ impl Simd for Fallback {
         dest.simd_into(self)
     }
     #[inline(always)]
+    fn count_ones_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        [
+            i16::try_from(a[0usize].count_ones()).unwrap(),
+            i16::try_from(a[1usize].count_ones()).unwrap(),
+            i16::try_from(a[2usize].count_ones()).unwrap(),
+            i16::try_from(a[3usize].count_ones()).unwrap(),
+            i16::try_from(a[4usize].count_ones()).unwrap(),
+            i16::try_from(a[5usize].count_ones()).unwrap(),
+            i16::try_from(a[6usize].count_ones()).unwrap(),
+            i16::try_from(a[7usize].count_ones()).unwrap(),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        self.count_ones_i16x8(self.not_i16x8(a))
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         [
             i16::wrapping_add(a[0usize], b[0usize]),
@@ -2896,6 +2966,24 @@ impl Simd for Fallback {
         dest[..8usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
         dest[8usize - SHIFT..].copy_from_slice(&b.val.0[..SHIFT]);
         dest.simd_into(self)
+    }
+    #[inline(always)]
+    fn count_ones_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        [
+            u16::try_from(a[0usize].count_ones()).unwrap(),
+            u16::try_from(a[1usize].count_ones()).unwrap(),
+            u16::try_from(a[2usize].count_ones()).unwrap(),
+            u16::try_from(a[3usize].count_ones()).unwrap(),
+            u16::try_from(a[4usize].count_ones()).unwrap(),
+            u16::try_from(a[5usize].count_ones()).unwrap(),
+            u16::try_from(a[6usize].count_ones()).unwrap(),
+            u16::try_from(a[7usize].count_ones()).unwrap(),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        self.count_ones_u16x8(self.not_u16x8(a))
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -3601,6 +3689,20 @@ impl Simd for Fallback {
         dest.simd_into(self)
     }
     #[inline(always)]
+    fn count_ones_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        [
+            a[0usize].count_ones().cast_signed(),
+            a[1usize].count_ones().cast_signed(),
+            a[2usize].count_ones().cast_signed(),
+            a[3usize].count_ones().cast_signed(),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        self.count_ones_i32x4(self.not_i32x4(a))
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         [
             i32::wrapping_add(a[0usize], b[0usize]),
@@ -3927,6 +4029,20 @@ impl Simd for Fallback {
         dest[..4usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
         dest[4usize - SHIFT..].copy_from_slice(&b.val.0[..SHIFT]);
         dest.simd_into(self)
+    }
+    #[inline(always)]
+    fn count_ones_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        [
+            a[0usize].count_ones(),
+            a[1usize].count_ones(),
+            a[2usize].count_ones(),
+            a[3usize].count_ones(),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        self.count_ones_u32x4(self.not_u32x4(a))
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4670,6 +4786,18 @@ impl Simd for Fallback {
         dest.simd_into(self)
     }
     #[inline(always)]
+    fn count_ones_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        [
+            i64::from(a[0usize].count_ones()),
+            i64::from(a[1usize].count_ones()),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        self.count_ones_i64x2(self.not_i64x2(a))
+    }
+    #[inline(always)]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         [
             i64::wrapping_add(a[0usize], b[0usize]),
@@ -4915,6 +5043,18 @@ impl Simd for Fallback {
         dest[..2usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
         dest[2usize - SHIFT..].copy_from_slice(&b.val.0[..SHIFT]);
         dest.simd_into(self)
+    }
+    #[inline(always)]
+    fn count_ones_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        [
+            u64::from(a[0usize].count_ones()),
+            u64::from(a[1usize].count_ones()),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        self.count_ones_u64x2(self.not_u64x2(a))
     }
     #[inline(always)]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -539,6 +539,20 @@ impl Simd for Neon {
         })
     }
     #[inline(always)]
+    fn count_ones_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i8x16<Neon>) -> i8x16<Neon> {
+                vreinterpretq_s8_u8(vcntq_u8(vreinterpretq_u8_s8(a.into()))).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        self.count_ones_i8x16(self.not_i8x16(a))
+    }
+    #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -880,6 +894,20 @@ impl Simd for Neon {
             }
         );
         kernel(self, a, indices)
+    }
+    #[inline(always)]
+    fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u8x16<Neon>) -> u8x16<Neon> {
+                vcntq_u8(a.into()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        self.count_ones_u8x16(self.not_u8x16(a))
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1359,6 +1387,21 @@ impl Simd for Neon {
         })
     }
     #[inline(always)]
+    fn count_ones_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i16x8<Neon>) -> i16x8<Neon> {
+                vreinterpretq_s16_u16(vpaddlq_u8(vcntq_u8(vreinterpretq_u8_s16(a.into()))))
+                    .simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        self.count_ones_i16x8(self.not_i16x8(a))
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1699,6 +1742,20 @@ impl Simd for Neon {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u16x8<Neon>) -> u16x8<Neon> {
+                vpaddlq_u8(vcntq_u8(vreinterpretq_u8_u16(a.into()))).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        self.count_ones_u16x8(self.not_u16x8(a))
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2201,6 +2258,23 @@ impl Simd for Neon {
         })
     }
     #[inline(always)]
+    fn count_ones_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i32x4<Neon>) -> i32x4<Neon> {
+                vreinterpretq_s32_u32(vpaddlq_u16(vpaddlq_u8(vcntq_u8(vreinterpretq_u8_s32(
+                    a.into(),
+                )))))
+                .simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        self.count_ones_i32x4(self.not_i32x4(a))
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2551,6 +2625,20 @@ impl Simd for Neon {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u32x4<Neon>) -> u32x4<Neon> {
+                vpaddlq_u16(vpaddlq_u8(vcntq_u8(vreinterpretq_u8_u32(a.into())))).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        self.count_ones_u32x4(self.not_u32x4(a))
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -3471,6 +3559,23 @@ impl Simd for Neon {
         })
     }
     #[inline(always)]
+    fn count_ones_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i64x2<Neon>) -> i64x2<Neon> {
+                vreinterpretq_s64_u64(vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(vcntq_u8(
+                    vreinterpretq_u8_s64(a.into()),
+                )))))
+                .simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        self.count_ones_i64x2(self.not_i64x2(a))
+    }
+    #[inline(always)]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3802,6 +3907,23 @@ impl Simd for Neon {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u64x2<Neon>) -> u64x2<Neon> {
+                vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(vcntq_u8(vreinterpretq_u8_u64(
+                    a.into(),
+                )))))
+                .simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        self.count_ones_u64x2(self.not_u64x2(a))
     }
     #[inline(always)]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -365,6 +365,10 @@ pub trait Simd:
     fn swizzle_dyn_precise_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    fn count_ones_i8x16(self, a: i8x16<Self>) -> i8x16<Self>;
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -456,6 +460,10 @@ pub trait Simd:
     fn swizzle_dyn_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Dynamically swizzle this vector's bytes across the whole vector.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the vector's byte length select the corresponding byte from the input vector. Out-of-range indices produce zero."]
     fn swizzle_dyn_precise_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self>;
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self>;
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -589,6 +597,10 @@ pub trait Simd:
     fn swizzle_dyn_precise_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    fn count_ones_i16x8(self, a: i16x8<Self>) -> i16x8<Self>;
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -695,6 +707,10 @@ pub trait Simd:
     fn swizzle_dyn_precise_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    fn count_ones_u16x8(self, a: u16x8<Self>) -> u16x8<Self>;
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -834,6 +850,10 @@ pub trait Simd:
     fn swizzle_dyn_precise_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    fn count_ones_i32x4(self, a: i32x4<Self>) -> i32x4<Self>;
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -942,6 +962,10 @@ pub trait Simd:
     fn swizzle_dyn_precise_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    fn count_ones_u32x4(self, a: u32x4<Self>) -> u32x4<Self>;
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -1211,6 +1235,10 @@ pub trait Simd:
     fn swizzle_dyn_precise_i64x2(self, a: i64x2<Self>, indices: u8x16<Self>) -> i64x2<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    fn count_ones_i64x2(self, a: i64x2<Self>) -> i64x2<Self>;
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -1317,6 +1345,10 @@ pub trait Simd:
     fn swizzle_dyn_precise_u64x2(self, a: u64x2<Self>, indices: u8x16<Self>) -> u64x2<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    fn count_ones_u64x2(self, a: u64x2<Self>) -> u64x2<Self>;
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
@@ -1812,6 +1844,18 @@ pub trait Simd:
     fn swizzle_dyn_precise_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_i8x32(self, a: i8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        self.combine_i8x16(self.count_ones_i8x16(a0), self.count_ones_i8x16(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_i8x32(self, a: i8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        self.combine_i8x16(self.count_zeros_i8x16(a0), self.count_zeros_i8x16(a1))
+    }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -2049,6 +2093,18 @@ pub trait Simd:
     fn swizzle_dyn_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self>;
     #[doc = "Dynamically swizzle this vector's bytes across the whole vector.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the vector's byte length select the corresponding byte from the input vector. Out-of-range indices produce zero."]
     fn swizzle_dyn_precise_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self>;
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        self.combine_u8x16(self.count_ones_u8x16(a0), self.count_ones_u8x16(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        self.combine_u8x16(self.count_zeros_u8x16(a0), self.count_zeros_u8x16(a1))
+    }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
@@ -2386,6 +2442,18 @@ pub trait Simd:
     fn swizzle_dyn_precise_i16x16(self, a: i16x16<Self>, indices: u8x32<Self>) -> i16x16<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_i16x16(self, a: i16x16<Self>) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        self.combine_i16x8(self.count_ones_i16x8(a0), self.count_ones_i16x8(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_i16x16(self, a: i16x16<Self>) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        self.combine_i16x8(self.count_zeros_i16x8(a0), self.count_zeros_i16x8(a1))
+    }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -2654,6 +2722,18 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u16x16(self, a: u16x16<Self>, indices: u8x32<Self>) -> u16x16<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_u16x16(self, a: u16x16<Self>) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        self.combine_u16x8(self.count_ones_u16x8(a0), self.count_ones_u16x8(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_u16x16(self, a: u16x16<Self>) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        self.combine_u16x8(self.count_zeros_u16x8(a0), self.count_zeros_u16x8(a1))
     }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -3015,6 +3095,18 @@ pub trait Simd:
     fn swizzle_dyn_precise_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_i32x8(self, a: i32x8<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        self.combine_i32x4(self.count_ones_i32x4(a0), self.count_ones_i32x4(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_i32x8(self, a: i32x8<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        self.combine_i32x4(self.count_zeros_i32x4(a0), self.count_zeros_i32x4(a1))
+    }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -3285,6 +3377,18 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_u32x8(self, a: u32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        self.combine_u32x4(self.count_ones_u32x4(a0), self.count_ones_u32x4(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_u32x8(self, a: u32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        self.combine_u32x4(self.count_zeros_u32x4(a0), self.count_zeros_u32x4(a1))
     }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -4018,6 +4122,18 @@ pub trait Simd:
     fn swizzle_dyn_precise_i64x4(self, a: i64x4<Self>, indices: u8x32<Self>) -> i64x4<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_i64x4(self, a: i64x4<Self>) -> i64x4<Self> {
+        let (a0, a1) = self.split_i64x4(a);
+        self.combine_i64x2(self.count_ones_i64x2(a0), self.count_ones_i64x2(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_i64x4(self, a: i64x4<Self>) -> i64x4<Self> {
+        let (a0, a1) = self.split_i64x4(a);
+        self.combine_i64x2(self.count_zeros_i64x2(a0), self.count_zeros_i64x2(a1))
+    }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn add_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
@@ -4280,6 +4396,18 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u64x4(self, a: u64x4<Self>, indices: u8x32<Self>) -> u64x4<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_u64x4(self, a: u64x4<Self>) -> u64x4<Self> {
+        let (a0, a1) = self.split_u64x4(a);
+        self.combine_u64x2(self.count_ones_u64x2(a0), self.count_ones_u64x2(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_u64x4(self, a: u64x4<Self>) -> u64x4<Self> {
+        let (a0, a1) = self.split_u64x4(a);
+        self.combine_u64x2(self.count_zeros_u64x2(a0), self.count_zeros_u64x2(a1))
     }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -4998,6 +5126,18 @@ pub trait Simd:
     fn swizzle_dyn_precise_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_i8x64(self, a: i8x64<Self>) -> i8x64<Self> {
+        let (a0, a1) = self.split_i8x64(a);
+        self.combine_i8x32(self.count_ones_i8x32(a0), self.count_ones_i8x32(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_i8x64(self, a: i8x64<Self>) -> i8x64<Self> {
+        let (a0, a1) = self.split_i8x64(a);
+        self.combine_i8x32(self.count_zeros_i8x32(a0), self.count_zeros_i8x32(a1))
+    }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -5233,6 +5373,18 @@ pub trait Simd:
     fn swizzle_dyn_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self>;
     #[doc = "Dynamically swizzle this vector's bytes across the whole vector.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the vector's byte length select the corresponding byte from the input vector. Out-of-range indices produce zero."]
     fn swizzle_dyn_precise_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self>;
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
+        let (a0, a1) = self.split_u8x64(a);
+        self.combine_u8x32(self.count_ones_u8x32(a0), self.count_ones_u8x32(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
+        let (a0, a1) = self.split_u8x64(a);
+        self.combine_u8x32(self.count_zeros_u8x32(a0), self.count_zeros_u8x32(a1))
+    }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn add_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -5566,6 +5718,18 @@ pub trait Simd:
     fn swizzle_dyn_precise_i16x32(self, a: i16x32<Self>, indices: u8x64<Self>) -> i16x32<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_i16x32(self, a: i16x32<Self>) -> i16x32<Self> {
+        let (a0, a1) = self.split_i16x32(a);
+        self.combine_i16x16(self.count_ones_i16x16(a0), self.count_ones_i16x16(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_i16x32(self, a: i16x32<Self>) -> i16x32<Self> {
+        let (a0, a1) = self.split_i16x32(a);
+        self.combine_i16x16(self.count_zeros_i16x16(a0), self.count_zeros_i16x16(a1))
+    }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -5838,6 +6002,18 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u16x32(self, a: u16x32<Self>, indices: u8x64<Self>) -> u16x32<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_u16x32(self, a: u16x32<Self>) -> u16x32<Self> {
+        let (a0, a1) = self.split_u16x32(a);
+        self.combine_u16x16(self.count_ones_u16x16(a0), self.count_ones_u16x16(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_u16x32(self, a: u16x32<Self>) -> u16x32<Self> {
+        let (a0, a1) = self.split_u16x32(a);
+        self.combine_u16x16(self.count_zeros_u16x16(a0), self.count_zeros_u16x16(a1))
     }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -6208,6 +6384,18 @@ pub trait Simd:
     fn swizzle_dyn_precise_i32x16(self, a: i32x16<Self>, indices: u8x64<Self>) -> i32x16<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_i32x16(self, a: i32x16<Self>) -> i32x16<Self> {
+        let (a0, a1) = self.split_i32x16(a);
+        self.combine_i32x8(self.count_ones_i32x8(a0), self.count_ones_i32x8(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_i32x16(self, a: i32x16<Self>) -> i32x16<Self> {
+        let (a0, a1) = self.split_i32x16(a);
+        self.combine_i32x8(self.count_zeros_i32x8(a0), self.count_zeros_i32x8(a1))
+    }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -6480,6 +6668,18 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u32x16(self, a: u32x16<Self>, indices: u8x64<Self>) -> u32x16<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_u32x16(self, a: u32x16<Self>) -> u32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        self.combine_u32x8(self.count_ones_u32x8(a0), self.count_ones_u32x8(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_u32x16(self, a: u32x16<Self>) -> u32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        self.combine_u32x8(self.count_zeros_u32x8(a0), self.count_zeros_u32x8(a1))
     }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -7207,6 +7407,18 @@ pub trait Simd:
     fn swizzle_dyn_precise_i64x8(self, a: i64x8<Self>, indices: u8x64<Self>) -> i64x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_i64x8(self, a: i64x8<Self>) -> i64x8<Self> {
+        let (a0, a1) = self.split_i64x8(a);
+        self.combine_i64x4(self.count_ones_i64x4(a0), self.count_ones_i64x4(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_i64x8(self, a: i64x8<Self>) -> i64x8<Self> {
+        let (a0, a1) = self.split_i64x8(a);
+        self.combine_i64x4(self.count_zeros_i64x4(a0), self.count_zeros_i64x4(a1))
+    }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn add_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
@@ -7467,6 +7679,18 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u64x8(self, a: u64x8<Self>, indices: u8x64<Self>) -> u64x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    #[inline(always)]
+    fn count_ones_u64x8(self, a: u64x8<Self>) -> u64x8<Self> {
+        let (a0, a1) = self.split_u64x8(a);
+        self.combine_u64x4(self.count_ones_u64x4(a0), self.count_ones_u64x4(a1))
+    }
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    #[inline(always)]
+    fn count_zeros_u64x8(self, a: u64x8<Self>) -> u64x8<Self> {
+        let (a0, a1) = self.split_u64x8(a);
+        self.combine_u64x4(self.count_zeros_u64x4(a0), self.count_zeros_u64x4(a1))
     }
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -8473,6 +8697,10 @@ pub trait SimdInt<S: Simd>:
     fn to_float<T: SimdCvtFloat<Self>>(self) -> T {
         T::float_from(self)
     }
+    #[doc = "Return the number of ones in the binary representation of each element."]
+    fn count_ones(self) -> Self;
+    #[doc = "Return the number of zeros in the binary representation of each element."]
+    fn count_zeros(self) -> Self;
 }
 #[doc = r" Functionality implemented by SIMD masks."]
 #[doc = r""]

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -541,7 +541,16 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
         self.simd.deinterleave_i8x16(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for i8x16<S> {}
+impl<S: Simd> crate::SimdInt<S> for i8x16<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_i8x16(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_i8x16(self)
+    }
+}
 impl<S: Simd> SimdWiden<S> for i8x16<S> {
     type Widened = i16x8<S>;
     #[inline(always)]
@@ -796,7 +805,16 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
         self.simd.deinterleave_u8x16(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for u8x16<S> {}
+impl<S: Simd> crate::SimdInt<S> for u8x16<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_u8x16(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_u8x16(self)
+    }
+}
 impl<S: Simd> SimdWiden<S> for u8x16<S> {
     type Widened = u16x8<S>;
     #[inline(always)]
@@ -1137,7 +1155,16 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
         self.simd.deinterleave_i16x8(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for i16x8<S> {}
+impl<S: Simd> crate::SimdInt<S> for i16x8<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_i16x8(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_i16x8(self)
+    }
+}
 impl<S: Simd> SimdWiden<S> for i16x8<S> {
     type Widened = i32x4<S>;
     #[inline(always)]
@@ -1399,7 +1426,16 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
         self.simd.deinterleave_u16x8(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for u16x8<S> {}
+impl<S: Simd> crate::SimdInt<S> for u16x8<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_u16x8(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_u16x8(self)
+    }
+}
 impl<S: Simd> SimdWiden<S> for u16x8<S> {
     type Widened = u32x4<S>;
     #[inline(always)]
@@ -1743,7 +1779,16 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
         self.simd.deinterleave_i32x4(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for i32x4<S> {}
+impl<S: Simd> crate::SimdInt<S> for i32x4<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_i32x4(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_i32x4(self)
+    }
+}
 impl<S: Simd> SimdCvtTruncate<f32x4<S>> for i32x4<S> {
     #[doc = "Convert each floating-point element to a signed 32-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
     #[inline(always)]
@@ -2005,7 +2050,16 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
         self.simd.deinterleave_u32x4(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for u32x4<S> {}
+impl<S: Simd> crate::SimdInt<S> for u32x4<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_u32x4(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_u32x4(self)
+    }
+}
 impl<S: Simd> SimdCvtTruncate<f32x4<S>> for u32x4<S> {
     #[doc = "Convert each floating-point element to an unsigned 32-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results.\n\nOn x86 platforms below AVX-512, this operation will still be slower than converting to `i32`, because there is no native instruction for converting to `u32`.\nIf you know your values fit within range of an `i32`, you should convert to an `i32` and cast to your desired datatype afterwards."]
     #[inline(always)]
@@ -2675,7 +2729,16 @@ impl<S: Simd> SimdBase<S> for i64x2<S> {
         self.simd.deinterleave_i64x2(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for i64x2<S> {}
+impl<S: Simd> crate::SimdInt<S> for i64x2<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_i64x2(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_i64x2(self)
+    }
+}
 impl<S: Simd> SimdCvtTruncate<f64x2<S>> for i64x2<S> {
     #[doc = "Convert each floating-point element to a signed 64-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
     #[inline(always)]
@@ -2930,7 +2993,16 @@ impl<S: Simd> SimdBase<S> for u64x2<S> {
         self.simd.deinterleave_u64x2(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for u64x2<S> {}
+impl<S: Simd> crate::SimdInt<S> for u64x2<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_u64x2(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_u64x2(self)
+    }
+}
 impl<S: Simd> SimdCvtTruncate<f64x2<S>> for u64x2<S> {
     #[doc = "Convert each floating-point element to an unsigned 64-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
     #[inline(always)]
@@ -3628,7 +3700,16 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
         self.simd.deinterleave_i8x32(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for i8x32<S> {}
+impl<S: Simd> crate::SimdInt<S> for i8x32<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_i8x32(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_i8x32(self)
+    }
+}
 impl<S: Simd> SimdWiden<S> for i8x32<S> {
     type Widened = i16x16<S>;
     #[inline(always)]
@@ -3894,7 +3975,16 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
         self.simd.deinterleave_u8x32(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for u8x32<S> {}
+impl<S: Simd> crate::SimdInt<S> for u8x32<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_u8x32(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_u8x32(self)
+    }
+}
 impl<S: Simd> SimdWiden<S> for u8x32<S> {
     type Widened = u16x16<S>;
     #[inline(always)]
@@ -4239,7 +4329,16 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
             .deinterleave_i16x16(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for i16x16<S> {}
+impl<S: Simd> crate::SimdInt<S> for i16x16<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_i16x16(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_i16x16(self)
+    }
+}
 impl<S: Simd> SimdWiden<S> for i16x16<S> {
     type Widened = i32x8<S>;
     #[inline(always)]
@@ -4505,7 +4604,16 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
             .deinterleave_u16x16(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for u16x16<S> {}
+impl<S: Simd> crate::SimdInt<S> for u16x16<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_u16x16(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_u16x16(self)
+    }
+}
 impl<S: Simd> SimdWiden<S> for u16x16<S> {
     type Widened = u32x8<S>;
     #[inline(always)]
@@ -4856,7 +4964,16 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
         self.simd.deinterleave_i32x8(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for i32x8<S> {}
+impl<S: Simd> crate::SimdInt<S> for i32x8<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_i32x8(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_i32x8(self)
+    }
+}
 impl<S: Simd> SimdCvtTruncate<f32x8<S>> for i32x8<S> {
     #[doc = "Convert each floating-point element to a signed 32-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
     #[inline(always)]
@@ -5125,7 +5242,16 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
         self.simd.deinterleave_u32x8(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for u32x8<S> {}
+impl<S: Simd> crate::SimdInt<S> for u32x8<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_u32x8(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_u32x8(self)
+    }
+}
 impl<S: Simd> SimdCvtTruncate<f32x8<S>> for u32x8<S> {
     #[doc = "Convert each floating-point element to an unsigned 32-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results.\n\nOn x86 platforms below AVX-512, this operation will still be slower than converting to `i32`, because there is no native instruction for converting to `u32`.\nIf you know your values fit within range of an `i32`, you should convert to an `i32` and cast to your desired datatype afterwards."]
     #[inline(always)]
@@ -5785,7 +5911,16 @@ impl<S: Simd> SimdBase<S> for i64x4<S> {
         self.simd.deinterleave_i64x4(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for i64x4<S> {}
+impl<S: Simd> crate::SimdInt<S> for i64x4<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_i64x4(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_i64x4(self)
+    }
+}
 impl<S: Simd> SimdCvtTruncate<f64x4<S>> for i64x4<S> {
     #[doc = "Convert each floating-point element to a signed 64-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
     #[inline(always)]
@@ -6035,7 +6170,16 @@ impl<S: Simd> SimdBase<S> for u64x4<S> {
         self.simd.deinterleave_u64x4(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for u64x4<S> {}
+impl<S: Simd> crate::SimdInt<S> for u64x4<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_u64x4(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_u64x4(self)
+    }
+}
 impl<S: Simd> SimdCvtTruncate<f64x4<S>> for u64x4<S> {
     #[doc = "Convert each floating-point element to an unsigned 64-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
     #[inline(always)]
@@ -6764,7 +6908,16 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
         self.simd.deinterleave_i8x64(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for i8x64<S> {}
+impl<S: Simd> crate::SimdInt<S> for i8x64<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_i8x64(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_i8x64(self)
+    }
+}
 impl<S: Simd> SimdWiden<S> for i8x64<S> {
     type Widened = i16x32<S>;
     #[inline(always)]
@@ -7056,7 +7209,16 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
         self.simd.deinterleave_u8x64(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for u8x64<S> {}
+impl<S: Simd> crate::SimdInt<S> for u8x64<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_u8x64(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_u8x64(self)
+    }
+}
 impl<S: Simd> SimdWiden<S> for u8x64<S> {
     type Widened = u16x32<S>;
     #[inline(always)]
@@ -7411,7 +7573,16 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
             .deinterleave_i16x32(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for i16x32<S> {}
+impl<S: Simd> crate::SimdInt<S> for i16x32<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_i16x32(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_i16x32(self)
+    }
+}
 impl<S: Simd> SimdWiden<S> for i16x32<S> {
     type Widened = i32x16<S>;
     #[inline(always)]
@@ -7687,7 +7858,16 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
             .deinterleave_u16x32(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for u16x32<S> {}
+impl<S: Simd> crate::SimdInt<S> for u16x32<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_u16x32(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_u16x32(self)
+    }
+}
 impl<S: Simd> SimdWiden<S> for u16x32<S> {
     type Widened = u32x16<S>;
     #[inline(always)]
@@ -8041,7 +8221,16 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
             .deinterleave_i32x16(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for i32x16<S> {}
+impl<S: Simd> crate::SimdInt<S> for i32x16<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_i32x16(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_i32x16(self)
+    }
+}
 impl<S: Simd> SimdCvtTruncate<f32x16<S>> for i32x16<S> {
     #[doc = "Convert each floating-point element to a signed 32-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
     #[inline(always)]
@@ -8313,7 +8502,16 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
             .deinterleave_u32x16(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for u32x16<S> {}
+impl<S: Simd> crate::SimdInt<S> for u32x16<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_u32x16(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_u32x16(self)
+    }
+}
 impl<S: Simd> SimdCvtTruncate<f32x16<S>> for u32x16<S> {
     #[doc = "Convert each floating-point element to an unsigned 32-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results.\n\nOn x86 platforms below AVX-512, this operation will still be slower than converting to `i32`, because there is no native instruction for converting to `u32`.\nIf you know your values fit within range of an `i32`, you should convert to an `i32` and cast to your desired datatype afterwards."]
     #[inline(always)]
@@ -8985,7 +9183,16 @@ impl<S: Simd> SimdBase<S> for i64x8<S> {
         self.simd.deinterleave_i64x8(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for i64x8<S> {}
+impl<S: Simd> crate::SimdInt<S> for i64x8<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_i64x8(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_i64x8(self)
+    }
+}
 impl<S: Simd> SimdCvtTruncate<f64x8<S>> for i64x8<S> {
     #[doc = "Convert each floating-point element to a signed 64-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
     #[inline(always)]
@@ -9241,7 +9448,16 @@ impl<S: Simd> SimdBase<S> for u64x8<S> {
         self.simd.deinterleave_u64x8(self, rhs.simd_into(self.simd))
     }
 }
-impl<S: Simd> crate::SimdInt<S> for u64x8<S> {}
+impl<S: Simd> crate::SimdInt<S> for u64x8<S> {
+    #[inline(always)]
+    fn count_ones(self) -> Self {
+        self.simd.count_ones_u64x8(self)
+    }
+    #[inline(always)]
+    fn count_zeros(self) -> Self {
+        self.simd.count_zeros_u64x8(self)
+    }
+}
 impl<S: Simd> SimdCvtTruncate<f64x8<S>> for u64x8<S> {
     #[doc = "Convert each floating-point element to an unsigned 64-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
     #[inline(always)]

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -719,6 +719,32 @@ impl Simd for Sse2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        [
+            i8::try_from(a[0usize].count_ones()).unwrap(),
+            i8::try_from(a[1usize].count_ones()).unwrap(),
+            i8::try_from(a[2usize].count_ones()).unwrap(),
+            i8::try_from(a[3usize].count_ones()).unwrap(),
+            i8::try_from(a[4usize].count_ones()).unwrap(),
+            i8::try_from(a[5usize].count_ones()).unwrap(),
+            i8::try_from(a[6usize].count_ones()).unwrap(),
+            i8::try_from(a[7usize].count_ones()).unwrap(),
+            i8::try_from(a[8usize].count_ones()).unwrap(),
+            i8::try_from(a[9usize].count_ones()).unwrap(),
+            i8::try_from(a[10usize].count_ones()).unwrap(),
+            i8::try_from(a[11usize].count_ones()).unwrap(),
+            i8::try_from(a[12usize].count_ones()).unwrap(),
+            i8::try_from(a[13usize].count_ones()).unwrap(),
+            i8::try_from(a[14usize].count_ones()).unwrap(),
+            i8::try_from(a[15usize].count_ones()).unwrap(),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        self.count_ones_i8x16(self.not_i8x16(a))
+    }
+    #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1306,6 +1332,32 @@ impl Simd for Sse2 {
         }
         let result: u8x16<Self> = output.simd_into(self);
         Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        [
+            u8::try_from(a[0usize].count_ones()).unwrap(),
+            u8::try_from(a[1usize].count_ones()).unwrap(),
+            u8::try_from(a[2usize].count_ones()).unwrap(),
+            u8::try_from(a[3usize].count_ones()).unwrap(),
+            u8::try_from(a[4usize].count_ones()).unwrap(),
+            u8::try_from(a[5usize].count_ones()).unwrap(),
+            u8::try_from(a[6usize].count_ones()).unwrap(),
+            u8::try_from(a[7usize].count_ones()).unwrap(),
+            u8::try_from(a[8usize].count_ones()).unwrap(),
+            u8::try_from(a[9usize].count_ones()).unwrap(),
+            u8::try_from(a[10usize].count_ones()).unwrap(),
+            u8::try_from(a[11usize].count_ones()).unwrap(),
+            u8::try_from(a[12usize].count_ones()).unwrap(),
+            u8::try_from(a[13usize].count_ones()).unwrap(),
+            u8::try_from(a[14usize].count_ones()).unwrap(),
+            u8::try_from(a[15usize].count_ones()).unwrap(),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        self.count_ones_u8x16(self.not_u8x16(a))
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1957,6 +2009,24 @@ impl Simd for Sse2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        [
+            i16::try_from(a[0usize].count_ones()).unwrap(),
+            i16::try_from(a[1usize].count_ones()).unwrap(),
+            i16::try_from(a[2usize].count_ones()).unwrap(),
+            i16::try_from(a[3usize].count_ones()).unwrap(),
+            i16::try_from(a[4usize].count_ones()).unwrap(),
+            i16::try_from(a[5usize].count_ones()).unwrap(),
+            i16::try_from(a[6usize].count_ones()).unwrap(),
+            i16::try_from(a[7usize].count_ones()).unwrap(),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        self.count_ones_i16x8(self.not_i16x8(a))
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2363,6 +2433,24 @@ impl Simd for Sse2 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        [
+            u16::try_from(a[0usize].count_ones()).unwrap(),
+            u16::try_from(a[1usize].count_ones()).unwrap(),
+            u16::try_from(a[2usize].count_ones()).unwrap(),
+            u16::try_from(a[3usize].count_ones()).unwrap(),
+            u16::try_from(a[4usize].count_ones()).unwrap(),
+            u16::try_from(a[5usize].count_ones()).unwrap(),
+            u16::try_from(a[6usize].count_ones()).unwrap(),
+            u16::try_from(a[7usize].count_ones()).unwrap(),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        self.count_ones_u16x8(self.not_u16x8(a))
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2969,6 +3057,20 @@ impl Simd for Sse2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        [
+            a[0usize].count_ones().cast_signed(),
+            a[1usize].count_ones().cast_signed(),
+            a[2usize].count_ones().cast_signed(),
+            a[3usize].count_ones().cast_signed(),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        self.count_ones_i32x4(self.not_i32x4(a))
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3394,6 +3496,20 @@ impl Simd for Sse2 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        [
+            a[0usize].count_ones(),
+            a[1usize].count_ones(),
+            a[2usize].count_ones(),
+            a[3usize].count_ones(),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        self.count_ones_u32x4(self.not_u32x4(a))
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4426,6 +4542,18 @@ impl Simd for Sse2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        [
+            i64::from(a[0usize].count_ones()),
+            i64::from(a[1usize].count_ones()),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        self.count_ones_i64x2(self.not_i64x2(a))
+    }
+    #[inline(always)]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -4787,6 +4915,18 @@ impl Simd for Sse2 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        [
+            u64::from(a[0usize].count_ones()),
+            u64::from(a[1usize].count_ones()),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        self.count_ones_u64x2(self.not_u64x2(a))
     }
     #[inline(always)]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -742,7 +742,25 @@ impl Simd for Sse2 {
     }
     #[inline(always)]
     fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
-        self.count_ones_i8x16(self.not_i8x16(a))
+        [
+            i8::try_from(a[0usize].count_zeros()).unwrap(),
+            i8::try_from(a[1usize].count_zeros()).unwrap(),
+            i8::try_from(a[2usize].count_zeros()).unwrap(),
+            i8::try_from(a[3usize].count_zeros()).unwrap(),
+            i8::try_from(a[4usize].count_zeros()).unwrap(),
+            i8::try_from(a[5usize].count_zeros()).unwrap(),
+            i8::try_from(a[6usize].count_zeros()).unwrap(),
+            i8::try_from(a[7usize].count_zeros()).unwrap(),
+            i8::try_from(a[8usize].count_zeros()).unwrap(),
+            i8::try_from(a[9usize].count_zeros()).unwrap(),
+            i8::try_from(a[10usize].count_zeros()).unwrap(),
+            i8::try_from(a[11usize].count_zeros()).unwrap(),
+            i8::try_from(a[12usize].count_zeros()).unwrap(),
+            i8::try_from(a[13usize].count_zeros()).unwrap(),
+            i8::try_from(a[14usize].count_zeros()).unwrap(),
+            i8::try_from(a[15usize].count_zeros()).unwrap(),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
@@ -1357,7 +1375,25 @@ impl Simd for Sse2 {
     }
     #[inline(always)]
     fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
-        self.count_ones_u8x16(self.not_u8x16(a))
+        [
+            u8::try_from(a[0usize].count_zeros()).unwrap(),
+            u8::try_from(a[1usize].count_zeros()).unwrap(),
+            u8::try_from(a[2usize].count_zeros()).unwrap(),
+            u8::try_from(a[3usize].count_zeros()).unwrap(),
+            u8::try_from(a[4usize].count_zeros()).unwrap(),
+            u8::try_from(a[5usize].count_zeros()).unwrap(),
+            u8::try_from(a[6usize].count_zeros()).unwrap(),
+            u8::try_from(a[7usize].count_zeros()).unwrap(),
+            u8::try_from(a[8usize].count_zeros()).unwrap(),
+            u8::try_from(a[9usize].count_zeros()).unwrap(),
+            u8::try_from(a[10usize].count_zeros()).unwrap(),
+            u8::try_from(a[11usize].count_zeros()).unwrap(),
+            u8::try_from(a[12usize].count_zeros()).unwrap(),
+            u8::try_from(a[13usize].count_zeros()).unwrap(),
+            u8::try_from(a[14usize].count_zeros()).unwrap(),
+            u8::try_from(a[15usize].count_zeros()).unwrap(),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -2024,7 +2060,17 @@ impl Simd for Sse2 {
     }
     #[inline(always)]
     fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
-        self.count_ones_i16x8(self.not_i16x8(a))
+        [
+            i16::try_from(a[0usize].count_zeros()).unwrap(),
+            i16::try_from(a[1usize].count_zeros()).unwrap(),
+            i16::try_from(a[2usize].count_zeros()).unwrap(),
+            i16::try_from(a[3usize].count_zeros()).unwrap(),
+            i16::try_from(a[4usize].count_zeros()).unwrap(),
+            i16::try_from(a[5usize].count_zeros()).unwrap(),
+            i16::try_from(a[6usize].count_zeros()).unwrap(),
+            i16::try_from(a[7usize].count_zeros()).unwrap(),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
@@ -2450,7 +2496,17 @@ impl Simd for Sse2 {
     }
     #[inline(always)]
     fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
-        self.count_ones_u16x8(self.not_u16x8(a))
+        [
+            u16::try_from(a[0usize].count_zeros()).unwrap(),
+            u16::try_from(a[1usize].count_zeros()).unwrap(),
+            u16::try_from(a[2usize].count_zeros()).unwrap(),
+            u16::try_from(a[3usize].count_zeros()).unwrap(),
+            u16::try_from(a[4usize].count_zeros()).unwrap(),
+            u16::try_from(a[5usize].count_zeros()).unwrap(),
+            u16::try_from(a[6usize].count_zeros()).unwrap(),
+            u16::try_from(a[7usize].count_zeros()).unwrap(),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -3068,7 +3124,13 @@ impl Simd for Sse2 {
     }
     #[inline(always)]
     fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
-        self.count_ones_i32x4(self.not_i32x4(a))
+        [
+            a[0usize].count_zeros().cast_signed(),
+            a[1usize].count_zeros().cast_signed(),
+            a[2usize].count_zeros().cast_signed(),
+            a[3usize].count_zeros().cast_signed(),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
@@ -3509,7 +3571,13 @@ impl Simd for Sse2 {
     }
     #[inline(always)]
     fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
-        self.count_ones_u32x4(self.not_u32x4(a))
+        [
+            a[0usize].count_zeros(),
+            a[1usize].count_zeros(),
+            a[2usize].count_zeros(),
+            a[3usize].count_zeros(),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4551,7 +4619,11 @@ impl Simd for Sse2 {
     }
     #[inline(always)]
     fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
-        self.count_ones_i64x2(self.not_i64x2(a))
+        [
+            i64::from(a[0usize].count_zeros()),
+            i64::from(a[1usize].count_zeros()),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
@@ -4926,7 +4998,11 @@ impl Simd for Sse2 {
     }
     #[inline(always)]
     fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
-        self.count_ones_u64x2(self.not_u64x2(a))
+        [
+            u64::from(a[0usize].count_zeros()),
+            u64::from(a[1usize].count_zeros()),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -807,6 +807,29 @@ impl Simd for Sse4_2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i8x16<Sse4_2>) -> i8x16<Sse4_2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                byte_counts.simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        self.count_ones_i8x16(self.not_i8x16(a))
+    }
+    #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1271,6 +1294,29 @@ impl Simd for Sse4_2 {
             }
         );
         kernel(self, a, indices)
+    }
+    #[inline(always)]
+    fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u8x16<Sse4_2>) -> u8x16<Sse4_2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                byte_counts.simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        self.count_ones_u8x16(self.not_u8x16(a))
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1846,6 +1892,29 @@ impl Simd for Sse4_2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i16x8<Sse4_2>) -> i16x8<Sse4_2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                _mm_maddubs_epi16(byte_counts, _mm_set1_epi8(1)).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        self.count_ones_i16x8(self.not_i16x8(a))
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2258,6 +2327,29 @@ impl Simd for Sse4_2 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u16x8<Sse4_2>) -> u16x8<Sse4_2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                _mm_maddubs_epi16(byte_counts, _mm_set1_epi8(1)).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        self.count_ones_u16x8(self.not_u16x8(a))
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2836,6 +2928,33 @@ impl Simd for Sse4_2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i32x4<Sse4_2>) -> i32x4<Sse4_2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                _mm_madd_epi16(
+                    _mm_maddubs_epi16(byte_counts, _mm_set1_epi8(1)),
+                    _mm_set1_epi16(1),
+                )
+                .simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        self.count_ones_i32x4(self.not_i32x4(a))
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3238,6 +3357,33 @@ impl Simd for Sse4_2 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u32x4<Sse4_2>) -> u32x4<Sse4_2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                _mm_madd_epi16(
+                    _mm_maddubs_epi16(byte_counts, _mm_set1_epi8(1)),
+                    _mm_set1_epi16(1),
+                )
+                .simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        self.count_ones_u32x4(self.not_u32x4(a))
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4340,6 +4486,29 @@ impl Simd for Sse4_2 {
         })
     }
     #[inline(always)]
+    fn count_ones_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i64x2<Sse4_2>) -> i64x2<Sse4_2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                _mm_sad_epu8(byte_counts, _mm_setzero_si128()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        self.count_ones_i64x2(self.not_i64x2(a))
+    }
+    #[inline(always)]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -4710,6 +4879,29 @@ impl Simd for Sse4_2 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u64x2<Sse4_2>) -> u64x2<Sse4_2> {
+                let value = a.into();
+                let nibble_mask = _mm_set1_epi8(0x0f);
+                let lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+                let low = _mm_and_si128(value, nibble_mask);
+                let high = _mm_and_si128(_mm_srli_epi16::<4>(value), nibble_mask);
+                let byte_counts = _mm_add_epi8(
+                    _mm_shuffle_epi8(lookup, low),
+                    _mm_shuffle_epi8(lookup, high),
+                );
+                _mm_sad_epu8(byte_counts, _mm_setzero_si128()).simd_into(token)
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        self.count_ones_u64x2(self.not_u64x2(a))
     }
     #[inline(always)]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -505,6 +505,14 @@ impl Simd for WasmSimd128 {
         })
     }
     #[inline(always)]
+    fn count_ones_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        i8x16_popcnt(a.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        self.count_ones_i8x16(self.not_i8x16(a))
+    }
+    #[inline(always)]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         i8x16_add(a.into(), b.into()).simd_into(self)
     }
@@ -792,6 +800,14 @@ impl Simd for WasmSimd128 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        i8x16_popcnt(a.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        self.count_ones_u8x16(self.not_u8x16(a))
     }
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1140,6 +1156,14 @@ impl Simd for WasmSimd128 {
         })
     }
     #[inline(always)]
+    fn count_ones_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        u16x8_extadd_pairwise_u8x16(i8x16_popcnt(a.into())).simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        self.count_ones_i16x8(self.not_i16x8(a))
+    }
+    #[inline(always)]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         i16x8_add(a.into(), b.into()).simd_into(self)
     }
@@ -1364,6 +1388,14 @@ impl Simd for WasmSimd128 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        u16x8_extadd_pairwise_u8x16(i8x16_popcnt(a.into())).simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        self.count_ones_u16x8(self.not_u16x8(a))
     }
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -1675,6 +1707,15 @@ impl Simd for WasmSimd128 {
         })
     }
     #[inline(always)]
+    fn count_ones_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        u32x4_extadd_pairwise_u16x8(u16x8_extadd_pairwise_u8x16(i8x16_popcnt(a.into())))
+            .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        self.count_ones_i32x4(self.not_i32x4(a))
+    }
+    #[inline(always)]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         i32x4_add(a.into(), b.into()).simd_into(self)
     }
@@ -1895,6 +1936,15 @@ impl Simd for WasmSimd128 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        u32x4_extadd_pairwise_u16x8(u16x8_extadd_pairwise_u8x16(i8x16_popcnt(a.into())))
+            .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        self.count_ones_u32x4(self.not_u32x4(a))
     }
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -2474,6 +2524,21 @@ impl Simd for WasmSimd128 {
         })
     }
     #[inline(always)]
+    fn count_ones_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        {
+            let counts =
+                u32x4_extadd_pairwise_u16x8(u16x8_extadd_pairwise_u8x16(i8x16_popcnt(a.into())));
+            let even = u32x4_shuffle::<0, 2, 0, 2>(counts, counts);
+            let odd = u32x4_shuffle::<1, 3, 1, 3>(counts, counts);
+            i64x2_add(u64x2_extend_low_u32x4(even), u64x2_extend_low_u32x4(odd))
+        }
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        self.count_ones_i64x2(self.not_i64x2(a))
+    }
+    #[inline(always)]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         i64x2_add(a.into(), b.into()).simd_into(self)
     }
@@ -2692,6 +2757,21 @@ impl Simd for WasmSimd128 {
             val: crate::support::Aligned128(result),
             simd: self,
         })
+    }
+    #[inline(always)]
+    fn count_ones_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        {
+            let counts =
+                u32x4_extadd_pairwise_u16x8(u16x8_extadd_pairwise_u8x16(i8x16_popcnt(a.into())));
+            let even = u32x4_shuffle::<0, 2, 0, 2>(counts, counts);
+            let odd = u32x4_shuffle::<1, 3, 1, 3>(counts, counts);
+            i64x2_add(u64x2_extend_low_u32x4(even), u64x2_extend_low_u32x4(odd))
+        }
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        self.count_ones_u64x2(self.not_u64x2(a))
     }
     #[inline(always)]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -18,6 +18,23 @@ pub(crate) fn fallback_method(op: Op, vec_ty: &VecType) -> TokenStream {
     crate::mk_fallback::Fallback.make_method(op, vec_ty)
 }
 
+/// Implement `count_zeros` in terms of `count_ones`, matching the scalar and
+/// portable-SIMD formulations.
+pub(crate) fn count_zeros_method(op: Op, vec_ty: &VecType) -> TokenStream {
+    assert_eq!(
+        op.method, "count_zeros",
+        "count_zeros_method only implements count_zeros"
+    );
+    let method_sig = op.simd_trait_method_sig(vec_ty);
+    let not = generic_op_name("not", vec_ty);
+    let count_ones = generic_op_name("count_ones", vec_ty);
+    quote! {
+        #method_sig {
+            self.#count_ones(self.#not(a))
+        }
+    }
+}
+
 /// Implement a typed byte swizzle by forwarding to the corresponding byte-vector operation.
 pub(crate) fn byte_swizzle_op(op: &Op, vec_ty: &VecType) -> TokenStream {
     assert!(

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -3,8 +3,8 @@
 
 use crate::arch::fallback;
 use crate::generic::{
-    generic_mask_from_bitmask, generic_mask_set, generic_mask_to_bitmask, generic_op_name,
-    integer_lane_mask_splat_arg,
+    count_zeros_method, generic_mask_from_bitmask, generic_mask_set, generic_mask_to_bitmask,
+    generic_op_name, integer_lane_mask_splat_arg,
 };
 use crate::level::Level;
 use crate::ops::{NarrowingMode, Op, OpSig, relaxed_narrow_method};
@@ -141,6 +141,33 @@ pub(crate) fn float_ext_prelude() -> TokenStream {
     }
 }
 
+fn count_ones_method(op: Op, vec_ty: &VecType) -> TokenStream {
+    let method_sig = op.simd_trait_method_sig(vec_ty);
+    let scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
+    let items = make_list(
+        (0..vec_ty.len)
+            .map(|idx| {
+                let value = lane(quote! { a }, vec_ty, idx);
+                match (vec_ty.scalar, vec_ty.scalar_bits) {
+                    (ScalarType::Unsigned, 32) => quote! { #value.count_ones() },
+                    (ScalarType::Int, 32) => quote! { #value.count_ones().cast_signed() },
+                    (_, 64) => quote! { #scalar::from(#value.count_ones()) },
+                    (_, 8 | 16) => {
+                        quote! { #scalar::try_from(#value.count_ones()).unwrap() }
+                    }
+                    _ => unreachable!(),
+                }
+            })
+            .collect::<Vec<_>>(),
+    );
+
+    quote! {
+        #method_sig {
+            #items.simd_into(self)
+        }
+    }
+}
+
 impl Level for Fallback {
     fn name(&self) -> &'static str {
         "Fallback"
@@ -216,6 +243,14 @@ impl Level for Fallback {
                 }
             }
             OpSig::Unary => {
+                if method == "count_zeros" {
+                    return count_zeros_method(op, vec_ty);
+                }
+
+                if method == "count_ones" {
+                    return count_ones_method(op, vec_ty);
+                }
+
                 if method == "approximate_recip" {
                     return quote! {
                         #method_sig {

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -3,8 +3,8 @@
 
 use crate::arch::fallback;
 use crate::generic::{
-    count_zeros_method, generic_mask_from_bitmask, generic_mask_set, generic_mask_to_bitmask,
-    generic_op_name, integer_lane_mask_splat_arg,
+    generic_mask_from_bitmask, generic_mask_set, generic_mask_to_bitmask, generic_op_name,
+    integer_lane_mask_splat_arg,
 };
 use crate::level::Level;
 use crate::ops::{NarrowingMode, Op, OpSig, relaxed_narrow_method};
@@ -141,7 +141,12 @@ pub(crate) fn float_ext_prelude() -> TokenStream {
     }
 }
 
-fn count_ones_method(op: Op, vec_ty: &VecType) -> TokenStream {
+fn count_bits_method(op: Op, vec_ty: &VecType) -> TokenStream {
+    let count = match op.method {
+        "count_ones" => quote! { count_ones },
+        "count_zeros" => quote! { count_zeros },
+        _ => unreachable!("count_bits_method only implements bit-counting operations"),
+    };
     let method_sig = op.simd_trait_method_sig(vec_ty);
     let scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
     let items = make_list(
@@ -149,11 +154,11 @@ fn count_ones_method(op: Op, vec_ty: &VecType) -> TokenStream {
             .map(|idx| {
                 let value = lane(quote! { a }, vec_ty, idx);
                 match (vec_ty.scalar, vec_ty.scalar_bits) {
-                    (ScalarType::Unsigned, 32) => quote! { #value.count_ones() },
-                    (ScalarType::Int, 32) => quote! { #value.count_ones().cast_signed() },
-                    (_, 64) => quote! { #scalar::from(#value.count_ones()) },
+                    (ScalarType::Unsigned, 32) => quote! { #value.#count() },
+                    (ScalarType::Int, 32) => quote! { #value.#count().cast_signed() },
+                    (_, 64) => quote! { #scalar::from(#value.#count()) },
                     (_, 8 | 16) => {
-                        quote! { #scalar::try_from(#value.count_ones()).unwrap() }
+                        quote! { #scalar::try_from(#value.#count()).unwrap() }
                     }
                     _ => unreachable!(),
                 }
@@ -243,12 +248,8 @@ impl Level for Fallback {
                 }
             }
             OpSig::Unary => {
-                if method == "count_zeros" {
-                    return count_zeros_method(op, vec_ty);
-                }
-
-                if method == "count_ones" {
-                    return count_ones_method(op, vec_ty);
+                if matches!(method, "count_ones" | "count_zeros") {
+                    return count_bits_method(op, vec_ty);
                 }
 
                 if method == "approximate_recip" {

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -5,7 +5,8 @@ use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{ToTokens as _, format_ident, quote};
 
 use crate::generic::{
-    fallback_method, generic_mask_set, generic_op_name, integer_lane_mask_splat_arg,
+    count_zeros_method, fallback_method, generic_mask_set, generic_op_name,
+    integer_lane_mask_splat_arg,
 };
 use crate::level::Level;
 use crate::ops::{NarrowingMode, Op, SlideGranularity, relaxed_narrow_method};
@@ -17,6 +18,51 @@ use crate::{
 
 #[derive(Clone, Copy)]
 pub(crate) struct Neon;
+
+impl Neon {
+    fn handle_count_ones(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+        let input = match vec_ty.scalar {
+            ScalarType::Unsigned if vec_ty.scalar_bits == 8 => quote! { a.into() },
+            ScalarType::Unsigned => {
+                let reinterpret = Ident::new(
+                    &format!("vreinterpretq_u8_u{}", vec_ty.scalar_bits),
+                    Span::call_site(),
+                );
+                quote! { #reinterpret(a.into()) }
+            }
+            ScalarType::Int => {
+                let reinterpret = Ident::new(
+                    &format!("vreinterpretq_u8_s{}", vec_ty.scalar_bits),
+                    Span::call_site(),
+                );
+                quote! { #reinterpret(a.into()) }
+            }
+            _ => unreachable!("count_ones is only defined for integers"),
+        };
+        let count = match vec_ty.scalar_bits {
+            8 => quote! { vcntq_u8(#input) },
+            16 => quote! { vpaddlq_u8(vcntq_u8(#input)) },
+            32 => quote! { vpaddlq_u16(vpaddlq_u8(vcntq_u8(#input))) },
+            64 => quote! { vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(vcntq_u8(#input)))) },
+            _ => unreachable!(),
+        };
+        let result = if vec_ty.scalar == ScalarType::Int {
+            let reinterpret = Ident::new(
+                &format!(
+                    "vreinterpretq_s{}_u{}",
+                    vec_ty.scalar_bits, vec_ty.scalar_bits
+                ),
+                Span::call_site(),
+            );
+            quote! { #reinterpret(#count) }
+        } else {
+            count
+        };
+        self.kernel_method(op, vec_ty, |token| {
+            quote! { #result.simd_into(#token) }
+        })
+    }
+}
 
 fn neon_multi_vector_ty(vec_ty: &VecType, count: u16) -> Ident {
     let scalar = match vec_ty.scalar {
@@ -138,6 +184,14 @@ impl Level for Neon {
                 })
             }
             OpSig::Unary => {
+                if method == "count_zeros" {
+                    return count_zeros_method(op, vec_ty);
+                }
+
+                if method == "count_ones" {
+                    return self.handle_count_ones(op, vec_ty);
+                }
+
                 let args = [quote! { a.into() }];
 
                 let expr = neon::expr(method, vec_ty, &args);

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -6,8 +6,9 @@ use quote::{format_ident, quote};
 
 use crate::arch::wasm::{arch_prefix, v128_intrinsic};
 use crate::generic::{
-    fallback_method, generic_block_combine, generic_block_split, generic_mask_set, generic_op_name,
-    integer_lane_mask_splat_arg, recursive_swizzle_dyn_precise_body,
+    count_zeros_method, fallback_method, generic_block_combine, generic_block_split,
+    generic_mask_set, generic_op_name, integer_lane_mask_splat_arg,
+    recursive_swizzle_dyn_precise_body,
 };
 use crate::level::Level;
 use crate::ops::{NarrowingMode, Op, Quantifier, SlideGranularity, relaxed_narrow_method};
@@ -91,6 +92,40 @@ fn mask_to_bitmask(method_sig: TokenStream, vec_ty: &VecType) -> TokenStream {
     }
 }
 
+fn count_ones_method(op: Op, vec_ty: &VecType) -> TokenStream {
+    let method_sig = op.simd_trait_method_sig(vec_ty);
+    let expr = match vec_ty.scalar_bits {
+        8 => quote! { i8x16_popcnt(a.into()) },
+        16 => quote! {
+            u16x8_extadd_pairwise_u8x16(i8x16_popcnt(a.into()))
+        },
+        32 => quote! {
+            u32x4_extadd_pairwise_u16x8(
+                u16x8_extadd_pairwise_u8x16(i8x16_popcnt(a.into()))
+            )
+        },
+        64 => quote! {
+            {
+                let counts = u32x4_extadd_pairwise_u16x8(
+                    u16x8_extadd_pairwise_u8x16(i8x16_popcnt(a.into()))
+                );
+                let even = u32x4_shuffle::<0, 2, 0, 2>(counts, counts);
+                let odd = u32x4_shuffle::<1, 3, 1, 3>(counts, counts);
+                i64x2_add(
+                    u64x2_extend_low_u32x4(even),
+                    u64x2_extend_low_u32x4(odd),
+                )
+            }
+        },
+        _ => unreachable!(),
+    };
+    quote! {
+        #method_sig {
+            #expr.simd_into(self)
+        }
+    }
+}
+
 impl Level for WasmSimd128 {
     fn name(&self) -> &'static str {
         "WasmSimd128"
@@ -165,6 +200,14 @@ impl Level for WasmSimd128 {
                 }
             }
             OpSig::Unary => {
+                if method == "count_zeros" {
+                    return count_zeros_method(op, vec_ty);
+                }
+
+                if method == "count_ones" {
+                    return count_ones_method(op, vec_ty);
+                }
+
                 let args = [quote! { a.into() }];
                 let expr = if matches!(method, "fract") {
                     assert_eq!(

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -1105,6 +1105,13 @@ impl X86 {
         }
     }
 
+    fn handle_count_zeros(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+        match *self {
+            Self::Sse2 => fallback_method(op, vec_ty), // slightly faster than going through the generic code
+            Self::Sse4_2 | Self::Avx2 | Self::Avx512 => count_zeros_method(op, vec_ty),
+        }
+    }
+
     pub(crate) fn handle_splat(&self, op: Op, vec_ty: &VecType) -> TokenStream {
         if *self == Self::Avx512 && vec_ty.scalar == ScalarType::Mask {
             let lane_mask = avx512_mask_lane_bits(vec_ty);
@@ -1455,7 +1462,7 @@ impl X86 {
         vec_ty: &VecType,
     ) -> TokenStream {
         if method == "count_zeros" {
-            return count_zeros_method(op, vec_ty);
+            return self.handle_count_zeros(op, vec_ty);
         }
 
         if method == "count_ones" {

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -1048,61 +1048,61 @@ fn interleaved_store_indices(len: usize, block_count: usize) -> Vec<usize> {
 
 impl X86 {
     fn handle_count_ones(&self, op: Op, vec_ty: &VecType) -> TokenStream {
-        if *self == Self::Sse2 {
-            return fallback_method(op, vec_ty);
-        }
-
-        if *self == Self::Avx512 {
-            let suffix = format!("epi{}", vec_ty.scalar_bits);
-            let popcnt = intrinsic_ident("popcnt", &suffix, vec_ty.n_bits());
-            return self.kernel_method(op, vec_ty, |token| {
-                quote! { #popcnt(a.into()).simd_into(#token) }
-            });
-        }
-
-        let bits = vec_ty.n_bits();
-        let set1_epi8 = intrinsic_ident("set1", "epi8", bits);
-        let set1_epi16 = intrinsic_ident("set1", "epi16", bits);
-        let setzero = intrinsic_ident("setzero", coarse_type(vec_ty), bits);
-        let and = intrinsic_ident("and", coarse_type(vec_ty), bits);
-        let shift = intrinsic_ident("srli", "epi16", bits);
-        let shuffle = intrinsic_ident("shuffle", "epi8", bits);
-        let add = intrinsic_ident("add", "epi8", bits);
-        let maddubs = intrinsic_ident("maddubs", "epi16", bits);
-        let madd = intrinsic_ident("madd", "epi16", bits);
-        let sad = intrinsic_ident("sad", "epu8", bits);
-        let lookup = match bits {
-            128 => quote! {
-                _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4)
-            },
-            256 => quote! {
-                _mm256_setr_epi8(
-                    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
-                    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
-                )
-            },
-            _ => unreachable!(),
-        };
-        self.kernel_method(op, vec_ty, |token| {
-            let combine = match vec_ty.scalar_bits {
-                8 => quote! { byte_counts },
-                16 => quote! { #maddubs(byte_counts, #set1_epi8(1)) },
-                32 => quote! {
-                    #madd(#maddubs(byte_counts, #set1_epi8(1)), #set1_epi16(1))
-                },
-                64 => quote! { #sad(byte_counts, #setzero()) },
-                _ => unreachable!(),
-            };
-            quote! {
-                let value = a.into();
-                let nibble_mask = #set1_epi8(0x0f);
-                let lookup = #lookup;
-                let low = #and(value, nibble_mask);
-                let high = #and(#shift::<4>(value), nibble_mask);
-                let byte_counts = #add(#shuffle(lookup, low), #shuffle(lookup, high));
-                #combine.simd_into(#token)
+        match *self {
+            Self::Avx512 => {
+                let suffix = format!("epi{}", vec_ty.scalar_bits);
+                let popcnt = intrinsic_ident("popcnt", &suffix, vec_ty.n_bits());
+                self.kernel_method(op, vec_ty, |token| {
+                    quote! { #popcnt(a.into()).simd_into(#token) }
+                })
             }
-        })
+            Self::Sse4_2 | Self::Avx2 => {
+                let bits = vec_ty.n_bits();
+                let set1_epi8 = intrinsic_ident("set1", "epi8", bits);
+                let set1_epi16 = intrinsic_ident("set1", "epi16", bits);
+                let setzero = intrinsic_ident("setzero", coarse_type(vec_ty), bits);
+                let and = intrinsic_ident("and", coarse_type(vec_ty), bits);
+                let shift = intrinsic_ident("srli", "epi16", bits);
+                let shuffle = intrinsic_ident("shuffle", "epi8", bits);
+                let add = intrinsic_ident("add", "epi8", bits);
+                let maddubs = intrinsic_ident("maddubs", "epi16", bits);
+                let madd = intrinsic_ident("madd", "epi16", bits);
+                let sad = intrinsic_ident("sad", "epu8", bits);
+                let lookup = match bits {
+                    128 => quote! {
+                        _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4)
+                    },
+                    256 => quote! {
+                        _mm256_setr_epi8(
+                            0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
+                            0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
+                        )
+                    },
+                    _ => unreachable!(),
+                };
+                self.kernel_method(op, vec_ty, |token| {
+                    let combine = match vec_ty.scalar_bits {
+                        8 => quote! { byte_counts },
+                        16 => quote! { #maddubs(byte_counts, #set1_epi8(1)) },
+                        32 => quote! {
+                            #madd(#maddubs(byte_counts, #set1_epi8(1)), #set1_epi16(1))
+                        },
+                        64 => quote! { #sad(byte_counts, #setzero()) },
+                        _ => unreachable!(),
+                    };
+                    quote! {
+                        let value = a.into();
+                        let nibble_mask = #set1_epi8(0x0f);
+                        let lookup = #lookup;
+                        let low = #and(value, nibble_mask);
+                        let high = #and(#shift::<4>(value), nibble_mask);
+                        let byte_counts = #add(#shuffle(lookup, low), #shuffle(lookup, high));
+                        #combine.simd_into(#token)
+                    }
+                })
+            }
+            Self::Sse2 => fallback_method(op, vec_ty),
+        }
     }
 
     pub(crate) fn handle_splat(&self, op: Op, vec_ty: &VecType) -> TokenStream {

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -7,8 +7,8 @@ use crate::arch::x86::{
     unpack_intrinsic,
 };
 use crate::generic::{
-    fallback_method, generic_block_combine, generic_block_split, generic_mask_from_bitmask,
-    generic_mask_set, generic_op_name, integer_lane_mask_splat_arg,
+    count_zeros_method, fallback_method, generic_block_combine, generic_block_split,
+    generic_mask_from_bitmask, generic_mask_set, generic_op_name, integer_lane_mask_splat_arg,
     recursive_swizzle_dyn_precise_body,
 };
 use crate::level::Level;
@@ -1047,6 +1047,64 @@ fn interleaved_store_indices(len: usize, block_count: usize) -> Vec<usize> {
 }
 
 impl X86 {
+    fn handle_count_ones(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+        if *self == Self::Sse2 {
+            return fallback_method(op, vec_ty);
+        }
+
+        if *self == Self::Avx512 {
+            let suffix = format!("epi{}", vec_ty.scalar_bits);
+            let popcnt = intrinsic_ident("popcnt", &suffix, vec_ty.n_bits());
+            return self.kernel_method(op, vec_ty, |token| {
+                quote! { #popcnt(a.into()).simd_into(#token) }
+            });
+        }
+
+        let bits = vec_ty.n_bits();
+        let set1_epi8 = intrinsic_ident("set1", "epi8", bits);
+        let set1_epi16 = intrinsic_ident("set1", "epi16", bits);
+        let setzero = intrinsic_ident("setzero", coarse_type(vec_ty), bits);
+        let and = intrinsic_ident("and", coarse_type(vec_ty), bits);
+        let shift = intrinsic_ident("srli", "epi16", bits);
+        let shuffle = intrinsic_ident("shuffle", "epi8", bits);
+        let add = intrinsic_ident("add", "epi8", bits);
+        let maddubs = intrinsic_ident("maddubs", "epi16", bits);
+        let madd = intrinsic_ident("madd", "epi16", bits);
+        let sad = intrinsic_ident("sad", "epu8", bits);
+        let lookup = match bits {
+            128 => quote! {
+                _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4)
+            },
+            256 => quote! {
+                _mm256_setr_epi8(
+                    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
+                    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
+                )
+            },
+            _ => unreachable!(),
+        };
+        self.kernel_method(op, vec_ty, |token| {
+            let combine = match vec_ty.scalar_bits {
+                8 => quote! { byte_counts },
+                16 => quote! { #maddubs(byte_counts, #set1_epi8(1)) },
+                32 => quote! {
+                    #madd(#maddubs(byte_counts, #set1_epi8(1)), #set1_epi16(1))
+                },
+                64 => quote! { #sad(byte_counts, #setzero()) },
+                _ => unreachable!(),
+            };
+            quote! {
+                let value = a.into();
+                let nibble_mask = #set1_epi8(0x0f);
+                let lookup = #lookup;
+                let low = #and(value, nibble_mask);
+                let high = #and(#shift::<4>(value), nibble_mask);
+                let byte_counts = #add(#shuffle(lookup, low), #shuffle(lookup, high));
+                #combine.simd_into(#token)
+            }
+        })
+    }
+
     pub(crate) fn handle_splat(&self, op: Op, vec_ty: &VecType) -> TokenStream {
         if *self == Self::Avx512 && vec_ty.scalar == ScalarType::Mask {
             let lane_mask = avx512_mask_lane_bits(vec_ty);
@@ -1396,6 +1454,14 @@ impl X86 {
         method: &str,
         vec_ty: &VecType,
     ) -> TokenStream {
+        if method == "count_zeros" {
+            return count_zeros_method(op, vec_ty);
+        }
+
+        if method == "count_ones" {
+            return self.handle_count_ones(op, vec_ty);
+        }
+
         if *self == Self::Avx512 && vec_ty.scalar == ScalarType::Mask {
             let body = match method {
                 "not" => {

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -884,6 +884,18 @@ const FLOAT_OPS: &[Op] = &[
 
 const INT_OPS: &[Op] = &[
     Op::new(
+        "count_ones",
+        OpKind::VecTraitMethod,
+        OpSig::Unary,
+        "Return the number of ones in the binary representation of each element.",
+    ),
+    Op::new(
+        "count_zeros",
+        OpKind::VecTraitMethod,
+        OpSig::Unary,
+        "Return the number of zeros in the binary representation of each element.",
+    ),
+    Op::new(
         "add",
         OpKind::Overloaded(CoreOpTrait::Add),
         OpSig::Binary,

--- a/fearless_simd_tests/tests/harness/ops/count_ones.rs
+++ b/fearless_simd_tests/tests/harness/ops/count_ones.rs
@@ -1,0 +1,617 @@
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use fearless_simd::*;
+use fearless_simd_dev_macros::simd_test;
+
+// One concrete test row per supported integer vector type.
+
+#[simd_test]
+fn count_ones_i8x16<S: Simd>(simd: S) {
+    let values: [i8; 16] = [
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+    ];
+    let expected = values.map(|value| i8::try_from(value.count_ones()).unwrap());
+    let result: i8x16<S> = i8x16::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_i8x32<S: Simd>(simd: S) {
+    let values: [i8; 32] = [
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+    ];
+    let expected = values.map(|value| i8::try_from(value.count_ones()).unwrap());
+    let result: i8x32<S> = i8x32::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_i8x64<S: Simd>(simd: S) {
+    let values: [i8; 64] = [
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+    ];
+    let expected = values.map(|value| i8::try_from(value.count_ones()).unwrap());
+    let result: i8x64<S> = i8x64::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_u8x16<S: Simd>(simd: S) {
+    let values: [u8; 16] = [
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+    ];
+    let expected = values.map(|value| u8::try_from(value.count_ones()).unwrap());
+    let result: u8x16<S> = u8x16::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_u8x32<S: Simd>(simd: S) {
+    let values: [u8; 32] = [
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+    ];
+    let expected = values.map(|value| u8::try_from(value.count_ones()).unwrap());
+    let result: u8x32<S> = u8x32::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_u8x64<S: Simd>(simd: S) {
+    let values: [u8; 64] = [
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+    ];
+    let expected = values.map(|value| u8::try_from(value.count_ones()).unwrap());
+    let result: u8x64<S> = u8x64::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_i16x8<S: Simd>(simd: S) {
+    let values: [i16; 8] = [
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+    ];
+    let expected = values.map(|value| i16::try_from(value.count_ones()).unwrap());
+    let result: i16x8<S> = i16x8::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_i16x16<S: Simd>(simd: S) {
+    let values: [i16; 16] = [
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+    ];
+    let expected = values.map(|value| i16::try_from(value.count_ones()).unwrap());
+    let result: i16x16<S> = i16x16::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_i16x32<S: Simd>(simd: S) {
+    let values: [i16; 32] = [
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+    ];
+    let expected = values.map(|value| i16::try_from(value.count_ones()).unwrap());
+    let result: i16x32<S> = i16x32::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_u16x8<S: Simd>(simd: S) {
+    let values: [u16; 8] = [
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+    ];
+    let expected = values.map(|value| u16::try_from(value.count_ones()).unwrap());
+    let result: u16x8<S> = u16x8::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_u16x16<S: Simd>(simd: S) {
+    let values: [u16; 16] = [
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+    ];
+    let expected = values.map(|value| u16::try_from(value.count_ones()).unwrap());
+    let result: u16x16<S> = u16x16::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_u16x32<S: Simd>(simd: S) {
+    let values: [u16; 32] = [
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+    ];
+    let expected = values.map(|value| u16::try_from(value.count_ones()).unwrap());
+    let result: u16x32<S> = u16x32::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_i32x4<S: Simd>(simd: S) {
+    let values: [i32; 4] = [0_i32, -1_i32, i32::MIN, i32::MAX];
+    let expected = values.map(|value| value.count_ones().cast_signed());
+    let result: i32x4<S> = i32x4::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_i32x8<S: Simd>(simd: S) {
+    let values: [i32; 8] = [
+        0_i32,
+        -1_i32,
+        i32::MIN,
+        i32::MAX,
+        0x5555_5555_i32,
+        -0x5555_5556_i32,
+        0_i32,
+        -1_i32,
+    ];
+    let expected = values.map(|value| value.count_ones().cast_signed());
+    let result: i32x8<S> = i32x8::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_i32x16<S: Simd>(simd: S) {
+    let values: [i32; 16] = [
+        0_i32,
+        -1_i32,
+        i32::MIN,
+        i32::MAX,
+        0x5555_5555_i32,
+        -0x5555_5556_i32,
+        0_i32,
+        -1_i32,
+        i32::MIN,
+        i32::MAX,
+        0x5555_5555_i32,
+        -0x5555_5556_i32,
+        0_i32,
+        -1_i32,
+        i32::MIN,
+        i32::MAX,
+    ];
+    let expected = values.map(|value| value.count_ones().cast_signed());
+    let result: i32x16<S> = i32x16::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_u32x4<S: Simd>(simd: S) {
+    let values: [u32; 4] = [0_u32, u32::MAX, 1_u32 << 31, u32::MAX >> 1];
+    let expected = values.map(|value| value.count_ones());
+    let result: u32x4<S> = u32x4::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_u32x8<S: Simd>(simd: S) {
+    let values: [u32; 8] = [
+        0_u32,
+        u32::MAX,
+        1_u32 << 31,
+        u32::MAX >> 1,
+        0x5555_5555_u32,
+        0xaaaa_aaaa_u32,
+        0_u32,
+        u32::MAX,
+    ];
+    let expected = values.map(|value| value.count_ones());
+    let result: u32x8<S> = u32x8::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_u32x16<S: Simd>(simd: S) {
+    let values: [u32; 16] = [
+        0_u32,
+        u32::MAX,
+        1_u32 << 31,
+        u32::MAX >> 1,
+        0x5555_5555_u32,
+        0xaaaa_aaaa_u32,
+        0_u32,
+        u32::MAX,
+        1_u32 << 31,
+        u32::MAX >> 1,
+        0x5555_5555_u32,
+        0xaaaa_aaaa_u32,
+        0_u32,
+        u32::MAX,
+        1_u32 << 31,
+        u32::MAX >> 1,
+    ];
+    let expected = values.map(|value| value.count_ones());
+    let result: u32x16<S> = u32x16::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_i64x2<S: Simd>(simd: S) {
+    let values: [i64; 2] = [0_i64, -1_i64];
+    let expected = values.map(|value| i64::from(value.count_ones()));
+    let result: i64x2<S> = i64x2::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_i64x4<S: Simd>(simd: S) {
+    let values: [i64; 4] = [0_i64, -1_i64, i64::MIN, i64::MAX];
+    let expected = values.map(|value| i64::from(value.count_ones()));
+    let result: i64x4<S> = i64x4::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_i64x8<S: Simd>(simd: S) {
+    let values: [i64; 8] = [
+        0_i64,
+        -1_i64,
+        i64::MIN,
+        i64::MAX,
+        0x5555_5555_5555_5555_i64,
+        -0x5555_5555_5555_5556_i64,
+        0_i64,
+        -1_i64,
+    ];
+    let expected = values.map(|value| i64::from(value.count_ones()));
+    let result: i64x8<S> = i64x8::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_u64x2<S: Simd>(simd: S) {
+    let values: [u64; 2] = [0_u64, u64::MAX];
+    let expected = values.map(|value| u64::from(value.count_ones()));
+    let result: u64x2<S> = u64x2::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_u64x4<S: Simd>(simd: S) {
+    let values: [u64; 4] = [0_u64, u64::MAX, 1_u64 << 63, u64::MAX >> 1];
+    let expected = values.map(|value| u64::from(value.count_ones()));
+    let result: u64x4<S> = u64x4::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_ones_u64x8<S: Simd>(simd: S) {
+    let values: [u64; 8] = [
+        0_u64,
+        u64::MAX,
+        1_u64 << 63,
+        u64::MAX >> 1,
+        0x5555_5555_5555_5555_u64,
+        0xaaaa_aaaa_aaaa_aaaa_u64,
+        0_u64,
+        u64::MAX,
+    ];
+    let expected = values.map(|value| u64::from(value.count_ones()));
+    let result: u64x8<S> = u64x8::from_slice(simd, &values).count_ones();
+    assert_eq!(*result, expected);
+}

--- a/fearless_simd_tests/tests/harness/ops/count_zeros.rs
+++ b/fearless_simd_tests/tests/harness/ops/count_zeros.rs
@@ -1,0 +1,617 @@
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use fearless_simd::*;
+use fearless_simd_dev_macros::simd_test;
+
+// One concrete test row per supported integer vector type.
+
+#[simd_test]
+fn count_zeros_i8x16<S: Simd>(simd: S) {
+    let values: [i8; 16] = [
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+    ];
+    let expected = values.map(|value| i8::try_from(value.count_zeros()).unwrap());
+    let result: i8x16<S> = i8x16::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_i8x32<S: Simd>(simd: S) {
+    let values: [i8; 32] = [
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+    ];
+    let expected = values.map(|value| i8::try_from(value.count_zeros()).unwrap());
+    let result: i8x32<S> = i8x32::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_i8x64<S: Simd>(simd: S) {
+    let values: [i8; 64] = [
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+        0x55_i8,
+        -0x56_i8,
+        0_i8,
+        -1_i8,
+        i8::MIN,
+        i8::MAX,
+    ];
+    let expected = values.map(|value| i8::try_from(value.count_zeros()).unwrap());
+    let result: i8x64<S> = i8x64::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_u8x16<S: Simd>(simd: S) {
+    let values: [u8; 16] = [
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+    ];
+    let expected = values.map(|value| u8::try_from(value.count_zeros()).unwrap());
+    let result: u8x16<S> = u8x16::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_u8x32<S: Simd>(simd: S) {
+    let values: [u8; 32] = [
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+    ];
+    let expected = values.map(|value| u8::try_from(value.count_zeros()).unwrap());
+    let result: u8x32<S> = u8x32::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_u8x64<S: Simd>(simd: S) {
+    let values: [u8; 64] = [
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+        0x55_u8,
+        0xaa_u8,
+        0_u8,
+        u8::MAX,
+        1_u8 << 7,
+        u8::MAX >> 1,
+    ];
+    let expected = values.map(|value| u8::try_from(value.count_zeros()).unwrap());
+    let result: u8x64<S> = u8x64::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_i16x8<S: Simd>(simd: S) {
+    let values: [i16; 8] = [
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+    ];
+    let expected = values.map(|value| i16::try_from(value.count_zeros()).unwrap());
+    let result: i16x8<S> = i16x8::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_i16x16<S: Simd>(simd: S) {
+    let values: [i16; 16] = [
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+    ];
+    let expected = values.map(|value| i16::try_from(value.count_zeros()).unwrap());
+    let result: i16x16<S> = i16x16::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_i16x32<S: Simd>(simd: S) {
+    let values: [i16; 32] = [
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+        i16::MIN,
+        i16::MAX,
+        0x5555_i16,
+        -0x5556_i16,
+        0_i16,
+        -1_i16,
+    ];
+    let expected = values.map(|value| i16::try_from(value.count_zeros()).unwrap());
+    let result: i16x32<S> = i16x32::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_u16x8<S: Simd>(simd: S) {
+    let values: [u16; 8] = [
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+    ];
+    let expected = values.map(|value| u16::try_from(value.count_zeros()).unwrap());
+    let result: u16x8<S> = u16x8::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_u16x16<S: Simd>(simd: S) {
+    let values: [u16; 16] = [
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+    ];
+    let expected = values.map(|value| u16::try_from(value.count_zeros()).unwrap());
+    let result: u16x16<S> = u16x16::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_u16x32<S: Simd>(simd: S) {
+    let values: [u16; 32] = [
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+        1_u16 << 15,
+        u16::MAX >> 1,
+        0x5555_u16,
+        0xaaaa_u16,
+        0_u16,
+        u16::MAX,
+    ];
+    let expected = values.map(|value| u16::try_from(value.count_zeros()).unwrap());
+    let result: u16x32<S> = u16x32::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_i32x4<S: Simd>(simd: S) {
+    let values: [i32; 4] = [0_i32, -1_i32, i32::MIN, i32::MAX];
+    let expected = values.map(|value| value.count_zeros().cast_signed());
+    let result: i32x4<S> = i32x4::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_i32x8<S: Simd>(simd: S) {
+    let values: [i32; 8] = [
+        0_i32,
+        -1_i32,
+        i32::MIN,
+        i32::MAX,
+        0x5555_5555_i32,
+        -0x5555_5556_i32,
+        0_i32,
+        -1_i32,
+    ];
+    let expected = values.map(|value| value.count_zeros().cast_signed());
+    let result: i32x8<S> = i32x8::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_i32x16<S: Simd>(simd: S) {
+    let values: [i32; 16] = [
+        0_i32,
+        -1_i32,
+        i32::MIN,
+        i32::MAX,
+        0x5555_5555_i32,
+        -0x5555_5556_i32,
+        0_i32,
+        -1_i32,
+        i32::MIN,
+        i32::MAX,
+        0x5555_5555_i32,
+        -0x5555_5556_i32,
+        0_i32,
+        -1_i32,
+        i32::MIN,
+        i32::MAX,
+    ];
+    let expected = values.map(|value| value.count_zeros().cast_signed());
+    let result: i32x16<S> = i32x16::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_u32x4<S: Simd>(simd: S) {
+    let values: [u32; 4] = [0_u32, u32::MAX, 1_u32 << 31, u32::MAX >> 1];
+    let expected = values.map(|value| value.count_zeros());
+    let result: u32x4<S> = u32x4::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_u32x8<S: Simd>(simd: S) {
+    let values: [u32; 8] = [
+        0_u32,
+        u32::MAX,
+        1_u32 << 31,
+        u32::MAX >> 1,
+        0x5555_5555_u32,
+        0xaaaa_aaaa_u32,
+        0_u32,
+        u32::MAX,
+    ];
+    let expected = values.map(|value| value.count_zeros());
+    let result: u32x8<S> = u32x8::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_u32x16<S: Simd>(simd: S) {
+    let values: [u32; 16] = [
+        0_u32,
+        u32::MAX,
+        1_u32 << 31,
+        u32::MAX >> 1,
+        0x5555_5555_u32,
+        0xaaaa_aaaa_u32,
+        0_u32,
+        u32::MAX,
+        1_u32 << 31,
+        u32::MAX >> 1,
+        0x5555_5555_u32,
+        0xaaaa_aaaa_u32,
+        0_u32,
+        u32::MAX,
+        1_u32 << 31,
+        u32::MAX >> 1,
+    ];
+    let expected = values.map(|value| value.count_zeros());
+    let result: u32x16<S> = u32x16::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_i64x2<S: Simd>(simd: S) {
+    let values: [i64; 2] = [0_i64, -1_i64];
+    let expected = values.map(|value| i64::from(value.count_zeros()));
+    let result: i64x2<S> = i64x2::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_i64x4<S: Simd>(simd: S) {
+    let values: [i64; 4] = [0_i64, -1_i64, i64::MIN, i64::MAX];
+    let expected = values.map(|value| i64::from(value.count_zeros()));
+    let result: i64x4<S> = i64x4::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_i64x8<S: Simd>(simd: S) {
+    let values: [i64; 8] = [
+        0_i64,
+        -1_i64,
+        i64::MIN,
+        i64::MAX,
+        0x5555_5555_5555_5555_i64,
+        -0x5555_5555_5555_5556_i64,
+        0_i64,
+        -1_i64,
+    ];
+    let expected = values.map(|value| i64::from(value.count_zeros()));
+    let result: i64x8<S> = i64x8::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_u64x2<S: Simd>(simd: S) {
+    let values: [u64; 2] = [0_u64, u64::MAX];
+    let expected = values.map(|value| u64::from(value.count_zeros()));
+    let result: u64x2<S> = u64x2::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_u64x4<S: Simd>(simd: S) {
+    let values: [u64; 4] = [0_u64, u64::MAX, 1_u64 << 63, u64::MAX >> 1];
+    let expected = values.map(|value| u64::from(value.count_zeros()));
+    let result: u64x4<S> = u64x4::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn count_zeros_u64x8<S: Simd>(simd: S) {
+    let values: [u64; 8] = [
+        0_u64,
+        u64::MAX,
+        1_u64 << 63,
+        u64::MAX >> 1,
+        0x5555_5555_5555_5555_u64,
+        0xaaaa_aaaa_aaaa_aaaa_u64,
+        0_u64,
+        u64::MAX,
+    ];
+    let expected = values.map(|value| u64::from(value.count_zeros()));
+    let result: u64x8<S> = u64x8::from_slice(simd, &values).count_zeros();
+    assert_eq!(*result, expected);
+}

--- a/fearless_simd_tests/tests/harness/ops/mod.rs
+++ b/fearless_simd_tests/tests/harness/ops/mod.rs
@@ -19,6 +19,8 @@ mod block_splat;
 mod ceil;
 mod combine;
 mod copysign;
+mod count_ones;
+mod count_zeros;
 mod cvt_f32;
 mod cvt_f64;
 mod cvt_i32;


### PR DESCRIPTION
The API mirrors std::simd. Unlike std::simd, we return `Self` from all vector types rather than creating an `Unsigned` associated type and returning that. The counts always fit into the signed values, and this simplifies generic code a lot. Vectors can be explicitly bitcast if the unsigned variant is needed.

The lowerings for u8/i8 and u64/i64 are identical to std::simd; for u16 and u32 we have 1.5x to 2x better throughput but worse latency (9 vs 7 cycles for u16, 14 vs 12 for u32), which seems fine for SIMD code.

Closes #341