### PR TITLE
Add saturating_add() and saturating_sub() to integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ You can find its changes [documented below](#070-2026-08-11).
 ### Added
 
 - Added `reverse` for all SIMD vector and mask types.
-- Added lane-wise `saturating_add` for all integer vector types and backends.
+- Added lane-wise `saturating_add` and `saturating_sub` for all integer vector types and backends.
 - Added lane-wise `count_ones` and `count_zeros` operations for all integer vector types and backends.
 - Added `mul_add_precise` and `mul_sub_precise` for floating-point vectors. They guarantee the infinite-precision product-plus-add rounded once, including on SIMD levels without hardware fused multiply-add instructions. They are not susceptible to the [bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library, `std::simd` and musl libc that causes incorrect rounding for subnormal results. SSE4.2 gets SIMD emulation of these operations for better performance. ([#323][], [#324][] by [@Shnatsel][])
 - Documented the storage representation of the SIMD vector types. The documented representation will not change without a semver major version change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can find its changes [documented below](#070-2026-08-11).
 ### Added
 
 - Added `reverse` for all SIMD vector and mask types.
+- Added lane-wise `saturating_add` for all integer vector types and backends.
 - Added lane-wise `count_ones` and `count_zeros` operations for all integer vector types and backends.
 - Added `mul_add_precise` and `mul_sub_precise` for floating-point vectors. They guarantee the infinite-precision product-plus-add rounded once, including on SIMD levels without hardware fused multiply-add instructions. They are not susceptible to the [bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library, `std::simd` and musl libc that causes incorrect rounding for subnormal results. SSE4.2 gets SIMD emulation of these operations for better performance. ([#323][], [#324][] by [@Shnatsel][])
 - Documented the storage representation of the SIMD vector types. The documented representation will not change without a semver major version change.

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -803,6 +803,16 @@ impl Simd for Avx2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i8x16<Avx2>, b: i8x16<Avx2>) -> i8x16<Avx2> {
+                _mm_subs_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1376,6 +1386,16 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u8x16<Avx2>, b: u8x16<Avx2>) -> u8x16<Avx2> {
                 _mm_sub_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u8x16<Avx2>, b: u8x16<Avx2>) -> u8x16<Avx2> {
+                _mm_subs_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -2081,6 +2101,16 @@ impl Simd for Avx2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i16x8<Avx2>, b: i16x8<Avx2>) -> i16x8<Avx2> {
+                _mm_subs_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2599,6 +2629,16 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u16x8<Avx2>, b: u16x8<Avx2>) -> u16x8<Avx2> {
                 _mm_sub_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u16x8<Avx2>, b: u16x8<Avx2>) -> u16x8<Avx2> {
+                _mm_subs_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3294,11 +3334,11 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: i32x4<Avx2>, b: i32x4<Avx2>) -> i32x4<Avx2> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm_add_epi32(a, b);
-                let overflow = _mm_xor_si128(_mm_cmpgt_epi32(a, sum), b);
-                let bound = _mm_xor_si128(_mm_srai_epi32::<31>(sum), _mm_set1_epi32(i32::MIN));
+                let wrapped = _mm_add_epi32(a, b);
+                let overflow = _mm_xor_si128(_mm_cmpgt_epi32(a, wrapped), b);
+                let bound = _mm_xor_si128(_mm_srai_epi32::<31>(a), _mm_set1_epi32(i32::MAX));
                 let result = _mm_blendv_ps(
-                    _mm_castsi128_ps(sum),
+                    _mm_castsi128_ps(wrapped),
                     _mm_castsi128_ps(bound),
                     _mm_castsi128_ps(overflow),
                 );
@@ -3313,6 +3353,26 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: i32x4<Avx2>, b: i32x4<Avx2>) -> i32x4<Avx2> {
                 _mm_sub_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i32x4<Avx2>, b: i32x4<Avx2>) -> i32x4<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm_sub_epi32(a, b);
+                let overflow = _mm_xor_si128(_mm_cmpgt_epi32(wrapped, a), b);
+                let bound = _mm_xor_si128(_mm_srai_epi32::<31>(a), _mm_set1_epi32(i32::MAX));
+                let result = _mm_blendv_ps(
+                    _mm_castsi128_ps(wrapped),
+                    _mm_castsi128_ps(bound),
+                    _mm_castsi128_ps(overflow),
+                );
+                _mm_castps_si128(result).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3816,6 +3876,18 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u32x4<Avx2>, b: u32x4<Avx2>) -> u32x4<Avx2> {
                 _mm_sub_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u32x4<Avx2>, b: u32x4<Avx2>) -> u32x4<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                _mm_sub_epi32(_mm_max_epu32(a, b), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -5080,11 +5152,11 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: i64x2<Avx2>, b: i64x2<Avx2>) -> i64x2<Avx2> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm_add_epi64(a, b);
-                let overflow = _mm_xor_si128(_mm_cmpgt_epi64(a, sum), b);
+                let wrapped = _mm_add_epi64(a, b);
+                let overflow = _mm_xor_si128(_mm_cmpgt_epi64(a, wrapped), b);
                 let bound = _mm_add_epi64(_mm_srli_epi64::<63>(a), _mm_set1_epi64x(i64::MAX));
                 let result = _mm_blendv_pd(
-                    _mm_castsi128_pd(sum),
+                    _mm_castsi128_pd(wrapped),
                     _mm_castsi128_pd(bound),
                     _mm_castsi128_pd(overflow),
                 );
@@ -5099,6 +5171,26 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: i64x2<Avx2>, b: i64x2<Avx2>) -> i64x2<Avx2> {
                 _mm_sub_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i64x2<Avx2>, b: i64x2<Avx2>) -> i64x2<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm_sub_epi64(a, b);
+                let overflow = _mm_xor_si128(_mm_cmpgt_epi64(wrapped, a), b);
+                let bound = _mm_add_epi64(_mm_srli_epi64::<63>(a), _mm_set1_epi64x(i64::MAX));
+                let result = _mm_blendv_pd(
+                    _mm_castsi128_pd(wrapped),
+                    _mm_castsi128_pd(bound),
+                    _mm_castsi128_pd(overflow),
+                );
+                _mm_castpd_si128(result).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -5552,11 +5644,13 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: u64x2<Avx2>, b: u64x2<Avx2>) -> u64x2<Avx2> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm_add_epi64(a, b);
+                let wrapped = _mm_add_epi64(a, b);
                 let sign_bias = _mm_set1_epi64x(i64::MIN);
-                let overflow =
-                    _mm_cmpgt_epi64(_mm_xor_si128(a, sign_bias), _mm_xor_si128(sum, sign_bias));
-                _mm_or_si128(sum, overflow).simd_into(token)
+                let overflow = _mm_cmpgt_epi64(
+                    _mm_xor_si128(a, sign_bias),
+                    _mm_xor_si128(wrapped, sign_bias),
+                );
+                _mm_or_si128(wrapped, overflow).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -5567,6 +5661,22 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u64x2<Avx2>, b: u64x2<Avx2>) -> u64x2<Avx2> {
                 _mm_sub_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u64x2<Avx2>, b: u64x2<Avx2>) -> u64x2<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm_sub_epi64(a, b);
+                let sign_bias = _mm_set1_epi64x(i64::MIN);
+                let no_borrow =
+                    _mm_cmpgt_epi64(_mm_xor_si128(a, sign_bias), _mm_xor_si128(b, sign_bias));
+                _mm_and_si128(wrapped, no_borrow).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -6724,6 +6834,16 @@ impl Simd for Avx2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i8x32<Avx2>, b: i8x32<Avx2>) -> i8x32<Avx2> {
+                _mm256_subs_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7271,6 +7391,16 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u8x32<Avx2>, b: u8x32<Avx2>) -> u8x32<Avx2> {
                 _mm256_sub_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u8x32<Avx2>, b: u8x32<Avx2>) -> u8x32<Avx2> {
+                _mm256_subs_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -7952,6 +8082,16 @@ impl Simd for Avx2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i16x16<Avx2>, b: i16x16<Avx2>) -> i16x16<Avx2> {
+                _mm256_subs_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -8430,6 +8570,16 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u16x16<Avx2>, b: u16x16<Avx2>) -> u16x16<Avx2> {
                 _mm256_sub_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u16x16<Avx2>, b: u16x16<Avx2>) -> u16x16<Avx2> {
+                _mm256_subs_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -9101,12 +9251,12 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: i32x8<Avx2>, b: i32x8<Avx2>) -> i32x8<Avx2> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm256_add_epi32(a, b);
-                let overflow = _mm256_xor_si256(_mm256_cmpgt_epi32(a, sum), b);
+                let wrapped = _mm256_add_epi32(a, b);
+                let overflow = _mm256_xor_si256(_mm256_cmpgt_epi32(a, wrapped), b);
                 let bound =
-                    _mm256_xor_si256(_mm256_srai_epi32::<31>(sum), _mm256_set1_epi32(i32::MIN));
+                    _mm256_xor_si256(_mm256_srai_epi32::<31>(a), _mm256_set1_epi32(i32::MAX));
                 let result = _mm256_blendv_ps(
-                    _mm256_castsi256_ps(sum),
+                    _mm256_castsi256_ps(wrapped),
                     _mm256_castsi256_ps(bound),
                     _mm256_castsi256_ps(overflow),
                 );
@@ -9121,6 +9271,27 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: i32x8<Avx2>, b: i32x8<Avx2>) -> i32x8<Avx2> {
                 _mm256_sub_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i32x8<Avx2>, b: i32x8<Avx2>) -> i32x8<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm256_sub_epi32(a, b);
+                let overflow = _mm256_xor_si256(_mm256_cmpgt_epi32(wrapped, a), b);
+                let bound =
+                    _mm256_xor_si256(_mm256_srai_epi32::<31>(a), _mm256_set1_epi32(i32::MAX));
+                let result = _mm256_blendv_ps(
+                    _mm256_castsi256_ps(wrapped),
+                    _mm256_castsi256_ps(bound),
+                    _mm256_castsi256_ps(overflow),
+                );
+                _mm256_castps_si256(result).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -9577,6 +9748,18 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u32x8<Avx2>, b: u32x8<Avx2>) -> u32x8<Avx2> {
                 _mm256_sub_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u32x8<Avx2>, b: u32x8<Avx2>) -> u32x8<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                _mm256_sub_epi32(_mm256_max_epu32(a, b), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -10751,12 +10934,12 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: i64x4<Avx2>, b: i64x4<Avx2>) -> i64x4<Avx2> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm256_add_epi64(a, b);
-                let overflow = _mm256_xor_si256(_mm256_cmpgt_epi64(a, sum), b);
+                let wrapped = _mm256_add_epi64(a, b);
+                let overflow = _mm256_xor_si256(_mm256_cmpgt_epi64(a, wrapped), b);
                 let bound =
                     _mm256_add_epi64(_mm256_srli_epi64::<63>(a), _mm256_set1_epi64x(i64::MAX));
                 let result = _mm256_blendv_pd(
-                    _mm256_castsi256_pd(sum),
+                    _mm256_castsi256_pd(wrapped),
                     _mm256_castsi256_pd(bound),
                     _mm256_castsi256_pd(overflow),
                 );
@@ -10771,6 +10954,27 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: i64x4<Avx2>, b: i64x4<Avx2>) -> i64x4<Avx2> {
                 _mm256_sub_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i64x4<Avx2>, b: i64x4<Avx2>) -> i64x4<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm256_sub_epi64(a, b);
+                let overflow = _mm256_xor_si256(_mm256_cmpgt_epi64(wrapped, a), b);
+                let bound =
+                    _mm256_add_epi64(_mm256_srli_epi64::<63>(a), _mm256_set1_epi64x(i64::MAX));
+                let result = _mm256_blendv_pd(
+                    _mm256_castsi256_pd(wrapped),
+                    _mm256_castsi256_pd(bound),
+                    _mm256_castsi256_pd(overflow),
+                );
+                _mm256_castpd_si256(result).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -11201,13 +11405,13 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: u64x4<Avx2>, b: u64x4<Avx2>) -> u64x4<Avx2> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm256_add_epi64(a, b);
+                let wrapped = _mm256_add_epi64(a, b);
                 let sign_bias = _mm256_set1_epi64x(i64::MIN);
                 let overflow = _mm256_cmpgt_epi64(
                     _mm256_xor_si256(a, sign_bias),
-                    _mm256_xor_si256(sum, sign_bias),
+                    _mm256_xor_si256(wrapped, sign_bias),
                 );
-                _mm256_or_si256(sum, overflow).simd_into(token)
+                _mm256_or_si256(wrapped, overflow).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -11218,6 +11422,24 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u64x4<Avx2>, b: u64x4<Avx2>) -> u64x4<Avx2> {
                 _mm256_sub_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u64x4(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u64x4<Avx2>, b: u64x4<Avx2>) -> u64x4<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm256_sub_epi64(a, b);
+                let sign_bias = _mm256_set1_epi64x(i64::MIN);
+                let no_borrow = _mm256_cmpgt_epi64(
+                    _mm256_xor_si256(a, sign_bias),
+                    _mm256_xor_si256(b, sign_bias),
+                );
+                _mm256_and_si256(wrapped, no_borrow).simd_into(token)
             }
         );
         kernel(self, a, b)

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -783,6 +783,16 @@ impl Simd for Avx2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i8x16<Avx2>, b: i8x16<Avx2>) -> i8x16<Avx2> {
+                _mm_adds_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1346,6 +1356,16 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u8x16<Avx2>, b: u8x16<Avx2>) -> u8x16<Avx2> {
                 _mm_add_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u8x16<Avx2>, b: u8x16<Avx2>) -> u8x16<Avx2> {
+                _mm_adds_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -2041,6 +2061,16 @@ impl Simd for Avx2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i16x8<Avx2>, b: i16x8<Avx2>) -> i16x8<Avx2> {
+                _mm_adds_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2549,6 +2579,16 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u16x8<Avx2>, b: u16x8<Avx2>) -> u16x8<Avx2> {
                 _mm_add_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u16x8<Avx2>, b: u16x8<Avx2>) -> u16x8<Avx2> {
+                _mm_adds_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3248,6 +3288,26 @@ impl Simd for Avx2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i32x4<Avx2>, b: i32x4<Avx2>) -> i32x4<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm_add_epi32(a, b);
+                let overflow = _mm_xor_si128(_mm_cmpgt_epi32(a, sum), b);
+                let bound = _mm_xor_si128(_mm_srai_epi32::<31>(sum), _mm_set1_epi32(i32::MIN));
+                let result = _mm_blendv_ps(
+                    _mm_castsi128_ps(sum),
+                    _mm_castsi128_ps(bound),
+                    _mm_castsi128_ps(overflow),
+                );
+                _mm_castps_si128(result).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3733,6 +3793,19 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u32x4<Avx2>, b: u32x4<Avx2>) -> u32x4<Avx2> {
                 _mm_add_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u32x4<Avx2>, b: u32x4<Avx2>) -> u32x4<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let threshold = _mm_xor_si128(b, _mm_set1_epi32(-1));
+                _mm_add_epi32(_mm_min_epu32(a, threshold), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -5001,6 +5074,26 @@ impl Simd for Avx2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i64x2<Avx2>, b: i64x2<Avx2>) -> i64x2<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm_add_epi64(a, b);
+                let overflow = _mm_xor_si128(_mm_cmpgt_epi64(a, sum), b);
+                let bound = _mm_add_epi64(_mm_srli_epi64::<63>(a), _mm_set1_epi64x(i64::MAX));
+                let result = _mm_blendv_pd(
+                    _mm_castsi128_pd(sum),
+                    _mm_castsi128_pd(bound),
+                    _mm_castsi128_pd(overflow),
+                );
+                _mm_castpd_si128(result).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5448,6 +5541,22 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u64x2<Avx2>, b: u64x2<Avx2>) -> u64x2<Avx2> {
                 _mm_add_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u64x2<Avx2>, b: u64x2<Avx2>) -> u64x2<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm_add_epi64(a, b);
+                let sign_bias = _mm_set1_epi64x(i64::MIN);
+                let overflow =
+                    _mm_cmpgt_epi64(_mm_xor_si128(a, sign_bias), _mm_xor_si128(sum, sign_bias));
+                _mm_or_si128(sum, overflow).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -6595,6 +6704,16 @@ impl Simd for Avx2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i8x32<Avx2>, b: i8x32<Avx2>) -> i8x32<Avx2> {
+                _mm256_adds_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7132,6 +7251,16 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u8x32<Avx2>, b: u8x32<Avx2>) -> u8x32<Avx2> {
                 _mm256_add_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u8x32<Avx2>, b: u8x32<Avx2>) -> u8x32<Avx2> {
+                _mm256_adds_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -7803,6 +7932,16 @@ impl Simd for Avx2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i16x16<Avx2>, b: i16x16<Avx2>) -> i16x16<Avx2> {
+                _mm256_adds_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -8271,6 +8410,16 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u16x16<Avx2>, b: u16x16<Avx2>) -> u16x16<Avx2> {
                 _mm256_add_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u16x16<Avx2>, b: u16x16<Avx2>) -> u16x16<Avx2> {
+                _mm256_adds_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -8946,6 +9095,27 @@ impl Simd for Avx2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i32x8<Avx2>, b: i32x8<Avx2>) -> i32x8<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm256_add_epi32(a, b);
+                let overflow = _mm256_xor_si256(_mm256_cmpgt_epi32(a, sum), b);
+                let bound =
+                    _mm256_xor_si256(_mm256_srai_epi32::<31>(sum), _mm256_set1_epi32(i32::MIN));
+                let result = _mm256_blendv_ps(
+                    _mm256_castsi256_ps(sum),
+                    _mm256_castsi256_ps(bound),
+                    _mm256_castsi256_ps(overflow),
+                );
+                _mm256_castps_si256(result).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -9384,6 +9554,19 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u32x8<Avx2>, b: u32x8<Avx2>) -> u32x8<Avx2> {
                 _mm256_add_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u32x8<Avx2>, b: u32x8<Avx2>) -> u32x8<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let threshold = _mm256_xor_si256(b, _mm256_set1_epi32(-1));
+                _mm256_add_epi32(_mm256_min_epu32(a, threshold), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -10562,6 +10745,27 @@ impl Simd for Avx2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i64x4<Avx2>, b: i64x4<Avx2>) -> i64x4<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm256_add_epi64(a, b);
+                let overflow = _mm256_xor_si256(_mm256_cmpgt_epi64(a, sum), b);
+                let bound =
+                    _mm256_add_epi64(_mm256_srli_epi64::<63>(a), _mm256_set1_epi64x(i64::MAX));
+                let result = _mm256_blendv_pd(
+                    _mm256_castsi256_pd(sum),
+                    _mm256_castsi256_pd(bound),
+                    _mm256_castsi256_pd(overflow),
+                );
+                _mm256_castpd_si256(result).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -10986,6 +11190,24 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u64x4<Avx2>, b: u64x4<Avx2>) -> u64x4<Avx2> {
                 _mm256_add_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u64x4(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u64x4<Avx2>, b: u64x4<Avx2>) -> u64x4<Avx2> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm256_add_epi64(a, b);
+                let sign_bias = _mm256_set1_epi64x(i64::MIN);
+                let overflow = _mm256_cmpgt_epi64(
+                    _mm256_xor_si256(a, sign_bias),
+                    _mm256_xor_si256(sum, sign_bias),
+                );
+                _mm256_or_si256(sum, overflow).simd_into(token)
             }
         );
         kernel(self, a, b)

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -1013,6 +1013,16 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x16<Avx512>, b: i8x16<Avx512>) -> i8x16<Avx512> {
+                _mm_subs_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1569,6 +1579,16 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u8x16<Avx512>, b: u8x16<Avx512>) -> u8x16<Avx512> {
                 _mm_sub_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x16<Avx512>, b: u8x16<Avx512>) -> u8x16<Avx512> {
+                _mm_subs_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -2192,6 +2212,16 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x8<Avx512>, b: i16x8<Avx512>) -> i16x8<Avx512> {
+                _mm_subs_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2678,6 +2708,16 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u16x8<Avx512>, b: u16x8<Avx512>) -> u16x8<Avx512> {
                 _mm_sub_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x8<Avx512>, b: u16x8<Avx512>) -> u16x8<Avx512> {
+                _mm_subs_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3267,11 +3307,11 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i32x4<Avx512>, b: i32x4<Avx512>) -> i32x4<Avx512> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm_add_epi32(a, b);
-                let overflow_bits = _mm_ternarylogic_epi32::<0x42>(a, b, sum);
+                let wrapped = _mm_add_epi32(a, b);
+                let overflow_bits = _mm_ternarylogic_epi32::<0x42>(a, b, wrapped);
                 let overflow_mask = _mm_srai_epi32::<31>(overflow_bits);
                 let direction = _mm_add_epi32(_mm_srli_epi32::<31>(a), _mm_set1_epi32(i32::MAX));
-                _mm_ternarylogic_epi32::<0xca>(overflow_mask, direction, sum).simd_into(token)
+                _mm_ternarylogic_epi32::<0xca>(overflow_mask, direction, wrapped).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3282,6 +3322,22 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: i32x4<Avx512>, b: i32x4<Avx512>) -> i32x4<Avx512> {
                 _mm_sub_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x4<Avx512>, b: i32x4<Avx512>) -> i32x4<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm_sub_epi32(a, b);
+                let overflow_bits = _mm_ternarylogic_epi32::<0x18>(a, b, wrapped);
+                let overflow_mask = _mm_srai_epi32::<31>(overflow_bits);
+                let direction = _mm_add_epi32(_mm_srli_epi32::<31>(a), _mm_set1_epi32(i32::MAX));
+                _mm_ternarylogic_epi32::<0xca>(overflow_mask, direction, wrapped).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3765,6 +3821,18 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u32x4<Avx512>, b: u32x4<Avx512>) -> u32x4<Avx512> {
                 _mm_sub_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x4<Avx512>, b: u32x4<Avx512>) -> u32x4<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                _mm_sub_epi32(_mm_max_epu32(a, b), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -4882,11 +4950,11 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i64x2<Avx512>, b: i64x2<Avx512>) -> i64x2<Avx512> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm_add_epi64(a, b);
-                let overflow_bits = _mm_ternarylogic_epi64::<0x42>(a, b, sum);
+                let wrapped = _mm_add_epi64(a, b);
+                let overflow_bits = _mm_ternarylogic_epi64::<0x42>(a, b, wrapped);
                 let overflow_mask = _mm_srai_epi64::<63>(overflow_bits);
                 let direction = _mm_add_epi64(_mm_srli_epi64::<63>(a), _mm_set1_epi64x(i64::MAX));
-                _mm_ternarylogic_epi64::<0xca>(overflow_mask, direction, sum).simd_into(token)
+                _mm_ternarylogic_epi64::<0xca>(overflow_mask, direction, wrapped).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -4897,6 +4965,22 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: i64x2<Avx512>, b: i64x2<Avx512>) -> i64x2<Avx512> {
                 _mm_sub_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i64x2<Avx512>, b: i64x2<Avx512>) -> i64x2<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm_sub_epi64(a, b);
+                let overflow_bits = _mm_ternarylogic_epi64::<0x18>(a, b, wrapped);
+                let overflow_mask = _mm_srai_epi64::<63>(overflow_bits);
+                let direction = _mm_add_epi64(_mm_srli_epi64::<63>(a), _mm_set1_epi64x(i64::MAX));
+                _mm_ternarylogic_epi64::<0xca>(overflow_mask, direction, wrapped).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -5345,6 +5429,18 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u64x2<Avx512>, b: u64x2<Avx512>) -> u64x2<Avx512> {
                 _mm_sub_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u64x2<Avx512>, b: u64x2<Avx512>) -> u64x2<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                _mm_sub_epi64(_mm_max_epu64(a, b), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -6476,6 +6572,16 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x32<Avx512>, b: i8x32<Avx512>) -> i8x32<Avx512> {
+                _mm256_subs_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7024,6 +7130,16 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u8x32<Avx512>, b: u8x32<Avx512>) -> u8x32<Avx512> {
                 _mm256_sub_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x32<Avx512>, b: u8x32<Avx512>) -> u8x32<Avx512> {
+                _mm256_subs_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -7653,6 +7769,16 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x16<Avx512>, b: i16x16<Avx512>) -> i16x16<Avx512> {
+                _mm256_subs_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -8128,6 +8254,16 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u16x16<Avx512>, b: u16x16<Avx512>) -> u16x16<Avx512> {
                 _mm256_sub_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x16<Avx512>, b: u16x16<Avx512>) -> u16x16<Avx512> {
+                _mm256_subs_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -8720,12 +8856,13 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i32x8<Avx512>, b: i32x8<Avx512>) -> i32x8<Avx512> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm256_add_epi32(a, b);
-                let overflow_bits = _mm256_ternarylogic_epi32::<0x42>(a, b, sum);
+                let wrapped = _mm256_add_epi32(a, b);
+                let overflow_bits = _mm256_ternarylogic_epi32::<0x42>(a, b, wrapped);
                 let overflow_mask = _mm256_srai_epi32::<31>(overflow_bits);
                 let direction =
                     _mm256_add_epi32(_mm256_srli_epi32::<31>(a), _mm256_set1_epi32(i32::MAX));
-                _mm256_ternarylogic_epi32::<0xca>(overflow_mask, direction, sum).simd_into(token)
+                _mm256_ternarylogic_epi32::<0xca>(overflow_mask, direction, wrapped)
+                    .simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -8736,6 +8873,24 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: i32x8<Avx512>, b: i32x8<Avx512>) -> i32x8<Avx512> {
                 _mm256_sub_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x8<Avx512>, b: i32x8<Avx512>) -> i32x8<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm256_sub_epi32(a, b);
+                let overflow_bits = _mm256_ternarylogic_epi32::<0x18>(a, b, wrapped);
+                let overflow_mask = _mm256_srai_epi32::<31>(overflow_bits);
+                let direction =
+                    _mm256_add_epi32(_mm256_srli_epi32::<31>(a), _mm256_set1_epi32(i32::MAX));
+                _mm256_ternarylogic_epi32::<0xca>(overflow_mask, direction, wrapped)
+                    .simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -9207,6 +9362,18 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u32x8<Avx512>, b: u32x8<Avx512>) -> u32x8<Avx512> {
                 _mm256_sub_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x8<Avx512>, b: u32x8<Avx512>) -> u32x8<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                _mm256_sub_epi32(_mm256_max_epu32(a, b), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -10309,12 +10476,13 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i64x4<Avx512>, b: i64x4<Avx512>) -> i64x4<Avx512> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm256_add_epi64(a, b);
-                let overflow_bits = _mm256_ternarylogic_epi64::<0x42>(a, b, sum);
+                let wrapped = _mm256_add_epi64(a, b);
+                let overflow_bits = _mm256_ternarylogic_epi64::<0x42>(a, b, wrapped);
                 let overflow_mask = _mm256_srai_epi64::<63>(overflow_bits);
                 let direction =
                     _mm256_add_epi64(_mm256_srli_epi64::<63>(a), _mm256_set1_epi64x(i64::MAX));
-                _mm256_ternarylogic_epi64::<0xca>(overflow_mask, direction, sum).simd_into(token)
+                _mm256_ternarylogic_epi64::<0xca>(overflow_mask, direction, wrapped)
+                    .simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -10325,6 +10493,24 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: i64x4<Avx512>, b: i64x4<Avx512>) -> i64x4<Avx512> {
                 _mm256_sub_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i64x4<Avx512>, b: i64x4<Avx512>) -> i64x4<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm256_sub_epi64(a, b);
+                let overflow_bits = _mm256_ternarylogic_epi64::<0x18>(a, b, wrapped);
+                let overflow_mask = _mm256_srai_epi64::<63>(overflow_bits);
+                let direction =
+                    _mm256_add_epi64(_mm256_srli_epi64::<63>(a), _mm256_set1_epi64x(i64::MAX));
+                _mm256_ternarylogic_epi64::<0xca>(overflow_mask, direction, wrapped)
+                    .simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -10766,6 +10952,18 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u64x4<Avx512>, b: u64x4<Avx512>) -> u64x4<Avx512> {
                 _mm256_sub_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u64x4(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u64x4<Avx512>, b: u64x4<Avx512>) -> u64x4<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                _mm256_sub_epi64(_mm256_max_epu64(a, b), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -11892,6 +12090,16 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x64<Avx512>, b: i8x64<Avx512>) -> i8x64<Avx512> {
+                _mm512_subs_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -12450,6 +12658,16 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u8x64<Avx512>, b: u8x64<Avx512>) -> u8x64<Avx512> {
                 _mm512_sub_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x64<Avx512>, b: u8x64<Avx512>) -> u8x64<Avx512> {
+                _mm512_subs_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -13081,6 +13299,16 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x32<Avx512>, b: i16x32<Avx512>) -> i16x32<Avx512> {
+                _mm512_subs_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -13567,6 +13795,16 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u16x32<Avx512>, b: u16x32<Avx512>) -> u16x32<Avx512> {
                 _mm512_sub_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x32<Avx512>, b: u16x32<Avx512>) -> u16x32<Avx512> {
+                _mm512_subs_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -14162,12 +14400,13 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i32x16<Avx512>, b: i32x16<Avx512>) -> i32x16<Avx512> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm512_add_epi32(a, b);
-                let overflow_bits = _mm512_ternarylogic_epi32::<0x42>(a, b, sum);
+                let wrapped = _mm512_add_epi32(a, b);
+                let overflow_bits = _mm512_ternarylogic_epi32::<0x42>(a, b, wrapped);
                 let overflow_mask = _mm512_srai_epi32::<31>(overflow_bits);
                 let direction =
                     _mm512_add_epi32(_mm512_srli_epi32::<31>(a), _mm512_set1_epi32(i32::MAX));
-                _mm512_ternarylogic_epi32::<0xca>(overflow_mask, direction, sum).simd_into(token)
+                _mm512_ternarylogic_epi32::<0xca>(overflow_mask, direction, wrapped)
+                    .simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -14178,6 +14417,24 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: i32x16<Avx512>, b: i32x16<Avx512>) -> i32x16<Avx512> {
                 _mm512_sub_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x16<Avx512>, b: i32x16<Avx512>) -> i32x16<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm512_sub_epi32(a, b);
