### PR TITLE
LLVM-inspired optimizations for x86

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -697,12 +697,14 @@ impl Simd for Avx2 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Avx2, a: i8x16<Avx2>, b: i8x16<Avx2>) -> i8x16<Avx2> {
-                let dst_even = _mm_mullo_epi16(a.into(), b.into());
-                let dst_odd =
-                    _mm_mullo_epi16(_mm_srli_epi16::<8>(a.into()), _mm_srli_epi16::<8>(b.into()));
+                let a = a.into();
+                let b = b.into();
+                let low_mask = _mm_set1_epi16(0xFF);
+                let dst_even = _mm_mullo_epi16(a, b);
+                let dst_odd = _mm_maddubs_epi16(a, _mm_andnot_si128(low_mask, b));
                 _mm_or_si128(
                     _mm_slli_epi16(dst_odd, 8),
-                    _mm_and_si128(dst_even, _mm_set1_epi16(0xFF)),
+                    _mm_and_si128(dst_even, low_mask),
                 )
                 .simd_into(token)
             }
@@ -1185,12 +1187,14 @@ impl Simd for Avx2 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Avx2, a: u8x16<Avx2>, b: u8x16<Avx2>) -> u8x16<Avx2> {
-                let dst_even = _mm_mullo_epi16(a.into(), b.into());
-                let dst_odd =
-                    _mm_mullo_epi16(_mm_srli_epi16::<8>(a.into()), _mm_srli_epi16::<8>(b.into()));
+                let a = a.into();
+                let b = b.into();
+                let low_mask = _mm_set1_epi16(0xFF);
+                let dst_even = _mm_mullo_epi16(a, b);
+                let dst_odd = _mm_maddubs_epi16(a, _mm_andnot_si128(low_mask, b));
                 _mm_or_si128(
                     _mm_slli_epi16(dst_odd, 8),
-                    _mm_and_si128(dst_even, _mm_set1_epi16(0xFF)),
+                    _mm_and_si128(dst_even, low_mask),
                 )
                 .simd_into(token)
             }
@@ -5872,14 +5876,14 @@ impl Simd for Avx2 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Avx2, a: i8x32<Avx2>, b: i8x32<Avx2>) -> i8x32<Avx2> {
-                let dst_even = _mm256_mullo_epi16(a.into(), b.into());
-                let dst_odd = _mm256_mullo_epi16(
-                    _mm256_srli_epi16::<8>(a.into()),
-                    _mm256_srli_epi16::<8>(b.into()),
-                );
+                let a = a.into();
+                let b = b.into();
+                let low_mask = _mm256_set1_epi16(0xFF);
+                let dst_even = _mm256_mullo_epi16(a, b);
+                let dst_odd = _mm256_maddubs_epi16(a, _mm256_andnot_si256(low_mask, b));
                 _mm256_or_si256(
                     _mm256_slli_epi16(dst_odd, 8),
-                    _mm256_and_si256(dst_even, _mm256_set1_epi16(0xFF)),
+                    _mm256_and_si256(dst_even, low_mask),
                 )
                 .simd_into(token)
             }
@@ -6411,14 +6415,14 @@ impl Simd for Avx2 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Avx2, a: u8x32<Avx2>, b: u8x32<Avx2>) -> u8x32<Avx2> {
-                let dst_even = _mm256_mullo_epi16(a.into(), b.into());
-                let dst_odd = _mm256_mullo_epi16(
-                    _mm256_srli_epi16::<8>(a.into()),
-                    _mm256_srli_epi16::<8>(b.into()),
-                );
+                let a = a.into();
+                let b = b.into();
+                let low_mask = _mm256_set1_epi16(0xFF);
+                let dst_even = _mm256_mullo_epi16(a, b);
+                let dst_odd = _mm256_maddubs_epi16(a, _mm256_andnot_si256(low_mask, b));
                 _mm256_or_si256(
                     _mm256_slli_epi16(dst_odd, 8),
-                    _mm256_and_si256(dst_even, _mm256_set1_epi16(0xFF)),
+                    _mm256_and_si256(dst_even, low_mask),
                 )
                 .simd_into(token)
             }

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -6226,23 +6226,17 @@ impl Simd for Avx2 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Avx2, a: i8x32<Avx2>, b: i8x32<Avx2>) -> (i8x32<Avx2>, i8x32<Avx2>) {
-                let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
-                    a.into(),
-                    _mm256_setr_epi8(
-                        0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10,
-                        12, 14, 1, 3, 5, 7, 9, 11, 13, 15,
-                    ),
-                ));
-                let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
-                    b.into(),
-                    _mm256_setr_epi8(
-                        0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10,
-                        12, 14, 1, 3, 5, 7, 9, 11, 13, 15,
-                    ),
-                ));
+                let mask = _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                );
+                let a = _mm256_shuffle_epi8(a.into(), mask);
+                let b = _mm256_shuffle_epi8(b.into(), mask);
+                let low = _mm256_permute2x128_si256::<0b0010_0000>(a, b);
+                let high = _mm256_permute2x128_si256::<0b0011_0001>(a, b);
                 (
-                    _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(token),
-                    _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(token),
+                    _mm256_unpacklo_epi64(low, high).simd_into(token),
+                    _mm256_unpackhi_epi64(low, high).simd_into(token),
                 )
             }
         );
