### PR TITLE
Add concat_swizzle_dyn and concat_swizzle_dyn_precise

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -1366,8 +1366,7 @@ impl Simd for Avx2 {
             #[inline(always)]
             fn kernel(token: Avx2, a: u8x16<Avx2>, indices: u8x16<Avx2>) -> u8x16<Avx2> {
                 let indices = indices.into();
-                let index_out_of_range = _mm_add_epi8(indices, _mm_set1_epi8(112));
-                let zeroing_indices = _mm_or_si128(indices, index_out_of_range);
+                let zeroing_indices = _mm_adds_epu8(indices, _mm_set1_epi8(0x70));
                 let result = _mm_shuffle_epi8(Bytes::to_bytes(a).val.0, zeroing_indices);
                 let result_bytes = u8x16 {
                     val: crate::support::Aligned128(result),
@@ -1377,6 +1376,31 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, a, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        self.concat_swizzle_dyn_precise_u8x16(a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let second_table_offset = self.splat_u8x16(16);
+        let from_first = self.swizzle_dyn_precise_u8x16(first_table, indices);
+        let from_second = self
+            .swizzle_dyn_precise_u8x16(second_table, self.sub_u8x16(indices, second_table_offset));
+        let result_bytes = self.or_u8x16(from_first, from_second);
+        Bytes::from_bytes(result_bytes)
     }
     #[inline(always)]
     fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
@@ -7631,6 +7655,62 @@ impl Simd for Avx2 {
         kernel(self, a, indices)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        self.concat_swizzle_dyn_precise_u8x32(a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Avx2,
+                a: u8x32<Avx2>,
+                b: u8x32<Avx2>,
+                indices: u8x32<Avx2>,
+            ) -> u8x32<Avx2> {
+                let result = {
+                    let a = Bytes::to_bytes(a).val.0;
+                    let b = Bytes::to_bytes(b).val.0;
+                    let indices = indices.into();
+                    let control = _mm256_adds_epu8(indices, _mm256_set1_epi8(0x40));
+                    let a_swapped = _mm256_permute2x128_si256::<0x01>(a, a);
+                    let b_swapped = _mm256_permute2x128_si256::<0x01>(b, b);
+                    let flip_high_lane =
+                        _mm256_set_m128i(_mm_set1_epi8(i8::MIN), _mm_setzero_si128());
+                    let select_remote =
+                        _mm256_xor_si256(_mm256_slli_epi16::<3>(control), flip_high_lane);
+                    let from_a = _mm256_blendv_epi8(
+                        _mm256_shuffle_epi8(a, control),
+                        _mm256_shuffle_epi8(a_swapped, control),
+                        select_remote,
+                    );
+                    let from_b = _mm256_blendv_epi8(
+                        _mm256_shuffle_epi8(b, control),
+                        _mm256_shuffle_epi8(b_swapped, control),
+                        select_remote,
+                    );
+                    _mm256_blendv_epi8(from_a, from_b, _mm256_slli_epi16::<2>(control))
+                };
+                let result_bytes = u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                };
+                Bytes::from_bytes(result_bytes)
+            }
+        );
+        kernel(self, a, b, indices)
+    }
+    #[inline(always)]
     fn count_ones_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -12486,6 +12566,139 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, a, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        self.concat_swizzle_dyn_precise_u8x64(a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Avx2,
+                a: u8x64<Avx2>,
+                b: u8x64<Avx2>,
+                indices: u8x64<Avx2>,
+            ) -> u8x64<Avx2> {
+                let a_bytes = Bytes::to_bytes(a).val.0;
+                let b_bytes = Bytes::to_bytes(b).val.0;
+                let indices_bytes = indices.val.0;
+                let second_table_offset = _mm256_set1_epi8(64);
+                let result_low = _mm256_or_si256(
+                    {
+                        let a = a_bytes[0];
+                        let b = a_bytes[1];
+                        let indices = indices_bytes[0];
+                        let control = _mm256_adds_epu8(indices, _mm256_set1_epi8(0x40));
+                        let a_swapped = _mm256_permute2x128_si256::<0x01>(a, a);
+                        let b_swapped = _mm256_permute2x128_si256::<0x01>(b, b);
+                        let flip_high_lane =
+                            _mm256_set_m128i(_mm_set1_epi8(i8::MIN), _mm_setzero_si128());
+                        let select_remote =
+                            _mm256_xor_si256(_mm256_slli_epi16::<3>(control), flip_high_lane);
+                        let from_a = _mm256_blendv_epi8(
+                            _mm256_shuffle_epi8(a, control),
+                            _mm256_shuffle_epi8(a_swapped, control),
+                            select_remote,
+                        );
+                        let from_b = _mm256_blendv_epi8(
+                            _mm256_shuffle_epi8(b, control),
+                            _mm256_shuffle_epi8(b_swapped, control),
+                            select_remote,
+                        );
+                        _mm256_blendv_epi8(from_a, from_b, _mm256_slli_epi16::<2>(control))
+                    },
+                    {
+                        let a = b_bytes[0];
+                        let b = b_bytes[1];
+                        let indices = _mm256_sub_epi8(indices_bytes[0], second_table_offset);
+                        let control = _mm256_adds_epu8(indices, _mm256_set1_epi8(0x40));
+                        let a_swapped = _mm256_permute2x128_si256::<0x01>(a, a);
+                        let b_swapped = _mm256_permute2x128_si256::<0x01>(b, b);
+                        let flip_high_lane =
+                            _mm256_set_m128i(_mm_set1_epi8(i8::MIN), _mm_setzero_si128());
+                        let select_remote =
+                            _mm256_xor_si256(_mm256_slli_epi16::<3>(control), flip_high_lane);
+                        let from_a = _mm256_blendv_epi8(
+                            _mm256_shuffle_epi8(a, control),
+                            _mm256_shuffle_epi8(a_swapped, control),
+                            select_remote,
+                        );
+                        let from_b = _mm256_blendv_epi8(
+                            _mm256_shuffle_epi8(b, control),
+                            _mm256_shuffle_epi8(b_swapped, control),
+                            select_remote,
+                        );
+                        _mm256_blendv_epi8(from_a, from_b, _mm256_slli_epi16::<2>(control))
+                    },
+                );
+                let result_high = _mm256_or_si256(
+                    {
+                        let a = a_bytes[0];
+                        let b = a_bytes[1];
+                        let indices = indices_bytes[1];
+                        let control = _mm256_adds_epu8(indices, _mm256_set1_epi8(0x40));
+                        let a_swapped = _mm256_permute2x128_si256::<0x01>(a, a);
+                        let b_swapped = _mm256_permute2x128_si256::<0x01>(b, b);
+                        let flip_high_lane =
+                            _mm256_set_m128i(_mm_set1_epi8(i8::MIN), _mm_setzero_si128());
+                        let select_remote =
+                            _mm256_xor_si256(_mm256_slli_epi16::<3>(control), flip_high_lane);
+                        let from_a = _mm256_blendv_epi8(
+                            _mm256_shuffle_epi8(a, control),
+                            _mm256_shuffle_epi8(a_swapped, control),
+                            select_remote,
+                        );
+                        let from_b = _mm256_blendv_epi8(
+                            _mm256_shuffle_epi8(b, control),
+                            _mm256_shuffle_epi8(b_swapped, control),
+                            select_remote,
+                        );
+                        _mm256_blendv_epi8(from_a, from_b, _mm256_slli_epi16::<2>(control))
+                    },
+                    {
+                        let a = b_bytes[0];
+                        let b = b_bytes[1];
+                        let indices = _mm256_sub_epi8(indices_bytes[1], second_table_offset);
+                        let control = _mm256_adds_epu8(indices, _mm256_set1_epi8(0x40));
+                        let a_swapped = _mm256_permute2x128_si256::<0x01>(a, a);
+                        let b_swapped = _mm256_permute2x128_si256::<0x01>(b, b);
+                        let flip_high_lane =
+                            _mm256_set_m128i(_mm_set1_epi8(i8::MIN), _mm_setzero_si128());
+                        let select_remote =
+                            _mm256_xor_si256(_mm256_slli_epi16::<3>(control), flip_high_lane);
+                        let from_a = _mm256_blendv_epi8(
+                            _mm256_shuffle_epi8(a, control),
+                            _mm256_shuffle_epi8(a_swapped, control),
+                            select_remote,
+                        );
+                        let from_b = _mm256_blendv_epi8(
+                            _mm256_shuffle_epi8(b, control),
+                            _mm256_shuffle_epi8(b_swapped, control),
+                            select_remote,
+                        );
+                        _mm256_blendv_epi8(from_a, from_b, _mm256_slli_epi16::<2>(control))
+                    },
+                );
+                let result_bytes = u8x64 {
+                    val: crate::support::Aligned512([result_low, result_high]),
+                    simd: token,
+                };
+                Bytes::from_bytes(result_bytes)
+            }
+        );
+        kernel(self, a, b, indices)
     }
     #[inline(always)]
     fn split_u8x64(self, a: u8x64<Self>) -> (u8x32<Self>, u8x32<Self>) {

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -1581,6 +1581,63 @@ impl Simd for Avx512 {
         kernel(self, a, indices)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Avx512,
+                a: u8x16<Avx512>,
+                b: u8x16<Avx512>,
+                indices: u8x16<Avx512>,
+            ) -> u8x16<Avx512> {
+                let result = _mm_permutex2var_epi8(
+                    Bytes::to_bytes(a).val.0,
+                    indices.into(),
+                    Bytes::to_bytes(b).val.0,
+                );
+                Bytes::from_bytes(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Avx512,
+                a: u8x16<Avx512>,
+                b: u8x16<Avx512>,
+                indices: u8x16<Avx512>,
+            ) -> u8x16<Avx512> {
+                let a_bytes = Bytes::to_bytes(a).val.0;
+                let b_bytes = Bytes::to_bytes(b).val.0;
+                let indices = indices.into();
+                let in_range = _mm_cmplt_epu8_mask(indices, _mm_set1_epi8(32));
+                let result = _mm_maskz_permutex2var_epi8(in_range, a_bytes, indices, b_bytes);
+                let result_bytes = u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                };
+                Bytes::from_bytes(result_bytes)
+            }
+        );
+        kernel(self, a, b, indices)
+    }
+    #[inline(always)]
     fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7368,6 +7425,63 @@ impl Simd for Avx512 {
         kernel(self, a, indices)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Avx512,
+                a: u8x32<Avx512>,
+                b: u8x32<Avx512>,
+                indices: u8x32<Avx512>,
+            ) -> u8x32<Avx512> {
+                let result = _mm256_permutex2var_epi8(
+                    Bytes::to_bytes(a).val.0,
+                    indices.into(),
+                    Bytes::to_bytes(b).val.0,
+                );
+                Bytes::from_bytes(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Avx512,
+                a: u8x32<Avx512>,
+                b: u8x32<Avx512>,
+                indices: u8x32<Avx512>,
+            ) -> u8x32<Avx512> {
+                let a_bytes = Bytes::to_bytes(a).val.0;
+                let b_bytes = Bytes::to_bytes(b).val.0;
+                let indices = indices.into();
+                let in_range = _mm256_cmplt_epu8_mask(indices, _mm256_set1_epi8(64));
+                let result = _mm256_maskz_permutex2var_epi8(in_range, a_bytes, indices, b_bytes);
+                let result_bytes = u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                };
+                Bytes::from_bytes(result_bytes)
+            }
+        );
+        kernel(self, a, b, indices)
+    }
+    #[inline(always)]
     fn count_ones_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -13028,6 +13142,63 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, a, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Avx512,