+                let overflow_bits = _mm512_ternarylogic_epi32::<0x18>(a, b, wrapped);
+                let overflow_mask = _mm512_srai_epi32::<31>(overflow_bits);
+                let direction =
+                    _mm512_add_epi32(_mm512_srli_epi32::<31>(a), _mm512_set1_epi32(i32::MAX));
+                _mm512_ternarylogic_epi32::<0xca>(overflow_mask, direction, wrapped)
+                    .simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -14664,6 +14921,18 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u32x16<Avx512>, b: u32x16<Avx512>) -> u32x16<Avx512> {
                 _mm512_sub_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x16<Avx512>, b: u32x16<Avx512>) -> u32x16<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                _mm512_sub_epi32(_mm512_max_epu32(a, b), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -15785,12 +16054,13 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: i64x8<Avx512>, b: i64x8<Avx512>) -> i64x8<Avx512> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm512_add_epi64(a, b);
-                let overflow_bits = _mm512_ternarylogic_epi64::<0x42>(a, b, sum);
+                let wrapped = _mm512_add_epi64(a, b);
+                let overflow_bits = _mm512_ternarylogic_epi64::<0x42>(a, b, wrapped);
                 let overflow_mask = _mm512_srai_epi64::<63>(overflow_bits);
                 let direction =
                     _mm512_add_epi64(_mm512_srli_epi64::<63>(a), _mm512_set1_epi64(i64::MAX));
-                _mm512_ternarylogic_epi64::<0xca>(overflow_mask, direction, sum).simd_into(token)
+                _mm512_ternarylogic_epi64::<0xca>(overflow_mask, direction, wrapped)
+                    .simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -15801,6 +16071,24 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: i64x8<Avx512>, b: i64x8<Avx512>) -> i64x8<Avx512> {
                 _mm512_sub_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i64x8<Avx512>, b: i64x8<Avx512>) -> i64x8<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm512_sub_epi64(a, b);
+                let overflow_bits = _mm512_ternarylogic_epi64::<0x18>(a, b, wrapped);
+                let overflow_mask = _mm512_srai_epi64::<63>(overflow_bits);
+                let direction =
+                    _mm512_add_epi64(_mm512_srli_epi64::<63>(a), _mm512_set1_epi64(i64::MAX));
+                _mm512_ternarylogic_epi64::<0xca>(overflow_mask, direction, wrapped)
+                    .simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -16251,6 +16539,18 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u64x8<Avx512>, b: u64x8<Avx512>) -> u64x8<Avx512> {
                 _mm512_sub_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u64x8(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u64x8<Avx512>, b: u64x8<Avx512>) -> u64x8<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                _mm512_sub_epi64(_mm512_max_epu64(a, b), b).simd_into(token)
             }
         );
         kernel(self, a, b)

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -993,6 +993,16 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x16<Avx512>, b: i8x16<Avx512>) -> i8x16<Avx512> {
+                _mm_adds_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1539,6 +1549,16 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u8x16<Avx512>, b: u8x16<Avx512>) -> u8x16<Avx512> {
                 _mm_add_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x16<Avx512>, b: u8x16<Avx512>) -> u8x16<Avx512> {
+                _mm_adds_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -2152,6 +2172,16 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x8<Avx512>, b: i16x8<Avx512>) -> i16x8<Avx512> {
+                _mm_adds_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2628,6 +2658,16 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u16x8<Avx512>, b: u16x8<Avx512>) -> u16x8<Avx512> {
                 _mm_add_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x8<Avx512>, b: u16x8<Avx512>) -> u16x8<Avx512> {
+                _mm_adds_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3221,6 +3261,22 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x4<Avx512>, b: i32x4<Avx512>) -> i32x4<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm_add_epi32(a, b);
+                let overflow_bits = _mm_ternarylogic_epi32::<0x42>(a, b, sum);
+                let overflow_mask = _mm_srai_epi32::<31>(overflow_bits);
+                let direction = _mm_add_epi32(_mm_srli_epi32::<31>(a), _mm_set1_epi32(i32::MAX));
+                _mm_ternarylogic_epi32::<0xca>(overflow_mask, direction, sum).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3686,6 +3742,19 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u32x4<Avx512>, b: u32x4<Avx512>) -> u32x4<Avx512> {
                 _mm_add_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x4<Avx512>, b: u32x4<Avx512>) -> u32x4<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let threshold = _mm_xor_si128(b, _mm_set1_epi32(-1));
+                _mm_add_epi32(_mm_min_epu32(a, threshold), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -4807,6 +4876,22 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i64x2<Avx512>, b: i64x2<Avx512>) -> i64x2<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm_add_epi64(a, b);
+                let overflow_bits = _mm_ternarylogic_epi64::<0x42>(a, b, sum);
+                let overflow_mask = _mm_srai_epi64::<63>(overflow_bits);
+                let direction = _mm_add_epi64(_mm_srli_epi64::<63>(a), _mm_set1_epi64x(i64::MAX));
+                _mm_ternarylogic_epi64::<0xca>(overflow_mask, direction, sum).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5237,6 +5322,19 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u64x2<Avx512>, b: u64x2<Avx512>) -> u64x2<Avx512> {
                 _mm_add_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u64x2<Avx512>, b: u64x2<Avx512>) -> u64x2<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let threshold = _mm_xor_si128(b, _mm_set1_epi64x(-1));
+                _mm_add_epi64(_mm_min_epu64(a, threshold), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -6358,6 +6456,16 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x32<Avx512>, b: i8x32<Avx512>) -> i8x32<Avx512> {
+                _mm256_adds_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -6896,6 +7004,16 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u8x32<Avx512>, b: u8x32<Avx512>) -> u8x32<Avx512> {
                 _mm256_add_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x32<Avx512>, b: u8x32<Avx512>) -> u8x32<Avx512> {
+                _mm256_adds_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -7515,6 +7633,16 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x16<Avx512>, b: i16x16<Avx512>) -> i16x16<Avx512> {
+                _mm256_adds_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7980,6 +8108,16 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u16x16<Avx512>, b: u16x16<Avx512>) -> u16x16<Avx512> {
                 _mm256_add_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x16<Avx512>, b: u16x16<Avx512>) -> u16x16<Avx512> {
+                _mm256_adds_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -8576,6 +8714,23 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x8<Avx512>, b: i32x8<Avx512>) -> i32x8<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm256_add_epi32(a, b);
+                let overflow_bits = _mm256_ternarylogic_epi32::<0x42>(a, b, sum);
+                let overflow_mask = _mm256_srai_epi32::<31>(overflow_bits);
+                let direction =
+                    _mm256_add_epi32(_mm256_srli_epi32::<31>(a), _mm256_set1_epi32(i32::MAX));
+                _mm256_ternarylogic_epi32::<0xca>(overflow_mask, direction, sum).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -9029,6 +9184,19 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u32x8<Avx512>, b: u32x8<Avx512>) -> u32x8<Avx512> {
                 _mm256_add_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x8<Avx512>, b: u32x8<Avx512>) -> u32x8<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let threshold = _mm256_xor_si256(b, _mm256_set1_epi32(-1));
+                _mm256_add_epi32(_mm256_min_epu32(a, threshold), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -10135,6 +10303,23 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i64x4<Avx512>, b: i64x4<Avx512>) -> i64x4<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm256_add_epi64(a, b);
+                let overflow_bits = _mm256_ternarylogic_epi64::<0x42>(a, b, sum);
+                let overflow_mask = _mm256_srai_epi64::<63>(overflow_bits);
+                let direction =
+                    _mm256_add_epi64(_mm256_srli_epi64::<63>(a), _mm256_set1_epi64x(i64::MAX));
+                _mm256_ternarylogic_epi64::<0xca>(overflow_mask, direction, sum).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -10558,6 +10743,19 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u64x4<Avx512>, b: u64x4<Avx512>) -> u64x4<Avx512> {
                 _mm256_add_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u64x4(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u64x4<Avx512>, b: u64x4<Avx512>) -> u64x4<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let threshold = _mm256_xor_si256(b, _mm256_set1_epi64x(-1));
+                _mm256_add_epi64(_mm256_min_epu64(a, threshold), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -11674,6 +11872,16 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x64<Avx512>, b: i8x64<Avx512>) -> i8x64<Avx512> {
+                _mm512_adds_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -12222,6 +12430,16 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u8x64<Avx512>, b: u8x64<Avx512>) -> u8x64<Avx512> {
                 _mm512_add_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x64<Avx512>, b: u8x64<Avx512>) -> u8x64<Avx512> {
+                _mm512_adds_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -12843,6 +13061,16 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x32<Avx512>, b: i16x32<Avx512>) -> i16x32<Avx512> {
+                _mm512_adds_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -13319,6 +13547,16 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u16x32<Avx512>, b: u16x32<Avx512>) -> u16x32<Avx512> {
                 _mm512_add_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x32<Avx512>, b: u16x32<Avx512>) -> u16x32<Avx512> {
+                _mm512_adds_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -13918,6 +14156,23 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x16<Avx512>, b: i32x16<Avx512>) -> i32x16<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm512_add_epi32(a, b);
+                let overflow_bits = _mm512_ternarylogic_epi32::<0x42>(a, b, sum);
+                let overflow_mask = _mm512_srai_epi32::<31>(overflow_bits);
+                let direction =
+                    _mm512_add_epi32(_mm512_srli_epi32::<31>(a), _mm512_set1_epi32(i32::MAX));
+                _mm512_ternarylogic_epi32::<0xca>(overflow_mask, direction, sum).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -14386,6 +14641,19 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u32x16<Avx512>, b: u32x16<Avx512>) -> u32x16<Avx512> {
                 _mm512_add_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x16<Avx512>, b: u32x16<Avx512>) -> u32x16<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let threshold = _mm512_xor_si512(b, _mm512_set1_epi32(-1));