@@ -6765,23 +6759,17 @@ impl Simd for Avx2 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Avx2, a: u8x32<Avx2>, b: u8x32<Avx2>) -> (u8x32<Avx2>, u8x32<Avx2>) {
-                let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
-                    a.into(),
-                    _mm256_setr_epi8(
-                        0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10,
-                        12, 14, 1, 3, 5, 7, 9, 11, 13, 15,
-                    ),
-                ));
-                let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
-                    b.into(),
-                    _mm256_setr_epi8(
-                        0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10,
-                        12, 14, 1, 3, 5, 7, 9, 11, 13, 15,
-                    ),
-                ));
+                let mask = _mm256_setr_epi8(
+                    0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12,
+                    14, 1, 3, 5, 7, 9, 11, 13, 15,
+                );
+                let a = _mm256_shuffle_epi8(a.into(), mask);
+                let b = _mm256_shuffle_epi8(b.into(), mask);
+                let low = _mm256_permute2x128_si256::<0b0010_0000>(a, b);
+                let high = _mm256_permute2x128_si256::<0b0011_0001>(a, b);
                 (
-                    _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(token),
-                    _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(token),
+                    _mm256_unpacklo_epi64(low, high).simd_into(token),
+                    _mm256_unpackhi_epi64(low, high).simd_into(token),
                 )
             }
         );
@@ -7367,23 +7355,17 @@ impl Simd for Avx2 {
                 a: i16x16<Avx2>,
                 b: i16x16<Avx2>,
             ) -> (i16x16<Avx2>, i16x16<Avx2>) {
-                let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
-                    a.into(),
-                    _mm256_setr_epi8(
-                        0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12,
-                        13, 2, 3, 6, 7, 10, 11, 14, 15,
-                    ),
-                ));
-                let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
-                    b.into(),
-                    _mm256_setr_epi8(
-                        0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12,
-                        13, 2, 3, 6, 7, 10, 11, 14, 15,
-                    ),
-                ));
+                let mask = _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                );
+                let a = _mm256_shuffle_epi8(a.into(), mask);
+                let b = _mm256_shuffle_epi8(b.into(), mask);
+                let low = _mm256_permute2x128_si256::<0b0010_0000>(a, b);
+                let high = _mm256_permute2x128_si256::<0b0011_0001>(a, b);
                 (
-                    _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(token),
-                    _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(token),
+                    _mm256_unpacklo_epi64(low, high).simd_into(token),
+                    _mm256_unpackhi_epi64(low, high).simd_into(token),
                 )
             }
         );
@@ -7843,23 +7825,17 @@ impl Simd for Avx2 {
                 a: u16x16<Avx2>,
                 b: u16x16<Avx2>,
             ) -> (u16x16<Avx2>, u16x16<Avx2>) {
-                let t1 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
-                    a.into(),
-                    _mm256_setr_epi8(
-                        0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12,
-                        13, 2, 3, 6, 7, 10, 11, 14, 15,
-                    ),
-                ));
-                let t2 = _mm256_permute4x64_epi64::<0b11_01_10_00>(_mm256_shuffle_epi8(
-                    b.into(),
-                    _mm256_setr_epi8(
-                        0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12,
-                        13, 2, 3, 6, 7, 10, 11, 14, 15,
-                    ),
-                ));
+                let mask = _mm256_setr_epi8(
+                    0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 4, 5, 8, 9, 12, 13,
+                    2, 3, 6, 7, 10, 11, 14, 15,
+                );
+                let a = _mm256_shuffle_epi8(a.into(), mask);
+                let b = _mm256_shuffle_epi8(b.into(), mask);
+                let low = _mm256_permute2x128_si256::<0b0010_0000>(a, b);
+                let high = _mm256_permute2x128_si256::<0b0011_0001>(a, b);
                 (
-                    _mm256_permute2x128_si256::<0b0010_0000>(t1, t2).simd_into(token),
-                    _mm256_permute2x128_si256::<0b0011_0001>(t1, t2).simd_into(token),
+                    _mm256_unpacklo_epi64(low, high).simd_into(token),
+                    _mm256_unpackhi_epi64(low, high).simd_into(token),
                 )
             }
         );

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -927,7 +927,19 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn deinterleave_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> (i8x16<Self>, i8x16<Self>) {
-        (self.unzip_low_i8x16(a, b), self.unzip_high_i8x16(a, b))
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i8x16<Avx2>, b: i8x16<Avx2>) -> (i8x16<Avx2>, i8x16<Avx2>) {
+                let mask = _mm_setr_epi8(0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15);
+                let a = _mm_shuffle_epi8(a.into(), mask);
+                let b = _mm_shuffle_epi8(b.into(), mask);
+                (
+                    _mm_unpacklo_epi64(a, b).simd_into(token),
+                    _mm_unpackhi_epi64(a, b).simd_into(token),
+                )
+            }
+        );
+        kernel(self, a, b)
     }
     #[inline(always)]
     fn select_i8x16(self, a: mask8x16<Self>, b: i8x16<Self>, c: i8x16<Self>) -> i8x16<Self> {
@@ -1417,7 +1429,19 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn deinterleave_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> (u8x16<Self>, u8x16<Self>) {
-        (self.unzip_low_u8x16(a, b), self.unzip_high_u8x16(a, b))
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u8x16<Avx2>, b: u8x16<Avx2>) -> (u8x16<Avx2>, u8x16<Avx2>) {
+                let mask = _mm_setr_epi8(0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15);
+                let a = _mm_shuffle_epi8(a.into(), mask);
+                let b = _mm_shuffle_epi8(b.into(), mask);
+                (
+                    _mm_unpacklo_epi64(a, b).simd_into(token),
+                    _mm_unpackhi_epi64(a, b).simd_into(token),
+                )
+            }
+        );
+        kernel(self, a, b)
     }
     #[inline(always)]
     fn select_u8x16(self, a: mask8x16<Self>, b: u8x16<Self>, c: u8x16<Self>) -> u8x16<Self> {
@@ -1976,7 +2000,19 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn deinterleave_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> (i16x8<Self>, i16x8<Self>) {
-        (self.unzip_low_i16x8(a, b), self.unzip_high_i16x8(a, b))
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i16x8<Avx2>, b: i16x8<Avx2>) -> (i16x8<Avx2>, i16x8<Avx2>) {
+                let mask = _mm_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
+                let a = _mm_shuffle_epi8(a.into(), mask);
+                let b = _mm_shuffle_epi8(b.into(), mask);
+                (
+                    _mm_unpacklo_epi64(a, b).simd_into(token),
+                    _mm_unpackhi_epi64(a, b).simd_into(token),
+                )
+            }
+        );
+        kernel(self, a, b)
     }
     #[inline(always)]
     fn select_i16x8(self, a: mask16x8<Self>, b: i16x8<Self>, c: i16x8<Self>) -> i16x8<Self> {
@@ -2422,7 +2458,19 @@ impl Simd for Avx2 {
     }
     #[inline(always)]
     fn deinterleave_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> (u16x8<Self>, u16x8<Self>) {
-        (self.unzip_low_u16x8(a, b), self.unzip_high_u16x8(a, b))
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u16x8<Avx2>, b: u16x8<Avx2>) -> (u16x8<Avx2>, u16x8<Avx2>) {
+                let mask = _mm_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
+                let a = _mm_shuffle_epi8(a.into(), mask);
+                let b = _mm_shuffle_epi8(b.into(), mask);
+                (
+                    _mm_unpacklo_epi64(a, b).simd_into(token),
+                    _mm_unpackhi_epi64(a, b).simd_into(token),
+                )
+            }
+        );
+        kernel(self, a, b)
     }
     #[inline(always)]
     fn select_u16x8(self, a: mask16x8<Self>, b: u16x8<Self>, c: u16x8<Self>) -> u16x8<Self> {

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -923,12 +923,14 @@ impl Simd for Avx512 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Avx512, a: i8x16<Avx512>, b: i8x16<Avx512>) -> i8x16<Avx512> {
-                let dst_even = _mm_mullo_epi16(a.into(), b.into());
-                let dst_odd =
-                    _mm_mullo_epi16(_mm_srli_epi16::<8>(a.into()), _mm_srli_epi16::<8>(b.into()));
+                let a = a.into();
+                let b = b.into();
+                let low_mask = _mm_set1_epi16(0xFF);
+                let dst_even = _mm_mullo_epi16(a, b);
+                let dst_odd = _mm_maddubs_epi16(a, _mm_andnot_si128(low_mask, b));
                 _mm_or_si128(
                     _mm_slli_epi16(dst_odd, 8),
-                    _mm_and_si128(dst_even, _mm_set1_epi16(0xFF)),
+                    _mm_and_si128(dst_even, low_mask),
                 )
                 .simd_into(token)
             }