+                a: u8x64<Avx512>,
+                b: u8x64<Avx512>,
+                indices: u8x64<Avx512>,
+            ) -> u8x64<Avx512> {
+                let result = _mm512_permutex2var_epi8(
+                    Bytes::to_bytes(a).val.0,
+                    indices.into(),
+                    Bytes::to_bytes(b).val.0,
+                );
+                Bytes::from_bytes(u8x64 {
+                    val: crate::support::Aligned512(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Avx512,
+                a: u8x64<Avx512>,
+                b: u8x64<Avx512>,
+                indices: u8x64<Avx512>,
+            ) -> u8x64<Avx512> {
+                let a_bytes = Bytes::to_bytes(a).val.0;
+                let b_bytes = Bytes::to_bytes(b).val.0;
+                let indices = indices.into();
+                let in_range = _mm512_cmplt_epu8_mask(indices, _mm512_set1_epi8(-128));
+                let result = _mm512_maskz_permutex2var_epi8(in_range, a_bytes, indices, b_bytes);
+                let result_bytes = u8x64 {
+                    val: crate::support::Aligned512(result),
+                    simd: token,
+                };
+                Bytes::from_bytes(result_bytes)
+            }
+        );
+        kernel(self, a, b, indices)
     }
     #[inline(always)]
     fn count_ones_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -1655,7 +1655,7 @@ impl Simd for Fallback {
         for lane in 0..16usize {
             let index = indices[lane] as usize;
             let value = bytes[index % 16usize];
-            output[lane] = if index < 16usize { value } else { 0 };
+            output[lane] = core::hint::select_unpredictable(index < 16usize, value, 0u8);
         }
         let result: u8x16<Self> = output.simd_into(self);
         Bytes::from_bytes(result)
@@ -6596,7 +6596,7 @@ impl Simd for Fallback {
         for lane in 0..32usize {
             let index = indices[lane] as usize;
             let value = bytes[index % 32usize];
-            output[lane] = if index < 32usize { value } else { 0 };
+            output[lane] = core::hint::select_unpredictable(index < 32usize, value, 0u8);
         }
         let result: u8x32<Self> = output.simd_into(self);
         Bytes::from_bytes(result)
@@ -7093,7 +7093,7 @@ impl Simd for Fallback {
         for lane in 0..64usize {
             let index = indices[lane] as usize;
             let value = bytes[index % 64usize];
-            output[lane] = if index < 64usize { value } else { 0 };
+            output[lane] = core::hint::select_unpredictable(index < 64usize, value, 0u8);
         }
         let result: u8x64<Self> = output.simd_into(self);
         Bytes::from_bytes(result)

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -1661,6 +1661,50 @@ impl Simd for Fallback {
         Bytes::from_bytes(result)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 16usize];
+        for lane in 0..16usize {
+            let index = indices[lane] as usize % 32usize;
+            output[lane] = if index < 16usize {
+                first_table[index]
+            } else {
+                second_table[index - 16usize]
+            };
+        }
+        let result: u8x16<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 16usize];
+        for lane in 0..16usize {
+            let index = indices[lane] as usize;
+            let table_index = index % 16usize;
+            let value = if index < 16usize {
+                first_table[table_index]
+            } else {
+                second_table[table_index]
+            };
+            output[lane] = if index < 32usize { value } else { 0 };
+        }
+        let result: u8x16<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
     fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
         [
             u8::try_from(a[0usize].count_ones()).unwrap(),
@@ -6558,6 +6602,50 @@ impl Simd for Fallback {
         Bytes::from_bytes(result)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 32usize];
+        for lane in 0..32usize {
+            let index = indices[lane] as usize % 64usize;
+            output[lane] = if index < 32usize {
+                first_table[index]
+            } else {
+                second_table[index - 32usize]
+            };
+        }
+        let result: u8x32<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 32usize];
+        for lane in 0..32usize {
+            let index = indices[lane] as usize;
+            let table_index = index % 32usize;
+            let value = if index < 32usize {
+                first_table[table_index]
+            } else {
+                second_table[table_index]
+            };
+            output[lane] = if index < 64usize { value } else { 0 };
+        }
+        let result: u8x32<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
     fn combine_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x64<Self> {
         let mut result = [0; 64usize];
         result[0..32usize].copy_from_slice(&a.val.0);
@@ -7006,6 +7094,50 @@ impl Simd for Fallback {
             let index = indices[lane] as usize;
             let value = bytes[index % 64usize];
             output[lane] = if index < 64usize { value } else { 0 };
+        }
+        let result: u8x64<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 64usize];
+        for lane in 0..64usize {
+            let index = indices[lane] as usize % 128usize;
+            output[lane] = if index < 64usize {
+                first_table[index]
+            } else {
+                second_table[index - 64usize]
+            };
+        }
+        let result: u8x64<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 64usize];
+        for lane in 0..64usize {
+            let index = indices[lane] as usize;
+            let table_index = index % 64usize;
+            let value = if index < 64usize {
+                first_table[table_index]
+            } else {
+                second_table[table_index]
+            };
+            output[lane] = if index < 128usize { value } else { 0 };
         }
         let result: u8x64<Self> = output.simd_into(self);
         Bytes::from_bytes(result)

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -1050,6 +1050,40 @@ impl Simd for Neon {
         kernel(self, a, indices)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        self.concat_swizzle_dyn_precise_u8x16(a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Neon,
+                a: u8x16<Neon>,
+                b: u8x16<Neon>,
+                indices: u8x16<Neon>,
+            ) -> u8x16<Neon> {
+                let table = uint8x16x2_t(Bytes::to_bytes(a).val.0, Bytes::to_bytes(b).val.0);
+                let result = vqtbl2q_u8(table, indices.into());
+                Bytes::from_bytes(u8x16 {
+                    val: crate::support::Aligned128(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, b, indices)
+    }
+    #[inline(always)]
     fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5427,6 +5461,44 @@ impl Simd for Neon {
         kernel(self, a, indices)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        self.concat_swizzle_dyn_precise_u8x32(a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Neon,
+                a: u8x32<Neon>,
+                b: u8x32<Neon>,
+                indices: u8x32<Neon>,
+            ) -> u8x32<Neon> {
+                let a = Bytes::to_bytes(a).val.0;
+                let b = Bytes::to_bytes(b).val.0;
+                let table = uint8x16x4_t(a.0, a.1, b.0, b.1);
+                let indices: uint8x16x2_t = indices.into();
+                let result =
+                    uint8x16x2_t(vqtbl4q_u8(table, indices.0), vqtbl4q_u8(table, indices.1));
+                Bytes::from_bytes(u8x32 {
+                    val: crate::support::Aligned256(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, b, indices)
+    }
+    #[inline(always)]
     fn combine_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x64<Self> {
         u8x64 {
             val: crate::support::Aligned512(uint8x16x4_t(
@@ -6395,6 +6467,48 @@ impl Simd for Neon {
             }
         );
         kernel(self, a, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        self.concat_swizzle_dyn_precise_u8x64(a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(
+                token: Neon,
+                a: u8x64<Neon>,
+                b: u8x64<Neon>,
+                indices: u8x64<Neon>,
+            ) -> u8x64<Neon> {
+                let a = Bytes::to_bytes(a).val.0;
+                let b = Bytes::to_bytes(b).val.0;
+                let indices: uint8x16x4_t = indices.into();
+                let b_offset = vdupq_n_u8(64);
+                let result = uint8x16x4_t(
+                    vqtbx4q_u8(vqtbl4q_u8(a, indices.0), b, vsubq_u8(indices.0, b_offset)),
+                    vqtbx4q_u8(vqtbl4q_u8(a, indices.1), b, vsubq_u8(indices.1, b_offset)),
+                    vqtbx4q_u8(vqtbl4q_u8(a, indices.2), b, vsubq_u8(indices.2, b_offset)),
+                    vqtbx4q_u8(vqtbl4q_u8(a, indices.3), b, vsubq_u8(indices.3, b_offset)),
+                );
+                Bytes::from_bytes(u8x64 {
+                    val: crate::support::Aligned512(result),
+                    simd: token,
+                })
+            }
+        );
+        kernel(self, a, b, indices)
     }
     #[inline(always)]
     fn split_u8x64(self, a: u8x64<Self>) -> (u8x32<Self>, u8x32<Self>) {

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -245,6 +245,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_f32x4(self, a: f32x4<Self>, indices: u8x16<Self>) -> f32x4<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_f32x4(
+        self,
+        a: f32x4<Self>,
+        b: f32x4<Self>,
+        indices: u8x16<Self>,
+    ) -> f32x4<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_f32x4(
+        self,
+        a: f32x4<Self>,
+        b: f32x4<Self>,
+        indices: u8x16<Self>,
+    ) -> f32x4<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Negate each element of the vector."]
     fn neg_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
@@ -383,6 +411,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_i8x16(self, a: i8x16<Self>, indices: u8x16<Self>) -> i8x16<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_i8x16(
+        self,
+        a: i8x16<Self>,
+        b: i8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> i8x16<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_i8x16(
+        self,
+        a: i8x16<Self>,
+        b: i8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> i8x16<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Return the number of ones in the binary representation of each element."]
     fn count_ones_i8x16(self, a: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Return the number of zeros in the binary representation of each element."]
@@ -497,6 +553,20 @@ pub trait Simd:
     fn swizzle_dyn_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Dynamically swizzle this vector's bytes across the whole vector.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the vector's byte length select the corresponding byte from the input vector. Out-of-range indices produce zero."]
     fn swizzle_dyn_precise_u8x16(self, a: u8x16<Self>, indices: u8x16<Self>) -> u8x16<Self>;
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    fn concat_swizzle_dyn_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self>;
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    fn concat_swizzle_dyn_precise_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self>;
     #[doc = "Return the number of ones in the binary representation of each element."]
     fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Return the number of zeros in the binary representation of each element."]
@@ -662,6 +732,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_i16x8(self, a: i16x8<Self>, indices: u8x16<Self>) -> i16x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_i16x8(
+        self,
+        a: i16x8<Self>,
+        b: i16x8<Self>,
+        indices: u8x16<Self>,
+    ) -> i16x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_i16x8(
+        self,
+        a: i16x8<Self>,
+        b: i16x8<Self>,
+        indices: u8x16<Self>,
+    ) -> i16x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Return the number of ones in the binary representation of each element."]
     fn count_ones_i16x8(self, a: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Return the number of zeros in the binary representation of each element."]
@@ -790,6 +888,34 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u16x8(self, a: u16x8<Self>, indices: u8x16<Self>) -> u16x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_u16x8(
+        self,
+        a: u16x8<Self>,
+        b: u16x8<Self>,
+        indices: u8x16<Self>,
+    ) -> u16x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u16x8(
+        self,
+        a: u16x8<Self>,
+        b: u16x8<Self>,
+        indices: u8x16<Self>,
+    ) -> u16x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
     }
     #[doc = "Return the number of ones in the binary representation of each element."]
     fn count_ones_u16x8(self, a: u16x8<Self>) -> u16x8<Self>;
@@ -962,6 +1088,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_i32x4(self, a: i32x4<Self>, indices: u8x16<Self>) -> i32x4<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_i32x4(
+        self,
+        a: i32x4<Self>,
+        b: i32x4<Self>,
+        indices: u8x16<Self>,
+    ) -> i32x4<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_i32x4(
+        self,
+        a: i32x4<Self>,
+        b: i32x4<Self>,
+        indices: u8x16<Self>,
+    ) -> i32x4<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Return the number of ones in the binary representation of each element."]
     fn count_ones_i32x4(self, a: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Return the number of zeros in the binary representation of each element."]
@@ -1092,6 +1246,34 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u32x4(self, a: u32x4<Self>, indices: u8x16<Self>) -> u32x4<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_u32x4(
+        self,
+        a: u32x4<Self>,
+        b: u32x4<Self>,
+        indices: u8x16<Self>,
+    ) -> u32x4<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u32x4(
+        self,
+        a: u32x4<Self>,
+        b: u32x4<Self>,
+        indices: u8x16<Self>,
+    ) -> u32x4<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
     }
     #[doc = "Return the number of ones in the binary representation of each element."]
     fn count_ones_u32x4(self, a: u32x4<Self>) -> u32x4<Self>;
@@ -1266,6 +1448,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_f64x2(self, a: f64x2<Self>, indices: u8x16<Self>) -> f64x2<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_f64x2(
+        self,
+        a: f64x2<Self>,
+        b: f64x2<Self>,
+        indices: u8x16<Self>,
+    ) -> f64x2<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_f64x2(
+        self,
+        a: f64x2<Self>,
+        b: f64x2<Self>,
+        indices: u8x16<Self>,
+    ) -> f64x2<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Negate each element of the vector."]
     fn neg_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Compute the square root of each element.\n\nNegative elements other than `-0.0` will become NaN."]
@@ -1408,6 +1618,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_i64x2(self, a: i64x2<Self>, indices: u8x16<Self>) -> i64x2<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_i64x2(
+        self,
+        a: i64x2<Self>,
+        b: i64x2<Self>,
+        indices: u8x16<Self>,
+    ) -> i64x2<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_i64x2(
+        self,
+        a: i64x2<Self>,
+        b: i64x2<Self>,
+        indices: u8x16<Self>,
+    ) -> i64x2<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Return the number of ones in the binary representation of each element."]
     fn count_ones_i64x2(self, a: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Return the number of zeros in the binary representation of each element."]
@@ -1536,6 +1774,34 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u64x2(self, a: u64x2<Self>, indices: u8x16<Self>) -> u64x2<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x16(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_u64x2(
+        self,
+        a: u64x2<Self>,
+        b: u64x2<Self>,
+        indices: u8x16<Self>,
+    ) -> u64x2<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u64x2(
+        self,
+        a: u64x2<Self>,
+        b: u64x2<Self>,
+        indices: u8x16<Self>,
+    ) -> u64x2<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x16(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
     }
     #[doc = "Return the number of ones in the binary representation of each element."]
     fn count_ones_u64x2(self, a: u64x2<Self>) -> u64x2<Self>;
@@ -1724,6 +1990,34 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_f32x8(self, a: f32x8<Self>, indices: u8x32<Self>) -> f32x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_f32x8(
+        self,
+        a: f32x8<Self>,
+        b: f32x8<Self>,
+        indices: u8x32<Self>,
+    ) -> f32x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_f32x8(
+        self,
+        a: f32x8<Self>,
+        b: f32x8<Self>,
+        indices: u8x32<Self>,
+    ) -> f32x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
     }
     #[doc = "Negate each element of the vector."]
     #[inline(always)]
@@ -2114,6 +2408,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_i8x32(self, a: i8x32<Self>, indices: u8x32<Self>) -> i8x32<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_i8x32(
+        self,
+        a: i8x32<Self>,
+        b: i8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> i8x32<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_i8x32(
+        self,
+        a: i8x32<Self>,
+        b: i8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> i8x32<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
     fn count_ones_i8x32(self, a: i8x32<Self>) -> i8x32<Self> {
@@ -2418,6 +2740,20 @@ pub trait Simd:
     fn swizzle_dyn_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self>;
     #[doc = "Dynamically swizzle this vector's bytes across the whole vector.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the vector's byte length select the corresponding byte from the input vector. Out-of-range indices produce zero."]
     fn swizzle_dyn_precise_u8x32(self, a: u8x32<Self>, indices: u8x32<Self>) -> u8x32<Self>;
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    fn concat_swizzle_dyn_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self>;
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    fn concat_swizzle_dyn_precise_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self>;
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
     fn count_ones_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
@@ -2839,6 +3175,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_i16x16(self, a: i16x16<Self>, indices: u8x32<Self>) -> i16x16<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_i16x16(
+        self,
+        a: i16x16<Self>,
+        b: i16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> i16x16<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_i16x16(
+        self,
+        a: i16x16<Self>,
+        b: i16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> i16x16<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
     fn count_ones_i16x16(self, a: i16x16<Self>) -> i16x16<Self> {
@@ -3174,6 +3538,34 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u16x16(self, a: u16x16<Self>, indices: u8x32<Self>) -> u16x16<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_u16x16(
+        self,
+        a: u16x16<Self>,
+        b: u16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> u16x16<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u16x16(
+        self,
+        a: u16x16<Self>,
+        b: u16x16<Self>,
+        indices: u8x32<Self>,
+    ) -> u16x16<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
     }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
@@ -3619,6 +4011,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_i32x8(self, a: i32x8<Self>, indices: u8x32<Self>) -> i32x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_i32x8(
+        self,
+        a: i32x8<Self>,
+        b: i32x8<Self>,
+        indices: u8x32<Self>,
+    ) -> i32x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_i32x8(
+        self,
+        a: i32x8<Self>,
+        b: i32x8<Self>,
+        indices: u8x32<Self>,
+    ) -> i32x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
     fn count_ones_i32x8(self, a: i32x8<Self>) -> i32x8<Self> {
@@ -3956,6 +4376,34 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u32x8(self, a: u32x8<Self>, indices: u8x32<Self>) -> u32x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_u32x8(
+        self,
+        a: u32x8<Self>,
+        b: u32x8<Self>,
+        indices: u8x32<Self>,
+    ) -> u32x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u32x8(
+        self,
+        a: u32x8<Self>,
+        b: u32x8<Self>,
+        indices: u8x32<Self>,
+    ) -> u32x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
     }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
@@ -4407,6 +4855,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_f64x4(self, a: f64x4<Self>, indices: u8x32<Self>) -> f64x4<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_f64x4(
+        self,
+        a: f64x4<Self>,
+        b: f64x4<Self>,
+        indices: u8x32<Self>,
+    ) -> f64x4<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_f64x4(
+        self,
+        a: f64x4<Self>,
+        b: f64x4<Self>,
+        indices: u8x32<Self>,
+    ) -> f64x4<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Negate each element of the vector."]
     #[inline(always)]
     fn neg_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
@@ -4815,6 +5291,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_i64x4(self, a: i64x4<Self>, indices: u8x32<Self>) -> i64x4<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_i64x4(
+        self,
+        a: i64x4<Self>,
+        b: i64x4<Self>,
+        indices: u8x32<Self>,
+    ) -> i64x4<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_i64x4(
+        self,
+        a: i64x4<Self>,
+        b: i64x4<Self>,
+        indices: u8x32<Self>,
+    ) -> i64x4<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
     fn count_ones_i64x4(self, a: i64x4<Self>) -> i64x4<Self> {
@@ -5144,6 +5648,34 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u64x4(self, a: u64x4<Self>, indices: u8x32<Self>) -> u64x4<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x32(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_u64x4(
+        self,
+        a: u64x4<Self>,
+        b: u64x4<Self>,
+        indices: u8x32<Self>,
+    ) -> u64x4<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u64x4(
+        self,
+        a: u64x4<Self>,
+        b: u64x4<Self>,
+        indices: u8x32<Self>,
+    ) -> u64x4<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x32(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
     }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
@@ -5591,6 +6123,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_f32x16(self, a: f32x16<Self>, indices: u8x64<Self>) -> f32x16<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_f32x16(
+        self,
+        a: f32x16<Self>,
+        b: f32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> f32x16<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_f32x16(
+        self,
+        a: f32x16<Self>,
+        b: f32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> f32x16<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Negate each element of the vector."]
     #[inline(always)]
     fn neg_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
@@ -5988,6 +6548,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_i8x64(self, a: i8x64<Self>, indices: u8x64<Self>) -> i8x64<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_i8x64(
+        self,
+        a: i8x64<Self>,
+        b: i8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> i8x64<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_i8x64(
+        self,
+        a: i8x64<Self>,
+        b: i8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> i8x64<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
     fn count_ones_i8x64(self, a: i8x64<Self>) -> i8x64<Self> {
@@ -6290,6 +6878,20 @@ pub trait Simd:
     fn swizzle_dyn_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self>;
     #[doc = "Dynamically swizzle this vector's bytes across the whole vector.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the vector's byte length select the corresponding byte from the input vector. Out-of-range indices produce zero."]
     fn swizzle_dyn_precise_u8x64(self, a: u8x64<Self>, indices: u8x64<Self>) -> u8x64<Self>;
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    fn concat_swizzle_dyn_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self>;
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    fn concat_swizzle_dyn_precise_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self>;
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
     fn count_ones_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
@@ -6707,6 +7309,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_i16x32(self, a: i16x32<Self>, indices: u8x64<Self>) -> i16x32<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_i16x32(
+        self,
+        a: i16x32<Self>,
+        b: i16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> i16x32<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_i16x32(
+        self,
+        a: i16x32<Self>,
+        b: i16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> i16x32<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
     fn count_ones_i16x32(self, a: i16x32<Self>) -> i16x32<Self> {
@@ -7046,6 +7676,34 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u16x32(self, a: u16x32<Self>, indices: u8x64<Self>) -> u16x32<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_u16x32(
+        self,
+        a: u16x32<Self>,
+        b: u16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> u16x32<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u16x32(
+        self,
+        a: u16x32<Self>,
+        b: u16x32<Self>,
+        indices: u8x64<Self>,
+    ) -> u16x32<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
     }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
@@ -7500,6 +8158,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_i32x16(self, a: i32x16<Self>, indices: u8x64<Self>) -> i32x16<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_i32x16(
+        self,
+        a: i32x16<Self>,
+        b: i32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> i32x16<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_i32x16(
+        self,
+        a: i32x16<Self>,
+        b: i32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> i32x16<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
     fn count_ones_i32x16(self, a: i32x16<Self>) -> i32x16<Self> {
@@ -7839,6 +8525,34 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u32x16(self, a: u32x16<Self>, indices: u8x64<Self>) -> u32x16<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_u32x16(
+        self,
+        a: u32x16<Self>,
+        b: u32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> u32x16<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u32x16(
+        self,
+        a: u32x16<Self>,
+        b: u32x16<Self>,
+        indices: u8x64<Self>,
+    ) -> u32x16<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
     }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
@@ -8286,6 +9000,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_f64x8(self, a: f64x8<Self>, indices: u8x64<Self>) -> f64x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_f64x8(
+        self,
+        a: f64x8<Self>,
+        b: f64x8<Self>,
+        indices: u8x64<Self>,
+    ) -> f64x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_f64x8(
+        self,
+        a: f64x8<Self>,
+        b: f64x8<Self>,
+        indices: u8x64<Self>,
+    ) -> f64x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Negate each element of the vector."]
     #[inline(always)]
     fn neg_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
@@ -8692,6 +9434,34 @@ pub trait Simd:
     fn swizzle_dyn_precise_i64x8(self, a: i64x8<Self>, indices: u8x64<Self>) -> i64x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
     }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_i64x8(
+        self,
+        a: i64x8<Self>,
+        b: i64x8<Self>,
+        indices: u8x64<Self>,
+    ) -> i64x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_i64x8(
+        self,
+        a: i64x8<Self>,
+        b: i64x8<Self>,
+        indices: u8x64<Self>,
+    ) -> i64x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
     fn count_ones_i64x8(self, a: i64x8<Self>) -> i64x8<Self> {
@@ -9019,6 +9789,34 @@ pub trait Simd:
     #[inline(always)]
     fn swizzle_dyn_precise_u64x8(self, a: u64x8<Self>, indices: u8x64<Self>) -> u64x8<Self> {
         Bytes::from_bytes(self.swizzle_dyn_precise_u8x64(Bytes::to_bytes(a), indices))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_u64x8(
+        self,
+        a: u64x8<Self>,
+        b: u64x8<Self>,
+        indices: u8x64<Self>,
+    ) -> u64x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
+    }
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u64x8(
+        self,
+        a: u64x8<Self>,
+        b: u64x8<Self>,
+        indices: u8x64<Self>,
+    ) -> u64x8<Self> {
+        Bytes::from_bytes(self.concat_swizzle_dyn_precise_u8x64(
+            Bytes::to_bytes(a),
+            Bytes::to_bytes(b),
+            indices,
+        ))
     }
     #[doc = "Return the number of ones in the binary representation of each element."]
     #[inline(always)]
@@ -9977,6 +10775,18 @@ pub trait SimdBase<S: Simd>:
     fn swizzle_dyn(self, indices: impl SimdInto<Self::Bytes, S>) -> Self;
     #[doc = "Dynamically swizzle this vector's bytes across the whole vector.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the vector's byte length select the corresponding byte from the input vector. Out-of-range indices produce zero."]
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self;
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\nUse [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero."]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self;
+    #[doc = "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\nThe `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero."]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self;
     #[doc = "Return the maximum element in the vector. Integer vectors always return the exact maximum.\n\nFor floating-point vectors with no NaNs, this returns the true maximum. If any lane is NaN, the entire result is implementation-defined: it may be NaN or a numeric lane that is not the true maximum. See `reduce_max_precise` for a version that ignores quiet NaNs.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned."]
     fn reduce_max(self) -> Self::Element;
     #[doc = "Return the minimum element in the vector. Integer vectors always return the exact minimum.\n\nFor floating-point vectors with no NaNs, this returns the true minimum. If any lane is NaN, the entire result is implementation-defined: it may be NaN or a numeric lane that is not the true minimum. See `reduce_min_precise` for a version that ignores quiet NaNs.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned."]

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -163,6 +163,30 @@ impl<S: Simd> SimdBase<S> for f32x4<S> {
         self.simd.reverse_f32x4(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_f32x4(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_f32x4(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_f32x4(self)
     }
@@ -517,6 +541,30 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
         self.simd.reverse_i8x16(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_i8x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_i8x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_i8x16(self)
     }
@@ -821,6 +869,30 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
     #[inline(always)]
     fn reverse(self) -> Self {
         self.simd.reverse_u8x16(self)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_u8x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_u8x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
     }
     #[inline(always)]
     fn reduce_max(self) -> Self::Element {
@@ -1227,6 +1299,30 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
         self.simd.reverse_i16x8(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_i16x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_i16x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_i16x8(self)
     }
@@ -1538,6 +1634,30 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
     #[inline(always)]
     fn reverse(self) -> Self {
         self.simd.reverse_u16x8(self)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_u16x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_u16x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
     }
     #[inline(always)]
     fn reduce_max(self) -> Self::Element {
@@ -1947,6 +2067,30 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
         self.simd.reverse_i32x4(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_i32x4(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_i32x4(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_i32x4(self)
     }
@@ -2258,6 +2402,30 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
     #[inline(always)]
     fn reverse(self) -> Self {
         self.simd.reverse_u32x4(self)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_u32x4(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_u32x4(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
     }
     #[inline(always)]
     fn reduce_max(self) -> Self::Element {
@@ -2679,6 +2847,30 @@ impl<S: Simd> SimdBase<S> for f64x2<S> {
         self.simd.reverse_f64x2(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_f64x2(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_f64x2(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_f64x2(self)
     }
@@ -3021,6 +3213,30 @@ impl<S: Simd> SimdBase<S> for i64x2<S> {
         self.simd.reverse_i64x2(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_i64x2(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_i64x2(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_i64x2(self)
     }
@@ -3325,6 +3541,30 @@ impl<S: Simd> SimdBase<S> for u64x2<S> {
     #[inline(always)]
     fn reverse(self) -> Self {
         self.simd.reverse_u64x2(self)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_u64x2(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_u64x2(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
     }
     #[inline(always)]
     fn reduce_max(self) -> Self::Element {
@@ -3751,6 +3991,30 @@ impl<S: Simd> SimdBase<S> for f32x8<S> {
         self.simd.reverse_f32x8(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_f32x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_f32x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_f32x8(self)
     }
@@ -4116,6 +4380,30 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
         self.simd.reverse_i8x32(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_i8x32(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_i8x32(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_i8x32(self)
     }
@@ -4431,6 +4719,30 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
     #[inline(always)]
     fn reverse(self) -> Self {
         self.simd.reverse_u8x32(self)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_u8x32(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_u8x32(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
     }
     #[inline(always)]
     fn reduce_max(self) -> Self::Element {
@@ -4840,6 +5152,30 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
         self.simd.reverse_i16x16(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_i16x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_i16x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_i16x16(self)
     }
@@ -5155,6 +5491,30 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
     #[inline(always)]
     fn reverse(self) -> Self {
         self.simd.reverse_u16x16(self)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_u16x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_u16x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
     }
     #[inline(always)]
     fn reduce_max(self) -> Self::Element {
@@ -5572,6 +5932,30 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
         self.simd.reverse_i32x8(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_i32x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_i32x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_i32x8(self)
     }
@@ -5890,6 +6274,30 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
     #[inline(always)]
     fn reverse(self) -> Self {
         self.simd.reverse_u32x8(self)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_u32x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_u32x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
     }
     #[inline(always)]
     fn reduce_max(self) -> Self::Element {
@@ -6306,6 +6714,30 @@ impl<S: Simd> SimdBase<S> for f64x4<S> {
         self.simd.reverse_f64x4(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_f64x4(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_f64x4(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_f64x4(self)
     }
@@ -6643,6 +7075,30 @@ impl<S: Simd> SimdBase<S> for i64x4<S> {
         self.simd.reverse_i64x4(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_i64x4(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_i64x4(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_i64x4(self)
     }
@@ -6942,6 +7398,30 @@ impl<S: Simd> SimdBase<S> for u64x4<S> {
     #[inline(always)]
     fn reverse(self) -> Self {
         self.simd.reverse_u64x4(self)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_u64x4(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_u64x4(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
     }
     #[inline(always)]
     fn reduce_max(self) -> Self::Element {
@@ -7372,6 +7852,30 @@ impl<S: Simd> SimdBase<S> for f32x16<S> {
         self.simd.reverse_f32x16(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_f32x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_f32x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_f32x16(self)
     }
@@ -7764,6 +8268,30 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
         self.simd.reverse_i8x64(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_i8x64(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_i8x64(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_i8x64(self)
     }
@@ -8105,6 +8633,30 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
     #[inline(always)]
     fn reverse(self) -> Self {
         self.simd.reverse_u8x64(self)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_u8x64(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_u8x64(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
     }
     #[inline(always)]
     fn reduce_max(self) -> Self::Element {
@@ -8524,6 +9076,30 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
         self.simd.reverse_i16x32(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_i16x32(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_i16x32(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_i16x32(self)
     }
@@ -8849,6 +9425,30 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
     #[inline(always)]
     fn reverse(self) -> Self {
         self.simd.reverse_u16x32(self)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_u16x32(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_u16x32(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
     }
     #[inline(always)]
     fn reduce_max(self) -> Self::Element {
@@ -9268,6 +9868,30 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
         self.simd.reverse_i32x16(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_i32x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_i32x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_i32x16(self)
     }
@@ -9589,6 +10213,30 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
     #[inline(always)]
     fn reverse(self) -> Self {
         self.simd.reverse_u32x16(self)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_u32x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_u32x16(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
     }
     #[inline(always)]
     fn reduce_max(self) -> Self::Element {
@@ -10012,6 +10660,30 @@ impl<S: Simd> SimdBase<S> for f64x8<S> {
         self.simd.reverse_f64x8(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_f64x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_f64x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_f64x8(self)
     }
@@ -10355,6 +11027,30 @@ impl<S: Simd> SimdBase<S> for i64x8<S> {
         self.simd.reverse_i64x8(self)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_i64x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_i64x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
     fn reduce_max(self) -> Self::Element {
         self.simd.reduce_max_i64x8(self)
     }
@@ -10660,6 +11356,30 @@ impl<S: Simd> SimdBase<S> for u64x8<S> {
     #[inline(always)]
     fn reverse(self) -> Self {
         self.simd.reverse_u64x8(self)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_u64x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise(
+        self,
+        rhs: impl SimdInto<Self, S>,
+        indices: impl SimdInto<Self::Bytes, S>,
+    ) -> Self {
+        self.simd.concat_swizzle_dyn_precise_u64x8(
+            self,
+            rhs.simd_into(self.simd),
+            indices.simd_into(self.simd),
+        )
     }
     #[inline(always)]
     fn reduce_max(self) -> Self::Element {

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -1663,6 +1663,50 @@ impl Simd for Sse2 {
         Bytes::from_bytes(result)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 16usize];
+        for lane in 0..16usize {
+            let index = indices[lane] as usize % 32usize;
+            output[lane] = if index < 16usize {
+                first_table[index]
+            } else {
+                second_table[index - 16usize]
+            };
+        }
+        let result: u8x16<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 16usize];
+        for lane in 0..16usize {
+            let index = indices[lane] as usize;
+            let table_index = index % 16usize;
+            let value = if index < 16usize {
+                first_table[table_index]
+            } else {
+                second_table[table_index]
+            };
+            output[lane] = if index < 32usize { value } else { 0 };
+        }
+        let result: u8x16<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
     fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
         [
             u8::try_from(a[0usize].count_ones()).unwrap(),
@@ -6945,6 +6989,50 @@ impl Simd for Sse2 {
         Bytes::from_bytes(result)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 32usize];
+        for lane in 0..32usize {
+            let index = indices[lane] as usize % 64usize;
+            output[lane] = if index < 32usize {
+                first_table[index]
+            } else {
+                second_table[index - 32usize]
+            };
+        }
+        let result: u8x32<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 32usize];
+        for lane in 0..32usize {
+            let index = indices[lane] as usize;
+            let table_index = index % 32usize;
+            let value = if index < 32usize {
+                first_table[table_index]
+            } else {
+                second_table[table_index]
+            };
+            output[lane] = if index < 64usize { value } else { 0 };
+        }
+        let result: u8x32<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
     fn combine_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x64<Self> {
         u8x64 {
             val: crate::support::Aligned512([a.val.0[0], a.val.0[1], b.val.0[0], b.val.0[1]]),
@@ -7566,6 +7654,50 @@ impl Simd for Sse2 {
             let index = indices[lane] as usize;
             let value = bytes[index % 64usize];
             output[lane] = if index < 64usize { value } else { 0 };
+        }
+        let result: u8x64<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 64usize];
+        for lane in 0..64usize {
+            let index = indices[lane] as usize % 128usize;
+            output[lane] = if index < 64usize {
+                first_table[index]
+            } else {
+                second_table[index - 64usize]
+            };
+        }
+        let result: u8x64<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 64usize];
+        for lane in 0..64usize {
+            let index = indices[lane] as usize;
+            let table_index = index % 64usize;
+            let value = if index < 64usize {
+                first_table[table_index]
+            } else {
+                second_table[table_index]
+            };
+            output[lane] = if index < 128usize { value } else { 0 };
         }
         let result: u8x64<Self> = output.simd_into(self);
         Bytes::from_bytes(result)

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -1657,7 +1657,7 @@ impl Simd for Sse2 {
         for lane in 0..16usize {
             let index = indices[lane] as usize;
             let value = bytes[index % 16usize];
-            output[lane] = if index < 16usize { value } else { 0 };
+            output[lane] = core::hint::select_unpredictable(index < 16usize, value, 0u8);
         }
         let result: u8x16<Self> = output.simd_into(self);
         Bytes::from_bytes(result)
@@ -6983,7 +6983,7 @@ impl Simd for Sse2 {
         for lane in 0..32usize {
             let index = indices[lane] as usize;
             let value = bytes[index % 32usize];
-            output[lane] = if index < 32usize { value } else { 0 };
+            output[lane] = core::hint::select_unpredictable(index < 32usize, value, 0u8);
         }
         let result: u8x32<Self> = output.simd_into(self);
         Bytes::from_bytes(result)
@@ -7653,7 +7653,7 @@ impl Simd for Sse2 {
         for lane in 0..64usize {
             let index = indices[lane] as usize;
             let value = bytes[index % 64usize];
-            output[lane] = if index < 64usize { value } else { 0 };
+            output[lane] = core::hint::select_unpredictable(index < 64usize, value, 0u8);
         }
         let result: u8x64<Self> = output.simd_into(self);
         Bytes::from_bytes(result)

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -1521,8 +1521,7 @@ impl Simd for Sse4_2 {
             #[inline(always)]
             fn kernel(token: Sse4_2, a: u8x16<Sse4_2>, indices: u8x16<Sse4_2>) -> u8x16<Sse4_2> {
                 let indices = indices.into();
-                let index_out_of_range = _mm_add_epi8(indices, _mm_set1_epi8(112));
-                let zeroing_indices = _mm_or_si128(indices, index_out_of_range);
+                let zeroing_indices = _mm_adds_epu8(indices, _mm_set1_epi8(0x70));
                 let result = _mm_shuffle_epi8(Bytes::to_bytes(a).val.0, zeroing_indices);
                 let result_bytes = u8x16 {
                     val: crate::support::Aligned128(result),
@@ -1532,6 +1531,31 @@ impl Simd for Sse4_2 {
             }
         );
         kernel(self, a, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        self.concat_swizzle_dyn_precise_u8x16(a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let second_table_offset = self.splat_u8x16(16);
+        let from_first = self.swizzle_dyn_precise_u8x16(first_table, indices);
+        let from_second = self
+            .swizzle_dyn_precise_u8x16(second_table, self.sub_u8x16(indices, second_table_offset));
+        let result_bytes = self.or_u8x16(from_first, from_second);
+        Bytes::from_bytes(result_bytes)
     }
     #[inline(always)]
     fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
@@ -6790,6 +6814,31 @@ impl Simd for Sse4_2 {
         kernel(self, a, indices)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        self.concat_swizzle_dyn_precise_u8x32(a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let second_table_offset = self.splat_u8x32(32);
+        let from_first = self.swizzle_dyn_precise_u8x32(first_table, indices);
+        let from_second = self
+            .swizzle_dyn_precise_u8x32(second_table, self.sub_u8x32(indices, second_table_offset));
+        let result_bytes = self.or_u8x32(from_first, from_second);
+        Bytes::from_bytes(result_bytes)
+    }
+    #[inline(always)]
     fn combine_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x64<Self> {
         u8x64 {
             val: crate::support::Aligned512([a.val.0[0], a.val.0[1], b.val.0[0], b.val.0[1]]),
@@ -7411,6 +7460,50 @@ impl Simd for Sse4_2 {
             let index = indices[lane] as usize;
             let value = bytes[index % 64usize];
             output[lane] = if index < 64usize { value } else { 0 };
+        }
+        let result: u8x64<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 64usize];
+        for lane in 0..64usize {
+            let index = indices[lane] as usize % 128usize;
+            output[lane] = if index < 64usize {
+                first_table[index]
+            } else {
+                second_table[index - 64usize]
+            };
+        }
+        let result: u8x64<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 64usize];
+        for lane in 0..64usize {
+            let index = indices[lane] as usize;
+            let table_index = index % 64usize;
+            let value = if index < 64usize {
+                first_table[table_index]
+            } else {
+                second_table[table_index]
+            };
+            output[lane] = if index < 128usize { value } else { 0 };
         }
         let result: u8x64<Self> = output.simd_into(self);
         Bytes::from_bytes(result)

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -7459,7 +7459,7 @@ impl Simd for Sse4_2 {
         for lane in 0..64usize {
             let index = indices[lane] as usize;
             let value = bytes[index % 64usize];
-            output[lane] = if index < 64usize { value } else { 0 };
+            output[lane] = core::hint::select_unpredictable(index < 64usize, value, 0u8);
         }
         let result: u8x64<Self> = output.simd_into(self);
         Bytes::from_bytes(result)

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -968,6 +968,35 @@ impl Simd for WasmSimd128 {
         })
     }
     #[inline(always)]
+    fn concat_swizzle_dyn_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        self.concat_swizzle_dyn_precise_u8x16(a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x16(
+        self,
+        a: u8x16<Self>,
+        b: u8x16<Self>,
+        indices: u8x16<Self>,
+    ) -> u8x16<Self> {
+        let indices: v128 = indices.into();
+        let result = v128_or(
+            u8x16_swizzle(Bytes::to_bytes(a).val.0, indices),
+            u8x16_swizzle(
+                Bytes::to_bytes(b).val.0,
+                u8x16_sub(indices, u8x16_splat(16)),
+            ),
+        );
+        Bytes::from_bytes(u8x16 {
+            val: crate::support::Aligned128(result),
+            simd: self,
+        })
+    }
+    #[inline(always)]
     fn count_ones_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
         i8x16_popcnt(a.into()).simd_into(self)
     }
@@ -3963,6 +3992,58 @@ impl Simd for WasmSimd128 {
         Bytes::from_bytes(result_bytes)
     }
     #[inline(always)]
+    fn concat_swizzle_dyn_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        self.concat_swizzle_dyn_precise_u8x32(a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x32(
+        self,
+        a: u8x32<Self>,
+        b: u8x32<Self>,
+        indices: u8x32<Self>,
+    ) -> u8x32<Self> {
+        let a = Bytes::to_bytes(a).val.0;
+        let b = Bytes::to_bytes(b).val.0;
+        let indices = indices.val.0;
+        let result = [
+            {
+                let indices = indices[0];
+                v128_or(
+                    v128_or(
+                        u8x16_swizzle(a[0], indices),
+                        u8x16_swizzle(a[1], u8x16_sub(indices, u8x16_splat(16))),
+                    ),
+                    v128_or(
+                        u8x16_swizzle(b[0], u8x16_sub(indices, u8x16_splat(32))),
+                        u8x16_swizzle(b[1], u8x16_sub(indices, u8x16_splat(48))),
+                    ),
+                )
+            },
+            {
+                let indices = indices[1];
+                v128_or(
+                    v128_or(
+                        u8x16_swizzle(a[0], indices),
+                        u8x16_swizzle(a[1], u8x16_sub(indices, u8x16_splat(16))),
+                    ),
+                    v128_or(
+                        u8x16_swizzle(b[0], u8x16_sub(indices, u8x16_splat(32))),
+                        u8x16_swizzle(b[1], u8x16_sub(indices, u8x16_splat(48))),
+                    ),
+                )
+            },
+        ];
+        Bytes::from_bytes(u8x32 {
+            val: crate::support::Aligned256(result),
+            simd: self,
+        })
+    }
+    #[inline(always)]
     fn combine_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x64<Self> {
         u8x64 {
             val: crate::support::Aligned512([a.val.0[0], a.val.0[1], b.val.0[0], b.val.0[1]]),
@@ -4548,6 +4629,38 @@ impl Simd for WasmSimd128 {
             let index = indices[lane] as usize;
             let value = bytes[index % 64usize];
             output[lane] = if index < 64usize { value } else { 0 };
+        }
+        let result: u8x64<Self> = output.simd_into(self);
+        Bytes::from_bytes(result)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        self.concat_swizzle_dyn_precise_u8x64(a, b, indices)
+    }
+    #[inline(always)]
+    fn concat_swizzle_dyn_precise_u8x64(
+        self,
+        a: u8x64<Self>,
+        b: u8x64<Self>,
+        indices: u8x64<Self>,
+    ) -> u8x64<Self> {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let mut output = [0u8; 64usize];
+        for lane in 0..64usize {
+            let index = indices[lane] as usize;
+            let table_index = index % 64usize;
+            let value = if index < 64usize {
+                first_table[table_index]
+            } else {
+                second_table[table_index]
+            };
+            output[lane] = if index < 128usize { value } else { 0 };
         }
         let result: u8x64<Self> = output.simd_into(self);
         Bytes::from_bytes(result)

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -4628,7 +4628,7 @@ impl Simd for WasmSimd128 {
         for lane in 0..64usize {
             let index = indices[lane] as usize;
             let value = bytes[index % 64usize];
-            output[lane] = if index < 64usize { value } else { 0 };
+            output[lane] = core::hint::select_unpredictable(index < 64usize, value, 0u8);
         }
         let result: u8x64<Self> = output.simd_into(self);
         Bytes::from_bytes(result)

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -44,10 +44,26 @@ pub(crate) fn byte_swizzle_op(op: &Op, vec_ty: &VecType) -> TokenStream {
 
     let method_sig = op.simd_trait_method_sig(vec_ty);
     let byte_method = generic_op_name(op.method, &vec_ty.bytes_ty());
-    quote! {
-        #method_sig {
-            Bytes::from_bytes(self.#byte_method(Bytes::to_bytes(a), indices))
+    match op.sig {
+        OpSig::SwizzleDynWithinBlocks | OpSig::SwizzleDyn | OpSig::SwizzleDynPrecise => {
+            quote! {
+                #method_sig {
+                    Bytes::from_bytes(self.#byte_method(Bytes::to_bytes(a), indices))
+                }
+            }
         }
+        OpSig::ConcatSwizzleDyn | OpSig::ConcatSwizzleDynPrecise => {
+            quote! {
+                #method_sig {
+                    Bytes::from_bytes(self.#byte_method(
+                        Bytes::to_bytes(a),
+                        Bytes::to_bytes(b),
+                        indices,
+                    ))
+                }
+            }
+        }
+        _ => unreachable!("non-swizzle operation routed through bytes"),
     }
 }
 
@@ -174,6 +190,32 @@ pub(crate) fn recursive_swizzle_dyn_precise_body<T: ToTokens + ?Sized>(
         let output_high = #token.#or_half(output_high_from_low, output_high_from_high);
 
         let result_bytes = #token.#combine_half_bytes(output_low, output_high);
+    }
+}
+
+/// Implement a precise swizzle from a concatenated pair of vectors by combining two zeroing
+/// whole-vector swizzles with bitwise OR.
+pub(crate) fn concat_swizzle_dyn_precise_body<T: ToTokens + ?Sized>(
+    vec_ty: &VecType,
+    token: &T,
+) -> TokenStream {
+    let bytes_ty = vec_ty.bytes_ty();
+    let swizzle = generic_op_name("swizzle_dyn_precise", &bytes_ty);
+    let splat = generic_op_name("splat", &bytes_ty);
+    let sub = generic_op_name("sub", &bytes_ty);
+    let or = generic_op_name("or", &bytes_ty);
+    let second_table_offset = Literal::u8_unsuffixed(u8::try_from(bytes_ty.len).unwrap());
+
+    quote! {
+        let first_table = Bytes::to_bytes(a);
+        let second_table = Bytes::to_bytes(b);
+        let second_table_offset = #token.#splat(#second_table_offset);
+        let from_first = #token.#swizzle(first_table, indices);
+        let from_second = #token.#swizzle(
+            second_table,
+            #token.#sub(indices, second_table_offset),
+        );
+        let result_bytes = #token.#or(from_first, from_second);
     }
 }
 
@@ -305,7 +347,10 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
                 }
             }
         }
-        OpSig::SwizzleDyn | OpSig::SwizzleDynPrecise => {
+        OpSig::SwizzleDyn
+        | OpSig::SwizzleDynPrecise
+        | OpSig::ConcatSwizzleDyn
+        | OpSig::ConcatSwizzleDynPrecise => {
             panic!("whole-vector swizzles cannot be done via split/combine");
         }
         OpSig::Ternary => {

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -642,7 +642,7 @@ impl Level for Fallback {
                 let bytes_ty = vec_ty.bytes_ty();
                 let bytes_rust = bytes_ty.rust();
                 let byte_count = bytes_ty.len;
-                // This formulation lowers into one cmov per element on SSE2/SSE4.2
+                // This formulation requests branchless selection on scalar targets
                 // and autovectorizes on RISC-V.
                 quote! {
                     #method_sig {
@@ -653,7 +653,11 @@ impl Level for Fallback {
                             // and select zero afterwards. This avoids a branch that could be mispredicted.
                             let index = indices[lane] as usize;
                             let value = bytes[index % #byte_count];
-                            output[lane] = if index < #byte_count { value } else { 0 };
+                            output[lane] = core::hint::select_unpredictable(
+                                index < #byte_count,
+                                value,
+                                0u8,
+                            );
                         }
                         let result: #bytes_rust<Self> = output.simd_into(self);
                         Bytes::from_bytes(result)

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -660,6 +660,58 @@ impl Level for Fallback {
                     }
                 }
             }
+            OpSig::ConcatSwizzleDyn => {
+                let bytes_ty = vec_ty.bytes_ty();
+                let bytes_rust = bytes_ty.rust();
+                let byte_count = bytes_ty.len;
+                let table_byte_count = byte_count * 2;
+
+                quote! {
+                    #method_sig {
+                        let first_table = Bytes::to_bytes(a);
+                        let second_table = Bytes::to_bytes(b);
+                        let mut output = [0u8; #byte_count];
+                        for lane in 0..#byte_count {
+                            let index = indices[lane] as usize % #table_byte_count;
+                            output[lane] = if index < #byte_count {
+                                first_table[index]
+                            } else {
+                                second_table[index - #byte_count]
+                            };
+                        }
+                        let result: #bytes_rust<Self> = output.simd_into(self);
+                        Bytes::from_bytes(result)
+                    }
+                }
+            }
+            OpSig::ConcatSwizzleDynPrecise => {
+                let bytes_ty = vec_ty.bytes_ty();
+                let bytes_rust = bytes_ty.rust();
+                let byte_count = bytes_ty.len;
+                let table_byte_count = byte_count * 2;
+
+                quote! {
+                    #method_sig {
+                        let first_table = Bytes::to_bytes(a);
+                        let second_table = Bytes::to_bytes(b);
+                        let mut output = [0u8; #byte_count];
+                        for lane in 0..#byte_count {
+                            // Keep both possible loads in bounds so LLVM may execute them
+                            // unconditionally, then select zero for an out-of-range index.
+                            let index = indices[lane] as usize;
+                            let table_index = index % #byte_count;
+                            let value = if index < #byte_count {
+                                first_table[table_index]
+                            } else {
+                                second_table[table_index]
+                            };
+                            output[lane] = if index < #table_byte_count { value } else { 0 };
+                        }
+                        let result: #bytes_rust<Self> = output.simd_into(self);
+                        Bytes::from_bytes(result)
+                    }
+                }
+            }
             OpSig::Cvt {
                 target_ty,
                 scalar_bits,

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -725,6 +725,75 @@ impl Level for Neon {
                     }
                 })
             }
+            OpSig::ConcatSwizzleDyn => {
+                let precise = generic_op_name("concat_swizzle_dyn_precise", vec_ty);
+                quote! {
+                    #method_sig {
+                        self.#precise(a, b, indices)
+                    }
+                }
+            }
+            OpSig::ConcatSwizzleDynPrecise => {
+                let bytes_ty = vec_ty.bytes_ty();
+                let bytes = bytes_ty.rust();
+                let wrapper = bytes_ty.aligned_wrapper();
+
+                self.kernel_method(op, vec_ty, |token| {
+                    let body = match vec_ty.n_bits() {
+                        128 => quote! {
+                            let table = uint8x16x2_t(
+                                Bytes::to_bytes(a).val.0,
+                                Bytes::to_bytes(b).val.0,
+                            );
+                            let result = vqtbl2q_u8(table, indices.into());
+                        },
+                        256 => quote! {
+                            let a = Bytes::to_bytes(a).val.0;
+                            let b = Bytes::to_bytes(b).val.0;
+                            let table = uint8x16x4_t(a.0, a.1, b.0, b.1);
+                            let indices: uint8x16x2_t = indices.into();
+                            let result = uint8x16x2_t(
+                                vqtbl4q_u8(table, indices.0),
+                                vqtbl4q_u8(table, indices.1),
+                            );
+                        },
+                        512 => quote! {
+                            let a = Bytes::to_bytes(a).val.0;
+                            let b = Bytes::to_bytes(b).val.0;
+                            let indices: uint8x16x4_t = indices.into();
+                            let b_offset = vdupq_n_u8(64);
+                            let result = uint8x16x4_t(
+                                vqtbx4q_u8(
+                                    vqtbl4q_u8(a, indices.0),
+                                    b,
+                                    vsubq_u8(indices.0, b_offset),
+                                ),
+                                vqtbx4q_u8(
+                                    vqtbl4q_u8(a, indices.1),
+                                    b,
+                                    vsubq_u8(indices.1, b_offset),
+                                ),
+                                vqtbx4q_u8(
+                                    vqtbl4q_u8(a, indices.2),
+                                    b,
+                                    vsubq_u8(indices.2, b_offset),
+                                ),
+                                vqtbx4q_u8(
+                                    vqtbl4q_u8(a, indices.3),
+                                    b,
+                                    vsubq_u8(indices.3, b_offset),
+                                ),
+                            );
+                        },
+                        _ => unreachable!(),
+                    };
+
+                    quote! {
+                        #body
+                        Bytes::from_bytes(#bytes { val: #wrapper(result), simd: #token })
+                    }
+                })
+            }
             OpSig::Cvt {
                 target_ty,
                 scalar_bits,

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -1086,6 +1086,75 @@ impl Level for WasmSimd128 {
                 // and express it in terms of 256-bit or 512-bit vectors.
                 _ => crate::mk_fallback::Fallback.make_method(op, vec_ty),
             },
+            OpSig::ConcatSwizzleDyn => {
+                let precise = generic_op_name("concat_swizzle_dyn_precise", vec_ty);
+                quote! {
+                    #method_sig {
+                        self.#precise(a, b, indices)
+                    }
+                }
+            }
+            OpSig::ConcatSwizzleDynPrecise => match vec_ty.n_bits() {
+                128 => {
+                    let bytes_ty = vec_ty.bytes_ty();
+                    let bytes = bytes_ty.rust();
+                    let wrapper = bytes_ty.aligned_wrapper();
+
+                    quote! {
+                        #method_sig {
+                            let indices: v128 = indices.into();
+                            let result = v128_or(
+                                u8x16_swizzle(Bytes::to_bytes(a).val.0, indices),
+                                u8x16_swizzle(
+                                    Bytes::to_bytes(b).val.0,
+                                    u8x16_sub(indices, u8x16_splat(16)),
+                                ),
+                            );
+                            Bytes::from_bytes(#bytes { val: #wrapper(result), simd: self })
+                        }
+                    }
+                }
+                256 => {
+                    let bytes_ty = vec_ty.bytes_ty();
+                    let bytes = bytes_ty.rust();
+                    let wrapper = bytes_ty.aligned_wrapper();
+                    let blocks = (0..2).map(Literal::usize_unsuffixed);
+
+                    quote! {
+                        #method_sig {
+                            let a = Bytes::to_bytes(a).val.0;
+                            let b = Bytes::to_bytes(b).val.0;
+                            let indices = indices.val.0;
+                            let result = [#({
+                                let indices = indices[#blocks];
+                                v128_or(
+                                    v128_or(
+                                        u8x16_swizzle(a[0], indices),
+                                        u8x16_swizzle(
+                                            a[1],
+                                            u8x16_sub(indices, u8x16_splat(16)),
+                                        ),
+                                    ),
+                                    v128_or(
+                                        u8x16_swizzle(
+                                            b[0],
+                                            u8x16_sub(indices, u8x16_splat(32)),
+                                        ),
+                                        u8x16_swizzle(
+                                            b[1],
+                                            u8x16_sub(indices, u8x16_splat(48)),
+                                        ),
+                                    ),
+                                )
+                            }),*];
+                            Bytes::from_bytes(#bytes { val: #wrapper(result), simd: self })
+                        }
+                    }
+                }
+                // Register spills make a decomposed 512-bit implementation less attractive
+                // than leaving instruction selection to the scalar fallback.
+                _ => crate::mk_fallback::Fallback.make_method(op, vec_ty),
+            },
             OpSig::Cvt {
                 target_ty,
                 scalar_bits,

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -7,10 +7,10 @@ use crate::arch::x86::{
     unpack_intrinsic,
 };
 use crate::generic::{
-    count_zeros_method, fallback_method, generic_block_combine, generic_block_split,
-    generic_mask_from_bitmask, generic_mask_set, generic_op_name, integer_lane_mask_rotate,
-    integer_lane_mask_splat_arg, recursive_swizzle_dyn_precise_body, reverse_method,
-    reverse_vector_mask_method,
+    concat_swizzle_dyn_precise_body, count_zeros_method, fallback_method, generic_block_combine,
+    generic_block_split, generic_mask_from_bitmask, generic_mask_set, generic_op_name,
+    integer_lane_mask_rotate, integer_lane_mask_splat_arg, recursive_swizzle_dyn_precise_body,
+    reverse_method, reverse_vector_mask_method,
 };
 use crate::level::Level;
 use crate::ops::{
@@ -344,6 +344,8 @@ impl Level for X86 {
             OpSig::SwizzleDynWithinBlocks => self.handle_swizzle_dyn_within_blocks(op, vec_ty),
             OpSig::SwizzleDyn => self.handle_swizzle_dyn(op, vec_ty),
             OpSig::SwizzleDynPrecise => self.handle_swizzle_dyn_precise(op, vec_ty),
+            OpSig::ConcatSwizzleDyn => self.handle_concat_swizzle_dyn(op, vec_ty),
+            OpSig::ConcatSwizzleDynPrecise => self.handle_concat_swizzle_dyn_precise(op, vec_ty),
             OpSig::Cvt {
                 target_ty,
                 scalar_bits,
@@ -1040,6 +1042,48 @@ fn avx512_permutexvar_intrinsic(vec_ty: &VecType) -> Ident {
 fn avx512_mask_blend_intrinsic(vec_ty: &VecType) -> Ident {
     let suffix = op_suffix(vec_ty.scalar, vec_ty.scalar_bits, false);
     intrinsic_ident("mask_blend", suffix, vec_ty.n_bits())
+}
+
+/// Three-blend AVX2 implementation for selecting from a concatenated pair of 256-bit tables.
+///
+/// This uses one fewer live YMM register than the zeroing-shuffle-and-OR formulation and has better
+/// throughput on anything but Haswell. It is slower on Haswell, which isn't relevant in 2026.
+/// Keeping fewer temporaries live also avoids spilling a YMM register
+/// after rustc inlines four copies into the 512-bit recursive expansion.
+fn avx2_concat_swizzle_256_precise(
+    a: TokenStream,
+    b: TokenStream,
+    indices: TokenStream,
+) -> TokenStream {
+    quote! {{
+        let a = #a;
+        let b = #b;
+        let indices = #indices;
+        let control = _mm256_adds_epu8(indices, _mm256_set1_epi8(0x40));
+        let a_swapped = _mm256_permute2x128_si256::<0x01>(a, a);
+        let b_swapped = _mm256_permute2x128_si256::<0x01>(b, b);
+
+        let flip_high_lane = _mm256_set_m128i(
+            _mm_set1_epi8(i8::MIN),
+            _mm_setzero_si128(),
+        );
+        let select_remote = _mm256_xor_si256(
+            _mm256_slli_epi16::<3>(control),
+            flip_high_lane,
+        );
+        let from_a = _mm256_blendv_epi8(
+            _mm256_shuffle_epi8(a, control),
+            _mm256_shuffle_epi8(a_swapped, control),
+            select_remote,
+        );
+        let from_b = _mm256_blendv_epi8(
+            _mm256_shuffle_epi8(b, control),
+            _mm256_shuffle_epi8(b_swapped, control),
+            select_remote,
+        );
+
+        _mm256_blendv_epi8(from_a, from_b, _mm256_slli_epi16::<2>(control))
+    }}
 }
 
 fn avx512_index_vector(vec_ty: &VecType, indices: impl IntoIterator<Item = usize>) -> TokenStream {
@@ -4402,10 +4446,11 @@ impl X86 {
             let body = match (*self, vec_ty.n_bits()) {
                 (Self::Sse4_2 | Self::Avx2, 128) => quote! {
                     let indices = indices.into();
-                    // Preserve the original high bit, and set it for indices 16..=127.
-                    // The added value only changes bits that PSHUFB ignores for valid indices.
-                    let index_out_of_range = _mm_add_epi8(indices, _mm_set1_epi8(112));
-                    let zeroing_indices = _mm_or_si128(indices, index_out_of_range);
+                    // Adding 0x70 preserves the selector nibble for indices 0..=15.
+                    // Every larger index gets its high bit set, so PSHUFB returns zero.
+                    // This is about equivalent for native sizes, but performs much better
+                    // when decomposing concat_swizzle_dyn into these ops.
+                    let zeroing_indices = _mm_adds_epu8(indices, _mm_set1_epi8(0x70));
                     let result = _mm_shuffle_epi8(Bytes::to_bytes(a).val.0, zeroing_indices);
                     let result_bytes = #bytes { val: #wrapper(result), simd: #token };
                 },
@@ -4452,6 +4497,155 @@ impl X86 {
                         // second, all-zero table.
                         let indices = #min(indices, #set1(#byte_count));
                         let result = #permute(bytes, indices, #setzero());
+                        let result_bytes = #bytes { val: #wrapper(result), simd: #token };
+                    }
+                }
+                _ => unreachable!(),
+            };
+
+            quote! {
+                #body
+                Bytes::from_bytes(result_bytes)
+            }
+        })
+    }
+
+    pub(crate) fn handle_concat_swizzle_dyn(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+        let bytes_ty = vec_ty.bytes_ty();
+        let bytes = bytes_ty.rust();
+        let wrapper = bytes_ty.aligned_wrapper();
+
+        if *self == Self::Sse2 || (*self == Self::Sse4_2 && vec_ty.n_bits() == 512) {
+            return fallback_method(op, vec_ty);
+        }
+
+        // These paths already have cheap precise building blocks. Using them here also keeps the
+        // concat implementation shared with wider recursive expansions. AVX2 deliberately uses
+        // the lower-register-pressure precise formulation for relaxed 256-bit swizzles.
+        if matches!(
+            (*self, vec_ty.n_bits()),
+            (Self::Sse4_2, 128 | 256) | (Self::Avx2, 128 | 256 | 512)
+        ) {
+            let method_sig = op.simd_trait_method_sig(vec_ty);
+            let precise = generic_op_name("concat_swizzle_dyn_precise", vec_ty);
+            return quote! {
+                #method_sig {
+                    self.#precise(a, b, indices)
+                }
+            };
+        }
+
+        self.kernel_method(op, vec_ty, |token| {
+            let body = match (*self, vec_ty.n_bits()) {
+                (Self::Avx512, 128 | 256 | 512) => {
+                    let permute = intrinsic_ident("permutex2var", "epi8", vec_ty.n_bits());
+                    quote! {
+                        let result = #permute(
+                            Bytes::to_bytes(a).val.0,
+                            indices.into(),
+                            Bytes::to_bytes(b).val.0,
+                        );
+                    }
+                }
+                _ => unreachable!(),
+            };
+
+            quote! {
+                #body
+                Bytes::from_bytes(#bytes {
+                    val: #wrapper(result),
+                    simd: #token,
+                })
+            }
+        })
+    }
+
+    pub(crate) fn handle_concat_swizzle_dyn_precise(
+        &self,
+        op: Op,
+        vec_ty: &VecType,
+    ) -> TokenStream {
+        let bytes_ty = vec_ty.bytes_ty();
+        let bytes = bytes_ty.rust();
+        let wrapper = bytes_ty.aligned_wrapper();
+
+        if *self == Self::Sse2 || (*self == Self::Sse4_2 && vec_ty.n_bits() == 512) {
+            return fallback_method(op, vec_ty);
+        }
+
+        if matches!(
+            (*self, vec_ty.n_bits()),
+            (Self::Sse4_2, 128 | 256) | (Self::Avx2, 128)
+        ) {
+            let method_sig = op.simd_trait_method_sig(vec_ty);
+            let body = concat_swizzle_dyn_precise_body(vec_ty, &quote! { self });
+            return quote! {
+                #method_sig {
+                    #body
+                    Bytes::from_bytes(result_bytes)
+                }
+            };
+        }
+
+        self.kernel_method(op, vec_ty, |token| {
+            let body = match (*self, vec_ty.n_bits()) {
+                (Self::Avx2, 256) => {
+                    let result = avx2_concat_swizzle_256_precise(
+                        quote! { Bytes::to_bytes(a).val.0 },
+                        quote! { Bytes::to_bytes(b).val.0 },
+                        quote! { indices.into() },
+                    );
+                    quote! {
+                        let result = #result;
+                        let result_bytes = #bytes { val: #wrapper(result), simd: #token };
+                    }
+                }
+                (Self::Avx2, 512) => {
+                    let low_from_a = avx2_concat_swizzle_256_precise(
+                        quote! { a_bytes[0] },
+                        quote! { a_bytes[1] },
+                        quote! { indices_bytes[0] },
+                    );
+                    let low_from_b = avx2_concat_swizzle_256_precise(
+                        quote! { b_bytes[0] },
+                        quote! { b_bytes[1] },
+                        quote! { _mm256_sub_epi8(indices_bytes[0], second_table_offset) },
+                    );
+                    let high_from_a = avx2_concat_swizzle_256_precise(
+                        quote! { a_bytes[0] },
+                        quote! { a_bytes[1] },
+                        quote! { indices_bytes[1] },
+                    );
+                    let high_from_b = avx2_concat_swizzle_256_precise(
+                        quote! { b_bytes[0] },
+                        quote! { b_bytes[1] },
+                        quote! { _mm256_sub_epi8(indices_bytes[1], second_table_offset) },
+                    );
+                    quote! {
+                        let a_bytes = Bytes::to_bytes(a).val.0;
+                        let b_bytes = Bytes::to_bytes(b).val.0;
+                        let indices_bytes = indices.val.0;
+                        let second_table_offset = _mm256_set1_epi8(64);
+                        let result_low = _mm256_or_si256(#low_from_a, #low_from_b);
+                        let result_high = _mm256_or_si256(#high_from_a, #high_from_b);
+                        let result_bytes = #bytes {
+                            val: #wrapper([result_low, result_high]),
+                            simd: #token,
+                        };
+                    }
+                }
+                (Self::Avx512, 128 | 256 | 512) => {
+                    let cmplt = intrinsic_ident("cmplt", "epu8_mask", vec_ty.n_bits());
+                    let maskz_permute =
+                        intrinsic_ident("maskz_permutex2var", "epi8", vec_ty.n_bits());
+                    let set1 = set1_intrinsic(&bytes_ty);
+                    let table_len = signed_literal((bytes_ty.len * 2) as u64, 8);
+                    quote! {
+                        let a_bytes = Bytes::to_bytes(a).val.0;
+                        let b_bytes = Bytes::to_bytes(b).val.0;
+                        let indices = indices.into();
+                        let in_range = #cmplt(indices, #set1(#table_len));
+                        let result = #maskz_permute(in_range, a_bytes, indices, b_bytes);
                         let result_bytes = #bytes { val: #wrapper(result), simd: #token };
                     }
                 }

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -101,6 +101,13 @@ pub(crate) enum OpSig {
     /// Takes a vector and a same-width byte-index vector, and returns the original vector type with its bytes
     /// dynamically swizzled across the whole vector. Out-of-range indices produce zero.
     SwizzleDynPrecise,
+    /// Takes two vectors and a same-width byte-index vector, and returns the original vector type with its bytes
+    /// dynamically selected from the concatenation of both vectors. Out-of-range indices produce
+    /// implementation-defined bytes.
+    ConcatSwizzleDyn,
+    /// Takes two vectors and a same-width byte-index vector, and returns the original vector type with its bytes
+    /// dynamically selected from the concatenation of both vectors. Out-of-range indices produce zero.
+    ConcatSwizzleDynPrecise,
     /// Takes a single argument of the source vector type, and returns a vector type of the target scalar type and the
     /// same length.
     Cvt {
@@ -336,6 +343,13 @@ impl Op {
                 let bytes_ty = vec_ty.bytes_ty().rust();
                 (vec![vec.clone(), quote! { #bytes_ty<#simd_ty> }], vec)
             }
+            OpSig::ConcatSwizzleDyn | OpSig::ConcatSwizzleDynPrecise => {
+                let bytes_ty = vec_ty.bytes_ty().rust();
+                (
+                    vec![vec.clone(), vec.clone(), quote! { #bytes_ty<#simd_ty> }],
+                    vec,
+                )
+            }
             OpSig::Cvt {
                 target_ty,
                 scalar_bits,
@@ -432,6 +446,14 @@ impl Op {
                 let arg0 = &arg_names[0];
                 let arg1 = &arg_names[1];
                 quote! { (#arg0, #arg1: impl SimdInto<Self::Bytes, S>) -> Self }
+            }
+            OpSig::ConcatSwizzleDyn | OpSig::ConcatSwizzleDynPrecise => {
+                let arg0 = &arg_names[0];
+                let arg1 = &arg_names[1];
+                let arg2 = &arg_names[2];
+                quote! {
+                    (#arg0, #arg1: impl SimdInto<Self, S>, #arg2: impl SimdInto<Self::Bytes, S>) -> Self
+                }
             }
             OpSig::Compare => {
                 let arg0 = &arg_names[0];
@@ -623,6 +645,21 @@ const BASE_OPS: &[Op] = &[
         OpSig::SwizzleDynPrecise,
         "Dynamically swizzle this vector's bytes across the whole vector.\n\n\
         The `indices` operand is a same-width byte vector. For each output byte, index values within the vector's byte length select the corresponding byte from the input vector. Out-of-range indices produce zero.",
+    ),
+    Op::new(
+        "concat_swizzle_dyn",
+        OpKind::BaseTraitMethod,
+        OpSig::ConcatSwizzleDyn,
+        "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\n\
+        The `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices safely produce implementation-defined byte values.\n\n\
+        Use [`SimdBase::concat_swizzle_dyn_precise`] if out-of-range indices must produce zero.",
+    ),
+    Op::new(
+        "concat_swizzle_dyn_precise",
+        OpKind::BaseTraitMethod,
+        OpSig::ConcatSwizzleDynPrecise,
+        "Dynamically select bytes from the concatenation of this vector and `rhs`.\n\n\
+        The `indices` operand is a same-width byte vector. For each output byte, index values within the concatenated vectors' byte length select the corresponding byte: the first vector comes first, followed by `rhs`. Out-of-range indices produce zero.",
     ),
 ];
 
@@ -1723,7 +1760,11 @@ impl OpSig {
     pub(crate) fn should_route_swizzle_through_bytes(&self, vec_ty: &VecType) -> bool {
         matches!(
             self,
-            Self::SwizzleDynWithinBlocks | Self::SwizzleDyn | Self::SwizzleDynPrecise
+            Self::SwizzleDynWithinBlocks
+                | Self::SwizzleDyn
+                | Self::SwizzleDynPrecise
+                | Self::ConcatSwizzleDyn
+                | Self::ConcatSwizzleDynPrecise
         ) && *vec_ty != vec_ty.bytes_ty()
     }
 
@@ -1741,6 +1782,8 @@ impl OpSig {
                 | Self::RotateElements { .. }
                 | Self::SwizzleDyn
                 | Self::SwizzleDynPrecise
+                | Self::ConcatSwizzleDyn
+                | Self::ConcatSwizzleDynPrecise
                 | Self::Slide {
                     granularity: SlideGranularity::AcrossBlocks,
                     ..
@@ -1789,6 +1832,7 @@ impl OpSig {
             Self::SwizzleDynWithinBlocks | Self::SwizzleDyn | Self::SwizzleDynPrecise => {
                 &["a", "indices"]
             }
+            Self::ConcatSwizzleDyn | Self::ConcatSwizzleDynPrecise => &["a", "b", "indices"],
             Self::Binary
             | Self::Compare
             | Self::Combine { .. }
@@ -1823,6 +1867,7 @@ impl OpSig {
             Self::SwizzleDynWithinBlocks | Self::SwizzleDyn | Self::SwizzleDynPrecise => {
                 &["self", "indices"]
             }
+            Self::ConcatSwizzleDyn | Self::ConcatSwizzleDynPrecise => &["self", "rhs", "indices"],
             Self::Binary
             | Self::Compare
             | Self::Zip { .. }
@@ -1863,6 +1908,12 @@ impl OpSig {
                 quote! { #arg0, #arg1.simd_into(self.simd) }
             }
             Self::Ternary => {
+                let arg0 = &arg_names[0];
+                let arg1 = &arg_names[1];
+                let arg2 = &arg_names[2];
+                quote! { #arg0, #arg1.simd_into(self.simd), #arg2.simd_into(self.simd) }
+            }
+            Self::ConcatSwizzleDyn | Self::ConcatSwizzleDynPrecise => {
                 let arg0 = &arg_names[0];
                 let arg1 = &arg_names[1];
                 let arg2 = &arg_names[2];

--- a/fearless_simd_tests/tests/harness/ops/concat_swizzle_dyn.rs
+++ b/fearless_simd_tests/tests/harness/ops/concat_swizzle_dyn.rs
@@ -1,0 +1,111 @@
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use fearless_simd::*;
+use fearless_simd_dev_macros::simd_test;
+
+#[simd_test]
+fn concat_swizzle_dyn_u8x16<S: Simd>(simd: S) {
+    let a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    let b = [
+        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+    ];
+    let indices = [15, 16, 31, 0, 1, 14, 17, 30, 7, 8, 23, 24, 2, 13, 18, 29];
+    let expected = [16, 17, 32, 1, 2, 15, 18, 31, 8, 9, 24, 25, 3, 14, 19, 30];
+
+    let a = u8x16::simd_from(simd, a);
+    let b = u8x16::simd_from(simd, b);
+    let indices = u8x16::simd_from(simd, indices);
+
+    assert_eq!(*a.concat_swizzle_dyn(b, indices), expected);
+}
+
+#[simd_test]
+fn concat_swizzle_dyn_u8x32_generic<S: Simd>(simd: S) {
+    #[inline(always)]
+    fn do_concat_swizzle<S: Simd, V: SimdBase<S>>(a: V, b: V, indices: V::Bytes) -> V {
+        a.concat_swizzle_dyn(b, indices)
+    }
+
+    let a = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32,
+    ];
+    let b = [
+        33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+        56, 57, 58, 59, 60, 61, 62, 63, 64,
+    ];
+    let indices = [
+        0, 15, 16, 31, 32, 47, 48, 63, 1, 14, 17, 30, 33, 46, 49, 62, 7, 8, 23, 24, 39, 40, 55, 56,
+        2, 13, 18, 29, 34, 45, 50, 61,
+    ];
+    let expected = [
+        1, 16, 17, 32, 33, 48, 49, 64, 2, 15, 18, 31, 34, 47, 50, 63, 8, 9, 24, 25, 40, 41, 56, 57,
+        3, 14, 19, 30, 35, 46, 51, 62,
+    ];
+
+    let a = u8x32::simd_from(simd, a);
+    let b = u8x32::simd_from(simd, b);
+    let indices = u8x32::simd_from(simd, indices);
+    let result = do_concat_swizzle::<S, u8x32<S>>(a, b, indices);
+
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn concat_swizzle_dyn_u8x64<S: Simd>(simd: S) {
+    let a = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+        49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64,
+    ];
+    let b = [
+        65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87,
+        88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107,
+        108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125,
+        126, 127, 128,
+    ];
+    let indices = [
+        0, 15, 16, 31, 32, 47, 48, 63, 64, 79, 80, 95, 96, 111, 112, 127, 1, 14, 17, 30, 33, 46,
+        49, 62, 65, 78, 81, 94, 97, 110, 113, 126, 7, 8, 23, 24, 39, 40, 55, 56, 71, 72, 87, 88,
+        103, 104, 119, 120, 2, 13, 18, 29, 34, 45, 50, 61, 66, 77, 82, 93, 98, 109, 114, 125,
+    ];
+    let expected = [
+        1, 16, 17, 32, 33, 48, 49, 64, 65, 80, 81, 96, 97, 112, 113, 128, 2, 15, 18, 31, 34, 47,
+        50, 63, 66, 79, 82, 95, 98, 111, 114, 127, 8, 9, 24, 25, 40, 41, 56, 57, 72, 73, 88, 89,
+        104, 105, 120, 121, 3, 14, 19, 30, 35, 46, 51, 62, 67, 78, 83, 94, 99, 110, 115, 126,
+    ];
+
+    let a = u8x64::simd_from(simd, a);
+    let b = u8x64::simd_from(simd, b);
+    let indices = u8x64::simd_from(simd, indices);
+
+    assert_eq!(*a.concat_swizzle_dyn(b, indices), expected);
+}
+
+#[simd_test]
+fn concat_swizzle_dyn_f32x8_bytes<S: Simd>(simd: S) {
+    let a_bytes = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32,
+    ];
+    let b_bytes = [
+        33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+        56, 57, 58, 59, 60, 61, 62, 63, 64,
+    ];
+    let indices = [
+        63, 48, 47, 32, 31, 16, 15, 0, 1, 14, 17, 30, 33, 46, 49, 62, 7, 8, 23, 24, 39, 40, 55, 56,
+        2, 13, 18, 29, 34, 45, 50, 61,
+    ];
+    let expected = [
+        64, 49, 48, 33, 32, 17, 16, 1, 2, 15, 18, 31, 34, 47, 50, 63, 8, 9, 24, 25, 40, 41, 56, 57,
+        3, 14, 19, 30, 35, 46, 51, 62,
+    ];
+
+    let a: f32x8<S> = u8x32::simd_from(simd, a_bytes).bitcast();
+    let b: f32x8<S> = u8x32::simd_from(simd, b_bytes).bitcast();
+    let indices = u8x32::simd_from(simd, indices);
+    let result: u8x32<S> = a.concat_swizzle_dyn(b, indices).bitcast();
+
+    assert_eq!(*result, expected);
+}

--- a/fearless_simd_tests/tests/harness/ops/concat_swizzle_dyn_precise.rs
+++ b/fearless_simd_tests/tests/harness/ops/concat_swizzle_dyn_precise.rs
@@ -1,0 +1,113 @@
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use fearless_simd::*;
+use fearless_simd_dev_macros::simd_test;
+
+#[simd_test]
+fn concat_swizzle_dyn_precise_u8x16<S: Simd>(simd: S) {
+    let a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    let b = [
+        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+    ];
+    let indices = [
+        15, 16, 31, 0, 32, 127, 128, 255, 1, 14, 17, 30, 2, 13, 18, 29,
+    ];
+    let expected = [16, 17, 32, 1, 0, 0, 0, 0, 2, 15, 18, 31, 3, 14, 19, 30];
+
+    let a = u8x16::simd_from(simd, a);
+    let b = u8x16::simd_from(simd, b);
+    let indices = u8x16::simd_from(simd, indices);
+
+    assert_eq!(*a.concat_swizzle_dyn_precise(b, indices), expected);
+}
+
+#[simd_test]
+fn concat_swizzle_dyn_precise_u8x32_generic<S: Simd>(simd: S) {
+    #[inline(always)]
+    fn do_concat_swizzle<S: Simd, V: SimdBase<S>>(a: V, b: V, indices: V::Bytes) -> V {
+        a.concat_swizzle_dyn_precise(b, indices)
+    }
+
+    let a = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32,
+    ];
+    let b = [
+        33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+        56, 57, 58, 59, 60, 61, 62, 63, 64,
+    ];
+    let indices = [
+        0, 15, 16, 31, 32, 47, 48, 63, 64, 127, 128, 255, 1, 14, 17, 30, 33, 46, 49, 62, 65, 126,
+        129, 254, 7, 8, 23, 24, 39, 40, 55, 56,
+    ];
+    let expected = [
+        1, 16, 17, 32, 33, 48, 49, 64, 0, 0, 0, 0, 2, 15, 18, 31, 34, 47, 50, 63, 0, 0, 0, 0, 8, 9,
+        24, 25, 40, 41, 56, 57,
+    ];
+
+    let a = u8x32::simd_from(simd, a);
+    let b = u8x32::simd_from(simd, b);
+    let indices = u8x32::simd_from(simd, indices);
+    let result = do_concat_swizzle::<S, u8x32<S>>(a, b, indices);
+
+    assert_eq!(*result, expected);
+}
+
+#[simd_test]
+fn concat_swizzle_dyn_precise_u8x64<S: Simd>(simd: S) {
+    let a = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+        49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64,
+    ];
+    let b = [
+        65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87,
+        88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107,
+        108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125,
+        126, 127, 128,
+    ];
+    let indices = [
+        0, 15, 16, 31, 32, 47, 48, 63, 64, 79, 80, 95, 96, 111, 112, 127, 128, 255, 129, 254, 130,
+        253, 131, 252, 1, 14, 17, 30, 33, 46, 49, 62, 65, 78, 81, 94, 97, 110, 113, 126, 7, 8, 23,
+        24, 39, 40, 55, 56, 71, 72, 87, 88, 103, 104, 119, 120, 2, 13, 18, 29, 66, 77, 114, 125,
+    ];
+    let expected = [
+        1, 16, 17, 32, 33, 48, 49, 64, 65, 80, 81, 96, 97, 112, 113, 128, 0, 0, 0, 0, 0, 0, 0, 0,
+        2, 15, 18, 31, 34, 47, 50, 63, 66, 79, 82, 95, 98, 111, 114, 127, 8, 9, 24, 25, 40, 41, 56,
+        57, 72, 73, 88, 89, 104, 105, 120, 121, 3, 14, 19, 30, 67, 78, 115, 126,
+    ];
+
+    let a = u8x64::simd_from(simd, a);
+    let b = u8x64::simd_from(simd, b);
+    let indices = u8x64::simd_from(simd, indices);
+
+    assert_eq!(*a.concat_swizzle_dyn_precise(b, indices), expected);
+}
+
+#[simd_test]
+fn concat_swizzle_dyn_precise_f32x8_bytes<S: Simd>(simd: S) {
+    let a_bytes = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32,
+    ];
+    let b_bytes = [
+        33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+        56, 57, 58, 59, 60, 61, 62, 63, 64,
+    ];
+    let indices = [
+        63, 48, 47, 32, 31, 16, 15, 0, 64, 127, 128, 255, 33, 46, 49, 62, 7, 8, 23, 24, 39, 40, 55,
+        56, 65, 126, 129, 254, 34, 45, 50, 61,
+    ];
+    let expected = [
+        64, 49, 48, 33, 32, 17, 16, 1, 0, 0, 0, 0, 34, 47, 50, 63, 8, 9, 24, 25, 40, 41, 56, 57, 0,
+        0, 0, 0, 35, 46, 51, 62,
+    ];
+
+    let a: f32x8<S> = u8x32::simd_from(simd, a_bytes).bitcast();
+    let b: f32x8<S> = u8x32::simd_from(simd, b_bytes).bitcast();
+    let indices = u8x32::simd_from(simd, indices);
+    let result: u8x32<S> = a.concat_swizzle_dyn_precise(b, indices).bitcast();
+
+    assert_eq!(*result, expected);
+}

--- a/fearless_simd_tests/tests/harness/ops/mod.rs
+++ b/fearless_simd_tests/tests/harness/ops/mod.rs
@@ -17,6 +17,8 @@ mod bitcast;
 mod block_splat;
 mod ceil;
 mod combine;
+mod concat_swizzle_dyn;
+mod concat_swizzle_dyn_precise;
 mod copysign;
 mod count_ones;
 mod count_zeros;


### PR DESCRIPTION
1. Add concat_swizzle_dyn and concat_swizzle_dyn_precise
2. Change swizzle_dyn_precise SSE4.2 128-bit formulation; it's one fewer instruction, slightly worse latency, but much better optimization when larger vectors are decomposed into it.
3. Use [`select_unpredictable`](https://doc.rust-lang.org/stable/std/hint/fn.select_unpredictable.html) stabilized in 1.88 in scalar fallbacks of concat_swizzle_dyn_precise and swizzle_dyn_precise.

**Rationale for the branchless formulation:**  `cmov` is far from a silver bullet and is [often a bad idea](https://yarchive.net/comp/linux/cmov.html). In my benchmarks this is 20% to 40% slower than branches for swizzle_dyn_precise if the indices are all out of range, but avoids a 5x (400%) performance degradation on unpredictable indices. If you know your indices are predictable, you don't use `_precise` in the first place, so tuning for unpredictability seems fine. Most importantly, removing branches helps autovectorizer a lot, so we get more reliable autovectorization on e.g. RISC-V, which is the primary use case.

Implementation-wise, NEON and AVX-512 are straightforward with native-ish instructions, SSE4.2 uses [the same decomposition idea](https://shnatsel.github.io/improving-std-simd-swizzle-dyn/#doubling-the-vector-width) as swizzle_dyn_precise, and AVX2 needs babysitting as always.

The first commit is squashed because I did a bunch of experiments with different formulations, e.g. a specialized one for 256-bit AVX2 that reduces shuffle port pressure on haswell and doesn't regress recent AVX2 much if at all, but in the end decided those are not worth the extra complexity.

I'm not thrilled by the `lhs.concat_swizzle_dyn(rhs, indices)` API but I don't see how to do better without it getting really awkward in other ways: `concat_swizzle_dyn(simd, lhs, rhs, indices)` isn't any better and breaks convention, and `indices.concat_swizzle_dyn(lhs, rhs)` runs into issues with matching vector lengths.