+                _mm512_add_epi32(_mm512_min_epu32(a, threshold), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -15511,6 +15779,23 @@ impl Simd for Avx512 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i64x8<Avx512>, b: i64x8<Avx512>) -> i64x8<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm512_add_epi64(a, b);
+                let overflow_bits = _mm512_ternarylogic_epi64::<0x42>(a, b, sum);
+                let overflow_mask = _mm512_srai_epi64::<63>(overflow_bits);
+                let direction =
+                    _mm512_add_epi64(_mm512_srli_epi64::<63>(a), _mm512_set1_epi64(i64::MAX));
+                _mm512_ternarylogic_epi64::<0xca>(overflow_mask, direction, sum).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -15943,6 +16228,19 @@ impl Simd for Avx512 {
             #[inline(always)]
             fn kernel(token: Avx512, a: u64x8<Avx512>, b: u64x8<Avx512>) -> u64x8<Avx512> {
                 _mm512_add_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u64x8(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u64x8<Avx512>, b: u64x8<Avx512>) -> u64x8<Avx512> {
+                let a = a.into();
+                let b = b.into();
+                let threshold = _mm512_xor_si512(b, _mm512_set1_epi64(-1));
+                _mm512_add_epi64(_mm512_min_epu64(a, threshold), b).simd_into(token)
             }
         );
         kernel(self, a, b)

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -705,6 +705,28 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn saturating_add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        [
+            i8::saturating_add(a[0usize], b[0usize]),
+            i8::saturating_add(a[1usize], b[1usize]),
+            i8::saturating_add(a[2usize], b[2usize]),
+            i8::saturating_add(a[3usize], b[3usize]),
+            i8::saturating_add(a[4usize], b[4usize]),
+            i8::saturating_add(a[5usize], b[5usize]),
+            i8::saturating_add(a[6usize], b[6usize]),
+            i8::saturating_add(a[7usize], b[7usize]),
+            i8::saturating_add(a[8usize], b[8usize]),
+            i8::saturating_add(a[9usize], b[9usize]),
+            i8::saturating_add(a[10usize], b[10usize]),
+            i8::saturating_add(a[11usize], b[11usize]),
+            i8::saturating_add(a[12usize], b[12usize]),
+            i8::saturating_add(a[13usize], b[13usize]),
+            i8::saturating_add(a[14usize], b[14usize]),
+            i8::saturating_add(a[15usize], b[15usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         [
             i8::wrapping_sub(a[0usize], b[0usize]),
@@ -1626,6 +1648,28 @@ impl Simd for Fallback {
             u8::wrapping_add(a[13usize], b[13usize]),
             u8::wrapping_add(a[14usize], b[14usize]),
             u8::wrapping_add(a[15usize], b[15usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        [
+            u8::saturating_add(a[0usize], b[0usize]),
+            u8::saturating_add(a[1usize], b[1usize]),
+            u8::saturating_add(a[2usize], b[2usize]),
+            u8::saturating_add(a[3usize], b[3usize]),
+            u8::saturating_add(a[4usize], b[4usize]),
+            u8::saturating_add(a[5usize], b[5usize]),
+            u8::saturating_add(a[6usize], b[6usize]),
+            u8::saturating_add(a[7usize], b[7usize]),
+            u8::saturating_add(a[8usize], b[8usize]),
+            u8::saturating_add(a[9usize], b[9usize]),
+            u8::saturating_add(a[10usize], b[10usize]),
+            u8::saturating_add(a[11usize], b[11usize]),
+            u8::saturating_add(a[12usize], b[12usize]),
+            u8::saturating_add(a[13usize], b[13usize]),
+            u8::saturating_add(a[14usize], b[14usize]),
+            u8::saturating_add(a[15usize], b[15usize]),
         ]
         .simd_into(self)
     }
@@ -2769,6 +2813,20 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn saturating_add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        [
+            i16::saturating_add(a[0usize], b[0usize]),
+            i16::saturating_add(a[1usize], b[1usize]),
+            i16::saturating_add(a[2usize], b[2usize]),
+            i16::saturating_add(a[3usize], b[3usize]),
+            i16::saturating_add(a[4usize], b[4usize]),
+            i16::saturating_add(a[5usize], b[5usize]),
+            i16::saturating_add(a[6usize], b[6usize]),
+            i16::saturating_add(a[7usize], b[7usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         [
             i16::wrapping_sub(a[0usize], b[0usize]),
@@ -3347,6 +3405,20 @@ impl Simd for Fallback {
             u16::wrapping_add(a[5usize], b[5usize]),
             u16::wrapping_add(a[6usize], b[6usize]),
             u16::wrapping_add(a[7usize], b[7usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        [
+            u16::saturating_add(a[0usize], b[0usize]),
+            u16::saturating_add(a[1usize], b[1usize]),
+            u16::saturating_add(a[2usize], b[2usize]),
+            u16::saturating_add(a[3usize], b[3usize]),
+            u16::saturating_add(a[4usize], b[4usize]),
+            u16::saturating_add(a[5usize], b[5usize]),
+            u16::saturating_add(a[6usize], b[6usize]),
+            u16::saturating_add(a[7usize], b[7usize]),
         ]
         .simd_into(self)
     }
@@ -4133,6 +4205,16 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn saturating_add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        [
+            i32::saturating_add(a[0usize], b[0usize]),
+            i32::saturating_add(a[1usize], b[1usize]),
+            i32::saturating_add(a[2usize], b[2usize]),
+            i32::saturating_add(a[3usize], b[3usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         [
             i32::wrapping_sub(a[0usize], b[0usize]),
@@ -4508,6 +4590,16 @@ impl Simd for Fallback {
             u32::wrapping_add(a[1usize], b[1usize]),
             u32::wrapping_add(a[2usize], b[2usize]),
             u32::wrapping_add(a[3usize], b[3usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        [
+            u32::saturating_add(a[0usize], b[0usize]),
+            u32::saturating_add(a[1usize], b[1usize]),
+            u32::saturating_add(a[2usize], b[2usize]),
+            u32::saturating_add(a[3usize], b[3usize]),
         ]
         .simd_into(self)
     }
@@ -5337,6 +5429,14 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn saturating_add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        [
+            i64::saturating_add(a[0usize], b[0usize]),
+            i64::saturating_add(a[1usize], b[1usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         [
             i64::wrapping_sub(a[0usize], b[0usize]),
@@ -5615,6 +5715,14 @@ impl Simd for Fallback {
         [
             u64::wrapping_add(a[0usize], b[0usize]),
             u64::wrapping_add(a[1usize], b[1usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        [
+            u64::saturating_add(a[0usize], b[0usize]),
+            u64::saturating_add(a[1usize], b[1usize]),
         ]
         .simd_into(self)
     }

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -749,6 +749,28 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn saturating_sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        [
+            i8::saturating_sub(a[0usize], b[0usize]),
+            i8::saturating_sub(a[1usize], b[1usize]),
+            i8::saturating_sub(a[2usize], b[2usize]),
+            i8::saturating_sub(a[3usize], b[3usize]),
+            i8::saturating_sub(a[4usize], b[4usize]),
+            i8::saturating_sub(a[5usize], b[5usize]),
+            i8::saturating_sub(a[6usize], b[6usize]),
+            i8::saturating_sub(a[7usize], b[7usize]),
+            i8::saturating_sub(a[8usize], b[8usize]),
+            i8::saturating_sub(a[9usize], b[9usize]),
+            i8::saturating_sub(a[10usize], b[10usize]),
+            i8::saturating_sub(a[11usize], b[11usize]),
+            i8::saturating_sub(a[12usize], b[12usize]),
+            i8::saturating_sub(a[13usize], b[13usize]),
+            i8::saturating_sub(a[14usize], b[14usize]),
+            i8::saturating_sub(a[15usize], b[15usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn mul_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         [
             i8::wrapping_mul(a[0usize], b[0usize]),
@@ -1692,6 +1714,28 @@ impl Simd for Fallback {
             u8::wrapping_sub(a[13usize], b[13usize]),
             u8::wrapping_sub(a[14usize], b[14usize]),
             u8::wrapping_sub(a[15usize], b[15usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        [
+            u8::saturating_sub(a[0usize], b[0usize]),
+            u8::saturating_sub(a[1usize], b[1usize]),
+            u8::saturating_sub(a[2usize], b[2usize]),
+            u8::saturating_sub(a[3usize], b[3usize]),
+            u8::saturating_sub(a[4usize], b[4usize]),
+            u8::saturating_sub(a[5usize], b[5usize]),
+            u8::saturating_sub(a[6usize], b[6usize]),
+            u8::saturating_sub(a[7usize], b[7usize]),
+            u8::saturating_sub(a[8usize], b[8usize]),
+            u8::saturating_sub(a[9usize], b[9usize]),
+            u8::saturating_sub(a[10usize], b[10usize]),
+            u8::saturating_sub(a[11usize], b[11usize]),
+            u8::saturating_sub(a[12usize], b[12usize]),
+            u8::saturating_sub(a[13usize], b[13usize]),
+            u8::saturating_sub(a[14usize], b[14usize]),
+            u8::saturating_sub(a[15usize], b[15usize]),
         ]
         .simd_into(self)
     }
@@ -2841,6 +2885,20 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn saturating_sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        [
+            i16::saturating_sub(a[0usize], b[0usize]),
+            i16::saturating_sub(a[1usize], b[1usize]),
+            i16::saturating_sub(a[2usize], b[2usize]),
+            i16::saturating_sub(a[3usize], b[3usize]),
+            i16::saturating_sub(a[4usize], b[4usize]),
+            i16::saturating_sub(a[5usize], b[5usize]),
+            i16::saturating_sub(a[6usize], b[6usize]),
+            i16::saturating_sub(a[7usize], b[7usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         [
             i16::wrapping_mul(a[0usize], b[0usize]),
@@ -3433,6 +3491,20 @@ impl Simd for Fallback {
             u16::wrapping_sub(a[5usize], b[5usize]),
             u16::wrapping_sub(a[6usize], b[6usize]),
             u16::wrapping_sub(a[7usize], b[7usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        [
+            u16::saturating_sub(a[0usize], b[0usize]),
+            u16::saturating_sub(a[1usize], b[1usize]),
+            u16::saturating_sub(a[2usize], b[2usize]),
+            u16::saturating_sub(a[3usize], b[3usize]),
+            u16::saturating_sub(a[4usize], b[4usize]),
+            u16::saturating_sub(a[5usize], b[5usize]),
+            u16::saturating_sub(a[6usize], b[6usize]),
+            u16::saturating_sub(a[7usize], b[7usize]),
         ]
         .simd_into(self)
     }
@@ -4225,6 +4297,16 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn saturating_sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        [
+            i32::saturating_sub(a[0usize], b[0usize]),
+            i32::saturating_sub(a[1usize], b[1usize]),
+            i32::saturating_sub(a[2usize], b[2usize]),
+            i32::saturating_sub(a[3usize], b[3usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn mul_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         [
             i32::wrapping_mul(a[0usize], b[0usize]),
@@ -4610,6 +4692,16 @@ impl Simd for Fallback {
             u32::wrapping_sub(a[1usize], b[1usize]),
             u32::wrapping_sub(a[2usize], b[2usize]),
             u32::wrapping_sub(a[3usize], b[3usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        [
+            u32::saturating_sub(a[0usize], b[0usize]),
+            u32::saturating_sub(a[1usize], b[1usize]),
+            u32::saturating_sub(a[2usize], b[2usize]),
+            u32::saturating_sub(a[3usize], b[3usize]),
         ]
         .simd_into(self)
     }
@@ -5445,6 +5537,14 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn saturating_sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        [
+            i64::saturating_sub(a[0usize], b[0usize]),
+            i64::saturating_sub(a[1usize], b[1usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn mul_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         [
             i64::wrapping_mul(a[0usize], b[0usize]),
@@ -5731,6 +5831,14 @@ impl Simd for Fallback {
         [
             u64::wrapping_sub(a[0usize], b[0usize]),
             u64::wrapping_sub(a[1usize], b[1usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        [
+            u64::saturating_sub(a[0usize], b[0usize]),
+            u64::saturating_sub(a[1usize], b[1usize]),
         ]
         .simd_into(self)
     }

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -625,6 +625,16 @@ impl Simd for Neon {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i8x16<Neon>, b: i8x16<Neon>) -> i8x16<Neon> {
+                vqaddq_s8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1013,6 +1023,16 @@ impl Simd for Neon {
             #[inline(always)]
             fn kernel(token: Neon, a: u8x16<Neon>, b: u8x16<Neon>) -> u8x16<Neon> {
                 vaddq_u8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u8x16<Neon>, b: u8x16<Neon>) -> u8x16<Neon> {
+                vqaddq_u8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -1558,6 +1578,16 @@ impl Simd for Neon {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i16x8<Neon>, b: i16x8<Neon>) -> i16x8<Neon> {
+                vqaddq_s16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1945,6 +1975,16 @@ impl Simd for Neon {
             #[inline(always)]
             fn kernel(token: Neon, a: u16x8<Neon>, b: u16x8<Neon>) -> u16x8<Neon> {
                 vaddq_u16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u16x8<Neon>, b: u16x8<Neon>) -> u16x8<Neon> {
+                vqaddq_u16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -2515,6 +2555,16 @@ impl Simd for Neon {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i32x4<Neon>, b: i32x4<Neon>) -> i32x4<Neon> {
+                vqaddq_s32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2912,6 +2962,16 @@ impl Simd for Neon {
             #[inline(always)]
             fn kernel(token: Neon, a: u32x4<Neon>, b: u32x4<Neon>) -> u32x4<Neon> {
                 vaddq_u32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u32x4<Neon>, b: u32x4<Neon>) -> u32x4<Neon> {
+                vqaddq_u32(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3956,6 +4016,16 @@ impl Simd for Neon {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i64x2<Neon>, b: i64x2<Neon>) -> i64x2<Neon> {
+                vqaddq_s64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -4327,6 +4397,16 @@ impl Simd for Neon {
             #[inline(always)]
             fn kernel(token: Neon, a: u64x2<Neon>, b: u64x2<Neon>) -> u64x2<Neon> {
                 vaddq_u64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u64x2<Neon>, b: u64x2<Neon>) -> u64x2<Neon> {
+                vqaddq_u64(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -645,6 +645,16 @@ impl Simd for Neon {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i8x16<Neon>, b: i8x16<Neon>) -> i8x16<Neon> {
+                vqsubq_s8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1043,6 +1053,16 @@ impl Simd for Neon {
             #[inline(always)]
             fn kernel(token: Neon, a: u8x16<Neon>, b: u8x16<Neon>) -> u8x16<Neon> {
                 vsubq_u8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u8x16<Neon>, b: u8x16<Neon>) -> u8x16<Neon> {
+                vqsubq_u8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -1598,6 +1618,16 @@ impl Simd for Neon {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i16x8<Neon>, b: i16x8<Neon>) -> i16x8<Neon> {
+                vqsubq_s16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1995,6 +2025,16 @@ impl Simd for Neon {
             #[inline(always)]
             fn kernel(token: Neon, a: u16x8<Neon>, b: u16x8<Neon>) -> u16x8<Neon> {
                 vsubq_u16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u16x8<Neon>, b: u16x8<Neon>) -> u16x8<Neon> {
+                vqsubq_u16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -2575,6 +2615,16 @@ impl Simd for Neon {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i32x4<Neon>, b: i32x4<Neon>) -> i32x4<Neon> {
+                vqsubq_s32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2982,6 +3032,16 @@ impl Simd for Neon {
             #[inline(always)]
             fn kernel(token: Neon, a: u32x4<Neon>, b: u32x4<Neon>) -> u32x4<Neon> {
                 vsubq_u32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u32x4<Neon>, b: u32x4<Neon>) -> u32x4<Neon> {
+                vqsubq_u32(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -4036,6 +4096,16 @@ impl Simd for Neon {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i64x2<Neon>, b: i64x2<Neon>) -> i64x2<Neon> {
+                vqsubq_s64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         [
             i64::wrapping_mul(a[0usize], b[0usize]),
@@ -4417,6 +4487,16 @@ impl Simd for Neon {
             #[inline(always)]
             fn kernel(token: Neon, a: u64x2<Neon>, b: u64x2<Neon>) -> u64x2<Neon> {
                 vsubq_u64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u64x2<Neon>, b: u64x2<Neon>) -> u64x2<Neon> {
+                vqsubq_u64(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -385,11 +385,11 @@ pub trait Simd:
     fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     fn saturating_add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     fn saturating_sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
@@ -492,11 +492,11 @@ pub trait Simd:
     fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     fn saturating_add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     fn saturating_sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
@@ -653,11 +653,11 @@ pub trait Simd:
     fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     fn saturating_add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     fn saturating_sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
@@ -775,11 +775,11 @@ pub trait Simd:
     fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     fn saturating_add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     fn saturating_sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
@@ -942,11 +942,11 @@ pub trait Simd:
     fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     fn saturating_add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     fn saturating_sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
@@ -1066,11 +1066,11 @@ pub trait Simd:
     fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     fn saturating_add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     fn saturating_sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
@@ -1375,11 +1375,11 @@ pub trait Simd:
     fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     fn saturating_add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     fn saturating_sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
@@ -1497,11 +1497,11 @@ pub trait Simd:
     fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     fn saturating_add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     fn saturating_sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
@@ -2073,7 +2073,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i8x32(b);
         self.combine_i8x16(self.add_i8x16(a0, b0), self.add_i8x16(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
@@ -2090,7 +2090,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i8x32(b);
         self.combine_i8x16(self.sub_i8x16(a0, b0), self.sub_i8x16(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
@@ -2366,7 +2366,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u8x32(b);
         self.combine_u8x16(self.add_u8x16(a0, b0), self.add_u8x16(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
         let (a0, a1) = self.split_u8x32(a);
@@ -2383,7 +2383,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u8x32(b);
         self.combine_u8x16(self.sub_u8x16(a0, b0), self.sub_u8x16(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
         let (a0, a1) = self.split_u8x32(a);
@@ -2775,7 +2775,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i16x16(b);
         self.combine_i16x8(self.add_i16x8(a0, b0), self.add_i16x8(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
@@ -2792,7 +2792,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i16x16(b);
         self.combine_i16x8(self.sub_i16x8(a0, b0), self.sub_i16x8(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
@@ -3100,7 +3100,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u16x16(b);
         self.combine_u16x8(self.add_u16x8(a0, b0), self.add_u16x8(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
         let (a0, a1) = self.split_u16x16(a);
@@ -3117,7 +3117,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u16x16(b);
         self.combine_u16x8(self.sub_u16x8(a0, b0), self.sub_u16x8(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
         let (a0, a1) = self.split_u16x16(a);
@@ -3532,7 +3532,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i32x8(b);
         self.combine_i32x4(self.add_i32x4(a0, b0), self.add_i32x4(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
@@ -3549,7 +3549,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i32x8(b);
         self.combine_i32x4(self.sub_i32x4(a0, b0), self.sub_i32x4(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
@@ -3859,7 +3859,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u32x8(b);
         self.combine_u32x4(self.add_u32x4(a0, b0), self.add_u32x4(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
         let (a0, a1) = self.split_u32x8(a);
@@ -3876,7 +3876,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u32x8(b);
         self.combine_u32x4(self.sub_u32x4(a0, b0), self.sub_u32x4(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
         let (a0, a1) = self.split_u32x8(a);
@@ -4699,7 +4699,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i64x4(b);
         self.combine_i64x2(self.add_i64x2(a0, b0), self.add_i64x2(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         let (a0, a1) = self.split_i64x4(a);
@@ -4716,7 +4716,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i64x4(b);
         self.combine_i64x2(self.sub_i64x2(a0, b0), self.sub_i64x2(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         let (a0, a1) = self.split_i64x4(a);
@@ -5018,7 +5018,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u64x4(b);
         self.combine_u64x2(self.add_u64x2(a0, b0), self.add_u64x2(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_u64x4(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
         let (a0, a1) = self.split_u64x4(a);
@@ -5035,7 +5035,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u64x4(b);
         self.combine_u64x2(self.sub_u64x2(a0, b0), self.sub_u64x2(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u64x4(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
         let (a0, a1) = self.split_u64x4(a);
@@ -5843,7 +5843,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i8x64(b);
         self.combine_i8x32(self.add_i8x32(a0, b0), self.add_i8x32(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
@@ -5860,7 +5860,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i8x64(b);
         self.combine_i8x32(self.sub_i8x32(a0, b0), self.sub_i8x32(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
@@ -6134,7 +6134,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u8x64(b);
         self.combine_u8x32(self.add_u8x32(a0, b0), self.add_u8x32(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
@@ -6151,7 +6151,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u8x64(b);
         self.combine_u8x32(self.sub_u8x32(a0, b0), self.sub_u8x32(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
@@ -6539,7 +6539,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i16x32(b);
         self.combine_i16x16(self.add_i16x16(a0, b0), self.add_i16x16(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
@@ -6556,7 +6556,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i16x32(b);
         self.combine_i16x16(self.sub_i16x16(a0, b0), self.sub_i16x16(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
@@ -6868,7 +6868,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u16x32(b);
         self.combine_u16x16(self.add_u16x16(a0, b0), self.add_u16x16(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
@@ -6885,7 +6885,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u16x32(b);
         self.combine_u16x16(self.sub_u16x16(a0, b0), self.sub_u16x16(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
@@ -7309,7 +7309,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i32x16(b);
         self.combine_i32x8(self.add_i32x8(a0, b0), self.add_i32x8(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
@@ -7326,7 +7326,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i32x16(b);
         self.combine_i32x8(self.sub_i32x8(a0, b0), self.sub_i32x8(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
@@ -7638,7 +7638,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u32x16(b);
         self.combine_u32x8(self.add_u32x8(a0, b0), self.add_u32x8(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
@@ -7655,7 +7655,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u32x16(b);
         self.combine_u32x8(self.sub_u32x8(a0, b0), self.sub_u32x8(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
@@ -8472,7 +8472,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i64x8(b);
         self.combine_i64x4(self.add_i64x4(a0, b0), self.add_i64x4(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         let (a0, a1) = self.split_i64x8(a);
@@ -8489,7 +8489,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i64x8(b);
         self.combine_i64x4(self.sub_i64x4(a0, b0), self.sub_i64x4(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         let (a0, a1) = self.split_i64x8(a);
@@ -8789,7 +8789,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u64x8(b);
         self.combine_u64x4(self.add_u64x4(a0, b0), self.add_u64x4(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     #[inline(always)]
     fn saturating_add_u64x8(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
         let (a0, a1) = self.split_u64x8(a);
@@ -8806,7 +8806,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u64x8(b);
         self.combine_u64x4(self.sub_u64x4(a0, b0), self.sub_u64x4(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u64x8(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
         let (a0, a1) = self.split_u64x8(a);
@@ -9857,9 +9857,9 @@ pub trait SimdInt<S: Simd>:
     fn count_ones(self) -> Self;
     #[doc = "Return the number of zeros in the binary representation of each element."]
     fn count_zeros(self) -> Self;
-    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
+    #[doc = "Add two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86."]
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
+    #[doc = "Subtract two vectors element-wise, saturating on overflow.\n\n\"Saturating\" means that if the result is not representable, the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86."]
     fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self;
 }
 #[doc = r" Functionality implemented by SIMD masks."]

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -385,11 +385,11 @@ pub trait Simd:
     fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     fn saturating_add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     fn saturating_sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
@@ -492,11 +492,11 @@ pub trait Simd:
     fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     fn saturating_add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     fn saturating_sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
@@ -643,11 +643,11 @@ pub trait Simd:
     fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     fn saturating_add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     fn saturating_sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
@@ -765,11 +765,11 @@ pub trait Simd:
     fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     fn saturating_add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     fn saturating_sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
@@ -922,11 +922,11 @@ pub trait Simd:
     fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     fn saturating_add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     fn saturating_sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
@@ -1046,11 +1046,11 @@ pub trait Simd:
     fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     fn saturating_add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     fn saturating_sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
@@ -1345,11 +1345,11 @@ pub trait Simd:
     fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     fn saturating_add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     fn saturating_sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
@@ -1467,11 +1467,11 @@ pub trait Simd:
     fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     fn saturating_add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     fn saturating_sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
@@ -2033,7 +2033,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i8x32(b);
         self.combine_i8x16(self.add_i8x16(a0, b0), self.add_i8x16(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
@@ -2050,7 +2050,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i8x32(b);
         self.combine_i8x16(self.sub_i8x16(a0, b0), self.sub_i8x16(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         let (a0, a1) = self.split_i8x32(a);
@@ -2326,7 +2326,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u8x32(b);
         self.combine_u8x16(self.add_u8x16(a0, b0), self.add_u8x16(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
         let (a0, a1) = self.split_u8x32(a);
@@ -2343,7 +2343,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u8x32(b);
         self.combine_u8x16(self.sub_u8x16(a0, b0), self.sub_u8x16(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
         let (a0, a1) = self.split_u8x32(a);
@@ -2725,7 +2725,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i16x16(b);
         self.combine_i16x8(self.add_i16x8(a0, b0), self.add_i16x8(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
@@ -2742,7 +2742,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i16x16(b);
         self.combine_i16x8(self.sub_i16x8(a0, b0), self.sub_i16x8(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         let (a0, a1) = self.split_i16x16(a);
@@ -3050,7 +3050,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u16x16(b);
         self.combine_u16x8(self.add_u16x8(a0, b0), self.add_u16x8(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
         let (a0, a1) = self.split_u16x16(a);
@@ -3067,7 +3067,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u16x16(b);
         self.combine_u16x8(self.sub_u16x8(a0, b0), self.sub_u16x8(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
         let (a0, a1) = self.split_u16x16(a);
@@ -3472,7 +3472,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i32x8(b);
         self.combine_i32x4(self.add_i32x4(a0, b0), self.add_i32x4(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
@@ -3489,7 +3489,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i32x8(b);
         self.combine_i32x4(self.sub_i32x4(a0, b0), self.sub_i32x4(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         let (a0, a1) = self.split_i32x8(a);
@@ -3799,7 +3799,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u32x8(b);
         self.combine_u32x4(self.add_u32x4(a0, b0), self.add_u32x4(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
         let (a0, a1) = self.split_u32x8(a);
@@ -3816,7 +3816,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u32x8(b);
         self.combine_u32x4(self.sub_u32x4(a0, b0), self.sub_u32x4(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
         let (a0, a1) = self.split_u32x8(a);
@@ -4629,7 +4629,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i64x4(b);
         self.combine_i64x2(self.add_i64x2(a0, b0), self.add_i64x2(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         let (a0, a1) = self.split_i64x4(a);
@@ -4646,7 +4646,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i64x4(b);
         self.combine_i64x2(self.sub_i64x2(a0, b0), self.sub_i64x2(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         let (a0, a1) = self.split_i64x4(a);
@@ -4948,7 +4948,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u64x4(b);
         self.combine_u64x2(self.add_u64x2(a0, b0), self.add_u64x2(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_u64x4(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
         let (a0, a1) = self.split_u64x4(a);
@@ -4965,7 +4965,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u64x4(b);
         self.combine_u64x2(self.sub_u64x2(a0, b0), self.sub_u64x2(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u64x4(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
         let (a0, a1) = self.split_u64x4(a);
@@ -5763,7 +5763,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i8x64(b);
         self.combine_i8x32(self.add_i8x32(a0, b0), self.add_i8x32(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
@@ -5780,7 +5780,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i8x64(b);
         self.combine_i8x32(self.sub_i8x32(a0, b0), self.sub_i8x32(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         let (a0, a1) = self.split_i8x64(a);
@@ -6054,7 +6054,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u8x64(b);
         self.combine_u8x32(self.add_u8x32(a0, b0), self.add_u8x32(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
@@ -6071,7 +6071,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u8x64(b);
         self.combine_u8x32(self.sub_u8x32(a0, b0), self.sub_u8x32(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
         let (a0, a1) = self.split_u8x64(a);
@@ -6449,7 +6449,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i16x32(b);
         self.combine_i16x16(self.add_i16x16(a0, b0), self.add_i16x16(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
@@ -6466,7 +6466,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i16x32(b);
         self.combine_i16x16(self.sub_i16x16(a0, b0), self.sub_i16x16(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         let (a0, a1) = self.split_i16x32(a);
@@ -6778,7 +6778,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u16x32(b);
         self.combine_u16x16(self.add_u16x16(a0, b0), self.add_u16x16(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
@@ -6795,7 +6795,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u16x32(b);
         self.combine_u16x16(self.sub_u16x16(a0, b0), self.sub_u16x16(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
@@ -7209,7 +7209,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i32x16(b);
         self.combine_i32x8(self.add_i32x8(a0, b0), self.add_i32x8(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
@@ -7226,7 +7226,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i32x16(b);
         self.combine_i32x8(self.sub_i32x8(a0, b0), self.sub_i32x8(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         let (a0, a1) = self.split_i32x16(a);
@@ -7538,7 +7538,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u32x16(b);
         self.combine_u32x8(self.add_u32x8(a0, b0), self.add_u32x8(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
@@ -7555,7 +7555,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u32x16(b);
         self.combine_u32x8(self.sub_u32x8(a0, b0), self.sub_u32x8(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
         let (a0, a1) = self.split_u32x16(a);
@@ -8362,7 +8362,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i64x8(b);
         self.combine_i64x4(self.add_i64x4(a0, b0), self.add_i64x4(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         let (a0, a1) = self.split_i64x8(a);
@@ -8379,7 +8379,7 @@ pub trait Simd:
         let (b0, b1) = self.split_i64x8(b);
         self.combine_i64x4(self.sub_i64x4(a0, b0), self.sub_i64x4(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         let (a0, a1) = self.split_i64x8(a);
@@ -8679,7 +8679,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u64x8(b);
         self.combine_u64x4(self.add_u64x4(a0, b0), self.add_u64x4(a1, b1))
     }
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     #[inline(always)]
     fn saturating_add_u64x8(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
         let (a0, a1) = self.split_u64x8(a);
@@ -8696,7 +8696,7 @@ pub trait Simd:
         let (b0, b1) = self.split_u64x8(b);
         self.combine_u64x4(self.sub_u64x4(a0, b0), self.sub_u64x4(a1, b1))
     }
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     #[inline(always)]
     fn saturating_sub_u64x8(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
         let (a0, a1) = self.split_u64x8(a);
@@ -9737,9 +9737,9 @@ pub trait SimdInt<S: Simd>:
     fn count_ones(self) -> Self;
     #[doc = "Return the number of zeros in the binary representation of each element."]
     fn count_zeros(self) -> Self;
-    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Add two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86."]
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self;
-    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[doc = "Subtract two vectors element-wise, returning the maximum value on overflow.\n\nOn x86 it is implemented in hardware only for 8-bit and 16-bit elements. For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86."]
     fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self;
 }
 #[doc = r" Functionality implemented by SIMD masks."]

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -385,6 +385,8 @@ pub trait Simd:
     fn count_zeros_i8x16(self, a: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
@@ -488,6 +490,8 @@ pub trait Simd:
     fn count_zeros_u8x16(self, a: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
@@ -635,6 +639,8 @@ pub trait Simd:
     fn count_zeros_i16x8(self, a: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
@@ -753,6 +759,8 @@ pub trait Simd:
     fn count_zeros_u16x8(self, a: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
@@ -906,6 +914,8 @@ pub trait Simd:
     fn count_zeros_i32x4(self, a: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
@@ -1026,6 +1036,8 @@ pub trait Simd:
     fn count_zeros_u32x4(self, a: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
@@ -1321,6 +1333,8 @@ pub trait Simd:
     fn count_zeros_i64x2(self, a: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
@@ -1439,6 +1453,8 @@ pub trait Simd:
     fn count_zeros_u64x2(self, a: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Add two vectors element-wise, wrapping on overflow."]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
@@ -2001,6 +2017,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i8x32(b);
         self.combine_i8x16(self.add_i8x16(a0, b0), self.add_i8x16(a1, b1))
     }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_i8x16(
+            self.saturating_add_i8x16(a0, b0),
+            self.saturating_add_i8x16(a1, b1),
+        )
+    }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn sub_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -2273,6 +2299,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u8x32(a);
         let (b0, b1) = self.split_u8x32(b);
         self.combine_u8x16(self.add_u8x16(a0, b0), self.add_u8x16(a1, b1))
+    }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_u8x16(
+            self.saturating_add_u8x16(a0, b0),
+            self.saturating_add_u8x16(a1, b1),
+        )
     }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -2653,6 +2689,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i16x16(b);
         self.combine_i16x8(self.add_i16x8(a0, b0), self.add_i16x8(a1, b1))
     }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_i16x8(
+            self.saturating_add_i16x8(a0, b0),
+            self.saturating_add_i16x8(a1, b1),
+        )
+    }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn sub_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -2957,6 +3003,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u16x16(a);
         let (b0, b1) = self.split_u16x16(b);
         self.combine_u16x8(self.add_u16x8(a0, b0), self.add_u16x8(a1, b1))
+    }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_u16x8(
+            self.saturating_add_u16x8(a0, b0),
+            self.saturating_add_u16x8(a1, b1),
+        )
     }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -3360,6 +3416,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i32x8(b);
         self.combine_i32x4(self.add_i32x4(a0, b0), self.add_i32x4(a1, b1))
     }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_i32x4(
+            self.saturating_add_i32x4(a0, b0),
+            self.saturating_add_i32x4(a1, b1),
+        )
+    }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn sub_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -3666,6 +3732,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u32x8(a);
         let (b0, b1) = self.split_u32x8(b);
         self.combine_u32x4(self.add_u32x4(a0, b0), self.add_u32x4(a1, b1))
+    }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_u32x4(
+            self.saturating_add_u32x4(a0, b0),
+            self.saturating_add_u32x4(a1, b1),
+        )
     }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -4477,6 +4553,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i64x4(b);
         self.combine_i64x2(self.add_i64x2(a0, b0), self.add_i64x2(a1, b1))
     }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
+        let (a0, a1) = self.split_i64x4(a);
+        let (b0, b1) = self.split_i64x4(b);
+        self.combine_i64x2(
+            self.saturating_add_i64x2(a0, b0),
+            self.saturating_add_i64x2(a1, b1),
+        )
+    }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn sub_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
@@ -4775,6 +4861,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u64x4(a);
         let (b0, b1) = self.split_u64x4(b);
         self.combine_u64x2(self.add_u64x2(a0, b0), self.add_u64x2(a1, b1))
+    }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_u64x4(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
+        let (a0, a1) = self.split_u64x4(a);
+        let (b0, b1) = self.split_u64x4(b);
+        self.combine_u64x2(
+            self.saturating_add_u64x2(a0, b0),
+            self.saturating_add_u64x2(a1, b1),
+        )
     }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -5571,6 +5667,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i8x64(b);
         self.combine_i8x32(self.add_i8x32(a0, b0), self.add_i8x32(a1, b1))
     }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
+        let (a0, a1) = self.split_i8x64(a);
+        let (b0, b1) = self.split_i8x64(b);
+        self.combine_i8x32(
+            self.saturating_add_i8x32(a0, b0),
+            self.saturating_add_i8x32(a1, b1),
+        )
+    }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn sub_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -5841,6 +5947,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u8x64(a);
         let (b0, b1) = self.split_u8x64(b);
         self.combine_u8x32(self.add_u8x32(a0, b0), self.add_u8x32(a1, b1))
+    }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
+        let (a0, a1) = self.split_u8x64(a);
+        let (b0, b1) = self.split_u8x64(b);
+        self.combine_u8x32(
+            self.saturating_add_u8x32(a0, b0),
+            self.saturating_add_u8x32(a1, b1),
+        )
     }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -6217,6 +6333,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i16x32(b);
         self.combine_i16x16(self.add_i16x16(a0, b0), self.add_i16x16(a1, b1))
     }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
+        let (a0, a1) = self.split_i16x32(a);
+        let (b0, b1) = self.split_i16x32(b);
+        self.combine_i16x16(
+            self.saturating_add_i16x16(a0, b0),
+            self.saturating_add_i16x16(a1, b1),
+        )
+    }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn sub_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -6525,6 +6651,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u16x32(a);
         let (b0, b1) = self.split_u16x32(b);
         self.combine_u16x16(self.add_u16x16(a0, b0), self.add_u16x16(a1, b1))
+    }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
+        let (a0, a1) = self.split_u16x32(a);
+        let (b0, b1) = self.split_u16x32(b);
+        self.combine_u16x16(
+            self.saturating_add_u16x16(a0, b0),
+            self.saturating_add_u16x16(a1, b1),
+        )
     }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -6937,6 +7073,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i32x16(b);
         self.combine_i32x8(self.add_i32x8(a0, b0), self.add_i32x8(a1, b1))
     }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
+        let (a0, a1) = self.split_i32x16(a);
+        let (b0, b1) = self.split_i32x16(b);
+        self.combine_i32x8(
+            self.saturating_add_i32x8(a0, b0),
+            self.saturating_add_i32x8(a1, b1),
+        )
+    }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn sub_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -7245,6 +7391,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u32x16(a);
         let (b0, b1) = self.split_u32x16(b);
         self.combine_u32x8(self.add_u32x8(a0, b0), self.add_u32x8(a1, b1))
+    }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        let (b0, b1) = self.split_u32x16(b);
+        self.combine_u32x8(
+            self.saturating_add_u32x8(a0, b0),
+            self.saturating_add_u32x8(a1, b1),
+        )
     }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -8050,6 +8206,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i64x8(b);
         self.combine_i64x4(self.add_i64x4(a0, b0), self.add_i64x4(a1, b1))
     }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
+        let (a0, a1) = self.split_i64x8(a);
+        let (b0, b1) = self.split_i64x8(b);
+        self.combine_i64x4(
+            self.saturating_add_i64x4(a0, b0),
+            self.saturating_add_i64x4(a1, b1),
+        )
+    }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn sub_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
@@ -8346,6 +8512,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u64x8(a);
         let (b0, b1) = self.split_u64x8(b);
         self.combine_u64x4(self.add_u64x4(a0, b0), self.add_u64x4(a1, b1))
+    }
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_add_u64x8(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
+        let (a0, a1) = self.split_u64x8(a);
+        let (b0, b1) = self.split_u64x8(b);
+        self.combine_u64x4(
+            self.saturating_add_u64x4(a0, b0),
+            self.saturating_add_u64x4(a1, b1),
+        )
     }
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -9385,6 +9561,8 @@ pub trait SimdInt<S: Simd>:
     fn count_ones(self) -> Self;
     #[doc = "Return the number of zeros in the binary representation of each element."]
     fn count_zeros(self) -> Self;
+    #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self;
 }
 #[doc = r" Functionality implemented by SIMD masks."]
 #[doc = r""]

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -389,6 +389,8 @@ pub trait Simd:
     fn saturating_add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Compute the bitwise AND of two vectors."]
@@ -494,6 +496,8 @@ pub trait Simd:
     fn saturating_add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Compute the bitwise AND of two vectors."]
@@ -643,6 +647,8 @@ pub trait Simd:
     fn saturating_add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Compute the bitwise AND of two vectors."]
@@ -763,6 +769,8 @@ pub trait Simd:
     fn saturating_add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Compute the bitwise AND of two vectors."]
@@ -918,6 +926,8 @@ pub trait Simd:
     fn saturating_add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Compute the bitwise AND of two vectors."]
@@ -1040,6 +1050,8 @@ pub trait Simd:
     fn saturating_add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Compute the bitwise AND of two vectors."]
@@ -1337,6 +1349,8 @@ pub trait Simd:
     fn saturating_add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Compute the bitwise AND of two vectors."]
@@ -1457,6 +1471,8 @@ pub trait Simd:
     fn saturating_add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Subtract two vectors element-wise, wrapping on overflow."]
     fn sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     fn mul_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Compute the bitwise AND of two vectors."]
@@ -2034,6 +2050,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i8x32(b);
         self.combine_i8x16(self.sub_i8x16(a0, b0), self.sub_i8x16(a1, b1))
     }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_i8x16(
+            self.saturating_sub_i8x16(a0, b0),
+            self.saturating_sub_i8x16(a1, b1),
+        )
+    }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn mul_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -2316,6 +2342,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u8x32(a);
         let (b0, b1) = self.split_u8x32(b);
         self.combine_u8x16(self.sub_u8x16(a0, b0), self.sub_u8x16(a1, b1))
+    }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_u8x16(
+            self.saturating_sub_u8x16(a0, b0),
+            self.saturating_sub_u8x16(a1, b1),
+        )
     }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -2706,6 +2742,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i16x16(b);
         self.combine_i16x8(self.sub_i16x8(a0, b0), self.sub_i16x8(a1, b1))
     }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_i16x8(
+            self.saturating_sub_i16x8(a0, b0),
+            self.saturating_sub_i16x8(a1, b1),
+        )
+    }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn mul_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -3020,6 +3066,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u16x16(a);
         let (b0, b1) = self.split_u16x16(b);
         self.combine_u16x8(self.sub_u16x8(a0, b0), self.sub_u16x8(a1, b1))
+    }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_u16x8(
+            self.saturating_sub_u16x8(a0, b0),
+            self.saturating_sub_u16x8(a1, b1),
+        )
     }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -3433,6 +3489,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i32x8(b);
         self.combine_i32x4(self.sub_i32x4(a0, b0), self.sub_i32x4(a1, b1))
     }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_i32x4(
+            self.saturating_sub_i32x4(a0, b0),
+            self.saturating_sub_i32x4(a1, b1),
+        )
+    }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn mul_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -3749,6 +3815,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u32x8(a);
         let (b0, b1) = self.split_u32x8(b);
         self.combine_u32x4(self.sub_u32x4(a0, b0), self.sub_u32x4(a1, b1))
+    }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_u32x4(
+            self.saturating_sub_u32x4(a0, b0),
+            self.saturating_sub_u32x4(a1, b1),
+        )
     }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -4570,6 +4646,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i64x4(b);
         self.combine_i64x2(self.sub_i64x2(a0, b0), self.sub_i64x2(a1, b1))
     }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
+        let (a0, a1) = self.split_i64x4(a);
+        let (b0, b1) = self.split_i64x4(b);
+        self.combine_i64x2(
+            self.saturating_sub_i64x2(a0, b0),
+            self.saturating_sub_i64x2(a1, b1),
+        )
+    }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn mul_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
@@ -4878,6 +4964,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u64x4(a);
         let (b0, b1) = self.split_u64x4(b);
         self.combine_u64x2(self.sub_u64x2(a0, b0), self.sub_u64x2(a1, b1))
+    }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_u64x4(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
+        let (a0, a1) = self.split_u64x4(a);
+        let (b0, b1) = self.split_u64x4(b);
+        self.combine_u64x2(
+            self.saturating_sub_u64x2(a0, b0),
+            self.saturating_sub_u64x2(a1, b1),
+        )
     }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -5684,6 +5780,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i8x64(b);
         self.combine_i8x32(self.sub_i8x32(a0, b0), self.sub_i8x32(a1, b1))
     }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
+        let (a0, a1) = self.split_i8x64(a);
+        let (b0, b1) = self.split_i8x64(b);
+        self.combine_i8x32(
+            self.saturating_sub_i8x32(a0, b0),
+            self.saturating_sub_i8x32(a1, b1),
+        )
+    }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn mul_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -5964,6 +6070,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u8x64(a);
         let (b0, b1) = self.split_u8x64(b);
         self.combine_u8x32(self.sub_u8x32(a0, b0), self.sub_u8x32(a1, b1))
+    }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
+        let (a0, a1) = self.split_u8x64(a);
+        let (b0, b1) = self.split_u8x64(b);
+        self.combine_u8x32(
+            self.saturating_sub_u8x32(a0, b0),
+            self.saturating_sub_u8x32(a1, b1),
+        )
     }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -6350,6 +6466,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i16x32(b);
         self.combine_i16x16(self.sub_i16x16(a0, b0), self.sub_i16x16(a1, b1))
     }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
+        let (a0, a1) = self.split_i16x32(a);
+        let (b0, b1) = self.split_i16x32(b);
+        self.combine_i16x16(
+            self.saturating_sub_i16x16(a0, b0),
+            self.saturating_sub_i16x16(a1, b1),
+        )
+    }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn mul_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -6668,6 +6794,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u16x32(a);
         let (b0, b1) = self.split_u16x32(b);
         self.combine_u16x16(self.sub_u16x16(a0, b0), self.sub_u16x16(a1, b1))
+    }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
+        let (a0, a1) = self.split_u16x32(a);
+        let (b0, b1) = self.split_u16x32(b);
+        self.combine_u16x16(
+            self.saturating_sub_u16x16(a0, b0),
+            self.saturating_sub_u16x16(a1, b1),
+        )
     }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -7090,6 +7226,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i32x16(b);
         self.combine_i32x8(self.sub_i32x8(a0, b0), self.sub_i32x8(a1, b1))
     }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
+        let (a0, a1) = self.split_i32x16(a);
+        let (b0, b1) = self.split_i32x16(b);
+        self.combine_i32x8(
+            self.saturating_sub_i32x8(a0, b0),
+            self.saturating_sub_i32x8(a1, b1),
+        )
+    }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn mul_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -7408,6 +7554,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u32x16(a);
         let (b0, b1) = self.split_u32x16(b);
         self.combine_u32x8(self.sub_u32x8(a0, b0), self.sub_u32x8(a1, b1))
+    }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        let (b0, b1) = self.split_u32x16(b);
+        self.combine_u32x8(
+            self.saturating_sub_u32x8(a0, b0),
+            self.saturating_sub_u32x8(a1, b1),
+        )
     }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -8223,6 +8379,16 @@ pub trait Simd:
         let (b0, b1) = self.split_i64x8(b);
         self.combine_i64x4(self.sub_i64x4(a0, b0), self.sub_i64x4(a1, b1))
     }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
+        let (a0, a1) = self.split_i64x8(a);
+        let (b0, b1) = self.split_i64x8(b);
+        self.combine_i64x4(
+            self.saturating_sub_i64x4(a0, b0),
+            self.saturating_sub_i64x4(a1, b1),
+        )
+    }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
     fn mul_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
@@ -8529,6 +8695,16 @@ pub trait Simd:
         let (a0, a1) = self.split_u64x8(a);
         let (b0, b1) = self.split_u64x8(b);
         self.combine_u64x4(self.sub_u64x4(a0, b0), self.sub_u64x4(a1, b1))
+    }
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    #[inline(always)]
+    fn saturating_sub_u64x8(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {
+        let (a0, a1) = self.split_u64x8(a);
+        let (b0, b1) = self.split_u64x8(b);
+        self.combine_u64x4(
+            self.saturating_sub_u64x4(a0, b0),
+            self.saturating_sub_u64x4(a1, b1),
+        )
     }
     #[doc = "Multiply two vectors element-wise, wrapping on overflow."]
     #[inline(always)]
@@ -9563,6 +9739,8 @@ pub trait SimdInt<S: Simd>:
     fn count_zeros(self) -> Self;
     #[doc = "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self;
+    #[doc = "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing."]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self;
 }
 #[doc = r" Functionality implemented by SIMD masks."]
 #[doc = r""]

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -603,6 +603,11 @@ impl<S: Simd> crate::SimdInt<S> for i8x16<S> {
         self.simd
             .saturating_add_i8x16(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_i8x16(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdWiden<S> for i8x16<S> {
     type Widened = i16x8<S>;
@@ -895,6 +900,11 @@ impl<S: Simd> crate::SimdInt<S> for u8x16<S> {
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .saturating_add_u8x16(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_u8x16(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdWiden<S> for u8x16<S> {
@@ -1279,6 +1289,11 @@ impl<S: Simd> crate::SimdInt<S> for i16x8<S> {
         self.simd
             .saturating_add_i16x8(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_i16x8(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdWiden<S> for i16x8<S> {
     type Widened = i32x4<S>;
@@ -1578,6 +1593,11 @@ impl<S: Simd> crate::SimdInt<S> for u16x8<S> {
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .saturating_add_u16x8(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_u16x8(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdWiden<S> for u16x8<S> {
@@ -1965,6 +1985,11 @@ impl<S: Simd> crate::SimdInt<S> for i32x4<S> {
         self.simd
             .saturating_add_i32x4(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_i32x4(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f32x4<S>> for i32x4<S> {
     #[doc = "Convert each floating-point element to a signed 32-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
@@ -2264,6 +2289,11 @@ impl<S: Simd> crate::SimdInt<S> for u32x4<S> {
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .saturating_add_u32x4(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_u32x4(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x4<S>> for u32x4<S> {
@@ -3001,6 +3031,11 @@ impl<S: Simd> crate::SimdInt<S> for i64x2<S> {
         self.simd
             .saturating_add_i64x2(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_i64x2(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f64x2<S>> for i64x2<S> {
     #[doc = "Convert each floating-point element to a signed 64-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
@@ -3293,6 +3328,11 @@ impl<S: Simd> crate::SimdInt<S> for u64x2<S> {
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .saturating_add_u64x2(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_u64x2(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdCvtTruncate<f64x2<S>> for u64x2<S> {
@@ -4058,6 +4098,11 @@ impl<S: Simd> crate::SimdInt<S> for i8x32<S> {
         self.simd
             .saturating_add_i8x32(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_i8x32(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdWiden<S> for i8x32<S> {
     type Widened = i16x16<S>;
@@ -4361,6 +4406,11 @@ impl<S: Simd> crate::SimdInt<S> for u8x32<S> {
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .saturating_add_u8x32(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_u8x32(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdWiden<S> for u8x32<S> {
@@ -4749,6 +4799,11 @@ impl<S: Simd> crate::SimdInt<S> for i16x16<S> {
         self.simd
             .saturating_add_i16x16(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_i16x16(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdWiden<S> for i16x16<S> {
     type Widened = i32x8<S>;
@@ -5052,6 +5107,11 @@ impl<S: Simd> crate::SimdInt<S> for u16x16<S> {
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .saturating_add_u16x16(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_u16x16(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdWiden<S> for u16x16<S> {
@@ -5446,6 +5506,11 @@ impl<S: Simd> crate::SimdInt<S> for i32x8<S> {
         self.simd
             .saturating_add_i32x8(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_i32x8(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f32x8<S>> for i32x8<S> {
     #[doc = "Convert each floating-point element to a signed 32-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
@@ -5752,6 +5817,11 @@ impl<S: Simd> crate::SimdInt<S> for u32x8<S> {
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .saturating_add_u32x8(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_u32x8(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x8<S>> for u32x8<S> {
@@ -6479,6 +6549,11 @@ impl<S: Simd> crate::SimdInt<S> for i64x4<S> {
         self.simd
             .saturating_add_i64x4(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_i64x4(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f64x4<S>> for i64x4<S> {
     #[doc = "Convert each floating-point element to a signed 64-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
@@ -6766,6 +6841,11 @@ impl<S: Simd> crate::SimdInt<S> for u64x4<S> {
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .saturating_add_u64x4(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_u64x4(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdCvtTruncate<f64x4<S>> for u64x4<S> {
@@ -7562,6 +7642,11 @@ impl<S: Simd> crate::SimdInt<S> for i8x64<S> {
         self.simd
             .saturating_add_i8x64(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_i8x64(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdWiden<S> for i8x64<S> {
     type Widened = i16x32<S>;
@@ -7891,6 +7976,11 @@ impl<S: Simd> crate::SimdInt<S> for u8x64<S> {
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .saturating_add_u8x64(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_u8x64(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdWiden<S> for u8x64<S> {
@@ -8289,6 +8379,11 @@ impl<S: Simd> crate::SimdInt<S> for i16x32<S> {
         self.simd
             .saturating_add_i16x32(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_i16x32(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdWiden<S> for i16x32<S> {
     type Widened = i32x16<S>;
@@ -8602,6 +8697,11 @@ impl<S: Simd> crate::SimdInt<S> for u16x32<S> {
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .saturating_add_u16x32(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_u16x32(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdWiden<S> for u16x32<S> {
@@ -8999,6 +9099,11 @@ impl<S: Simd> crate::SimdInt<S> for i32x16<S> {
         self.simd
             .saturating_add_i32x16(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_i32x16(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f32x16<S>> for i32x16<S> {
     #[doc = "Convert each floating-point element to a signed 32-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
@@ -9308,6 +9413,11 @@ impl<S: Simd> crate::SimdInt<S> for u32x16<S> {
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .saturating_add_u32x16(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_u32x16(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x16<S>> for u32x16<S> {
@@ -10047,6 +10157,11 @@ impl<S: Simd> crate::SimdInt<S> for i64x8<S> {
         self.simd
             .saturating_add_i64x8(self, rhs.simd_into(self.simd))
     }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_i64x8(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f64x8<S>> for i64x8<S> {
     #[doc = "Convert each floating-point element to a signed 64-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
@@ -10340,6 +10455,11 @@ impl<S: Simd> crate::SimdInt<S> for u64x8<S> {
     fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd
             .saturating_add_u64x8(self, rhs.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn saturating_sub(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_sub_u64x8(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdCvtTruncate<f64x8<S>> for u64x8<S> {

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -598,6 +598,11 @@ impl<S: Simd> crate::SimdInt<S> for i8x16<S> {
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_i8x16(self)
     }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_i8x16(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdWiden<S> for i8x16<S> {
     type Widened = i16x8<S>;
@@ -885,6 +890,11 @@ impl<S: Simd> crate::SimdInt<S> for u8x16<S> {
     #[inline(always)]
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_u8x16(self)
+    }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_u8x16(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdWiden<S> for u8x16<S> {
@@ -1264,6 +1274,11 @@ impl<S: Simd> crate::SimdInt<S> for i16x8<S> {
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_i16x8(self)
     }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_i16x8(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdWiden<S> for i16x8<S> {
     type Widened = i32x4<S>;
@@ -1558,6 +1573,11 @@ impl<S: Simd> crate::SimdInt<S> for u16x8<S> {
     #[inline(always)]
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_u16x8(self)
+    }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_u16x8(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdWiden<S> for u16x8<S> {
@@ -1940,6 +1960,11 @@ impl<S: Simd> crate::SimdInt<S> for i32x4<S> {
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_i32x4(self)
     }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_i32x4(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f32x4<S>> for i32x4<S> {
     #[doc = "Convert each floating-point element to a signed 32-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
@@ -2234,6 +2259,11 @@ impl<S: Simd> crate::SimdInt<S> for u32x4<S> {
     #[inline(always)]
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_u32x4(self)
+    }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_u32x4(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x4<S>> for u32x4<S> {
@@ -2966,6 +2996,11 @@ impl<S: Simd> crate::SimdInt<S> for i64x2<S> {
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_i64x2(self)
     }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_i64x2(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f64x2<S>> for i64x2<S> {
     #[doc = "Convert each floating-point element to a signed 64-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
@@ -3253,6 +3288,11 @@ impl<S: Simd> crate::SimdInt<S> for u64x2<S> {
     #[inline(always)]
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_u64x2(self)
+    }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_u64x2(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdCvtTruncate<f64x2<S>> for u64x2<S> {
@@ -4013,6 +4053,11 @@ impl<S: Simd> crate::SimdInt<S> for i8x32<S> {
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_i8x32(self)
     }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_i8x32(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdWiden<S> for i8x32<S> {
     type Widened = i16x16<S>;
@@ -4311,6 +4356,11 @@ impl<S: Simd> crate::SimdInt<S> for u8x32<S> {
     #[inline(always)]
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_u8x32(self)
+    }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_u8x32(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdWiden<S> for u8x32<S> {
@@ -4694,6 +4744,11 @@ impl<S: Simd> crate::SimdInt<S> for i16x16<S> {
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_i16x16(self)
     }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_i16x16(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdWiden<S> for i16x16<S> {
     type Widened = i32x8<S>;
@@ -4992,6 +5047,11 @@ impl<S: Simd> crate::SimdInt<S> for u16x16<S> {
     #[inline(always)]
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_u16x16(self)
+    }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_u16x16(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdWiden<S> for u16x16<S> {
@@ -5381,6 +5441,11 @@ impl<S: Simd> crate::SimdInt<S> for i32x8<S> {
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_i32x8(self)
     }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_i32x8(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f32x8<S>> for i32x8<S> {
     #[doc = "Convert each floating-point element to a signed 32-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
@@ -5682,6 +5747,11 @@ impl<S: Simd> crate::SimdInt<S> for u32x8<S> {
     #[inline(always)]
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_u32x8(self)
+    }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_u32x8(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x8<S>> for u32x8<S> {
@@ -6404,6 +6474,11 @@ impl<S: Simd> crate::SimdInt<S> for i64x4<S> {
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_i64x4(self)
     }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_i64x4(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f64x4<S>> for i64x4<S> {
     #[doc = "Convert each floating-point element to a signed 64-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
@@ -6686,6 +6761,11 @@ impl<S: Simd> crate::SimdInt<S> for u64x4<S> {
     #[inline(always)]
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_u64x4(self)
+    }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_u64x4(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdCvtTruncate<f64x4<S>> for u64x4<S> {
@@ -7477,6 +7557,11 @@ impl<S: Simd> crate::SimdInt<S> for i8x64<S> {
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_i8x64(self)
     }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_i8x64(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdWiden<S> for i8x64<S> {
     type Widened = i16x32<S>;
@@ -7801,6 +7886,11 @@ impl<S: Simd> crate::SimdInt<S> for u8x64<S> {
     #[inline(always)]
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_u8x64(self)
+    }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_u8x64(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdWiden<S> for u8x64<S> {
@@ -8194,6 +8284,11 @@ impl<S: Simd> crate::SimdInt<S> for i16x32<S> {
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_i16x32(self)
     }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_i16x32(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdWiden<S> for i16x32<S> {
     type Widened = i32x16<S>;
@@ -8502,6 +8597,11 @@ impl<S: Simd> crate::SimdInt<S> for u16x32<S> {
     #[inline(always)]
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_u16x32(self)
+    }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_u16x32(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdWiden<S> for u16x32<S> {
@@ -8894,6 +8994,11 @@ impl<S: Simd> crate::SimdInt<S> for i32x16<S> {
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_i32x16(self)
     }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_i32x16(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f32x16<S>> for i32x16<S> {
     #[doc = "Convert each floating-point element to a signed 32-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
@@ -9198,6 +9303,11 @@ impl<S: Simd> crate::SimdInt<S> for u32x16<S> {
     #[inline(always)]
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_u32x16(self)
+    }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_u32x16(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdCvtTruncate<f32x16<S>> for u32x16<S> {
@@ -9932,6 +10042,11 @@ impl<S: Simd> crate::SimdInt<S> for i64x8<S> {
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_i64x8(self)
     }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_i64x8(self, rhs.simd_into(self.simd))
+    }
 }
 impl<S: Simd> SimdCvtTruncate<f64x8<S>> for i64x8<S> {
     #[doc = "Convert each floating-point element to a signed 64-bit integer, truncating towards zero.\n\nOut-of-range values or NaN will produce implementation-defined results."]
@@ -10220,6 +10335,11 @@ impl<S: Simd> crate::SimdInt<S> for u64x8<S> {
     #[inline(always)]
     fn count_zeros(self) -> Self {
         self.simd.count_zeros_u64x8(self)
+    }
+    #[inline(always)]
+    fn saturating_add(self, rhs: impl SimdInto<Self, S>) -> Self {
+        self.simd
+            .saturating_add_u64x8(self, rhs.simd_into(self.simd))
     }
 }
 impl<S: Simd> SimdCvtTruncate<f64x8<S>> for u64x8<S> {

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -886,6 +886,16 @@ impl Simd for Sse2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: i8x16<Sse2>, b: i8x16<Sse2>) -> i8x16<Sse2> {
+                _mm_adds_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1639,6 +1649,16 @@ impl Simd for Sse2 {
             #[inline(always)]
             fn kernel(token: Sse2, a: u8x16<Sse2>, b: u8x16<Sse2>) -> u8x16<Sse2> {
                 _mm_add_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: u8x16<Sse2>, b: u8x16<Sse2>) -> u8x16<Sse2> {
+                _mm_adds_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -2400,6 +2420,16 @@ impl Simd for Sse2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: i16x8<Sse2>, b: i16x8<Sse2>) -> i16x8<Sse2> {
+                _mm_adds_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2893,6 +2923,16 @@ impl Simd for Sse2 {
             #[inline(always)]
             fn kernel(token: Sse2, a: u16x8<Sse2>, b: u16x8<Sse2>) -> u16x8<Sse2> {
                 _mm_add_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: u16x8<Sse2>, b: u16x8<Sse2>) -> u16x8<Sse2> {
+                _mm_adds_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3665,6 +3705,16 @@ impl Simd for Sse2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        [
+            i32::saturating_add(a[0usize], b[0usize]),
+            i32::saturating_add(a[1usize], b[1usize]),
+            i32::saturating_add(a[2usize], b[2usize]),
+            i32::saturating_add(a[3usize], b[3usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -4192,6 +4242,16 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        [
+            u32::saturating_add(a[0usize], b[0usize]),
+            u32::saturating_add(a[1usize], b[1usize]),
+            u32::saturating_add(a[2usize], b[2usize]),
+            u32::saturating_add(a[3usize], b[3usize]),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -5449,6 +5509,14 @@ impl Simd for Sse2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        [
+            i64::saturating_add(a[0usize], b[0usize]),
+            i64::saturating_add(a[1usize], b[1usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5865,6 +5933,14 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        [
+            u64::saturating_add(a[0usize], b[0usize]),
+            u64::saturating_add(a[1usize], b[1usize]),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -906,6 +906,16 @@ impl Simd for Sse2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: i8x16<Sse2>, b: i8x16<Sse2>) -> i8x16<Sse2> {
+                _mm_subs_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1669,6 +1679,16 @@ impl Simd for Sse2 {
             #[inline(always)]
             fn kernel(token: Sse2, a: u8x16<Sse2>, b: u8x16<Sse2>) -> u8x16<Sse2> {
                 _mm_sub_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: u8x16<Sse2>, b: u8x16<Sse2>) -> u8x16<Sse2> {
+                _mm_subs_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -2440,6 +2460,16 @@ impl Simd for Sse2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: i16x8<Sse2>, b: i16x8<Sse2>) -> i16x8<Sse2> {
+                _mm_subs_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2943,6 +2973,16 @@ impl Simd for Sse2 {
             #[inline(always)]
             fn kernel(token: Sse2, a: u16x8<Sse2>, b: u16x8<Sse2>) -> u16x8<Sse2> {
                 _mm_sub_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: u16x8<Sse2>, b: u16x8<Sse2>) -> u16x8<Sse2> {
+                _mm_subs_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3725,6 +3765,16 @@ impl Simd for Sse2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        [
+            i32::saturating_sub(a[0usize], b[0usize]),
+            i32::saturating_sub(a[1usize], b[1usize]),
+            i32::saturating_sub(a[2usize], b[2usize]),
+            i32::saturating_sub(a[3usize], b[3usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn mul_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         [
             i32::wrapping_mul(a[0usize], b[0usize]),
@@ -4262,6 +4312,16 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        [
+            u32::saturating_sub(a[0usize], b[0usize]),
+            u32::saturating_sub(a[1usize], b[1usize]),
+            u32::saturating_sub(a[2usize], b[2usize]),
+            u32::saturating_sub(a[3usize], b[3usize]),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn mul_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -5527,6 +5587,14 @@ impl Simd for Sse2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        [
+            i64::saturating_sub(a[0usize], b[0usize]),
+            i64::saturating_sub(a[1usize], b[1usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn mul_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         [
             i64::wrapping_mul(a[0usize], b[0usize]),
@@ -5951,6 +6019,14 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        [
+            u64::saturating_sub(a[0usize], b[0usize]),
+            u64::saturating_sub(a[1usize], b[1usize]),
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn mul_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -933,6 +933,16 @@ impl Simd for Sse4_2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i8x16<Sse4_2>, b: i8x16<Sse4_2>) -> i8x16<Sse4_2> {
+                _mm_adds_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1501,6 +1511,16 @@ impl Simd for Sse4_2 {
             #[inline(always)]
             fn kernel(token: Sse4_2, a: u8x16<Sse4_2>, b: u8x16<Sse4_2>) -> u8x16<Sse4_2> {
                 _mm_add_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u8x16<Sse4_2>, b: u8x16<Sse4_2>) -> u8x16<Sse4_2> {
+                _mm_adds_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -2198,6 +2218,16 @@ impl Simd for Sse4_2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i16x8<Sse4_2>, b: i16x8<Sse4_2>) -> i16x8<Sse4_2> {
+                _mm_adds_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2707,6 +2737,16 @@ impl Simd for Sse4_2 {
             #[inline(always)]
             fn kernel(token: Sse4_2, a: u16x8<Sse4_2>, b: u16x8<Sse4_2>) -> u16x8<Sse4_2> {
                 _mm_add_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u16x8<Sse4_2>, b: u16x8<Sse4_2>) -> u16x8<Sse4_2> {
+                _mm_adds_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3404,6 +3444,26 @@ impl Simd for Sse4_2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i32x4<Sse4_2>, b: i32x4<Sse4_2>) -> i32x4<Sse4_2> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm_add_epi32(a, b);
+                let overflow = _mm_xor_si128(_mm_cmpgt_epi32(a, sum), b);
+                let bound = _mm_xor_si128(_mm_srai_epi32::<31>(sum), _mm_set1_epi32(i32::MIN));
+                let result = _mm_blendv_ps(
+                    _mm_castsi128_ps(sum),
+                    _mm_castsi128_ps(bound),
+                    _mm_castsi128_ps(overflow),
+                );
+                _mm_castps_si128(result).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3886,6 +3946,19 @@ impl Simd for Sse4_2 {
             #[inline(always)]
             fn kernel(token: Sse4_2, a: u32x4<Sse4_2>, b: u32x4<Sse4_2>) -> u32x4<Sse4_2> {
                 _mm_add_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u32x4<Sse4_2>, b: u32x4<Sse4_2>) -> u32x4<Sse4_2> {
+                let a = a.into();
+                let b = b.into();
+                let threshold = _mm_xor_si128(b, _mm_set1_epi32(-1));
+                _mm_add_epi32(_mm_min_epu32(a, threshold), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -5173,6 +5246,27 @@ impl Simd for Sse4_2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i64x2<Sse4_2>, b: i64x2<Sse4_2>) -> i64x2<Sse4_2> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm_add_epi64(a, b);
+                let overflow = _mm_xor_si128(_mm_cmpgt_epi64(a, sum), b);
+                let sum_sign = _mm_srai_epi32::<31>(_mm_shuffle_epi32::<0xf5>(sum));
+                let bound = _mm_xor_si128(sum_sign, _mm_set1_epi64x(i64::MIN));
+                let result = _mm_blendv_pd(
+                    _mm_castsi128_pd(sum),
+                    _mm_castsi128_pd(bound),
+                    _mm_castsi128_pd(overflow),
+                );
+                _mm_castpd_si128(result).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5618,6 +5712,22 @@ impl Simd for Sse4_2 {
             #[inline(always)]
             fn kernel(token: Sse4_2, a: u64x2<Sse4_2>, b: u64x2<Sse4_2>) -> u64x2<Sse4_2> {
                 _mm_add_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u64x2<Sse4_2>, b: u64x2<Sse4_2>) -> u64x2<Sse4_2> {
+                let a = a.into();
+                let b = b.into();
+                let sum = _mm_add_epi64(a, b);
+                let sign_bias = _mm_set1_epi64x(i64::MIN);
+                let overflow =
+                    _mm_cmpgt_epi64(_mm_xor_si128(a, sign_bias), _mm_xor_si128(sum, sign_bias));
+                _mm_or_si128(sum, overflow).simd_into(token)
             }
         );
         kernel(self, a, b)

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -953,6 +953,16 @@ impl Simd for Sse4_2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i8x16<Sse4_2>, b: i8x16<Sse4_2>) -> i8x16<Sse4_2> {
+                _mm_subs_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1531,6 +1541,16 @@ impl Simd for Sse4_2 {
             #[inline(always)]
             fn kernel(token: Sse4_2, a: u8x16<Sse4_2>, b: u8x16<Sse4_2>) -> u8x16<Sse4_2> {
                 _mm_sub_epi8(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u8x16<Sse4_2>, b: u8x16<Sse4_2>) -> u8x16<Sse4_2> {
+                _mm_subs_epu8(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -2238,6 +2258,16 @@ impl Simd for Sse4_2 {
         kernel(self, a, b)
     }
     #[inline(always)]
+    fn saturating_sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i16x8<Sse4_2>, b: i16x8<Sse4_2>) -> i16x8<Sse4_2> {
+                _mm_subs_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
     fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2757,6 +2787,16 @@ impl Simd for Sse4_2 {
             #[inline(always)]
             fn kernel(token: Sse4_2, a: u16x8<Sse4_2>, b: u16x8<Sse4_2>) -> u16x8<Sse4_2> {
                 _mm_sub_epi16(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u16x8<Sse4_2>, b: u16x8<Sse4_2>) -> u16x8<Sse4_2> {
+                _mm_subs_epu16(a.into(), b.into()).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3450,11 +3490,11 @@ impl Simd for Sse4_2 {
             fn kernel(token: Sse4_2, a: i32x4<Sse4_2>, b: i32x4<Sse4_2>) -> i32x4<Sse4_2> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm_add_epi32(a, b);
-                let overflow = _mm_xor_si128(_mm_cmpgt_epi32(a, sum), b);
-                let bound = _mm_xor_si128(_mm_srai_epi32::<31>(sum), _mm_set1_epi32(i32::MIN));
+                let wrapped = _mm_add_epi32(a, b);
+                let overflow = _mm_xor_si128(_mm_cmpgt_epi32(a, wrapped), b);
+                let bound = _mm_xor_si128(_mm_srai_epi32::<31>(a), _mm_set1_epi32(i32::MAX));
                 let result = _mm_blendv_ps(
-                    _mm_castsi128_ps(sum),
+                    _mm_castsi128_ps(wrapped),
                     _mm_castsi128_ps(bound),
                     _mm_castsi128_ps(overflow),
                 );
@@ -3469,6 +3509,26 @@ impl Simd for Sse4_2 {
             #[inline(always)]
             fn kernel(token: Sse4_2, a: i32x4<Sse4_2>, b: i32x4<Sse4_2>) -> i32x4<Sse4_2> {
                 _mm_sub_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i32x4<Sse4_2>, b: i32x4<Sse4_2>) -> i32x4<Sse4_2> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm_sub_epi32(a, b);
+                let overflow = _mm_xor_si128(_mm_cmpgt_epi32(wrapped, a), b);
+                let bound = _mm_xor_si128(_mm_srai_epi32::<31>(a), _mm_set1_epi32(i32::MAX));
+                let result = _mm_blendv_ps(
+                    _mm_castsi128_ps(wrapped),
+                    _mm_castsi128_ps(bound),
+                    _mm_castsi128_ps(overflow),
+                );
+                _mm_castps_si128(result).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -3969,6 +4029,18 @@ impl Simd for Sse4_2 {
             #[inline(always)]
             fn kernel(token: Sse4_2, a: u32x4<Sse4_2>, b: u32x4<Sse4_2>) -> u32x4<Sse4_2> {
                 _mm_sub_epi32(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u32x4<Sse4_2>, b: u32x4<Sse4_2>) -> u32x4<Sse4_2> {
+                let a = a.into();
+                let b = b.into();
+                _mm_sub_epi32(_mm_max_epu32(a, b), b).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -5252,12 +5324,12 @@ impl Simd for Sse4_2 {
             fn kernel(token: Sse4_2, a: i64x2<Sse4_2>, b: i64x2<Sse4_2>) -> i64x2<Sse4_2> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm_add_epi64(a, b);
-                let overflow = _mm_xor_si128(_mm_cmpgt_epi64(a, sum), b);
-                let sum_sign = _mm_srai_epi32::<31>(_mm_shuffle_epi32::<0xf5>(sum));
-                let bound = _mm_xor_si128(sum_sign, _mm_set1_epi64x(i64::MIN));
+                let wrapped = _mm_add_epi64(a, b);
+                let overflow = _mm_xor_si128(_mm_cmpgt_epi64(a, wrapped), b);
+                let a_sign = _mm_srai_epi32::<31>(_mm_shuffle_epi32::<0xf5>(a));
+                let bound = _mm_xor_si128(a_sign, _mm_set1_epi64x(i64::MAX));
                 let result = _mm_blendv_pd(
-                    _mm_castsi128_pd(sum),
+                    _mm_castsi128_pd(wrapped),
                     _mm_castsi128_pd(bound),
                     _mm_castsi128_pd(overflow),
                 );
@@ -5272,6 +5344,27 @@ impl Simd for Sse4_2 {
             #[inline(always)]
             fn kernel(token: Sse4_2, a: i64x2<Sse4_2>, b: i64x2<Sse4_2>) -> i64x2<Sse4_2> {
                 _mm_sub_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i64x2<Sse4_2>, b: i64x2<Sse4_2>) -> i64x2<Sse4_2> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm_sub_epi64(a, b);
+                let overflow = _mm_xor_si128(_mm_cmpgt_epi64(wrapped, a), b);
+                let a_sign = _mm_srai_epi32::<31>(_mm_shuffle_epi32::<0xf5>(a));
+                let bound = _mm_xor_si128(a_sign, _mm_set1_epi64x(i64::MAX));
+                let result = _mm_blendv_pd(
+                    _mm_castsi128_pd(wrapped),
+                    _mm_castsi128_pd(bound),
+                    _mm_castsi128_pd(overflow),
+                );
+                _mm_castpd_si128(result).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -5723,11 +5816,13 @@ impl Simd for Sse4_2 {
             fn kernel(token: Sse4_2, a: u64x2<Sse4_2>, b: u64x2<Sse4_2>) -> u64x2<Sse4_2> {
                 let a = a.into();
                 let b = b.into();
-                let sum = _mm_add_epi64(a, b);
+                let wrapped = _mm_add_epi64(a, b);
                 let sign_bias = _mm_set1_epi64x(i64::MIN);
-                let overflow =
-                    _mm_cmpgt_epi64(_mm_xor_si128(a, sign_bias), _mm_xor_si128(sum, sign_bias));
-                _mm_or_si128(sum, overflow).simd_into(token)
+                let overflow = _mm_cmpgt_epi64(
+                    _mm_xor_si128(a, sign_bias),
+                    _mm_xor_si128(wrapped, sign_bias),
+                );
+                _mm_or_si128(wrapped, overflow).simd_into(token)
             }
         );
         kernel(self, a, b)
@@ -5738,6 +5833,22 @@ impl Simd for Sse4_2 {
             #[inline(always)]
             fn kernel(token: Sse4_2, a: u64x2<Sse4_2>, b: u64x2<Sse4_2>) -> u64x2<Sse4_2> {
                 _mm_sub_epi64(a.into(), b.into()).simd_into(token)
+            }
+        );
+        kernel(self, a, b)
+    }
+    #[inline(always)]
+    fn saturating_sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u64x2<Sse4_2>, b: u64x2<Sse4_2>) -> u64x2<Sse4_2> {
+                let a = a.into();
+                let b = b.into();
+                let wrapped = _mm_sub_epi64(a, b);
+                let sign_bias = _mm_set1_epi64x(i64::MIN);
+                let no_borrow =
+                    _mm_cmpgt_epi64(_mm_xor_si128(a, sign_bias), _mm_xor_si128(b, sign_bias));
+                _mm_and_si128(wrapped, no_borrow).simd_into(token)
             }
         );
         kernel(self, a, b)

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -580,6 +580,10 @@ impl Simd for WasmSimd128 {
         i8x16_sub(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
+    fn saturating_sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        i8x16_sub_sat(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
     fn mul_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         let low = i16x8_extmul_low_i8x16(a.into(), b.into());
         let high = i16x8_extmul_high_i8x16(a.into(), b.into());
@@ -964,6 +968,10 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
         u8x16_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        u8x16_sub_sat(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn mul_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1421,6 +1429,10 @@ impl Simd for WasmSimd128 {
         i16x8_sub(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
+    fn saturating_sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        i16x8_sub_sat(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
     fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         i16x8_mul(a.into(), b.into()).simd_into(self)
     }
@@ -1699,6 +1711,10 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
         u16x8_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        u16x8_sub_sat(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn mul_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2072,15 +2088,23 @@ impl Simd for WasmSimd128 {
     fn saturating_add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         let a: v128 = a.into();
         let b: v128 = b.into();
-        let sum = i32x4_add(a, b);
-        let overflow_bits = v128_and(v128_xor(sum, a), v128_xor(sum, b));
-        let overflow_mask = i32x4_shr(overflow_bits, 31);
-        let saturation = v128_xor(i32x4_shr(sum, 31), i32x4_splat(i32::MIN));
-        v128_bitselect(saturation, sum, overflow_mask).simd_into(self)
+        let wrapped = i32x4_add(a, b);
+        let overflow_mask = i32x4_shr(v128_and(v128_xor(a, wrapped), v128_xor(b, wrapped)), 31);
+        let saturation = v128_xor(i32x4_shr(wrapped, 31), i32x4_splat(i32::MIN));
+        v128_bitselect(saturation, wrapped, overflow_mask).simd_into(self)
     }
     #[inline(always)]
     fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         i32x4_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        let a: v128 = a.into();
+        let b: v128 = b.into();
+        let wrapped = i32x4_sub(a, b);
+        let overflow_mask = i32x4_shr(v128_and(v128_xor(a, b), v128_xor(a, wrapped)), 31);
+        let saturation = v128_xor(i32x4_shr(wrapped, 31), i32x4_splat(i32::MIN));
+        v128_bitselect(saturation, wrapped, overflow_mask).simd_into(self)
     }
     #[inline(always)]
     fn mul_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
@@ -2349,6 +2373,12 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
         u32x4_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        let a: v128 = a.into();
+        let b: v128 = b.into();
+        u32x4_sub(u32x4_max(a, b), b).simd_into(self)
     }
     #[inline(always)]
     fn mul_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -3025,15 +3055,23 @@ impl Simd for WasmSimd128 {
     fn saturating_add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         let a: v128 = a.into();
         let b: v128 = b.into();
-        let sum = i64x2_add(a, b);
-        let overflow_bits = v128_and(v128_xor(sum, a), v128_xor(sum, b));
-        let overflow_mask = i64x2_shr(overflow_bits, 63);
-        let saturation = v128_xor(i64x2_shr(sum, 63), i64x2_splat(i64::MIN));
-        v128_bitselect(saturation, sum, overflow_mask).simd_into(self)
+        let wrapped = i64x2_add(a, b);
+        let overflow_mask = i64x2_shr(v128_and(v128_xor(a, wrapped), v128_xor(b, wrapped)), 63);
+        let saturation = v128_xor(i64x2_shr(wrapped, 63), i64x2_splat(i64::MIN));
+        v128_bitselect(saturation, wrapped, overflow_mask).simd_into(self)
     }
     #[inline(always)]
     fn sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         i64x2_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        let a: v128 = a.into();
+        let b: v128 = b.into();
+        let wrapped = i64x2_sub(a, b);
+        let overflow_mask = i64x2_shr(v128_and(v128_xor(a, b), v128_xor(a, wrapped)), 63);
+        let saturation = v128_xor(i64x2_shr(wrapped, 63), i64x2_splat(i64::MIN));
+        v128_bitselect(saturation, wrapped, overflow_mask).simd_into(self)
     }
     #[inline(always)]
     fn mul_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
@@ -3292,14 +3330,23 @@ impl Simd for WasmSimd128 {
     fn saturating_add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
         let a: v128 = a.into();
         let b: v128 = b.into();
-        let sum = u64x2_add(a, b);
+        let wrapped = u64x2_add(a, b);
         let sign_bit = i64x2_splat(i64::MIN);
-        let overflow_mask = i64x2_gt(v128_xor(a, sign_bit), v128_xor(sum, sign_bit));
-        v128_or(sum, overflow_mask).simd_into(self)
+        let saturation_mask = i64x2_gt(v128_xor(a, sign_bit), v128_xor(wrapped, sign_bit));
+        v128_or(wrapped, saturation_mask).simd_into(self)
     }
     #[inline(always)]
     fn sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
         u64x2_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        let a: v128 = a.into();
+        let b: v128 = b.into();
+        let wrapped = u64x2_sub(a, b);
+        let sign_bit = i64x2_splat(i64::MIN);
+        let saturation_mask = i64x2_gt(v128_xor(b, sign_bit), v128_xor(a, sign_bit));
+        v128_andnot(wrapped, saturation_mask).simd_into(self)
     }
     #[inline(always)]
     fn mul_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -572,6 +572,10 @@ impl Simd for WasmSimd128 {
         i8x16_add(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
+    fn saturating_add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        i8x16_add_sat(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
     fn sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         i8x16_sub(a.into(), b.into()).simd_into(self)
     }
@@ -952,6 +956,10 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
         u8x16_add(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        u8x16_add_sat(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1405,6 +1413,10 @@ impl Simd for WasmSimd128 {
         i16x8_add(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
+    fn saturating_add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        i16x8_add_sat(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
     fn sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         i16x8_sub(a.into(), b.into()).simd_into(self)
     }
@@ -1679,6 +1691,10 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
         u16x8_add(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        u16x8_add_sat(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
     fn sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2053,6 +2069,16 @@ impl Simd for WasmSimd128 {
         i32x4_add(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
+    fn saturating_add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        let a: v128 = a.into();
+        let b: v128 = b.into();
+        let sum = i32x4_add(a, b);
+        let overflow_bits = v128_and(v128_xor(sum, a), v128_xor(sum, b));
+        let overflow_mask = i32x4_shr(overflow_bits, 31);
+        let saturation = v128_xor(i32x4_shr(sum, 31), i32x4_splat(i32::MIN));
+        v128_bitselect(saturation, sum, overflow_mask).simd_into(self)
+    }
+    #[inline(always)]
     fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         i32x4_sub(a.into(), b.into()).simd_into(self)
     }
@@ -2313,6 +2339,12 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
         u32x4_add(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        let a: v128 = a.into();
+        let b: v128 = b.into();
+        u32x4_add(u32x4_min(a, v128_not(b)), b).simd_into(self)
     }
     #[inline(always)]
     fn sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -2990,6 +3022,16 @@ impl Simd for WasmSimd128 {
         i64x2_add(a.into(), b.into()).simd_into(self)
     }
     #[inline(always)]
+    fn saturating_add_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
+        let a: v128 = a.into();
+        let b: v128 = b.into();
+        let sum = i64x2_add(a, b);
+        let overflow_bits = v128_and(v128_xor(sum, a), v128_xor(sum, b));
+        let overflow_mask = i64x2_shr(overflow_bits, 63);
+        let saturation = v128_xor(i64x2_shr(sum, 63), i64x2_splat(i64::MIN));
+        v128_bitselect(saturation, sum, overflow_mask).simd_into(self)
+    }
+    #[inline(always)]
     fn sub_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         i64x2_sub(a.into(), b.into()).simd_into(self)
     }
@@ -3245,6 +3287,15 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
         u64x2_add(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn saturating_add_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
+        let a: v128 = a.into();
+        let b: v128 = b.into();
+        let sum = u64x2_add(a, b);
+        let sign_bit = i64x2_splat(i64::MIN);
+        let overflow_mask = i64x2_gt(v128_xor(a, sign_bit), v128_xor(sum, sign_bit));
+        v128_or(sum, overflow_mask).simd_into(self)
     }
     #[inline(always)]
     fn sub_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd_gen/src/arch/fallback.rs
+++ b/fearless_simd_gen/src/arch/fallback.rs
@@ -29,6 +29,7 @@ pub(crate) fn translate_op(op: &str, is_float: bool) -> Option<&'static str> {
                 "wrapping_add"
             }
         }
+        "saturating_add" => "saturating_add",
         "sub" => {
             if is_float {
                 "sub"

--- a/fearless_simd_gen/src/arch/fallback.rs
+++ b/fearless_simd_gen/src/arch/fallback.rs
@@ -30,6 +30,7 @@ pub(crate) fn translate_op(op: &str, is_float: bool) -> Option<&'static str> {
             }
         }
         "saturating_add" => "saturating_add",
+        "saturating_sub" => "saturating_sub",
         "sub" => {
             if is_float {
                 "sub"

--- a/fearless_simd_gen/src/arch/neon.rs
+++ b/fearless_simd_gen/src/arch/neon.rs
@@ -15,6 +15,7 @@ fn translate_op(op: &str) -> Option<&'static str> {
         "trunc" => "vrnd",
         "sqrt" => "vsqrt",
         "add" => "vadd",
+        "saturating_add" => "vqadd",
         "sub" => "vsub",
         "mul" => "vmul",
         "div" => "vdiv",

--- a/fearless_simd_gen/src/arch/neon.rs
+++ b/fearless_simd_gen/src/arch/neon.rs
@@ -16,6 +16,7 @@ fn translate_op(op: &str) -> Option<&'static str> {
         "sqrt" => "vsqrt",
         "add" => "vadd",
         "saturating_add" => "vqadd",
+        "saturating_sub" => "vqsub",
         "sub" => "vsub",
         "mul" => "vmul",
         "div" => "vdiv",

--- a/fearless_simd_gen/src/arch/wasm.rs
+++ b/fearless_simd_gen/src/arch/wasm.rs
@@ -16,6 +16,7 @@ fn translate_op(op: &str) -> Option<&'static str> {
         "sqrt" => "sqrt",
         "add" => "add",
         "saturating_add" => "add_sat",
+        "saturating_sub" => "sub_sat",
         // TODO: Is wrapping sub same on WASM?
         "sub" => "sub",
         "mul" => "mul",

--- a/fearless_simd_gen/src/arch/wasm.rs
+++ b/fearless_simd_gen/src/arch/wasm.rs
@@ -15,6 +15,7 @@ fn translate_op(op: &str) -> Option<&'static str> {
         "trunc" => "trunc",
         "sqrt" => "sqrt",
         "add" => "add",
+        "saturating_add" => "add_sat",
         // TODO: Is wrapping sub same on WASM?
         "sub" => "sub",
         "mul" => "mul",

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -892,6 +892,7 @@ fn rhs_reference(method: &str) -> bool {
             | "wrapping_mul"
             | "wrapping_add"
             | "saturating_add"
+            | "saturating_sub"
             | "wrapping_shl"
             | "wrapping_shr"
     )

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -891,6 +891,7 @@ fn rhs_reference(method: &str) -> bool {
             | "wrapping_sub"
             | "wrapping_mul"
             | "wrapping_add"
+            | "saturating_add"
             | "wrapping_shl"
             | "wrapping_shr"
     )

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -309,7 +309,7 @@ fn saturating_add_sub_method(op: Op, vec_ty: &VecType, arithmetic: SaturatingOp)
             let shr = simple_intrinsic("shr", vec_ty);
             let splat = simple_intrinsic("splat", vec_ty);
             let scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
-            let sign_shift = Literal::u32_unsuffixed((vec_ty.scalar_bits - 1) as u32);
+            let sign_shift = Literal::u32_unsuffixed((vec_ty.scalar_bits - 1).try_into().unwrap());
             let overflow_bits = match arithmetic {
                 // `(a ^ wrapped) & (b ^ wrapped)` has its sign bit set exactly
                 // when signed addition overflows.

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -219,6 +219,90 @@ fn reduce_sum(method_sig: TokenStream, vec_ty: &VecType) -> TokenStream {
     }
 }
 
+fn saturating_add_method(op: Op, vec_ty: &VecType) -> TokenStream {
+    assert_eq!(
+        vec_ty.n_bits(),
+        128,
+        "WASM saturating-add lowering only handles one native vector"
+    );
+    assert!(
+        matches!(vec_ty.scalar, ScalarType::Int | ScalarType::Unsigned),
+        "saturating_add is only defined for integers"
+    );
+
+    let method_sig = op.simd_trait_method_sig(vec_ty);
+    if matches!(vec_ty.scalar_bits, 8 | 16) {
+        let expr = wasm::expr(
+            "saturating_add",
+            vec_ty,
+            &[quote! { a.into() }, quote! { b.into() }],
+        );
+        return quote! {
+            #method_sig {
+                #expr.simd_into(self)
+            }
+        };
+    }
+
+    let add = simple_intrinsic("add", vec_ty);
+    let body = match (vec_ty.scalar, vec_ty.scalar_bits) {
+        (ScalarType::Unsigned, 32) => {
+            // Clamp `a` to the greatest value that can be added to `b`, then add.
+            // `!b` is `u32::MAX - b` lane-wise.
+            let min = simple_intrinsic("min", vec_ty);
+            quote! {
+                #add(#min(a, v128_not(b)), b)
+            }
+        }
+        (ScalarType::Unsigned, 64) => {
+            // WebAssembly has no unsigned i64x2 comparison. Flip the sign bit so
+            // the signed ordering matches unsigned ordering, then detect carry by
+            // checking whether the wrapping sum is less than the first addend.
+            let signed_ty = vec_ty.cast(ScalarType::Int);
+            let signed_gt = simple_intrinsic("gt", &signed_ty);
+            let signed_splat = simple_intrinsic("splat", &signed_ty);
+            let signed_scalar = signed_ty.scalar.rust(signed_ty.scalar_bits);
+            quote! {
+                let sum = #add(a, b);
+                let sign_bit = #signed_splat(#signed_scalar::MIN);
+                let overflow_mask = #signed_gt(
+                    v128_xor(a, sign_bit),
+                    v128_xor(sum, sign_bit),
+                );
+                v128_or(sum, overflow_mask)
+            }
+        }
+        (ScalarType::Int, 32 | 64) => {
+            // Signed overflow has the same sign in `(sum ^ a)` and `(sum ^ b)`.
+            // Expand that sign bit into a lane mask, then select the appropriate
+            // endpoint. A wrapped negative sum means positive overflow and vice versa.
+            let shr = simple_intrinsic("shr", vec_ty);
+            let splat = simple_intrinsic("splat", vec_ty);
+            let scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
+            let sign_shift = Literal::u32_unsuffixed((vec_ty.scalar_bits - 1) as u32);
+            quote! {
+                let sum = #add(a, b);
+                let overflow_bits = v128_and(v128_xor(sum, a), v128_xor(sum, b));
+                let overflow_mask = #shr(overflow_bits, #sign_shift);
+                let saturation = v128_xor(
+                    #shr(sum, #sign_shift),
+                    #splat(#scalar::MIN),
+                );
+                v128_bitselect(saturation, sum, overflow_mask)
+            }
+        }
+        _ => unreachable!(),
+    };
+
+    quote! {
+        #method_sig {
+            let a: v128 = a.into();
+            let b: v128 = b.into();
+            #body.simd_into(self)
+        }
+    }
+}
+
 impl Level for WasmSimd128 {
     fn name(&self) -> &'static str {
         "WasmSimd128"
@@ -480,6 +564,10 @@ impl Level for WasmSimd128 {
                 mode: NarrowingMode::Relaxed,
             } => relaxed_narrow_method(op, vec_ty, target_ty, "narrow"),
             OpSig::Binary => {
+                if method == "saturating_add" {
+                    return saturating_add_method(op, vec_ty);
+                }
+
                 if matches!(method, "shlv" | "shrv")
                     || (matches!(method, "min" | "max")
                         && vec_ty.scalar_bits == 64

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -11,7 +11,9 @@ use crate::generic::{
     recursive_swizzle_dyn_precise_body, reverse_method, reverse_vector_mask_method,
 };
 use crate::level::Level;
-use crate::ops::{NarrowingMode, Op, Quantifier, SlideGranularity, relaxed_narrow_method};
+use crate::ops::{
+    NarrowingMode, Op, Quantifier, SaturatingOp, SlideGranularity, relaxed_narrow_method,
+};
 use crate::{
     arch::wasm::{self, simple_intrinsic},
     ops::OpSig,
@@ -219,24 +221,26 @@ fn reduce_sum(method_sig: TokenStream, vec_ty: &VecType) -> TokenStream {
     }
 }
 
-fn saturating_add_method(op: Op, vec_ty: &VecType) -> TokenStream {
+fn saturating_add_sub_method(op: Op, vec_ty: &VecType, arithmetic: SaturatingOp) -> TokenStream {
+    use SaturatingOp::{Add, Sub};
+
     assert_eq!(
         vec_ty.n_bits(),
         128,
-        "WASM saturating-add lowering only handles one native vector"
+        "WASM saturating add/sub lowering only handles one native vector"
     );
     assert!(
         matches!(vec_ty.scalar, ScalarType::Int | ScalarType::Unsigned),
-        "saturating_add is only defined for integers"
+        "saturating add/sub is only defined for integers"
     );
 
     let method_sig = op.simd_trait_method_sig(vec_ty);
     if matches!(vec_ty.scalar_bits, 8 | 16) {
-        let expr = wasm::expr(
-            "saturating_add",
-            vec_ty,
-            &[quote! { a.into() }, quote! { b.into() }],
-        );
+        let method = match arithmetic {
+            Add => "saturating_add",
+            Sub => "saturating_sub",
+        };
+        let expr = wasm::expr(method, vec_ty, &[quote! { a.into() }, quote! { b.into() }]);
         return quote! {
             #method_sig {
                 #expr.simd_into(self)
@@ -244,51 +248,86 @@ fn saturating_add_method(op: Op, vec_ty: &VecType) -> TokenStream {
         };
     }
 
-    let add = simple_intrinsic("add", vec_ty);
+    let wrapping = simple_intrinsic(
+        match arithmetic {
+            Add => "add",
+            Sub => "sub",
+        },
+        vec_ty,
+    );
     let body = match (vec_ty.scalar, vec_ty.scalar_bits) {
         (ScalarType::Unsigned, 32) => {
-            // Clamp `a` to the greatest value that can be added to `b`, then add.
-            // `!b` is `u32::MAX - b` lane-wise.
-            let min = simple_intrinsic("min", vec_ty);
+            let clamped = match arithmetic {
+                Add => {
+                    // Clamp `a` to the greatest value that can be added to `b`.
+                    // `!b` is `u32::MAX - b` lane-wise.
+                    let min = simple_intrinsic("min", vec_ty);
+                    quote! { #min(a, v128_not(b)) }
+                }
+                Sub => {
+                    // Raising `a` to at least `b` makes an underflowing difference zero.
+                    let max = simple_intrinsic("max", vec_ty);
+                    quote! { #max(a, b) }
+                }
+            };
             quote! {
-                #add(#min(a, v128_not(b)), b)
+                #wrapping(#clamped, b)
             }
         }
         (ScalarType::Unsigned, 64) => {
-            // WebAssembly has no unsigned i64x2 comparison. Flip the sign bit so
-            // the signed ordering matches unsigned ordering, then detect carry by
-            // checking whether the wrapping sum is less than the first addend.
             let signed_ty = vec_ty.cast(ScalarType::Int);
             let signed_gt = simple_intrinsic("gt", &signed_ty);
             let signed_splat = simple_intrinsic("splat", &signed_ty);
             let signed_scalar = signed_ty.scalar.rust(signed_ty.scalar_bits);
-            quote! {
-                let sum = #add(a, b);
-                let sign_bit = #signed_splat(#signed_scalar::MIN);
-                let overflow_mask = #signed_gt(
-                    v128_xor(a, sign_bit),
-                    v128_xor(sum, sign_bit),
-                );
-                v128_or(sum, overflow_mask)
+            match arithmetic {
+                Add => quote! {
+                    // WebAssembly has no unsigned i64x2 comparison. Flip the sign
+                    // bit so signed ordering matches unsigned ordering, then detect
+                    // carry by checking whether the sum is less than `a`.
+                    let wrapped = #wrapping(a, b);
+                    let sign_bit = #signed_splat(#signed_scalar::MIN);
+                    let saturation_mask = #signed_gt(
+                        v128_xor(a, sign_bit),
+                        v128_xor(wrapped, sign_bit),
+                    );
+                    v128_or(wrapped, saturation_mask)
+                },
+                Sub => quote! {
+                    // In sign-biased unsigned ordering, `b > a` identifies the lanes
+                    // whose wrapping difference must be replaced with zero.
+                    let wrapped = #wrapping(a, b);
+                    let sign_bit = #signed_splat(#signed_scalar::MIN);
+                    let saturation_mask = #signed_gt(
+                        v128_xor(b, sign_bit),
+                        v128_xor(a, sign_bit),
+                    );
+                    v128_andnot(wrapped, saturation_mask)
+                },
             }
         }
         (ScalarType::Int, 32 | 64) => {
-            // Signed overflow has the same sign in `(sum ^ a)` and `(sum ^ b)`.
-            // Expand that sign bit into a lane mask, then select the appropriate
-            // endpoint. A wrapped negative sum means positive overflow and vice versa.
             let shr = simple_intrinsic("shr", vec_ty);
             let splat = simple_intrinsic("splat", vec_ty);
             let scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
             let sign_shift = Literal::u32_unsuffixed((vec_ty.scalar_bits - 1) as u32);
+            let overflow_bits = match arithmetic {
+                // `(a ^ wrapped) & (b ^ wrapped)` has its sign bit set exactly
+                // when signed addition overflows.
+                Add => quote! { v128_and(v128_xor(a, wrapped), v128_xor(b, wrapped)) },
+                // `(a ^ b) & (a ^ wrapped)` has its sign bit set exactly when
+                // signed subtraction overflows.
+                Sub => quote! { v128_and(v128_xor(a, b), v128_xor(a, wrapped)) },
+            };
             quote! {
-                let sum = #add(a, b);
-                let overflow_bits = v128_and(v128_xor(sum, a), v128_xor(sum, b));
-                let overflow_mask = #shr(overflow_bits, #sign_shift);
+                let wrapped = #wrapping(a, b);
+                let overflow_mask = #shr(#overflow_bits, #sign_shift);
+                // On overflow, the wrapped result has the opposite sign from the
+                // saturation endpoint. This bound works for both add and subtract.
                 let saturation = v128_xor(
-                    #shr(sum, #sign_shift),
+                    #shr(wrapped, #sign_shift),
                     #splat(#scalar::MIN),
                 );
-                v128_bitselect(saturation, sum, overflow_mask)
+                v128_bitselect(saturation, wrapped, overflow_mask)
             }
         }
         _ => unreachable!(),
@@ -564,8 +603,13 @@ impl Level for WasmSimd128 {
                 mode: NarrowingMode::Relaxed,
             } => relaxed_narrow_method(op, vec_ty, target_ty, "narrow"),
             OpSig::Binary => {
-                if method == "saturating_add" {
-                    return saturating_add_method(op, vec_ty);
+                let saturating_op = match method {
+                    "saturating_add" => Some(SaturatingOp::Add),
+                    "saturating_sub" => Some(SaturatingOp::Sub),
+                    _ => None,
+                };
+                if let Some(arithmetic) = saturating_op {
+                    return saturating_add_sub_method(op, vec_ty, arithmetic);
                 }
 
                 if matches!(method, "shlv" | "shrv")

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2288,7 +2288,7 @@ impl X86 {
 
         assert!(
             matches!(vec_ty.scalar, Int | Unsigned),
-            "Saturating artihmetic is not implementable for floats"
+            "Saturating arithmetic is not implementable for floats"
         );
 
         match (*self, vec_ty.scalar, vec_ty.scalar_bits, vec_ty.n_bits()) {

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2275,8 +2275,191 @@ impl X86 {
         }
     }
 
+    fn handle_avx512_signed_saturating_add(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+        assert!(*self == Self::Avx512);
+        assert_eq!(vec_ty.scalar, ScalarType::Int);
+        assert!(matches!(vec_ty.scalar_bits, 32 | 64));
+
+        let bits = vec_ty.n_bits();
+        let lane_bits = vec_ty.scalar_bits;
+        let shift = Literal::usize_unsuffixed(lane_bits - 1);
+        let max = match lane_bits {
+            32 => quote! { i32::MAX },
+            64 => quote! { i64::MAX },
+            _ => unreachable!(),
+        };
+        let suffix = format!("epi{lane_bits}");
+        let add = intrinsic_ident("add", &suffix, bits);
+        let shift_right_logical = intrinsic_ident("srli", &suffix, bits);
+        let shift_right_arithmetic = intrinsic_ident("srai", &suffix, bits);
+        let set1 = set1_intrinsic(vec_ty);
+        let ternary = intrinsic_ident("ternarylogic", &suffix, bits);
+
+        self.kernel_method(op, vec_ty, |token| {
+            quote! {
+                let a = a.into();
+                let b = b.into();
+                let sum = #add(a, b);
+
+                // The 0x42 truth table computes `(a ^ sum) & (b ^ sum)`, whose
+                // sign bit is set exactly when signed addition overflows.
+                let overflow_bits = #ternary::<0x42>(a, b, sum);
+                let overflow_mask = #shift_right_arithmetic::<#shift>(overflow_bits);
+
+                // The top bit of `a` selects the saturation direction. Logical
+                // shift produces 0 or 1; adding that to MAX gives MAX or MIN.
+                let direction = #add(
+                    #shift_right_logical::<#shift>(a),
+                    #set1(#max),
+                );
+
+                // 0xca is a bitwise select: use `direction` where overflowed,
+                // and the wrapped sum everywhere else.
+                #ternary::<0xca>(overflow_mask, direction, sum).simd_into(#token)
+            }
+        })
+    }
+
+    fn handle_saturating_add(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+        assert!(matches!(
+            vec_ty.scalar,
+            ScalarType::Int | ScalarType::Unsigned
+        ));
+
+        if matches!(vec_ty.scalar_bits, 8 | 16) {
+            let adds = simple_intrinsic("adds", vec_ty);
+            return self.kernel_method(op, vec_ty, |token| {
+                quote! {
+                    #adds(a.into(), b.into()).simd_into(#token)
+                }
+            });
+        }
+
+        // SSE2 is a correctness target, not an optimization target. Its 32/64-bit
+        // packed emulations are substantially more complex than the scalar fallback.
+        if *self == Self::Sse2 {
+            return fallback_method(op, vec_ty);
+        }
+
+        if *self == Self::Avx512 && vec_ty.scalar == ScalarType::Int {
+            return self.handle_avx512_signed_saturating_add(op, vec_ty);
+        }
+
+        let bits = vec_ty.n_bits();
+        let add = simple_sign_unaware_intrinsic("add", vec_ty);
+        let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
+        let set1 = set1_intrinsic(vec_ty);
+
+        if vec_ty.scalar == ScalarType::Unsigned
+            && (vec_ty.scalar_bits == 32 || *self == Self::Avx512)
+        {
+            // Unsigned saturation can be expressed without detecting carry:
+            // clamp `a` to the greatest value that can be added to `b`, then add.
+            let min = simple_intrinsic("min", vec_ty);
+            return self.kernel_method(op, vec_ty, |token| {
+                quote! {
+                    let a = a.into();
+                    let b = b.into();
+                    let threshold = #xor(b, #set1(-1));
+                    #add(#min(a, threshold), b).simd_into(#token)
+                }
+            });
+        }
+
+        if vec_ty.scalar == ScalarType::Unsigned && vec_ty.scalar_bits == 64 {
+            // SSE4.2 and AVX2 have signed, but not unsigned, qword comparisons.
+            // Flipping the sign bit maps unsigned order onto signed order.
+            let cmpgt = simple_sign_unaware_intrinsic("cmpgt", vec_ty);
+            let or = intrinsic_ident("or", coarse_type(vec_ty), bits);
+            return self.kernel_method(op, vec_ty, |token| {
+                quote! {
+                    let a = a.into();
+                    let b = b.into();
+                    let sum = #add(a, b);
+                    let sign_bias = #set1(i64::MIN);
+                    let overflow = #cmpgt(
+                        #xor(a, sign_bias),
+                        #xor(sum, sign_bias),
+                    );
+                    #or(sum, overflow).simd_into(#token)
+                }
+            });
+        }
+
+        let cmpgt = simple_sign_unaware_intrinsic("cmpgt", vec_ty);
+        match vec_ty.scalar_bits {
+            32 => {
+                let shift = intrinsic_ident("srai", "epi32", bits);
+                let to_float = cast_ident(ScalarType::Int, ScalarType::Float, 32, 32, bits);
+                let to_int = cast_ident(ScalarType::Float, ScalarType::Int, 32, 32, bits);
+                let blend = intrinsic_ident("blendv", "ps", bits);
+                self.kernel_method(op, vec_ty, |token| {
+                    quote! {
+                        let a = a.into();
+                        let b = b.into();
+                        let sum = #add(a, b);
+
+                        // Only the sign bit of each lane is meaningful here, so use
+                        // BLENDVPS rather than the byte-granularity integer blend.
+                        let overflow = #xor(#cmpgt(a, sum), b);
+                        let bound = #xor(#shift::<31>(sum), #set1(i32::MIN));
+                        let result = #blend(
+                            #to_float(sum),
+                            #to_float(bound),
+                            #to_float(overflow),
+                        );
+                        #to_int(result).simd_into(#token)
+                    }
+                })
+            }
+            64 => {
+                let to_float = cast_ident(ScalarType::Int, ScalarType::Float, 64, 64, bits);
+                let to_int = cast_ident(ScalarType::Float, ScalarType::Int, 64, 64, bits);
+                let blend = intrinsic_ident("blendv", "pd", bits);
+                let bound = if *self == Self::Avx2 {
+                    let shift = intrinsic_ident("srli", "epi64", bits);
+                    quote! {
+                        // AVX2 can construct the endpoint directly from `a`'s sign
+                        // without the high-dword shuffle required by SSE4.2.
+                        let bound = #add(#shift::<63>(a), #set1(i64::MAX));
+                    }
+                } else {
+                    let shuffle = intrinsic_ident("shuffle", "epi32", bits);
+                    let shift = intrinsic_ident("srai", "epi32", bits);
+                    quote! {
+                        let sum_sign = #shift::<31>(#shuffle::<0xf5>(sum));
+                        let bound = #xor(sum_sign, #set1(i64::MIN));
+                    }
+                };
+                self.kernel_method(op, vec_ty, |token| {
+                    quote! {
+                        let a = a.into();
+                        let b = b.into();
+                        let sum = #add(a, b);
+
+                        // BLENDVPD reads one sign bit per qword, which is exactly the
+                        // meaningful part of this non-canonical overflow mask.
+                        let overflow = #xor(#cmpgt(a, sum), b);
+                        #bound
+                        let result = #blend(
+                            #to_float(sum),
+                            #to_float(bound),
+                            #to_float(overflow),
+                        );
+                        #to_int(result).simd_into(#token)
+                    }
+                })
+            }
+            _ => unreachable!(),
+        }
+    }
+
     pub(crate) fn handle_binary(&self, op: Op, method: &str, vec_ty: &VecType) -> TokenStream {
         let method_sig = op.simd_trait_method_sig(vec_ty);
+
+        if method == "saturating_add" {
+            return self.handle_saturating_add(op, vec_ty);
+        }
 
         if *self == Self::Avx512 && vec_ty.scalar == ScalarType::Mask {
             let lane_mask = avx512_mask_lane_bits(vec_ty);

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2291,9 +2291,7 @@ impl X86 {
                 })
             }
             // SSE2 emulations are possible but complex so we don't bother, SSE2 is too rare.
-            (Self::Sse2, _, 32 | 64, _) => {
-                fallback_method(op, vec_ty)
-            }
+            (Self::Sse2, _, 32 | 64, _) => fallback_method(op, vec_ty),
             (Self::Avx512, ScalarType::Int, lane_bits @ (32 | 64), bits) => {
                 let shift = Literal::usize_unsuffixed(lane_bits - 1);
                 let max = match lane_bits {
@@ -2333,7 +2331,8 @@ impl X86 {
                     }
                 })
             }
-            (Self::Sse4_2 | Self::Avx2 | Self::Avx512, ScalarType::Unsigned, 32, _bits) => {
+            (Self::Sse4_2 | Self::Avx2, ScalarType::Unsigned, 32, _bits)
+            | (Self::Avx512, ScalarType::Unsigned, 32 | 64, _bits) => {
                 let bits = vec_ty.n_bits();
                 let add = simple_sign_unaware_intrinsic("add", vec_ty);
                 let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
@@ -2375,88 +2374,66 @@ impl X86 {
                     }
                 })
             }
-            (Self::Sse4_2 | Self::Avx2, ScalarType::Int, 32, _bits) => {
-                let bits = vec_ty.n_bits();
+            (Self::Sse4_2 | Self::Avx2, ScalarType::Int, lane_bits  @ (32 | 64), bits) => {
                 let add = simple_sign_unaware_intrinsic("add", vec_ty);
                 let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
                 let set1 = set1_intrinsic(vec_ty);
                 let cmpgt = simple_sign_unaware_intrinsic("cmpgt", vec_ty);
-                let shift = intrinsic_ident("srai", "epi32", bits);
-                let to_float = cast_ident(ScalarType::Int, ScalarType::Float, 32, 32, bits);
-                let to_int = cast_ident(ScalarType::Float, ScalarType::Int, 32, 32, bits);
-                let blend = intrinsic_ident("blendv", "ps", bits);
-                self.kernel_method(op, vec_ty, |token| {
-                    quote! {
-                        let a = a.into();
-                        let b = b.into();
-                        let sum = #add(a, b);
-
-                        // Only the sign bit of each lane is meaningful here, so use
-                        // BLENDVPS rather than the byte-granularity integer blend.
-                        let overflow = #xor(#cmpgt(a, sum), b);
-                        let bound = #xor(#shift::<31>(sum), #set1(i32::MIN));
-                        let result = #blend(
-                            #to_float(sum),
-                            #to_float(bound),
-                            #to_float(overflow),
-                        );
-                        #to_int(result).simd_into(#token)
+                let bound = match (*self, lane_bits) {
+                    (_, 32) => {
+                        let shift = intrinsic_ident("srai", "epi32", bits);
+                        quote! {
+                            let bound = #xor(#shift::<31>(sum), #set1(i32::MIN));
+                        }
                     }
-                })
-            }
-            (Self::Sse4_2, ScalarType::Int, 64, 128) => {
-                let bits = vec_ty.n_bits();
-                let add = simple_sign_unaware_intrinsic("add", vec_ty);
-                let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
-                let set1 = set1_intrinsic(vec_ty);
-                let cmpgt = simple_sign_unaware_intrinsic("cmpgt", vec_ty);
-                let shuffle = intrinsic_ident("shuffle", "epi32", bits);
-                let shift = intrinsic_ident("srai", "epi32", bits);
-                let to_float = cast_ident(ScalarType::Int, ScalarType::Float, 64, 64, bits);
-                let to_int = cast_ident(ScalarType::Float, ScalarType::Int, 64, 64, bits);
-                let blend = intrinsic_ident("blendv", "pd", bits);
-                self.kernel_method(op, vec_ty, |token| {
-                    quote! {
-                        let a = a.into();
-                        let b = b.into();
-                        let sum = #add(a, b);
-
-                        // BLENDVPD reads one sign bit per qword, which is exactly the
-                        // meaningful part of this non-canonical overflow mask.
-                        let overflow = #xor(#cmpgt(a, sum), b);
-                        let sum_sign = #shift::<31>(#shuffle::<0xf5>(sum));
-                        let bound = #xor(sum_sign, #set1(i64::MIN));
-                        let result = #blend(
-                            #to_float(sum),
-                            #to_float(bound),
-                            #to_float(overflow),
-                        );
-                        #to_int(result).simd_into(#token)
+                    (Self::Sse4_2, 64) => {
+                        let shuffle = intrinsic_ident("shuffle", "epi32", bits);
+                        let shift = intrinsic_ident("srai", "epi32", bits);
+                        quote! {
+                            let sum_sign = #shift::<31>(#shuffle::<0xf5>(sum));
+                            let bound = #xor(sum_sign, #set1(i64::MIN));
+                        }
                     }
-                })
-            }
-            (Self::Avx2, ScalarType::Int, 64, 128 | 256) => {
-                let bits = vec_ty.n_bits();
-                let add = simple_sign_unaware_intrinsic("add", vec_ty);
-                let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
-                let set1 = set1_intrinsic(vec_ty);
-                let cmpgt = simple_sign_unaware_intrinsic("cmpgt", vec_ty);
-                let shift = intrinsic_ident("srli", "epi64", bits);
-                let to_float = cast_ident(ScalarType::Int, ScalarType::Float, 64, 64, bits);
-                let to_int = cast_ident(ScalarType::Float, ScalarType::Int, 64, 64, bits);
-                let blend = intrinsic_ident("blendv", "pd", bits);
+                    (Self::Avx2, 64) => {
+                        let shift = intrinsic_ident("srli", "epi64", bits);
+                        quote! {
+                            // AVX2 can construct the endpoint directly from `a`'s sign
+                            // without the high-dword shuffle required by SSE4.2.
+                            let bound = #add(#shift::<63>(a), #set1(i64::MAX));
+                        }
+                    }
+                    _ => unreachable!(),
+                };
+                let to_float = cast_ident(
+                    ScalarType::Int,
+                    ScalarType::Float,
+                    lane_bits,
+                    lane_bits,
+                    bits,
+                );
+                let to_int = cast_ident(
+                    ScalarType::Float,
+                    ScalarType::Int,
+                    lane_bits,
+                    lane_bits,
+                    bits,
+                );
+                let blend_suffix = match lane_bits {
+                    32 => "ps",
+                    64 => "pd",
+                    _ => unreachable!(),
+                };
+                let blend = intrinsic_ident("blendv", blend_suffix, bits);
                 self.kernel_method(op, vec_ty, |token| {
                     quote! {
                         let a = a.into();
                         let b = b.into();
                         let sum = #add(a, b);
 
-                        // BLENDVPD reads one sign bit per qword, which is exactly the
-                        // meaningful part of this non-canonical overflow mask.
+                        // Only the sign bit of each lane is meaningful here, so use a
+                        // lane-granularity floating-point blend instead of BLENDV_EPI8.
                         let overflow = #xor(#cmpgt(a, sum), b);
-                        // AVX2 can construct the endpoint directly from `a`'s sign
-                        // without the high-dword shuffle required by SSE4.2.
-                        let bound = #add(#shift::<63>(a), #set1(i64::MAX));
+                        #bound
                         let result = #blend(
                             #to_float(sum),
                             #to_float(bound),

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2275,120 +2275,112 @@ impl X86 {
         }
     }
 
-    fn handle_avx512_signed_saturating_add(&self, op: Op, vec_ty: &VecType) -> TokenStream {
-        assert!(*self == Self::Avx512);
-        assert_eq!(vec_ty.scalar, ScalarType::Int);
-        assert!(matches!(vec_ty.scalar_bits, 32 | 64));
-
-        let bits = vec_ty.n_bits();
-        let lane_bits = vec_ty.scalar_bits;
-        let shift = Literal::usize_unsuffixed(lane_bits - 1);
-        let max = match lane_bits {
-            32 => quote! { i32::MAX },
-            64 => quote! { i64::MAX },
-            _ => unreachable!(),
-        };
-        let suffix = format!("epi{lane_bits}");
-        let add = intrinsic_ident("add", &suffix, bits);
-        let shift_right_logical = intrinsic_ident("srli", &suffix, bits);
-        let shift_right_arithmetic = intrinsic_ident("srai", &suffix, bits);
-        let set1 = set1_intrinsic(vec_ty);
-        let ternary = intrinsic_ident("ternarylogic", &suffix, bits);
-
-        self.kernel_method(op, vec_ty, |token| {
-            quote! {
-                let a = a.into();
-                let b = b.into();
-                let sum = #add(a, b);
-
-                // The 0x42 truth table computes `(a ^ sum) & (b ^ sum)`, whose
-                // sign bit is set exactly when signed addition overflows.
-                let overflow_bits = #ternary::<0x42>(a, b, sum);
-                let overflow_mask = #shift_right_arithmetic::<#shift>(overflow_bits);
-
-                // The top bit of `a` selects the saturation direction. Logical
-                // shift produces 0 or 1; adding that to MAX gives MAX or MIN.
-                let direction = #add(
-                    #shift_right_logical::<#shift>(a),
-                    #set1(#max),
-                );
-
-                // 0xca is a bitwise select: use `direction` where overflowed,
-                // and the wrapped sum everywhere else.
-                #ternary::<0xca>(overflow_mask, direction, sum).simd_into(#token)
-            }
-        })
-    }
-
     fn handle_saturating_add(&self, op: Op, vec_ty: &VecType) -> TokenStream {
         assert!(matches!(
             vec_ty.scalar,
             ScalarType::Int | ScalarType::Unsigned
         ));
+        match (*self, vec_ty.scalar, vec_ty.scalar_bits, vec_ty.n_bits()) {
+            // x86 has native instructions for 8-bit and 16-bit elements only.
+            (_, _, 8 | 16, _) => {
+                let adds = simple_intrinsic("adds", vec_ty);
+                self.kernel_method(op, vec_ty, |token| {
+                    quote! {
+                        #adds(a.into(), b.into()).simd_into(#token)
+                    }
+                })
+            }
+            // SSE2 emulations are possible but complex so we don't bother, SSE2 is too rare.
+            (Self::Sse2, _, 32 | 64, _) => {
+                fallback_method(op, vec_ty)
+            }
+            (Self::Avx512, ScalarType::Int, lane_bits @ (32 | 64), bits) => {
+                let shift = Literal::usize_unsuffixed(lane_bits - 1);
+                let max = match lane_bits {
+                    32 => quote! { i32::MAX },
+                    64 => quote! { i64::MAX },
+                    _ => unreachable!(),
+                };
+                let suffix = format!("epi{lane_bits}");
+                let add = intrinsic_ident("add", &suffix, bits);
+                let shift_right_logical = intrinsic_ident("srli", &suffix, bits);
+                let shift_right_arithmetic = intrinsic_ident("srai", &suffix, bits);
+                let set1 = set1_intrinsic(vec_ty);
+                let ternary = intrinsic_ident("ternarylogic", &suffix, bits);
 
-        if matches!(vec_ty.scalar_bits, 8 | 16) {
-            let adds = simple_intrinsic("adds", vec_ty);
-            return self.kernel_method(op, vec_ty, |token| {
-                quote! {
-                    #adds(a.into(), b.into()).simd_into(#token)
-                }
-            });
-        }
+                self.kernel_method(op, vec_ty, |token| {
+                    quote! {
+                        let a = a.into();
+                        let b = b.into();
+                        let sum = #add(a, b);
 
-        // SSE2 is a correctness target, not an optimization target. Its 32/64-bit
-        // packed emulations are substantially more complex than the scalar fallback.
-        if *self == Self::Sse2 {
-            return fallback_method(op, vec_ty);
-        }
+                        // The 0x42 truth table computes `(a ^ sum) & (b ^ sum)`, whose
+                        // sign bit is set exactly when signed addition overflows.
+                        let overflow_bits = #ternary::<0x42>(a, b, sum);
+                        let overflow_mask =
+                            #shift_right_arithmetic::<#shift>(overflow_bits);
 
-        if *self == Self::Avx512 && vec_ty.scalar == ScalarType::Int {
-            return self.handle_avx512_signed_saturating_add(op, vec_ty);
-        }
+                        // The top bit of `a` selects the saturation direction. Logical
+                        // shift produces 0 or 1; adding that to MAX gives MAX or MIN.
+                        let direction = #add(
+                            #shift_right_logical::<#shift>(a),
+                            #set1(#max),
+                        );
 
-        let bits = vec_ty.n_bits();
-        let add = simple_sign_unaware_intrinsic("add", vec_ty);
-        let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
-        let set1 = set1_intrinsic(vec_ty);
+                        // 0xca is a bitwise select: use `direction` where overflowed,
+                        // and the wrapped sum everywhere else.
+                        #ternary::<0xca>(overflow_mask, direction, sum).simd_into(#token)
+                    }
+                })
+            }
+            (Self::Sse4_2 | Self::Avx2 | Self::Avx512, ScalarType::Unsigned, 32, _bits) => {
+                let bits = vec_ty.n_bits();
+                let add = simple_sign_unaware_intrinsic("add", vec_ty);
+                let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
+                let set1 = set1_intrinsic(vec_ty);
+                let min = simple_intrinsic("min", vec_ty);
 
-        if vec_ty.scalar == ScalarType::Unsigned
-            && (vec_ty.scalar_bits == 32 || *self == Self::Avx512)
-        {
-            // Unsigned saturation can be expressed without detecting carry:
-            // clamp `a` to the greatest value that can be added to `b`, then add.
-            let min = simple_intrinsic("min", vec_ty);
-            return self.kernel_method(op, vec_ty, |token| {
-                quote! {
-                    let a = a.into();
-                    let b = b.into();
-                    let threshold = #xor(b, #set1(-1));
-                    #add(#min(a, threshold), b).simd_into(#token)
-                }
-            });
-        }
+                // Unsigned saturation can be expressed without detecting carry:
+                // clamp `a` to the greatest value that can be added to `b`, then add.
+                self.kernel_method(op, vec_ty, |token| {
+                    quote! {
+                        let a = a.into();
+                        let b = b.into();
+                        let threshold = #xor(b, #set1(-1));
+                        #add(#min(a, threshold), b).simd_into(#token)
+                    }
+                })
+            }
+            (Self::Sse4_2 | Self::Avx2, ScalarType::Unsigned, 64, _bits) => {
+                let bits = vec_ty.n_bits();
+                let add = simple_sign_unaware_intrinsic("add", vec_ty);
+                let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
+                let set1 = set1_intrinsic(vec_ty);
+                let cmpgt = simple_sign_unaware_intrinsic("cmpgt", vec_ty);
+                let or = intrinsic_ident("or", coarse_type(vec_ty), bits);
 
-        if vec_ty.scalar == ScalarType::Unsigned && vec_ty.scalar_bits == 64 {
-            // SSE4.2 and AVX2 have signed, but not unsigned, qword comparisons.
-            // Flipping the sign bit maps unsigned order onto signed order.
-            let cmpgt = simple_sign_unaware_intrinsic("cmpgt", vec_ty);
-            let or = intrinsic_ident("or", coarse_type(vec_ty), bits);
-            return self.kernel_method(op, vec_ty, |token| {
-                quote! {
-                    let a = a.into();
-                    let b = b.into();
-                    let sum = #add(a, b);
-                    let sign_bias = #set1(i64::MIN);
-                    let overflow = #cmpgt(
-                        #xor(a, sign_bias),
-                        #xor(sum, sign_bias),
-                    );
-                    #or(sum, overflow).simd_into(#token)
-                }
-            });
-        }
-
-        let cmpgt = simple_sign_unaware_intrinsic("cmpgt", vec_ty);
-        match vec_ty.scalar_bits {
-            32 => {
+                // SSE4.2 and AVX2 have signed, but not unsigned, qword comparisons.
+                // Flipping the sign bit maps unsigned order onto signed order.
+                self.kernel_method(op, vec_ty, |token| {
+                    quote! {
+                        let a = a.into();
+                        let b = b.into();
+                        let sum = #add(a, b);
+                        let sign_bias = #set1(i64::MIN);
+                        let overflow = #cmpgt(
+                            #xor(a, sign_bias),
+                            #xor(sum, sign_bias),
+                        );
+                        #or(sum, overflow).simd_into(#token)
+                    }
+                })
+            }
+            (Self::Sse4_2 | Self::Avx2, ScalarType::Int, 32, _bits) => {
+                let bits = vec_ty.n_bits();
+                let add = simple_sign_unaware_intrinsic("add", vec_ty);
+                let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
+                let set1 = set1_intrinsic(vec_ty);
+                let cmpgt = simple_sign_unaware_intrinsic("cmpgt", vec_ty);
                 let shift = intrinsic_ident("srai", "epi32", bits);
                 let to_float = cast_ident(ScalarType::Int, ScalarType::Float, 32, 32, bits);
                 let to_int = cast_ident(ScalarType::Float, ScalarType::Int, 32, 32, bits);
@@ -2412,25 +2404,17 @@ impl X86 {
                     }
                 })
             }
-            64 => {
+            (Self::Sse4_2, ScalarType::Int, 64, 128) => {
+                let bits = vec_ty.n_bits();
+                let add = simple_sign_unaware_intrinsic("add", vec_ty);
+                let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
+                let set1 = set1_intrinsic(vec_ty);
+                let cmpgt = simple_sign_unaware_intrinsic("cmpgt", vec_ty);
+                let shuffle = intrinsic_ident("shuffle", "epi32", bits);
+                let shift = intrinsic_ident("srai", "epi32", bits);
                 let to_float = cast_ident(ScalarType::Int, ScalarType::Float, 64, 64, bits);
                 let to_int = cast_ident(ScalarType::Float, ScalarType::Int, 64, 64, bits);
                 let blend = intrinsic_ident("blendv", "pd", bits);
-                let bound = if *self == Self::Avx2 {
-                    let shift = intrinsic_ident("srli", "epi64", bits);
-                    quote! {
-                        // AVX2 can construct the endpoint directly from `a`'s sign
-                        // without the high-dword shuffle required by SSE4.2.
-                        let bound = #add(#shift::<63>(a), #set1(i64::MAX));
-                    }
-                } else {
-                    let shuffle = intrinsic_ident("shuffle", "epi32", bits);
-                    let shift = intrinsic_ident("srai", "epi32", bits);
-                    quote! {
-                        let sum_sign = #shift::<31>(#shuffle::<0xf5>(sum));
-                        let bound = #xor(sum_sign, #set1(i64::MIN));
-                    }
-                };
                 self.kernel_method(op, vec_ty, |token| {
                     quote! {
                         let a = a.into();
@@ -2440,7 +2424,39 @@ impl X86 {
                         // BLENDVPD reads one sign bit per qword, which is exactly the
                         // meaningful part of this non-canonical overflow mask.
                         let overflow = #xor(#cmpgt(a, sum), b);
-                        #bound
+                        let sum_sign = #shift::<31>(#shuffle::<0xf5>(sum));
+                        let bound = #xor(sum_sign, #set1(i64::MIN));
+                        let result = #blend(
+                            #to_float(sum),
+                            #to_float(bound),
+                            #to_float(overflow),
+                        );
+                        #to_int(result).simd_into(#token)
+                    }
+                })
+            }
+            (Self::Avx2, ScalarType::Int, 64, 128 | 256) => {
+                let bits = vec_ty.n_bits();
+                let add = simple_sign_unaware_intrinsic("add", vec_ty);
+                let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
+                let set1 = set1_intrinsic(vec_ty);
+                let cmpgt = simple_sign_unaware_intrinsic("cmpgt", vec_ty);
+                let shift = intrinsic_ident("srli", "epi64", bits);
+                let to_float = cast_ident(ScalarType::Int, ScalarType::Float, 64, 64, bits);
+                let to_int = cast_ident(ScalarType::Float, ScalarType::Int, 64, 64, bits);
+                let blend = intrinsic_ident("blendv", "pd", bits);
+                self.kernel_method(op, vec_ty, |token| {
+                    quote! {
+                        let a = a.into();
+                        let b = b.into();
+                        let sum = #add(a, b);
+
+                        // BLENDVPD reads one sign bit per qword, which is exactly the
+                        // meaningful part of this non-canonical overflow mask.
+                        let overflow = #xor(#cmpgt(a, sum), b);
+                        // AVX2 can construct the endpoint directly from `a`'s sign
+                        // without the high-dword shuffle required by SSE4.2.
+                        let bound = #add(#shift::<63>(a), #set1(i64::MAX));
                         let result = #blend(
                             #to_float(sum),
                             #to_float(bound),

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2276,10 +2276,8 @@ impl X86 {
     }
 
     fn handle_saturating_add(&self, op: Op, vec_ty: &VecType) -> TokenStream {
-        assert!(matches!(
-            vec_ty.scalar,
-            ScalarType::Int | ScalarType::Unsigned
-        ));
+        use ScalarType::{Float, Int, Unsigned};
+        assert!(matches!(vec_ty.scalar, Int | Unsigned));
         match (*self, vec_ty.scalar, vec_ty.scalar_bits, vec_ty.n_bits()) {
             // x86 has native instructions for 8-bit and 16-bit elements only.
             (_, _, 8 | 16, _) => {
@@ -2292,7 +2290,7 @@ impl X86 {
             }
             // SSE2 emulations are possible but complex so we don't bother, SSE2 is too rare.
             (Self::Sse2, _, 32 | 64, _) => fallback_method(op, vec_ty),
-            (Self::Avx512, ScalarType::Int, lane_bits @ (32 | 64), bits) => {
+            (Self::Avx512, Int, lane_bits @ (32 | 64), bits) => {
                 let shift = Literal::usize_unsuffixed(lane_bits - 1);
                 let max = match lane_bits {
                     32 => quote! { i32::MAX },
@@ -2331,8 +2329,8 @@ impl X86 {
                     }
                 })
             }
-            (Self::Sse4_2 | Self::Avx2, ScalarType::Unsigned, 32, _bits)
-            | (Self::Avx512, ScalarType::Unsigned, 32 | 64, _bits) => {
+            (Self::Sse4_2 | Self::Avx2, Unsigned, 32, _bits)
+            | (Self::Avx512, Unsigned, 32 | 64, _bits) => {
                 let bits = vec_ty.n_bits();
                 let add = simple_sign_unaware_intrinsic("add", vec_ty);
                 let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
@@ -2350,7 +2348,7 @@ impl X86 {
                     }
                 })
             }
-            (Self::Sse4_2 | Self::Avx2, ScalarType::Unsigned, 64, _bits) => {
+            (Self::Sse4_2 | Self::Avx2, Unsigned, 64, _bits) => {
                 let bits = vec_ty.n_bits();
                 let add = simple_sign_unaware_intrinsic("add", vec_ty);
                 let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
@@ -2374,7 +2372,7 @@ impl X86 {
                     }
                 })
             }
-            (Self::Sse4_2 | Self::Avx2, ScalarType::Int, lane_bits  @ (32 | 64), bits) => {
+            (Self::Sse4_2 | Self::Avx2, Int, lane_bits @ (32 | 64), bits) => {
                 let add = simple_sign_unaware_intrinsic("add", vec_ty);
                 let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
                 let set1 = set1_intrinsic(vec_ty);
@@ -2404,20 +2402,8 @@ impl X86 {
                     }
                     _ => unreachable!(),
                 };
-                let to_float = cast_ident(
-                    ScalarType::Int,
-                    ScalarType::Float,
-                    lane_bits,
-                    lane_bits,
-                    bits,
-                );
-                let to_int = cast_ident(
-                    ScalarType::Float,
-                    ScalarType::Int,
-                    lane_bits,
-                    lane_bits,
-                    bits,
-                );
+                let to_float = cast_ident(Int, Float, lane_bits, lane_bits, bits);
+                let to_int = cast_ident(Float, Int, lane_bits, lane_bits, bits);
                 let blend_suffix = match lane_bits {
                     32 => "ps",
                     64 => "pd",

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -12,7 +12,9 @@ use crate::generic::{
     recursive_swizzle_dyn_precise_body, reverse_method, reverse_vector_mask_method,
 };
 use crate::level::Level;
-use crate::ops::{NarrowingMode, Op, OpSig, Quantifier, SlideGranularity, relaxed_narrow_method};
+use crate::ops::{
+    NarrowingMode, Op, OpSig, Quantifier, SaturatingOp, SlideGranularity, relaxed_narrow_method,
+};
 use crate::types::{ScalarType, VecType};
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{ToTokens as _, format_ident, quote};
@@ -2275,16 +2277,30 @@ impl X86 {
         }
     }
 
-    fn handle_saturating_add(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+    fn handle_saturating_add_sub(
+        &self,
+        op: Op,
+        saturating_op: SaturatingOp,
+        vec_ty: &VecType,
+    ) -> TokenStream {
+        use SaturatingOp::{Add, Sub};
         use ScalarType::{Float, Int, Unsigned};
+
         assert!(matches!(vec_ty.scalar, Int | Unsigned));
+
         match (*self, vec_ty.scalar, vec_ty.scalar_bits, vec_ty.n_bits()) {
             // x86 has native instructions for 8-bit and 16-bit elements only.
             (_, _, 8 | 16, _) => {
-                let adds = simple_intrinsic("adds", vec_ty);
+                let intrinsic = simple_intrinsic(
+                    match saturating_op {
+                        Add => "adds",
+                        Sub => "subs",
+                    },
+                    vec_ty,
+                );
                 self.kernel_method(op, vec_ty, |token| {
                     quote! {
-                        #adds(a.into(), b.into()).simd_into(#token)
+                        #intrinsic(a.into(), b.into()).simd_into(#token)
                     }
                 })
             }
@@ -2298,21 +2314,39 @@ impl X86 {
                     _ => unreachable!(),
                 };
                 let suffix = format!("epi{lane_bits}");
+                let arithmetic = intrinsic_ident(
+                    match saturating_op {
+                        Add => "add",
+                        Sub => "sub",
+                    },
+                    &suffix,
+                    bits,
+                );
                 let add = intrinsic_ident("add", &suffix, bits);
                 let shift_right_logical = intrinsic_ident("srli", &suffix, bits);
                 let shift_right_arithmetic = intrinsic_ident("srai", &suffix, bits);
                 let set1 = set1_intrinsic(vec_ty);
                 let ternary = intrinsic_ident("ternarylogic", &suffix, bits);
+                let overflow_bits = match saturating_op {
+                    Add => quote! {
+                        // 0x42 computes `(a ^ wrapped) & (b ^ wrapped)`.
+                        let overflow_bits = #ternary::<0x42>(a, b, wrapped);
+                    },
+                    Sub => quote! {
+                        // 0x18 computes `(a ^ b) & (a ^ wrapped)`.
+                        let overflow_bits = #ternary::<0x18>(a, b, wrapped);
+                    },
+                };
 
                 self.kernel_method(op, vec_ty, |token| {
                     quote! {
                         let a = a.into();
                         let b = b.into();
-                        let sum = #add(a, b);
+                        let wrapped = #arithmetic(a, b);
 
-                        // The 0x42 truth table computes `(a ^ sum) & (b ^ sum)`, whose
-                        // sign bit is set exactly when signed addition overflows.
-                        let overflow_bits = #ternary::<0x42>(a, b, sum);
+                        // The sign bit of this expression is set exactly when the
+                        // signed arithmetic operation overflows.
+                        #overflow_bits
                         let overflow_mask =
                             #shift_right_arithmetic::<#shift>(overflow_bits);
 
@@ -2324,37 +2358,79 @@ impl X86 {
                         );
 
                         // 0xca is a bitwise select: use `direction` where overflowed,
-                        // and the wrapped sum everywhere else.
-                        #ternary::<0xca>(overflow_mask, direction, sum).simd_into(#token)
+                        // and the wrapped result everywhere else.
+                        #ternary::<0xca>(overflow_mask, direction, wrapped).simd_into(#token)
                     }
                 })
             }
             (Self::Sse4_2 | Self::Avx2, Unsigned, 32, _bits)
             | (Self::Avx512, Unsigned, 32 | 64, _bits) => {
-                let bits = vec_ty.n_bits();
-                let add = simple_sign_unaware_intrinsic("add", vec_ty);
-                let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
-                let set1 = set1_intrinsic(vec_ty);
-                let min = simple_intrinsic("min", vec_ty);
-
-                // Unsigned saturation can be expressed without detecting carry:
-                // clamp `a` to the greatest value that can be added to `b`, then add.
+                let expression = match saturating_op {
+                    Add => {
+                        let bits = vec_ty.n_bits();
+                        let add = simple_sign_unaware_intrinsic("add", vec_ty);
+                        let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
+                        let set1 = set1_intrinsic(vec_ty);
+                        let min = simple_intrinsic("min", vec_ty);
+                        quote! {
+                            // Clamp `a` to the greatest value that can be added to `b`.
+                            let threshold = #xor(b, #set1(-1));
+                            #add(#min(a, threshold), b)
+                        }
+                    }
+                    Sub => {
+                        let sub = simple_sign_unaware_intrinsic("sub", vec_ty);
+                        let max = simple_intrinsic("max", vec_ty);
+                        quote! {
+                            // Clamping `a` upward to `b` makes underflow produce zero.
+                            #sub(#max(a, b), b)
+                        }
+                    }
+                };
                 self.kernel_method(op, vec_ty, |token| {
                     quote! {
                         let a = a.into();
                         let b = b.into();
-                        let threshold = #xor(b, #set1(-1));
-                        #add(#min(a, threshold), b).simd_into(#token)
+                        #expression.simd_into(#token)
                     }
                 })
             }
             (Self::Sse4_2 | Self::Avx2, Unsigned, 64, _bits) => {
                 let bits = vec_ty.n_bits();
-                let add = simple_sign_unaware_intrinsic("add", vec_ty);
+                let arithmetic = simple_sign_unaware_intrinsic(
+                    match saturating_op {
+                        Add => "add",
+                        Sub => "sub",
+                    },
+                    vec_ty,
+                );
                 let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
                 let set1 = set1_intrinsic(vec_ty);
                 let cmpgt = simple_sign_unaware_intrinsic("cmpgt", vec_ty);
-                let or = intrinsic_ident("or", coarse_type(vec_ty), bits);
+                let finish = match saturating_op {
+                    Add => {
+                        let or = intrinsic_ident("or", coarse_type(vec_ty), bits);
+                        quote! {
+                            let overflow = #cmpgt(
+                                #xor(a, sign_bias),
+                                #xor(wrapped, sign_bias),
+                            );
+                            #or(wrapped, overflow)
+                        }
+                    }
+                    Sub => {
+                        let and = intrinsic_ident("and", coarse_type(vec_ty), bits);
+                        quote! {
+                            // A strict comparison is sufficient: when `a == b`, the
+                            // wrapped difference is already zero.
+                            let no_borrow = #cmpgt(
+                                #xor(a, sign_bias),
+                                #xor(b, sign_bias),
+                            );
+                            #and(wrapped, no_borrow)
+                        }
+                    }
+                };
 
                 // SSE4.2 and AVX2 have signed, but not unsigned, qword comparisons.
                 // Flipping the sign bit maps unsigned order onto signed order.
@@ -2362,17 +2438,20 @@ impl X86 {
                     quote! {
                         let a = a.into();
                         let b = b.into();
-                        let sum = #add(a, b);
+                        let wrapped = #arithmetic(a, b);
                         let sign_bias = #set1(i64::MIN);
-                        let overflow = #cmpgt(
-                            #xor(a, sign_bias),
-                            #xor(sum, sign_bias),
-                        );
-                        #or(sum, overflow).simd_into(#token)
+                        #finish.simd_into(#token)
                     }
                 })
             }
             (Self::Sse4_2 | Self::Avx2, Int, lane_bits @ (32 | 64), bits) => {
+                let arithmetic = simple_sign_unaware_intrinsic(
+                    match saturating_op {
+                        Add => "add",
+                        Sub => "sub",
+                    },
+                    vec_ty,
+                );
                 let add = simple_sign_unaware_intrinsic("add", vec_ty);
                 let xor = intrinsic_ident("xor", coarse_type(vec_ty), bits);
                 let set1 = set1_intrinsic(vec_ty);
@@ -2381,15 +2460,15 @@ impl X86 {
                     (_, 32) => {
                         let shift = intrinsic_ident("srai", "epi32", bits);
                         quote! {
-                            let bound = #xor(#shift::<31>(sum), #set1(i32::MIN));
+                            let bound = #xor(#shift::<31>(a), #set1(i32::MAX));
                         }
                     }
                     (Self::Sse4_2, 64) => {
                         let shuffle = intrinsic_ident("shuffle", "epi32", bits);
                         let shift = intrinsic_ident("srai", "epi32", bits);
                         quote! {
-                            let sum_sign = #shift::<31>(#shuffle::<0xf5>(sum));
-                            let bound = #xor(sum_sign, #set1(i64::MIN));
+                            let a_sign = #shift::<31>(#shuffle::<0xf5>(a));
+                            let bound = #xor(a_sign, #set1(i64::MAX));
                         }
                     }
                     (Self::Avx2, 64) => {
@@ -2401,6 +2480,10 @@ impl X86 {
                         }
                     }
                     _ => unreachable!(),
+                };
+                let comparison = match saturating_op {
+                    Add => quote! { #cmpgt(a, wrapped) },
+                    Sub => quote! { #cmpgt(wrapped, a) },
                 };
                 let to_float = cast_ident(Int, Float, lane_bits, lane_bits, bits);
                 let to_int = cast_ident(Float, Int, lane_bits, lane_bits, bits);
@@ -2414,14 +2497,14 @@ impl X86 {
                     quote! {
                         let a = a.into();
                         let b = b.into();
-                        let sum = #add(a, b);
+                        let wrapped = #arithmetic(a, b);
 
                         // Only the sign bit of each lane is meaningful here, so use a
                         // lane-granularity floating-point blend instead of BLENDV_EPI8.
-                        let overflow = #xor(#cmpgt(a, sum), b);
+                        let overflow = #xor(#comparison, b);
                         #bound
                         let result = #blend(
-                            #to_float(sum),
+                            #to_float(wrapped),
                             #to_float(bound),
                             #to_float(overflow),
                         );
@@ -2436,8 +2519,12 @@ impl X86 {
     pub(crate) fn handle_binary(&self, op: Op, method: &str, vec_ty: &VecType) -> TokenStream {
         let method_sig = op.simd_trait_method_sig(vec_ty);
 
-        if method == "saturating_add" {
-            return self.handle_saturating_add(op, vec_ty);
+        if let Some(saturating_op) = match method {
+            "saturating_add" => Some(SaturatingOp::Add),
+            "saturating_sub" => Some(SaturatingOp::Sub),
+            _ => None,
+        } {
+            return self.handle_saturating_add_sub(op, saturating_op, vec_ty);
         }
 
         if *self == Self::Avx512 && vec_ty.scalar == ScalarType::Mask {

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -2286,7 +2286,10 @@ impl X86 {
         use SaturatingOp::{Add, Sub};
         use ScalarType::{Float, Int, Unsigned};
 
-        assert!(matches!(vec_ty.scalar, Int | Unsigned));
+        assert!(
+            matches!(vec_ty.scalar, Int | Unsigned),
+            "Saturating artihmetic is not implementable for floats"
+        );
 
         match (*self, vec_ty.scalar, vec_ty.scalar_bits, vec_ty.n_bits()) {
             // x86 has native instructions for 8-bit and 16-bit elements only.

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -982,7 +982,9 @@ const INT_OPS: &[Op] = &[
         "saturating_add",
         OpKind::VecTraitMethod,
         OpSig::Binary,
-        "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing.",
+        "Add two vectors element-wise, returning the maximum value on overflow.\n\n\
+        On x86 it is implemented in hardware only for 8-bit and 16-bit elements. \
+        For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86.",
     ),
     Op::new(
         "sub",
@@ -994,7 +996,9 @@ const INT_OPS: &[Op] = &[
         "saturating_sub",
         OpKind::VecTraitMethod,
         OpSig::Binary,
-        "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing.",
+        "Subtract two vectors element-wise, returning the maximum value on overflow.\n\n\
+        On x86 it is implemented in hardware only for 8-bit and 16-bit elements. \
+        For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86.",
     ),
     Op::new(
         "mul",

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -41,6 +41,13 @@ pub(crate) enum NarrowingMode {
     Saturate,
     Relaxed,
 }
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SaturatingOp {
+    Add,
+    Sub,
+}
+
 #[derive(Clone, Copy)]
 pub(crate) enum OpSig {
     /// Takes a single scalar argument, and returns the corresponding vector type.
@@ -982,6 +989,12 @@ const INT_OPS: &[Op] = &[
         OpKind::Overloaded(CoreOpTrait::Sub),
         OpSig::Binary,
         "Subtract two vectors element-wise, wrapping on overflow.",
+    ),
+    Op::new(
+        "saturating_sub",
+        OpKind::VecTraitMethod,
+        OpSig::Binary,
+        "Subtract two vectors element-wise, saturating at the numeric bounds instead of overflowing.",
     ),
     Op::new(
         "mul",

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -972,6 +972,12 @@ const INT_OPS: &[Op] = &[
         "Add two vectors element-wise, wrapping on overflow.",
     ),
     Op::new(
+        "saturating_add",
+        OpKind::VecTraitMethod,
+        OpSig::Binary,
+        "Add two vectors element-wise, saturating at the numeric bounds instead of overflowing.",
+    ),
+    Op::new(
         "sub",
         OpKind::Overloaded(CoreOpTrait::Sub),
         OpSig::Binary,

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -996,9 +996,11 @@ const INT_OPS: &[Op] = &[
         "saturating_add",
         OpKind::VecTraitMethod,
         OpSig::Binary,
-        "Add two vectors element-wise, returning the maximum value on overflow.\n\n\
+        "Add two vectors element-wise, saturating on overflow.\n\n\
+        \"Saturating\" means that if the result is not representable, \
+        the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\n\
         On x86 it is implemented in hardware only for 8-bit and 16-bit elements. \
-        For 32-bit and 64-bit vectors this operation is slower than overflowing addition on x86.",
+        For 32-bit and 64-bit vectors this operation is slower than wrapping addition on x86.",
     ),
     Op::new(
         "sub",
@@ -1010,9 +1012,11 @@ const INT_OPS: &[Op] = &[
         "saturating_sub",
         OpKind::VecTraitMethod,
         OpSig::Binary,
-        "Subtract two vectors element-wise, returning the maximum value on overflow.\n\n\
+        "Subtract two vectors element-wise, saturating on overflow.\n\n\
+        \"Saturating\" means that if the result is not representable, \
+        the closest representable value (either `Element::MAX` or `Element::MIN`) is returned.\n\n\
         On x86 it is implemented in hardware only for 8-bit and 16-bit elements. \
-        For 32-bit and 64-bit vectors this operation is slower than overflowing subtraction on x86.",
+        For 32-bit and 64-bit vectors this operation is slower than wrapping subtraction on x86.",
     ),
     Op::new(
         "mul",

--- a/fearless_simd_tests/tests/generics.rs
+++ b/fearless_simd_tests/tests/generics.rs
@@ -36,6 +36,11 @@ fn generic_i64_to_f64<S: Simd>(x: S::i64s) -> S::f64s {
     x.to_float()
 }
 
+// Ensure that integer operations exposed through `SimdInt` are available to generic code.
+fn generic_saturating_add<S: Simd, V: SimdInt<S>>(lhs: V, rhs: V) -> V {
+    lhs.saturating_add(rhs)
+}
+
 // Ensure that a generic vector's byte representation is itself a same-token
 // byte vector whose byte representation is idempotent.
 fn generic_bytes<S: Simd, V: SimdBase<S>>(value: V) -> V {

--- a/fearless_simd_tests/tests/generics.rs
+++ b/fearless_simd_tests/tests/generics.rs
@@ -41,6 +41,10 @@ fn generic_saturating_add<S: Simd, V: SimdInt<S>>(lhs: V, rhs: V) -> V {
     lhs.saturating_add(rhs)
 }
 
+fn generic_saturating_sub<S: Simd, V: SimdInt<S>>(lhs: V, rhs: V) -> V {
+    lhs.saturating_sub(rhs)
+}
+
 // Ensure that a generic vector's byte representation is itself a same-token
 // byte vector whose byte representation is idempotent.
 fn generic_bytes<S: Simd, V: SimdBase<S>>(value: V) -> V {

--- a/fearless_simd_tests/tests/harness/ops/mod.rs
+++ b/fearless_simd_tests/tests/harness/ops/mod.rs
@@ -67,6 +67,7 @@ mod rotate_elements_left;
 mod rotate_elements_right;
 mod round_ties_even;
 mod saturating_add;
+mod saturating_sub;
 mod select;
 mod set;
 mod shift_elements_left;

--- a/fearless_simd_tests/tests/harness/ops/mod.rs
+++ b/fearless_simd_tests/tests/harness/ops/mod.rs
@@ -66,6 +66,7 @@ mod reverse;
 mod rotate_elements_left;
 mod rotate_elements_right;
 mod round_ties_even;
+mod saturating_add;
 mod select;
 mod set;
 mod shift_elements_left;

--- a/fearless_simd_tests/tests/harness/ops/saturating_add.rs
+++ b/fearless_simd_tests/tests/harness/ops/saturating_add.rs
@@ -1,0 +1,1539 @@
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use fearless_simd::*;
+use fearless_simd_dev_macros::simd_test;
+
+// One concrete test row per supported integer vector type.
+
+#[simd_test]
+fn saturating_add_i8x16<S: Simd>(simd: S) {
+    let a = i8x16::from_slice(
+        simd,
+        &[
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+        ],
+    );
+    let b = i8x16::from_slice(
+        simd,
+        &[
+            1,
+            -1,
+            1,
+            -1,
+            20,
+            -20,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            0,
+            0,
+            9,
+            -9,
+            -1,
+            1,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            -25,
+            25,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_i8x32<S: Simd>(simd: S) {
+    let a = i8x32::from_slice(
+        simd,
+        &[
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+        ],
+    );
+    let b = i8x32::from_slice(
+        simd,
+        &[
+            1,
+            -1,
+            1,
+            -1,
+            20,
+            -20,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            0,
+            0,
+            9,
+            -9,
+            -1,
+            1,
+            1,
+            -1,
+            1,
+            -1,
+            20,
+            -20,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            0,
+            0,
+            9,
+            -9,
+            -1,
+            1,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            -25,
+            25,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            -25,
+            25,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_i8x64<S: Simd>(simd: S) {
+    let a = i8x64::from_slice(
+        simd,
+        &[
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+        ],
+    );
+    let b = i8x64::from_slice(
+        simd,
+        &[
+            1,
+            -1,
+            1,
+            -1,
+            20,
+            -20,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            0,
+            0,
+            9,
+            -9,
+            -1,
+            1,
+            1,
+            -1,
+            1,
+            -1,
+            20,
+            -20,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            0,
+            0,
+            9,
+            -9,
+            -1,
+            1,
+            1,
+            -1,
+            1,
+            -1,
+            20,
+            -20,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            0,
+            0,
+            9,
+            -9,
+            -1,
+            1,
+            1,
+            -1,
+            1,
+            -1,
+            20,
+            -20,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            0,
+            0,
+            9,
+            -9,
+            -1,
+            1,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            -25,
+            25,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            -25,
+            25,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            -25,
+            25,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            -25,
+            25,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_u8x16<S: Simd>(simd: S) {
+    let a = u8x16::from_slice(
+        simd,
+        &[
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX - 1,
+            0,
+            40,
+            100,
+            u8::MAX - 10,
+            10,
+            0,
+            1,
+            0,
+            u8::MAX,
+            u8::MAX / 2,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            17,
+        ],
+    );
+    let b = u8x16::from_slice(
+        simd,
+        &[
+            1,
+            2,
+            1,
+            u8::MAX,
+            20,
+            20,
+            9,
+            u8::MAX - 5,
+            0,
+            0,
+            1,
+            0,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            u8::MAX / 2 + 1,
+            23,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            60,
+            120,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            1,
+            1,
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX,
+            u8::MAX,
+            40,
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_u8x32<S: Simd>(simd: S) {
+    let a = u8x32::from_slice(
+        simd,
+        &[
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX - 1,
+            0,
+            40,
+            100,
+            u8::MAX - 10,
+            10,
+            0,
+            1,
+            0,
+            u8::MAX,
+            u8::MAX / 2,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            17,
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX - 1,
+            0,
+            40,
+            100,
+            u8::MAX - 10,
+            10,
+            0,
+            1,
+            0,
+            u8::MAX,
+            u8::MAX / 2,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            17,
+        ],
+    );
+    let b = u8x32::from_slice(
+        simd,
+        &[
+            1,
+            2,
+            1,
+            u8::MAX,
+            20,
+            20,
+            9,
+            u8::MAX - 5,
+            0,
+            0,
+            1,
+            0,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            u8::MAX / 2 + 1,
+            23,
+            1,
+            2,
+            1,
+            u8::MAX,
+            20,
+            20,
+            9,
+            u8::MAX - 5,
+            0,
+            0,
+            1,
+            0,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            u8::MAX / 2 + 1,
+            23,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            60,
+            120,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            1,
+            1,
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX,
+            u8::MAX,
+            40,
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            60,
+            120,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            1,
+            1,
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX,
+            u8::MAX,
+            40,
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_u8x64<S: Simd>(simd: S) {
+    let a = u8x64::from_slice(
+        simd,
+        &[
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX - 1,
+            0,
+            40,
+            100,
+            u8::MAX - 10,
+            10,
+            0,
+            1,
+            0,
+            u8::MAX,
+            u8::MAX / 2,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            17,
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX - 1,
+            0,
+            40,
+            100,
+            u8::MAX - 10,
+            10,
+            0,
+            1,
+            0,
+            u8::MAX,
+            u8::MAX / 2,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            17,
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX - 1,
+            0,
+            40,
+            100,
+            u8::MAX - 10,
+            10,
+            0,
+            1,
+            0,
+            u8::MAX,
+            u8::MAX / 2,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            17,
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX - 1,
+            0,
+            40,
+            100,
+            u8::MAX - 10,
+            10,
+            0,
+            1,
+            0,
+            u8::MAX,
+            u8::MAX / 2,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            17,
+        ],
+    );
+    let b = u8x64::from_slice(
+        simd,
+        &[
+            1,
+            2,
+            1,
+            u8::MAX,
+            20,
+            20,
+            9,
+            u8::MAX - 5,
+            0,
+            0,
+            1,
+            0,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            u8::MAX / 2 + 1,
+            23,
+            1,
+            2,
+            1,
+            u8::MAX,
+            20,
+            20,
+            9,
+            u8::MAX - 5,
+            0,
+            0,
+            1,
+            0,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            u8::MAX / 2 + 1,
+            23,
+            1,
+            2,
+            1,
+            u8::MAX,
+            20,
+            20,
+            9,
+            u8::MAX - 5,
+            0,
+            0,
+            1,
+            0,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            u8::MAX / 2 + 1,
+            23,
+            1,
+            2,
+            1,
+            u8::MAX,
+            20,
+            20,
+            9,
+            u8::MAX - 5,
+            0,
+            0,
+            1,
+            0,
+            u8::MAX / 2,
+            u8::MAX / 2 + 1,
+            u8::MAX / 2 + 1,
+            23,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            60,
+            120,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            1,
+            1,
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX,
+            u8::MAX,
+            40,
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            60,
+            120,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            1,
+            1,
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX,
+            u8::MAX,
+            40,
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            60,
+            120,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            1,
+            1,
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX,
+            u8::MAX,
+            40,
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            u8::MAX,
+            60,
+            120,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            1,
+            1,
+            u8::MAX,
+            u8::MAX - 1,
+            u8::MAX,
+            u8::MAX,
+            40,
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_i16x8<S: Simd>(simd: S) {
+    let a = i16x8::from_slice(
+        simd,
+        &[
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+        ],
+    );
+    let b = i16x8::from_slice(simd, &[1, -1, 1, -1, 20, -20, -75, 75]);
+    assert_eq!(
+        *a.saturating_add(b),
+        [i16::MAX, i16::MIN, i16::MAX, i16::MIN, 60, -60, -25, 25]
+    );
+}
+
+#[simd_test]
+fn saturating_add_i16x16<S: Simd>(simd: S) {
+    let a = i16x16::from_slice(
+        simd,
+        &[
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+            0,
+            0,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 10,
+            i16::MIN + 10,
+            1,
+            -1,
+        ],
+    );
+    let b = i16x16::from_slice(
+        simd,
+        &[
+            1,
+            -1,
+            1,
+            -1,
+            20,
+            -20,
+            -75,
+            75,
+            i16::MAX,
+            i16::MIN,
+            0,
+            0,
+            9,
+            -9,
+            -1,
+            1,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            60,
+            -60,
+            -25,
+            25,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            0,
+            0,
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_i16x32<S: Simd>(simd: S) {
+    let a = i16x32::from_slice(
+        simd,
+        &[
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+            0,
+            0,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 10,
+            i16::MIN + 10,
+            1,
+            -1,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+            0,
+            0,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 10,
+            i16::MIN + 10,
+            1,
+            -1,
+        ],
+    );
+    let b = i16x32::from_slice(
+        simd,
+        &[
+            1,
+            -1,
+            1,
+            -1,
+            20,
+            -20,
+            -75,
+            75,
+            i16::MAX,
+            i16::MIN,
+            0,
+            0,
+            9,
+            -9,
+            -1,
+            1,
+            1,
+            -1,
+            1,
+            -1,
+            20,
+            -20,
+            -75,
+            75,
+            i16::MAX,
+            i16::MIN,
+            0,
+            0,
+            9,
+            -9,
+            -1,
+            1,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            60,
+            -60,
+            -25,
+            25,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            0,
+            0,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            60,
+            -60,
+            -25,
+            25,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            0,
+            0,
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_u16x8<S: Simd>(simd: S) {
+    let a = u16x8::from_slice(
+        simd,
+        &[
+            u16::MAX,
+            u16::MAX - 1,
+            u16::MAX - 1,
+            0,
+            40,
+            100,
+            u16::MAX - 10,
+            10,
+        ],
+    );
+    let b = u16x8::from_slice(simd, &[1, 2, 1, u16::MAX, 20, 20, 9, u16::MAX - 5]);
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            u16::MAX,
+            u16::MAX,
+            u16::MAX,
+            u16::MAX,
+            60,
+            120,
+            u16::MAX - 1,
+            u16::MAX
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_u16x16<S: Simd>(simd: S) {
+    let a = u16x16::from_slice(
+        simd,
+        &[
+            u16::MAX,
+            u16::MAX - 1,
+            u16::MAX - 1,
+            0,
+            40,
+            100,
+            u16::MAX - 10,
+            10,
+            0,
+            1,
+            0,
+            u16::MAX,
+            u16::MAX / 2,
+            u16::MAX / 2,
+            u16::MAX / 2 + 1,
+            17,
+        ],
+    );
+    let b = u16x16::from_slice(
+        simd,
+        &[
+            1,
+            2,
+            1,
+            u16::MAX,
+            20,
+            20,
+            9,
+            u16::MAX - 5,
+            0,
+            0,
+            1,
+            0,
+            u16::MAX / 2,
+            u16::MAX / 2 + 1,
+            u16::MAX / 2 + 1,
+            23,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            u16::MAX,
+            u16::MAX,
+            u16::MAX,
+            u16::MAX,
+            60,
+            120,
+            u16::MAX - 1,
+            u16::MAX,
+            0,
+            1,
+            1,
+            u16::MAX,
+            u16::MAX - 1,
+            u16::MAX,
+            u16::MAX,
+            40,
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_u16x32<S: Simd>(simd: S) {
+    let a = u16x32::from_slice(
+        simd,
+        &[
+            u16::MAX,
+            u16::MAX - 1,
+            u16::MAX - 1,
+            0,
+            40,
+            100,
+            u16::MAX - 10,
+            10,
+            0,
+            1,
+            0,
+            u16::MAX,
+            u16::MAX / 2,
+            u16::MAX / 2,
+            u16::MAX / 2 + 1,
+            17,
+            u16::MAX,
+            u16::MAX - 1,
+            u16::MAX - 1,
+            0,
+            40,
+            100,
+            u16::MAX - 10,
+            10,
+            0,
+            1,
+            0,
+            u16::MAX,
+            u16::MAX / 2,
+            u16::MAX / 2,
+            u16::MAX / 2 + 1,
+            17,
+        ],
+    );
+    let b = u16x32::from_slice(
+        simd,
+        &[
+            1,
+            2,
+            1,
+            u16::MAX,
+            20,
+            20,
+            9,
+            u16::MAX - 5,
+            0,
+            0,
+            1,
+            0,
+            u16::MAX / 2,
+            u16::MAX / 2 + 1,
+            u16::MAX / 2 + 1,
+            23,
+            1,
+            2,
+            1,
+            u16::MAX,
+            20,
+            20,
+            9,
+            u16::MAX - 5,
+            0,
+            0,
+            1,
+            0,
+            u16::MAX / 2,
+            u16::MAX / 2 + 1,
+            u16::MAX / 2 + 1,
+            23,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            u16::MAX,
+            u16::MAX,
+            u16::MAX,
+            u16::MAX,
+            60,
+            120,
+            u16::MAX - 1,
+            u16::MAX,
+            0,
+            1,
+            1,
+            u16::MAX,
+            u16::MAX - 1,
+            u16::MAX,
+            u16::MAX,
+            40,
+            u16::MAX,
+            u16::MAX,
+            u16::MAX,
+            u16::MAX,
+            60,
+            120,
+            u16::MAX - 1,
+            u16::MAX,
+            0,
+            1,
+            1,
+            u16::MAX,
+            u16::MAX - 1,
+            u16::MAX,
+            u16::MAX,
+            40,
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_i32x4<S: Simd>(simd: S) {
+    let a = i32x4::from_slice(simd, &[i32::MAX, i32::MIN, i32::MAX - 1, i32::MIN + 1]);
+    let b = i32x4::from_slice(simd, &[1, -1, 1, -1]);
+    assert_eq!(
+        *a.saturating_add(b),
+        [i32::MAX, i32::MIN, i32::MAX, i32::MIN]
+    );
+
+    let scalar_rhs = i32x4::from_slice(simd, &[i32::MAX, i32::MIN, 40, -40]);
+    assert_eq!(
+        *scalar_rhs.saturating_add(20),
+        [i32::MAX, i32::MIN + 20, 60, -20]
+    );
+}
+
+#[simd_test]
+fn saturating_add_i32x8<S: Simd>(simd: S) {
+    let a = i32x8::from_slice(
+        simd,
+        &[
+            i32::MAX,
+            i32::MIN,
+            i32::MAX - 1,
+            i32::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+        ],
+    );
+    let b = i32x8::from_slice(simd, &[1, -1, 1, -1, 20, -20, -75, 75]);
+    assert_eq!(
+        *a.saturating_add(b),
+        [i32::MAX, i32::MIN, i32::MAX, i32::MIN, 60, -60, -25, 25]
+    );
+}
+
+#[simd_test]
+fn saturating_add_i32x16<S: Simd>(simd: S) {
+    let a = i32x16::from_slice(
+        simd,
+        &[
+            i32::MAX,
+            i32::MIN,
+            i32::MAX - 1,
+            i32::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+            0,
+            0,
+            i32::MAX,
+            i32::MIN,
+            i32::MAX - 10,
+            i32::MIN + 10,
+            1,
+            -1,
+        ],
+    );
+    let b = i32x16::from_slice(
+        simd,
+        &[
+            1,
+            -1,
+            1,
+            -1,
+            20,
+            -20,
+            -75,
+            75,
+            i32::MAX,
+            i32::MIN,
+            0,
+            0,
+            9,
+            -9,
+            -1,
+            1,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            i32::MAX,
+            i32::MIN,
+            i32::MAX,
+            i32::MIN,
+            60,
+            -60,
+            -25,
+            25,
+            i32::MAX,
+            i32::MIN,
+            i32::MAX,
+            i32::MIN,
+            i32::MAX - 1,
+            i32::MIN + 1,
+            0,
+            0,
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_u32x4<S: Simd>(simd: S) {
+    let a = u32x4::from_slice(simd, &[u32::MAX, u32::MAX - 1, 40, 0]);
+    let b = u32x4::from_slice(simd, &[1, 2, 20, u32::MAX]);
+    assert_eq!(*a.saturating_add(b), [u32::MAX, u32::MAX, 60, u32::MAX]);
+}
+
+#[simd_test]
+fn saturating_add_u32x8<S: Simd>(simd: S) {
+    let a = u32x8::from_slice(
+        simd,
+        &[
+            u32::MAX,
+            u32::MAX - 1,
+            u32::MAX - 1,
+            0,
+            40,
+            100,
+            u32::MAX - 10,
+            10,
+        ],
+    );
+    let b = u32x8::from_slice(simd, &[1, 2, 1, u32::MAX, 20, 20, 9, u32::MAX - 5]);
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            u32::MAX,
+            u32::MAX,
+            u32::MAX,
+            u32::MAX,
+            60,
+            120,
+            u32::MAX - 1,
+            u32::MAX
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_u32x16<S: Simd>(simd: S) {
+    let a = u32x16::from_slice(
+        simd,
+        &[
+            u32::MAX,
+            u32::MAX - 1,
+            u32::MAX - 1,
+            0,
+            40,
+            100,
+            u32::MAX - 10,
+            10,
+            0,
+            1,
+            0,
+            u32::MAX,
+            u32::MAX / 2,
+            u32::MAX / 2,
+            u32::MAX / 2 + 1,
+            17,
+        ],
+    );
+    let b = u32x16::from_slice(
+        simd,
+        &[
+            1,
+            2,
+            1,
+            u32::MAX,
+            20,
+            20,
+            9,
+            u32::MAX - 5,
+            0,
+            0,
+            1,
+            0,
+            u32::MAX / 2,
+            u32::MAX / 2 + 1,
+            u32::MAX / 2 + 1,
+            23,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            u32::MAX,
+            u32::MAX,
+            u32::MAX,
+            u32::MAX,
+            60,
+            120,
+            u32::MAX - 1,
+            u32::MAX,
+            0,
+            1,
+            1,
+            u32::MAX,
+            u32::MAX - 1,
+            u32::MAX,
+            u32::MAX,
+            40,
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_add_i64x2<S: Simd>(simd: S) {
+    let overflow = i64x2::from_slice(simd, &[i64::MAX, i64::MIN]);
+    let overflow_rhs = i64x2::from_slice(simd, &[1, -1]);
+    assert_eq!(*overflow.saturating_add(overflow_rhs), [i64::MAX, i64::MIN]);
+
+    let boundary = i64x2::from_slice(simd, &[i64::MAX - 1, i64::MIN + 1]);
+    let boundary_rhs = i64x2::from_slice(simd, &[1, -1]);
+    assert_eq!(*boundary.saturating_add(boundary_rhs), [i64::MAX, i64::MIN]);
+
+    let ordinary = i64x2::from_slice(simd, &[40, -40]);
+    let ordinary_rhs = i64x2::from_slice(simd, &[20, -20]);
+    assert_eq!(*ordinary.saturating_add(ordinary_rhs), [60, -60]);
+
+    let mixed = i64x2::from_slice(simd, &[50, -50]);
+    let mixed_rhs = i64x2::from_slice(simd, &[-75, 75]);
+    assert_eq!(*mixed.saturating_add(mixed_rhs), [-25, 25]);
+}
+
+#[simd_test]
+fn saturating_add_i64x4<S: Simd>(simd: S) {
+    let a = i64x4::from_slice(simd, &[i64::MAX, i64::MIN, 40, -40]);
+    let b = i64x4::from_slice(simd, &[1, -1, 20, -20]);
+    assert_eq!(*a.saturating_add(b), [i64::MAX, i64::MIN, 60, -60]);
+
+    let boundary = i64x4::from_slice(simd, &[i64::MAX - 1, i64::MIN + 1, 50, -50]);
+    let boundary_rhs = i64x4::from_slice(simd, &[1, -1, -75, 75]);
+    assert_eq!(
+        *boundary.saturating_add(boundary_rhs),
+        [i64::MAX, i64::MIN, -25, 25]
+    );
+}
+
+#[simd_test]
+fn saturating_add_i64x8<S: Simd>(simd: S) {
+    let a = i64x8::from_slice(
+        simd,
+        &[
+            i64::MAX,
+            i64::MIN,
+            i64::MAX - 1,
+            i64::MIN + 1,
+            40,
+            -40,
+            50,
+            -50,
+        ],
+    );
+    let b = i64x8::from_slice(simd, &[1, -1, 1, -1, 20, -20, -75, 75]);
+    assert_eq!(
+        *a.saturating_add(b),
+        [i64::MAX, i64::MIN, i64::MAX, i64::MIN, 60, -60, -25, 25]
+    );
+}
+
+#[simd_test]
+fn saturating_add_u64x2<S: Simd>(simd: S) {
+    let overflow = u64x2::from_slice(simd, &[u64::MAX, u64::MAX - 1]);
+    let overflow_rhs = u64x2::from_slice(simd, &[1, 2]);
+    assert_eq!(*overflow.saturating_add(overflow_rhs), [u64::MAX, u64::MAX]);
+
+    let boundary = u64x2::from_slice(simd, &[u64::MAX - 1, 0]);
+    let boundary_rhs = u64x2::from_slice(simd, &[1, u64::MAX]);
+    assert_eq!(*boundary.saturating_add(boundary_rhs), [u64::MAX, u64::MAX]);
+
+    let ordinary = u64x2::from_slice(simd, &[40, u64::MAX - 10]);
+    let ordinary_rhs = u64x2::from_slice(simd, &[20, 9]);
+    assert_eq!(*ordinary.saturating_add(ordinary_rhs), [60, u64::MAX - 1]);
+
+    let mixed = u64x2::from_slice(simd, &[10, u64::MAX / 2 + 1]);
+    let mixed_rhs = u64x2::from_slice(simd, &[u64::MAX - 5, u64::MAX / 2 + 1]);
+    assert_eq!(*mixed.saturating_add(mixed_rhs), [u64::MAX, u64::MAX]);
+}
+
+#[simd_test]
+fn saturating_add_u64x4<S: Simd>(simd: S) {
+    let a = u64x4::from_slice(simd, &[u64::MAX, u64::MAX - 1, 40, 0]);
+    let b = u64x4::from_slice(simd, &[1, 2, 20, u64::MAX]);
+    assert_eq!(*a.saturating_add(b), [u64::MAX, u64::MAX, 60, u64::MAX]);
+
+    let boundary = u64x4::from_slice(simd, &[u64::MAX - 1, u64::MAX - 10, u64::MAX / 2, 17]);
+    let boundary_rhs = u64x4::from_slice(simd, &[1, 9, u64::MAX / 2, 23]);
+    assert_eq!(
+        *boundary.saturating_add(boundary_rhs),
+        [u64::MAX, u64::MAX - 1, u64::MAX - 1, 40]
+    );
+}
+
+#[simd_test]
+fn saturating_add_u64x8<S: Simd>(simd: S) {
+    let a = u64x8::from_slice(
+        simd,
+        &[
+            u64::MAX,
+            u64::MAX - 1,
+            u64::MAX - 1,
+            0,
+            40,
+            100,
+            u64::MAX - 10,
+            10,
+        ],
+    );
+    let b = u64x8::from_slice(simd, &[1, 2, 1, u64::MAX, 20, 20, 9, u64::MAX - 5]);
+    assert_eq!(
+        *a.saturating_add(b),
+        [
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            60,
+            120,
+            u64::MAX - 1,
+            u64::MAX
+        ]
+    );
+}

--- a/fearless_simd_tests/tests/harness/ops/saturating_sub.rs
+++ b/fearless_simd_tests/tests/harness/ops/saturating_sub.rs
@@ -1,0 +1,1386 @@
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use fearless_simd::*;
+use fearless_simd_dev_macros::simd_test;
+
+// One concrete test row per supported integer vector type.
+
+#[simd_test]
+fn saturating_sub_i8x16<S: Simd>(simd: S) {
+    let a = i8x16::from_slice(
+        simd,
+        &[
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            100,
+            -100,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+            40,
+            -40,
+        ],
+    );
+    let b = i8x16::from_slice(
+        simd,
+        &[
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            -9,
+            9,
+            1,
+            -1,
+            -20,
+            20,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            125,
+            -125,
+            -i8::MAX,
+            i8::MAX,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+            60,
+            -60
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_i8x32<S: Simd>(simd: S) {
+    let a = i8x32::from_slice(
+        simd,
+        &[
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            100,
+            -100,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+            40,
+            -40,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            100,
+            -100,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+            40,
+            -40,
+        ],
+    );
+    let b = i8x32::from_slice(
+        simd,
+        &[
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            -9,
+            9,
+            1,
+            -1,
+            -20,
+            20,
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            -9,
+            9,
+            1,
+            -1,
+            -20,
+            20,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            125,
+            -125,
+            -i8::MAX,
+            i8::MAX,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+            60,
+            -60,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            125,
+            -125,
+            -i8::MAX,
+            i8::MAX,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+            60,
+            -60
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_i8x64<S: Simd>(simd: S) {
+    let a = i8x64::from_slice(
+        simd,
+        &[
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            100,
+            -100,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+            40,
+            -40,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            100,
+            -100,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+            40,
+            -40,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            100,
+            -100,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+            40,
+            -40,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            100,
+            -100,
+            50,
+            -50,
+            0,
+            0,
+            i8::MAX - 10,
+            i8::MIN + 10,
+            1,
+            -1,
+            40,
+            -40,
+        ],
+    );
+    let b = i8x64::from_slice(
+        simd,
+        &[
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            -9,
+            9,
+            1,
+            -1,
+            -20,
+            20,
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            -9,
+            9,
+            1,
+            -1,
+            -20,
+            20,
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            -9,
+            9,
+            1,
+            -1,
+            -20,
+            20,
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            -75,
+            75,
+            i8::MAX,
+            i8::MIN,
+            -9,
+            9,
+            1,
+            -1,
+            -20,
+            20,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            125,
+            -125,
+            -i8::MAX,
+            i8::MAX,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+            60,
+            -60,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            125,
+            -125,
+            -i8::MAX,
+            i8::MAX,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+            60,
+            -60,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            125,
+            -125,
+            -i8::MAX,
+            i8::MAX,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+            60,
+            -60,
+            i8::MAX,
+            i8::MIN,
+            i8::MAX,
+            i8::MIN,
+            60,
+            -60,
+            125,
+            -125,
+            -i8::MAX,
+            i8::MAX,
+            i8::MAX - 1,
+            i8::MIN + 1,
+            0,
+            0,
+            60,
+            -60
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_u8x16<S: Simd>(simd: S) {
+    let a = u8x16::from_slice(
+        simd,
+        &[
+            100,
+            5,
+            50,
+            0,
+            u8::MAX,
+            u8::MAX,
+            1,
+            20,
+            200,
+            10,
+            0,
+            u8::MAX - 1,
+            60,
+            40,
+            u8::MAX,
+            128,
+        ],
+    );
+    let b = u8x16::from_slice(
+        simd,
+        &[
+            40,
+            10,
+            50,
+            0,
+            1,
+            0,
+            1,
+            30,
+            100,
+            10,
+            1,
+            u8::MAX,
+            20,
+            60,
+            u8::MAX,
+            128,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            60,
+            0,
+            0,
+            0,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            0,
+            100,
+            0,
+            0,
+            0,
+            40,
+            0,
+            0,
+            0
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_u8x32<S: Simd>(simd: S) {
+    let a = u8x32::from_slice(
+        simd,
+        &[
+            100,
+            5,
+            50,
+            0,
+            u8::MAX,
+            u8::MAX,
+            1,
+            20,
+            200,
+            10,
+            0,
+            u8::MAX - 1,
+            60,
+            40,
+            u8::MAX,
+            128,
+            100,
+            5,
+            50,
+            0,
+            u8::MAX,
+            u8::MAX,
+            1,
+            20,
+            200,
+            10,
+            0,
+            u8::MAX - 1,
+            60,
+            40,
+            u8::MAX,
+            128,
+        ],
+    );
+    let b = u8x32::from_slice(
+        simd,
+        &[
+            40,
+            10,
+            50,
+            0,
+            1,
+            0,
+            1,
+            30,
+            100,
+            10,
+            1,
+            u8::MAX,
+            20,
+            60,
+            u8::MAX,
+            128,
+            40,
+            10,
+            50,
+            0,
+            1,
+            0,
+            1,
+            30,
+            100,
+            10,
+            1,
+            u8::MAX,
+            20,
+            60,
+            u8::MAX,
+            128,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            60,
+            0,
+            0,
+            0,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            0,
+            100,
+            0,
+            0,
+            0,
+            40,
+            0,
+            0,
+            0,
+            60,
+            0,
+            0,
+            0,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            0,
+            100,
+            0,
+            0,
+            0,
+            40,
+            0,
+            0,
+            0
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_u8x64<S: Simd>(simd: S) {
+    let a = u8x64::from_slice(
+        simd,
+        &[
+            100,
+            5,
+            50,
+            0,
+            u8::MAX,
+            u8::MAX,
+            1,
+            20,
+            200,
+            10,
+            0,
+            u8::MAX - 1,
+            60,
+            40,
+            u8::MAX,
+            128,
+            100,
+            5,
+            50,
+            0,
+            u8::MAX,
+            u8::MAX,
+            1,
+            20,
+            200,
+            10,
+            0,
+            u8::MAX - 1,
+            60,
+            40,
+            u8::MAX,
+            128,
+            100,
+            5,
+            50,
+            0,
+            u8::MAX,
+            u8::MAX,
+            1,
+            20,
+            200,
+            10,
+            0,
+            u8::MAX - 1,
+            60,
+            40,
+            u8::MAX,
+            128,
+            100,
+            5,
+            50,
+            0,
+            u8::MAX,
+            u8::MAX,
+            1,
+            20,
+            200,
+            10,
+            0,
+            u8::MAX - 1,
+            60,
+            40,
+            u8::MAX,
+            128,
+        ],
+    );
+    let b = u8x64::from_slice(
+        simd,
+        &[
+            40,
+            10,
+            50,
+            0,
+            1,
+            0,
+            1,
+            30,
+            100,
+            10,
+            1,
+            u8::MAX,
+            20,
+            60,
+            u8::MAX,
+            128,
+            40,
+            10,
+            50,
+            0,
+            1,
+            0,
+            1,
+            30,
+            100,
+            10,
+            1,
+            u8::MAX,
+            20,
+            60,
+            u8::MAX,
+            128,
+            40,
+            10,
+            50,
+            0,
+            1,
+            0,
+            1,
+            30,
+            100,
+            10,
+            1,
+            u8::MAX,
+            20,
+            60,
+            u8::MAX,
+            128,
+            40,
+            10,
+            50,
+            0,
+            1,
+            0,
+            1,
+            30,
+            100,
+            10,
+            1,
+            u8::MAX,
+            20,
+            60,
+            u8::MAX,
+            128,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            60,
+            0,
+            0,
+            0,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            0,
+            100,
+            0,
+            0,
+            0,
+            40,
+            0,
+            0,
+            0,
+            60,
+            0,
+            0,
+            0,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            0,
+            100,
+            0,
+            0,
+            0,
+            40,
+            0,
+            0,
+            0,
+            60,
+            0,
+            0,
+            0,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            0,
+            100,
+            0,
+            0,
+            0,
+            40,
+            0,
+            0,
+            0,
+            60,
+            0,
+            0,
+            0,
+            u8::MAX - 1,
+            u8::MAX,
+            0,
+            0,
+            100,
+            0,
+            0,
+            0,
+            40,
+            0,
+            0,
+            0
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_i16x8<S: Simd>(simd: S) {
+    let a = i16x8::from_slice(
+        simd,
+        &[
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            100,
+            -100,
+            0,
+            0,
+        ],
+    );
+    let b = i16x8::from_slice(simd, &[-1, 1, -1, 1, 40, -40, i16::MAX, i16::MIN]);
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            60,
+            -60,
+            -i16::MAX,
+            i16::MAX
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_i16x16<S: Simd>(simd: S) {
+    let a = i16x16::from_slice(
+        simd,
+        &[
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            100,
+            -100,
+            0,
+            0,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            100,
+            -100,
+            0,
+            0,
+        ],
+    );
+    let b = i16x16::from_slice(
+        simd,
+        &[
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            i16::MAX,
+            i16::MIN,
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            i16::MAX,
+            i16::MIN,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            60,
+            -60,
+            -i16::MAX,
+            i16::MAX,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            60,
+            -60,
+            -i16::MAX,
+            i16::MAX
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_i16x32<S: Simd>(simd: S) {
+    let a = i16x32::from_slice(
+        simd,
+        &[
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            100,
+            -100,
+            0,
+            0,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            100,
+            -100,
+            0,
+            0,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            100,
+            -100,
+            0,
+            0,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX - 1,
+            i16::MIN + 1,
+            100,
+            -100,
+            0,
+            0,
+        ],
+    );
+    let b = i16x32::from_slice(
+        simd,
+        &[
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            i16::MAX,
+            i16::MIN,
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            i16::MAX,
+            i16::MIN,
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            i16::MAX,
+            i16::MIN,
+            -1,
+            1,
+            -1,
+            1,
+            40,
+            -40,
+            i16::MAX,
+            i16::MIN,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            60,
+            -60,
+            -i16::MAX,
+            i16::MAX,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            60,
+            -60,
+            -i16::MAX,
+            i16::MAX,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            60,
+            -60,
+            -i16::MAX,
+            i16::MAX,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            60,
+            -60,
+            -i16::MAX,
+            i16::MAX
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_u16x8<S: Simd>(simd: S) {
+    let a = u16x8::from_slice(simd, &[100, 5, 50, 0, u16::MAX, u16::MAX, 1, 20]);
+    let b = u16x8::from_slice(simd, &[40, 10, 50, 0, 1, 0, 1, 30]);
+    assert_eq!(
+        *a.saturating_sub(b),
+        [60, 0, 0, 0, u16::MAX - 1, u16::MAX, 0, 0]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_u16x16<S: Simd>(simd: S) {
+    let a = u16x16::from_slice(
+        simd,
+        &[
+            100,
+            5,
+            50,
+            0,
+            u16::MAX,
+            u16::MAX,
+            1,
+            20,
+            100,
+            5,
+            50,
+            0,
+            u16::MAX,
+            u16::MAX,
+            1,
+            20,
+        ],
+    );
+    let b = u16x16::from_slice(
+        simd,
+        &[40, 10, 50, 0, 1, 0, 1, 30, 40, 10, 50, 0, 1, 0, 1, 30],
+    );
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            60,
+            0,
+            0,
+            0,
+            u16::MAX - 1,
+            u16::MAX,
+            0,
+            0,
+            60,
+            0,
+            0,
+            0,
+            u16::MAX - 1,
+            u16::MAX,
+            0,
+            0
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_u16x32<S: Simd>(simd: S) {
+    let a = u16x32::from_slice(
+        simd,
+        &[
+            100,
+            5,
+            50,
+            0,
+            u16::MAX,
+            u16::MAX,
+            1,
+            20,
+            100,
+            5,
+            50,
+            0,
+            u16::MAX,
+            u16::MAX,
+            1,
+            20,
+            100,
+            5,
+            50,
+            0,
+            u16::MAX,
+            u16::MAX,
+            1,
+            20,
+            100,
+            5,
+            50,
+            0,
+            u16::MAX,
+            u16::MAX,
+            1,
+            20,
+        ],
+    );
+    let b = u16x32::from_slice(
+        simd,
+        &[
+            40, 10, 50, 0, 1, 0, 1, 30, 40, 10, 50, 0, 1, 0, 1, 30, 40, 10, 50, 0, 1, 0, 1, 30, 40,
+            10, 50, 0, 1, 0, 1, 30,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            60,
+            0,
+            0,
+            0,
+            u16::MAX - 1,
+            u16::MAX,
+            0,
+            0,
+            60,
+            0,
+            0,
+            0,
+            u16::MAX - 1,
+            u16::MAX,
+            0,
+            0,
+            60,
+            0,
+            0,
+            0,
+            u16::MAX - 1,
+            u16::MAX,
+            0,
+            0,
+            60,
+            0,
+            0,
+            0,
+            u16::MAX - 1,
+            u16::MAX,
+            0,
+            0
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_i32x4<S: Simd>(simd: S) {
+    let a = i32x4::from_slice(simd, &[i32::MAX, i32::MIN, 100, 0]);
+    let b = i32x4::from_slice(simd, &[-1, 1, 40, i32::MIN]);
+    assert_eq!(*a.saturating_sub(b), [i32::MAX, i32::MIN, 60, i32::MAX]);
+    let scalar_rhs = i32x4::from_slice(simd, &[i32::MAX, i32::MIN, 40, -40]);
+    assert_eq!(
+        *scalar_rhs.saturating_sub(20),
+        [i32::MAX - 20, i32::MIN, 20, -60]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_i32x8<S: Simd>(simd: S) {
+    let a = i32x8::from_slice(
+        simd,
+        &[i32::MAX, i32::MIN, 100, 0, i32::MAX, i32::MIN, 100, 0],
+    );
+    let b = i32x8::from_slice(simd, &[-1, 1, 40, i32::MIN, -1, 1, 40, i32::MIN]);
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            i32::MAX,
+            i32::MIN,
+            60,
+            i32::MAX,
+            i32::MAX,
+            i32::MIN,
+            60,
+            i32::MAX
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_i32x16<S: Simd>(simd: S) {
+    let a = i32x16::from_slice(
+        simd,
+        &[
+            i32::MAX,
+            i32::MIN,
+            100,
+            0,
+            i32::MAX,
+            i32::MIN,
+            100,
+            0,
+            i32::MAX,
+            i32::MIN,
+            100,
+            0,
+            i32::MAX,
+            i32::MIN,
+            100,
+            0,
+        ],
+    );
+    let b = i32x16::from_slice(
+        simd,
+        &[
+            -1,
+            1,
+            40,
+            i32::MIN,
+            -1,
+            1,
+            40,
+            i32::MIN,
+            -1,
+            1,
+            40,
+            i32::MIN,
+            -1,
+            1,
+            40,
+            i32::MIN,
+        ],
+    );
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            i32::MAX,
+            i32::MIN,
+            60,
+            i32::MAX,
+            i32::MAX,
+            i32::MIN,
+            60,
+            i32::MAX,
+            i32::MAX,
+            i32::MIN,
+            60,
+            i32::MAX,
+            i32::MAX,
+            i32::MIN,
+            60,
+            i32::MAX
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_u32x4<S: Simd>(simd: S) {
+    let a = u32x4::from_slice(simd, &[100, 5, 50, 0]);
+    let b = u32x4::from_slice(simd, &[40, 10, 50, 1]);
+    assert_eq!(*a.saturating_sub(b), [60, 0, 0, 0]);
+}
+
+#[simd_test]
+fn saturating_sub_u32x8<S: Simd>(simd: S) {
+    let a = u32x8::from_slice(simd, &[100, 5, 50, 0, 100, 5, 50, 0]);
+    let b = u32x8::from_slice(simd, &[40, 10, 50, 1, 40, 10, 50, 1]);
+    assert_eq!(*a.saturating_sub(b), [60, 0, 0, 0, 60, 0, 0, 0]);
+}
+
+#[simd_test]
+fn saturating_sub_u32x16<S: Simd>(simd: S) {
+    let a = u32x16::from_slice(
+        simd,
+        &[100, 5, 50, 0, 100, 5, 50, 0, 100, 5, 50, 0, 100, 5, 50, 0],
+    );
+    let b = u32x16::from_slice(
+        simd,
+        &[40, 10, 50, 1, 40, 10, 50, 1, 40, 10, 50, 1, 40, 10, 50, 1],
+    );
+    assert_eq!(
+        *a.saturating_sub(b),
+        [60, 0, 0, 0, 60, 0, 0, 0, 60, 0, 0, 0, 60, 0, 0, 0]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_i64x2<S: Simd>(simd: S) {
+    let a = i64x2::from_slice(simd, &[i64::MAX, i64::MIN]);
+    let b = i64x2::from_slice(simd, &[-1, 1]);
+    assert_eq!(*a.saturating_sub(b), [i64::MAX, i64::MIN]);
+    let boundary = i64x2::from_slice(simd, &[i64::MAX - 1, i64::MIN + 1]);
+    let boundary_rhs = i64x2::from_slice(simd, &[-1, 1]);
+    assert_eq!(*boundary.saturating_sub(boundary_rhs), [i64::MAX, i64::MIN]);
+
+    let ordinary = i64x2::from_slice(simd, &[100, -100]);
+    let ordinary_rhs = i64x2::from_slice(simd, &[40, -40]);
+    assert_eq!(*ordinary.saturating_sub(ordinary_rhs), [60, -60]);
+
+    let mixed = i64x2::from_slice(simd, &[50, -50]);
+    let mixed_rhs = i64x2::from_slice(simd, &[-75, 75]);
+    assert_eq!(*mixed.saturating_sub(mixed_rhs), [125, -125]);
+
+    let zero = i64x2::from_slice(simd, &[0, 0]);
+    let zero_rhs = i64x2::from_slice(simd, &[i64::MAX, i64::MIN]);
+    assert_eq!(*zero.saturating_sub(zero_rhs), [-i64::MAX, i64::MAX]);
+}
+
+#[simd_test]
+fn saturating_sub_i64x4<S: Simd>(simd: S) {
+    let a = i64x4::from_slice(simd, &[i64::MAX, i64::MIN, 100, -100]);
+    let b = i64x4::from_slice(simd, &[-1, 1, 40, -40]);
+    assert_eq!(*a.saturating_sub(b), [i64::MAX, i64::MIN, 60, -60]);
+    let boundary = i64x4::from_slice(simd, &[i64::MAX - 1, i64::MIN + 1, 50, -50]);
+    let boundary_rhs = i64x4::from_slice(simd, &[-1, 1, -75, 75]);
+    assert_eq!(
+        *boundary.saturating_sub(boundary_rhs),
+        [i64::MAX, i64::MIN, 125, -125]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_i64x8<S: Simd>(simd: S) {
+    let a = i64x8::from_slice(
+        simd,
+        &[
+            i64::MAX,
+            i64::MIN,
+            i64::MAX - 1,
+            i64::MIN + 1,
+            100,
+            -100,
+            0,
+            0,
+        ],
+    );
+    let b = i64x8::from_slice(simd, &[-1, 1, -1, 1, 40, -40, i64::MAX, i64::MIN]);
+    assert_eq!(
+        *a.saturating_sub(b),
+        [
+            i64::MAX,
+            i64::MIN,
+            i64::MAX,
+            i64::MIN,
+            60,
+            -60,
+            -i64::MAX,
+            i64::MAX
+        ]
+    );
+}
+
+#[simd_test]
+fn saturating_sub_u64x2<S: Simd>(simd: S) {
+    let a = u64x2::from_slice(simd, &[100, 5]);
+    let b = u64x2::from_slice(simd, &[40, 10]);
+    assert_eq!(*a.saturating_sub(b), [60, 0]);
+    let boundary = u64x2::from_slice(simd, &[u64::MAX, u64::MAX]);
+    let boundary_rhs = u64x2::from_slice(simd, &[1, 0]);
+    assert_eq!(
+        *boundary.saturating_sub(boundary_rhs),
+        [u64::MAX - 1, u64::MAX]
+    );
+
+    let exact = u64x2::from_slice(simd, &[50, 0]);
+    let exact_rhs = u64x2::from_slice(simd, &[50, 0]);
+    assert_eq!(*exact.saturating_sub(exact_rhs), [0, 0]);
+
+    let floor = u64x2::from_slice(simd, &[0, 1]);
+    let floor_rhs = u64x2::from_slice(simd, &[1, 1]);
+    assert_eq!(*floor.saturating_sub(floor_rhs), [0, 0]);
+}
+
+#[simd_test]
+fn saturating_sub_u64x4<S: Simd>(simd: S) {
+    let a = u64x4::from_slice(simd, &[100, 5, u64::MAX, 0]);
+    let b = u64x4::from_slice(simd, &[40, 10, 1, 1]);
+    assert_eq!(*a.saturating_sub(b), [60, 0, u64::MAX - 1, 0]);
+}
+
+#[simd_test]
+fn saturating_sub_u64x8<S: Simd>(simd: S) {
+    let a = u64x8::from_slice(simd, &[100, 5, 50, 0, u64::MAX, u64::MAX, 1, 20]);
+    let b = u64x8::from_slice(simd, &[40, 10, 50, 0, 1, 0, 1, 30]);
+    assert_eq!(
+        *a.saturating_sub(b),
+        [60, 0, 0, 0, u64::MAX - 1, u64::MAX, 0, 0]
+    );
+}


### PR DESCRIPTION
NEON has all these ops natively. x86 has u8/i8/u16/i16, but 32-bit and 64-bit element widths need to be emulated; that emulation is the source of most of the complexity.