@@ -1409,12 +1411,14 @@ impl Simd for Avx512 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Avx512, a: u8x16<Avx512>, b: u8x16<Avx512>) -> u8x16<Avx512> {
-                let dst_even = _mm_mullo_epi16(a.into(), b.into());
-                let dst_odd =
-                    _mm_mullo_epi16(_mm_srli_epi16::<8>(a.into()), _mm_srli_epi16::<8>(b.into()));
+                let a = a.into();
+                let b = b.into();
+                let low_mask = _mm_set1_epi16(0xFF);
+                let dst_even = _mm_mullo_epi16(a, b);
+                let dst_odd = _mm_maddubs_epi16(a, _mm_andnot_si128(low_mask, b));
                 _mm_or_si128(
                     _mm_slli_epi16(dst_odd, 8),
-                    _mm_and_si128(dst_even, _mm_set1_epi16(0xFF)),
+                    _mm_and_si128(dst_even, low_mask),
                 )
                 .simd_into(token)
             }
@@ -5733,14 +5737,14 @@ impl Simd for Avx512 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Avx512, a: i8x32<Avx512>, b: i8x32<Avx512>) -> i8x32<Avx512> {
-                let dst_even = _mm256_mullo_epi16(a.into(), b.into());
-                let dst_odd = _mm256_mullo_epi16(
-                    _mm256_srli_epi16::<8>(a.into()),
-                    _mm256_srli_epi16::<8>(b.into()),
-                );
+                let a = a.into();
+                let b = b.into();
+                let low_mask = _mm256_set1_epi16(0xFF);
+                let dst_even = _mm256_mullo_epi16(a, b);
+                let dst_odd = _mm256_maddubs_epi16(a, _mm256_andnot_si256(low_mask, b));
                 _mm256_or_si256(
                     _mm256_slli_epi16(dst_odd, 8),
-                    _mm256_and_si256(dst_even, _mm256_set1_epi16(0xFF)),
+                    _mm256_and_si256(dst_even, low_mask),
                 )
                 .simd_into(token)
             }
@@ -6272,14 +6276,14 @@ impl Simd for Avx512 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Avx512, a: u8x32<Avx512>, b: u8x32<Avx512>) -> u8x32<Avx512> {
-                let dst_even = _mm256_mullo_epi16(a.into(), b.into());
-                let dst_odd = _mm256_mullo_epi16(
-                    _mm256_srli_epi16::<8>(a.into()),
-                    _mm256_srli_epi16::<8>(b.into()),
-                );
+                let a = a.into();
+                let b = b.into();
+                let low_mask = _mm256_set1_epi16(0xFF);
+                let dst_even = _mm256_mullo_epi16(a, b);
+                let dst_odd = _mm256_maddubs_epi16(a, _mm256_andnot_si256(low_mask, b));
                 _mm256_or_si256(
                     _mm256_slli_epi16(dst_odd, 8),
-                    _mm256_and_si256(dst_even, _mm256_set1_epi16(0xFF)),
+                    _mm256_and_si256(dst_even, low_mask),
                 )
                 .simd_into(token)
             }
@@ -10939,14 +10943,14 @@ impl Simd for Avx512 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Avx512, a: i8x64<Avx512>, b: i8x64<Avx512>) -> i8x64<Avx512> {
-                let dst_even = _mm512_mullo_epi16(a.into(), b.into());
-                let dst_odd = _mm512_mullo_epi16(
-                    _mm512_srli_epi16::<8>(a.into()),
-                    _mm512_srli_epi16::<8>(b.into()),
-                );
+                let a = a.into();
+                let b = b.into();
+                let low_mask = _mm512_set1_epi16(0xFF);
+                let dst_even = _mm512_mullo_epi16(a, b);
+                let dst_odd = _mm512_maddubs_epi16(a, _mm512_andnot_si512(low_mask, b));
                 _mm512_or_si512(
                     _mm512_slli_epi16(dst_odd, 8),
-                    _mm512_and_si512(dst_even, _mm512_set1_epi16(0xFF)),
+                    _mm512_and_si512(dst_even, low_mask),
                 )
                 .simd_into(token)
             }
@@ -11486,14 +11490,14 @@ impl Simd for Avx512 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Avx512, a: u8x64<Avx512>, b: u8x64<Avx512>) -> u8x64<Avx512> {
-                let dst_even = _mm512_mullo_epi16(a.into(), b.into());
-                let dst_odd = _mm512_mullo_epi16(
-                    _mm512_srli_epi16::<8>(a.into()),
-                    _mm512_srli_epi16::<8>(b.into()),
-                );
+                let a = a.into();
+                let b = b.into();
+                let low_mask = _mm512_set1_epi16(0xFF);
+                let dst_even = _mm512_mullo_epi16(a, b);
+                let dst_odd = _mm512_maddubs_epi16(a, _mm512_andnot_si512(low_mask, b));
                 _mm512_or_si512(
                     _mm512_slli_epi16(dst_odd, 8),
-                    _mm512_and_si512(dst_even, _mm512_set1_epi16(0xFF)),
+                    _mm512_and_si512(dst_even, low_mask),
                 )
                 .simd_into(token)
             }

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -992,16 +992,13 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i8x16<Avx512>, b: i8x16<Avx512>) -> i8x16<Avx512> {
                 let val = a.into();
                 let counts = b.into();
-                let zero = _mm_setzero_si128();
-                let value_extend = zero;
-                let lo_values = _mm_unpacklo_epi8(val, value_extend);
-                let hi_values = _mm_unpackhi_epi8(val, value_extend);
-                let lo_counts = _mm_unpacklo_epi8(counts, zero);
-                let hi_counts = _mm_unpackhi_epi8(counts, zero);
                 let byte_mask = _mm_set1_epi16(0x00ff);
-                let lo_shifted = _mm_and_si128(_mm_sllv_epi16(lo_values, lo_counts), byte_mask);
-                let hi_shifted = _mm_and_si128(_mm_sllv_epi16(hi_values, hi_counts), byte_mask);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let lo_counts = _mm_and_si128(counts, byte_mask);
+                let hi_counts = _mm_srli_epi16::<8>(counts);
+                let lo_shifted = _mm_sllv_epi16(val, lo_counts);
+                let hi_values = _mm_andnot_si128(byte_mask, val);
+                let hi_shifted = _mm_sllv_epi16(hi_values, hi_counts);
+                _mm_mask_blend_epi8(0xaaaa_u16, lo_shifted, hi_shifted).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -1480,16 +1477,13 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u8x16<Avx512>, b: u8x16<Avx512>) -> u8x16<Avx512> {
                 let val = a.into();
                 let counts = b.into();
-                let zero = _mm_setzero_si128();
-                let value_extend = zero;
-                let lo_values = _mm_unpacklo_epi8(val, value_extend);
-                let hi_values = _mm_unpackhi_epi8(val, value_extend);
-                let lo_counts = _mm_unpacklo_epi8(counts, zero);
-                let hi_counts = _mm_unpackhi_epi8(counts, zero);
                 let byte_mask = _mm_set1_epi16(0x00ff);
-                let lo_shifted = _mm_and_si128(_mm_sllv_epi16(lo_values, lo_counts), byte_mask);
-                let hi_shifted = _mm_and_si128(_mm_sllv_epi16(hi_values, hi_counts), byte_mask);
-                _mm_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let lo_counts = _mm_and_si128(counts, byte_mask);
+                let hi_counts = _mm_srli_epi16::<8>(counts);
+                let lo_shifted = _mm_sllv_epi16(val, lo_counts);
+                let hi_values = _mm_andnot_si128(byte_mask, val);
+                let hi_shifted = _mm_sllv_epi16(hi_values, hi_counts);
+                _mm_mask_blend_epi8(0xaaaa_u16, lo_shifted, hi_shifted).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -5806,18 +5800,13 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i8x32<Avx512>, b: i8x32<Avx512>) -> i8x32<Avx512> {
                 let val = a.into();
                 let counts = b.into();
-                let zero = _mm256_setzero_si256();
-                let value_extend = zero;
-                let lo_values = _mm256_unpacklo_epi8(val, value_extend);
-                let hi_values = _mm256_unpackhi_epi8(val, value_extend);
-                let lo_counts = _mm256_unpacklo_epi8(counts, zero);
-                let hi_counts = _mm256_unpackhi_epi8(counts, zero);
                 let byte_mask = _mm256_set1_epi16(0x00ff);
-                let lo_shifted =
-                    _mm256_and_si256(_mm256_sllv_epi16(lo_values, lo_counts), byte_mask);
-                let hi_shifted =
-                    _mm256_and_si256(_mm256_sllv_epi16(hi_values, hi_counts), byte_mask);
-                _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let lo_counts = _mm256_and_si256(counts, byte_mask);
+                let hi_counts = _mm256_srli_epi16::<8>(counts);
+                let lo_shifted = _mm256_sllv_epi16(val, lo_counts);
+                let hi_values = _mm256_andnot_si256(byte_mask, val);
+                let hi_shifted = _mm256_sllv_epi16(hi_values, hi_counts);
+                _mm256_mask_blend_epi8(0xaaaa_aaaa_u32, lo_shifted, hi_shifted).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -6345,18 +6334,13 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u8x32<Avx512>, b: u8x32<Avx512>) -> u8x32<Avx512> {
                 let val = a.into();
                 let counts = b.into();
-                let zero = _mm256_setzero_si256();
-                let value_extend = zero;
-                let lo_values = _mm256_unpacklo_epi8(val, value_extend);
-                let hi_values = _mm256_unpackhi_epi8(val, value_extend);
-                let lo_counts = _mm256_unpacklo_epi8(counts, zero);
-                let hi_counts = _mm256_unpackhi_epi8(counts, zero);
                 let byte_mask = _mm256_set1_epi16(0x00ff);
-                let lo_shifted =
-                    _mm256_and_si256(_mm256_sllv_epi16(lo_values, lo_counts), byte_mask);
-                let hi_shifted =
-                    _mm256_and_si256(_mm256_sllv_epi16(hi_values, hi_counts), byte_mask);
-                _mm256_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let lo_counts = _mm256_and_si256(counts, byte_mask);
+                let hi_counts = _mm256_srli_epi16::<8>(counts);
+                let lo_shifted = _mm256_sllv_epi16(val, lo_counts);
+                let hi_values = _mm256_andnot_si256(byte_mask, val);
+                let hi_shifted = _mm256_sllv_epi16(hi_values, hi_counts);
+                _mm256_mask_blend_epi8(0xaaaa_aaaa_u32, lo_shifted, hi_shifted).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -11012,18 +10996,14 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i8x64<Avx512>, b: i8x64<Avx512>) -> i8x64<Avx512> {
                 let val = a.into();
                 let counts = b.into();
-                let zero = _mm512_setzero_si512();
-                let value_extend = zero;
-                let lo_values = _mm512_unpacklo_epi8(val, value_extend);
-                let hi_values = _mm512_unpackhi_epi8(val, value_extend);
-                let lo_counts = _mm512_unpacklo_epi8(counts, zero);
-                let hi_counts = _mm512_unpackhi_epi8(counts, zero);
                 let byte_mask = _mm512_set1_epi16(0x00ff);
-                let lo_shifted =
-                    _mm512_and_si512(_mm512_sllv_epi16(lo_values, lo_counts), byte_mask);
-                let hi_shifted =
-                    _mm512_and_si512(_mm512_sllv_epi16(hi_values, hi_counts), byte_mask);
-                _mm512_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let lo_counts = _mm512_and_si512(counts, byte_mask);
+                let hi_counts = _mm512_srli_epi16::<8>(counts);
+                let lo_shifted = _mm512_sllv_epi16(val, lo_counts);
+                let hi_values = _mm512_andnot_si512(byte_mask, val);
+                let hi_shifted = _mm512_sllv_epi16(hi_values, hi_counts);
+                _mm512_mask_blend_epi8(0xaaaa_aaaa_aaaa_aaaa_u64, lo_shifted, hi_shifted)
+                    .simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -11559,18 +11539,14 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u8x64<Avx512>, b: u8x64<Avx512>) -> u8x64<Avx512> {
                 let val = a.into();
                 let counts = b.into();
-                let zero = _mm512_setzero_si512();
-                let value_extend = zero;
-                let lo_values = _mm512_unpacklo_epi8(val, value_extend);
-                let hi_values = _mm512_unpackhi_epi8(val, value_extend);
-                let lo_counts = _mm512_unpacklo_epi8(counts, zero);
-                let hi_counts = _mm512_unpackhi_epi8(counts, zero);
                 let byte_mask = _mm512_set1_epi16(0x00ff);
-                let lo_shifted =
-                    _mm512_and_si512(_mm512_sllv_epi16(lo_values, lo_counts), byte_mask);
-                let hi_shifted =
-                    _mm512_and_si512(_mm512_sllv_epi16(hi_values, hi_counts), byte_mask);
-                _mm512_packus_epi16(lo_shifted, hi_shifted).simd_into(token)
+                let lo_counts = _mm512_and_si512(counts, byte_mask);
+                let hi_counts = _mm512_srli_epi16::<8>(counts);
+                let lo_shifted = _mm512_sllv_epi16(val, lo_counts);
+                let hi_values = _mm512_andnot_si512(byte_mask, val);
+                let hi_shifted = _mm512_sllv_epi16(hi_values, hi_counts);
+                _mm512_mask_blend_epi8(0xaaaa_aaaa_aaaa_aaaa_u64, lo_shifted, hi_shifted)
+                    .simd_into(token)
             }
         );
         kernel(self, a, b)

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -847,12 +847,14 @@ impl Simd for Sse4_2 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Sse4_2, a: i8x16<Sse4_2>, b: i8x16<Sse4_2>) -> i8x16<Sse4_2> {
-                let dst_even = _mm_mullo_epi16(a.into(), b.into());
-                let dst_odd =
-                    _mm_mullo_epi16(_mm_srli_epi16::<8>(a.into()), _mm_srli_epi16::<8>(b.into()));
+                let a = a.into();
+                let b = b.into();
+                let low_mask = _mm_set1_epi16(0xFF);
+                let dst_even = _mm_mullo_epi16(a, b);
+                let dst_odd = _mm_maddubs_epi16(a, _mm_andnot_si128(low_mask, b));
                 _mm_or_si128(
                     _mm_slli_epi16(dst_odd, 8),
-                    _mm_and_si128(dst_even, _mm_set1_epi16(0xFF)),
+                    _mm_and_si128(dst_even, low_mask),
                 )
                 .simd_into(token)
             }
@@ -1336,12 +1338,14 @@ impl Simd for Sse4_2 {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Sse4_2, a: u8x16<Sse4_2>, b: u8x16<Sse4_2>) -> u8x16<Sse4_2> {
-                let dst_even = _mm_mullo_epi16(a.into(), b.into());
-                let dst_odd =
-                    _mm_mullo_epi16(_mm_srli_epi16::<8>(a.into()), _mm_srli_epi16::<8>(b.into()));
+                let a = a.into();
+                let b = b.into();
+                let low_mask = _mm_set1_epi16(0xFF);
+                let dst_even = _mm_mullo_epi16(a, b);
+                let dst_odd = _mm_maddubs_epi16(a, _mm_andnot_si128(low_mask, b));
                 _mm_or_si128(
                     _mm_slli_epi16(dst_odd, 8),
-                    _mm_and_si128(dst_even, _mm_set1_epi16(0xFF)),
+                    _mm_and_si128(dst_even, low_mask),
                 )
                 .simd_into(token)
             }

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -1077,7 +1077,23 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn deinterleave_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> (i8x16<Self>, i8x16<Self>) {
-        (self.unzip_low_i8x16(a, b), self.unzip_high_i8x16(a, b))
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Sse4_2,
+                a: i8x16<Sse4_2>,
+                b: i8x16<Sse4_2>,
+            ) -> (i8x16<Sse4_2>, i8x16<Sse4_2>) {
+                let mask = _mm_setr_epi8(0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15);
+                let a = _mm_shuffle_epi8(a.into(), mask);
+                let b = _mm_shuffle_epi8(b.into(), mask);
+                (
+                    _mm_unpacklo_epi64(a, b).simd_into(token),
+                    _mm_unpackhi_epi64(a, b).simd_into(token),
+                )
+            }
+        );
+        kernel(self, a, b)
     }
     #[inline(always)]
     fn select_i8x16(self, a: mask8x16<Self>, b: i8x16<Self>, c: i8x16<Self>) -> i8x16<Self> {
@@ -1568,7 +1584,23 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn deinterleave_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> (u8x16<Self>, u8x16<Self>) {
-        (self.unzip_low_u8x16(a, b), self.unzip_high_u8x16(a, b))
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Sse4_2,
+                a: u8x16<Sse4_2>,
+                b: u8x16<Sse4_2>,
+            ) -> (u8x16<Sse4_2>, u8x16<Sse4_2>) {
+                let mask = _mm_setr_epi8(0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15);
+                let a = _mm_shuffle_epi8(a.into(), mask);
+                let b = _mm_shuffle_epi8(b.into(), mask);
+                (
+                    _mm_unpacklo_epi64(a, b).simd_into(token),
+                    _mm_unpackhi_epi64(a, b).simd_into(token),
+                )
+            }
+        );
+        kernel(self, a, b)
     }
     #[inline(always)]
     fn select_u8x16(self, a: mask8x16<Self>, b: u8x16<Self>, c: u8x16<Self>) -> u8x16<Self> {
@@ -2125,7 +2157,23 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn deinterleave_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> (i16x8<Self>, i16x8<Self>) {
-        (self.unzip_low_i16x8(a, b), self.unzip_high_i16x8(a, b))
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Sse4_2,
+                a: i16x8<Sse4_2>,
+                b: i16x8<Sse4_2>,
+            ) -> (i16x8<Sse4_2>, i16x8<Sse4_2>) {
+                let mask = _mm_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
+                let a = _mm_shuffle_epi8(a.into(), mask);
+                let b = _mm_shuffle_epi8(b.into(), mask);
+                (
+                    _mm_unpacklo_epi64(a, b).simd_into(token),
+                    _mm_unpackhi_epi64(a, b).simd_into(token),
+                )
+            }
+        );
+        kernel(self, a, b)
     }
     #[inline(always)]
     fn select_i16x8(self, a: mask16x8<Self>, b: i16x8<Self>, c: i16x8<Self>) -> i16x8<Self> {
@@ -2568,7 +2616,23 @@ impl Simd for Sse4_2 {
     }
     #[inline(always)]
     fn deinterleave_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> (u16x8<Self>, u16x8<Self>) {
-        (self.unzip_low_u16x8(a, b), self.unzip_high_u16x8(a, b))
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Sse4_2,
+                a: u16x8<Sse4_2>,
+                b: u16x8<Sse4_2>,
+            ) -> (u16x8<Sse4_2>, u16x8<Sse4_2>) {
+                let mask = _mm_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
+                let a = _mm_shuffle_epi8(a.into(), mask);
+                let b = _mm_shuffle_epi8(b.into(), mask);
+                (
+                    _mm_unpacklo_epi64(a, b).simd_into(token),
+                    _mm_unpackhi_epi64(a, b).simd_into(token),
+                )
+            }
+        );
+        kernel(self, a, b)
     }
     #[inline(always)]
     fn select_u16x8(self, a: mask16x8<Self>, b: u16x8<Self>, c: u16x8<Self>) -> u16x8<Self> {

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2177,12 +2177,32 @@ impl X86 {
                     let and = intrinsic_ident("and", coarse_type(vec_ty), vec_ty.n_bits());
                     let or = intrinsic_ident("or", coarse_type(vec_ty), vec_ty.n_bits());
                     let slli = intrinsic_ident("slli", "epi16", vec_ty.n_bits());
-                    let srli = intrinsic_ident("srli", "epi16", vec_ty.n_bits());
-                    quote! {
-                        let dst_even = #mullo(a.into(), b.into());
-                        let dst_odd = #mullo(#srli::<8>(a.into()), #srli::<8>(b.into()));
+                    if *self == Self::Sse2 {
+                        let srli = intrinsic_ident("srli", "epi16", vec_ty.n_bits());
+                        quote! {
+                            let dst_even = #mullo(a.into(), b.into());
+                            let dst_odd = #mullo(#srli::<8>(a.into()), #srli::<8>(b.into()));
 
-                        #or(#slli(dst_odd, 8), #and(dst_even, #set1(0xFF))).simd_into(#token)
+                            #or(#slli(dst_odd, 8), #and(dst_even, #set1(0xFF))).simd_into(#token)
+                        }
+                    } else {
+                        // LLVM's byte-multiplication lowering uses PMADDUBSW to calculate the
+                        // odd byte of every i16 lane. The cleared adjacent byte means there is
+                        // only one product per lane, so the saturating add cannot saturate.
+                        // LLVM only uses this for 128-bit vectors while we apply it everywhere.
+                        // Both llvm-mca and hardware benchmarks show this is beneficial.
+                        let andnot =
+                            intrinsic_ident("andnot", coarse_type(vec_ty), vec_ty.n_bits());
+                        let maddubs = intrinsic_ident("maddubs", "epi16", vec_ty.n_bits());
+                        quote! {
+                            let a = a.into();
+                            let b = b.into();
+                            let low_mask = #set1(0xFF);
+                            let dst_even = #mullo(a, b);
+                            let dst_odd = #maddubs(a, #andnot(low_mask, b));
+
+                            #or(#slli(dst_odd, 8), #and(dst_even, low_mask)).simd_into(#token)
+                        }
                     }
                 }
                 "shlv" | "shrv" => {

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2273,11 +2273,41 @@ impl X86 {
         }
 
         let ty_bits = vec_ty.n_bits();
+        let and = intrinsic_ident("and", coarse_type(vec_ty), ty_bits);
+        let set1_epi16 = intrinsic_ident("set1", "epi16", ty_bits);
+
+        if method == "shlv" {
+            // AVX-512 has variable shifts for i16 lanes but not i8 lanes. Treat each pair
+            // of bytes as an i16 and shift its even and odd bytes along separate paths.
+            let andnot = intrinsic_ident("andnot", coarse_type(vec_ty), ty_bits);
+            let srli = intrinsic_ident("srli", "epi16", ty_bits);
+            let blend = avx512_mask_blend_intrinsic(vec_ty);
+            let odd_byte_mask = match ty_bits {
+                128 => quote! { 0xaaaa_u16 },
+                256 => quote! { 0xaaaa_aaaa_u32 },
+                512 => quote! { 0xaaaa_aaaa_aaaa_aaaa_u64 },
+                _ => unreachable!(),
+            };
+
+            return quote! {
+                let val = a.into();
+                let counts = b.into();
+                let byte_mask = #set1_epi16(0x00ff);
+                let lo_counts = #and(counts, byte_mask);
+                let hi_counts = #srli::<8>(counts);
+                // Left shifts cannot move bits from the odd byte into the even byte, so
+                // only the odd-byte path needs its adjacent input byte cleared.
+                let lo_shifted = #shift_intrinsic(val, lo_counts);
+                let hi_values = #andnot(byte_mask, val);
+                let hi_shifted = #shift_intrinsic(hi_values, hi_counts);
+                // Mask bits set in odd byte positions select `hi_shifted`.
+                #blend(#odd_byte_mask, lo_shifted, hi_shifted).simd_into(#token)
+            };
+        }
+
         let unpack_hi = unpack_intrinsic(ScalarType::Int, 8, false, ty_bits);
         let unpack_lo = unpack_intrinsic(ScalarType::Int, 8, true, ty_bits);
         let set0 = intrinsic_ident("setzero", coarse_type(vec_ty), ty_bits);
-        let and = intrinsic_ident("and", coarse_type(vec_ty), ty_bits);
-        let set1_epi16 = intrinsic_ident("set1", "epi16", ty_bits);
         let pack = pack_intrinsic(16, false, ty_bits);
         let value_extend = match (method, vec_ty.scalar) {
             ("shlv", _) | (_, ScalarType::Unsigned) => quote! { zero },

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -1032,6 +1032,21 @@ fn avx512_index_vector(vec_ty: &VecType, indices: impl IntoIterator<Item = usize
     }
 }
 
+/// A lane-local `pshufb` mask that groups the even elements before the odd elements.
+fn narrow_unzip_shuffle_mask(vec_ty: &VecType) -> TokenStream {
+    let lane_mask = match vec_ty.scalar_bits {
+        8 => quote! { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 },
+        16 => quote! { 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15 },
+        _ => unreachable!(),
+    };
+
+    match vec_ty.n_bits() {
+        128 => quote! { _mm_setr_epi8(#lane_mask) },
+        256 => quote! { _mm256_setr_epi8(#lane_mask, #lane_mask) },
+        _ => unreachable!(),
+    }
+}
+
 fn interleaved_load_indices(len: usize, block_count: usize) -> Vec<usize> {
     let stream_len = len / block_count;
     (0..block_count)
@@ -3218,19 +3233,36 @@ impl X86 {
             && matches!(vec_ty.scalar, ScalarType::Int | ScalarType::Unsigned)
             && matches!(vec_ty.scalar_bits, 8 | 16)
         {
-            let mask = match vec_ty.scalar_bits {
-                8 => quote! { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 },
-                16 => quote! { 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15 },
-                _ => unreachable!(),
-            };
+            let mask = narrow_unzip_shuffle_mask(vec_ty);
             return self.kernel_method(op, vec_ty, |token| {
                 quote! {
-                    let mask = _mm_setr_epi8(#mask);
+                    let mask = #mask;
                     let a = _mm_shuffle_epi8(a.into(), mask);
                     let b = _mm_shuffle_epi8(b.into(), mask);
                     (
                         _mm_unpacklo_epi64(a, b).simd_into(#token),
                         _mm_unpackhi_epi64(a, b).simd_into(#token),
+                    )
+                }
+            });
+        }
+
+        if *self == Self::Avx2
+            && vec_ty.n_bits() == 256
+            && matches!(vec_ty.scalar, ScalarType::Int | ScalarType::Unsigned)
+            && matches!(vec_ty.scalar_bits, 8 | 16)
+        {
+            let mask = narrow_unzip_shuffle_mask(vec_ty);
+            return self.kernel_method(op, vec_ty, |token| {
+                quote! {
+                    let mask = #mask;
+                    let a = _mm256_shuffle_epi8(a.into(), mask);
+                    let b = _mm256_shuffle_epi8(b.into(), mask);
+                    let low = _mm256_permute2x128_si256::<0b0010_0000>(a, b);
+                    let high = _mm256_permute2x128_si256::<0b0011_0001>(a, b);
+                    (
+                        _mm256_unpacklo_epi64(low, high).simd_into(#token),
+                        _mm256_unpackhi_epi64(low, high).simd_into(#token),
                     )
                 }
             });
@@ -3301,15 +3333,11 @@ impl X86 {
                 (shuf(quote! { a.into() }), shuf(quote! { b.into() }))
             }
             8 | 16 => {
-                let mask = match vec_ty.scalar_bits {
-                    8 => quote! { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 },
-                    16 => quote! { 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15 },
-                    _ => unreachable!(),
-                };
+                let mask = narrow_unzip_shuffle_mask(vec_ty);
                 let shuf = |input: TokenStream| {
                     quote! {
                         _mm256_permute4x64_epi64::<0b11_01_10_00>(
-                            _mm256_shuffle_epi8(#input, _mm256_setr_epi8(#mask, #mask)),
+                            _mm256_shuffle_epi8(#input, #mask),
                         )
                     }
                 };
@@ -3390,20 +3418,7 @@ impl X86 {
                 }
                 (ScalarType::Int | ScalarType::Mask | ScalarType::Unsigned, 128, 16 | 8) => {
                     // Separate out the even-indexed and odd-indexed elements
-                    let mask = match vec_ty.scalar_bits {
-                        8 => {
-                            quote! { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 }
-                        }
-                        16 => {
-                            quote! { 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15 }
-                        }
-                        _ => unreachable!(),
-                    };
-                    let mask_reg = match vec_ty.n_bits() {
-                        128 => quote! { _mm_setr_epi8(#mask) },
-                        256 => quote! { _mm256_setr_epi8(#mask, #mask) },
-                        _ => unreachable!(),
-                    };
+                    let mask = narrow_unzip_shuffle_mask(vec_ty);
                     let shuffle_epi8 = intrinsic_ident("shuffle", "epi8", vec_ty.n_bits());
 
                     // Select either the low or high half of each one
@@ -3411,7 +3426,7 @@ impl X86 {
                     let unpack_epi64 = intrinsic_ident(op, "epi64", vec_ty.n_bits());
 
                     quote! {
-                        let mask = #mask_reg;
+                        let mask = #mask;
 
                         let t1 = #shuffle_epi8(a.into(), mask);
                         let t2 = #shuffle_epi8(b.into(), mask);

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -3213,6 +3213,29 @@ impl X86 {
             });
         }
 
+        if matches!(self, Self::Sse4_2 | Self::Avx2)
+            && vec_ty.n_bits() == 128
+            && matches!(vec_ty.scalar, ScalarType::Int | ScalarType::Unsigned)
+            && matches!(vec_ty.scalar_bits, 8 | 16)
+        {
+            let mask = match vec_ty.scalar_bits {
+                8 => quote! { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 },
+                16 => quote! { 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15 },
+                _ => unreachable!(),
+            };
+            return self.kernel_method(op, vec_ty, |token| {
+                quote! {
+                    let mask = _mm_setr_epi8(#mask);
+                    let a = _mm_shuffle_epi8(a.into(), mask);
+                    let b = _mm_shuffle_epi8(b.into(), mask);
+                    (
+                        _mm_unpacklo_epi64(a, b).simd_into(#token),
+                        _mm_unpackhi_epi64(a, b).simd_into(#token),
+                    )
+                }
+            });
+        }
+
         match vec_ty.n_bits() {
             256 => {
                 // Optimized path: compute the per-input shuffles once, then use permute2f128 /


### PR DESCRIPTION
Some lowerings are lifted from LLVM while others are original. Best reviewed commit by commit, one commit = one op. Each commit message includes llvm-mca data, and also benchmark results where possible.