### PR TITLE
Add reverse() to both vectors and masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find its changes [documented below](#070-2026-08-11).
 
 ### Added
 
-- Added `reverse` for all non-mask vector types.
+- Added `reverse` for all SIMD vector and mask types.
 - Added lane-wise `count_ones` and `count_zeros` operations for all integer vector types and backends.
 - Added `mul_add_precise` and `mul_sub_precise` for floating-point vectors. They guarantee the infinite-precision product-plus-add rounded once, including on SIMD levels without hardware fused multiply-add instructions. They are not susceptible to the [bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library, `std::simd` and musl libc that causes incorrect rounding for subnormal results. SSE4.2 gets SIMD emulation of these operations for better performance. ([#323][], [#324][] by [@Shnatsel][])
 - Documented the storage representation of the SIMD vector types. The documented representation will not change without a semver major version change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can find its changes [documented below](#070-2026-08-11).
 
 ### Added
 
+- Added `reverse` for all non-mask vector types.
 - Added lane-wise `count_ones` and `count_zeros` operations for all integer vector types and backends.
 - Added `mul_add_precise` and `mul_sub_precise` for floating-point vectors. They guarantee the infinite-precision product-plus-add rounded once, including on SIMD levels without hardware fused multiply-add instructions. They are not susceptible to the [bug](https://github.com/rust-lang/compiler-builtins/issues/1262) in Rust standard library, `std::simd` and musl libc that causes incorrect rounding for subnormal results. SSE4.2 gets SIMD emulation of these operations for better performance. ([#323][], [#324][] by [@Shnatsel][])
 - Documented the storage representation of the SIMD vector types. The documented representation will not change without a semver major version change.

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -126,6 +126,12 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_f32x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -634,6 +640,12 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        let indices: u8x16<Self> =
+            [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].simd_into(self);
+        self.swizzle_dyn_i8x16(a, indices)
+    }
+    #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         if SHIFT >= 16usize {
             return b;
@@ -1088,6 +1100,12 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        let indices: u8x16<Self> =
+            [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].simd_into(self);
+        self.swizzle_dyn_u8x16(a, indices)
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1748,6 +1766,12 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        let indices: u8x16<Self> =
+            [14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1].simd_into(self);
+        self.swizzle_dyn_i16x8(a, indices)
+    }
+    #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -2198,6 +2222,12 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        let indices: u8x16<Self> =
+            [14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1].simd_into(self);
+        self.swizzle_dyn_u16x8(a, indices)
     }
     #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2817,6 +2847,12 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_i32x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -3249,6 +3285,12 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_u32x4(a, indices)
     }
     #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -3853,6 +3895,12 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_f64x2(a, indices)
+    }
+    #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -4373,6 +4421,12 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_i64x2(a, indices)
+    }
+    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -4782,6 +4836,12 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_u64x2(a, indices)
     }
     #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
@@ -5342,6 +5402,15 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let indices: u8x32<Self> = [
+            28, 29, 30, 31, 24, 25, 26, 27, 20, 21, 22, 23, 16, 17, 18, 19, 12, 13, 14, 15, 8, 9,
+            10, 11, 4, 5, 6, 7, 0, 1, 2, 3,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_f32x8(a, indices)
+    }
+    #[inline(always)]
     fn slide_f32x8<const SHIFT: usize>(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -5838,6 +5907,15 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i8x32(self, a: i8x32<Self>) -> i8x32<Self> {
+        let indices: u8x32<Self> = [
+            31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
+            9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_i8x32(a, indices)
+    }
+    #[inline(always)]
     fn slide_i8x32<const SHIFT: usize>(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         if SHIFT >= 32usize {
             return b;
@@ -6310,6 +6388,15 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
+        let indices: u8x32<Self> = [
+            31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
+            9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_u8x32(a, indices)
     }
     #[inline(always)]
     fn slide_u8x32<const SHIFT: usize>(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
@@ -7016,6 +7103,15 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i16x16(self, a: i16x16<Self>) -> i16x16<Self> {
+        let indices: u8x32<Self> = [
+            30, 31, 28, 29, 26, 27, 24, 25, 22, 23, 20, 21, 18, 19, 16, 17, 14, 15, 12, 13, 10, 11,
+            8, 9, 6, 7, 4, 5, 2, 3, 0, 1,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_i16x16(a, indices)
+    }
+    #[inline(always)]
     fn slide_i16x16<const SHIFT: usize>(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         if SHIFT >= 16usize {
             return b;
@@ -7478,6 +7574,15 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u16x16(self, a: u16x16<Self>) -> u16x16<Self> {
+        let indices: u8x32<Self> = [
+            30, 31, 28, 29, 26, 27, 24, 25, 22, 23, 20, 21, 18, 19, 16, 17, 14, 15, 12, 13, 10, 11,
+            8, 9, 6, 7, 4, 5, 2, 3, 0, 1,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_u16x16(a, indices)
     }
     #[inline(always)]
     fn slide_u16x16<const SHIFT: usize>(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -8125,6 +8230,15 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i32x8(self, a: i32x8<Self>) -> i32x8<Self> {
+        let indices: u8x32<Self> = [
+            28, 29, 30, 31, 24, 25, 26, 27, 20, 21, 22, 23, 16, 17, 18, 19, 12, 13, 14, 15, 8, 9,
+            10, 11, 4, 5, 6, 7, 0, 1, 2, 3,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_i32x8(a, indices)
+    }
+    #[inline(always)]
     fn slide_i32x8<const SHIFT: usize>(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -8557,6 +8671,15 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u32x8(self, a: u32x8<Self>) -> u32x8<Self> {
+        let indices: u8x32<Self> = [
+            28, 29, 30, 31, 24, 25, 26, 27, 20, 21, 22, 23, 16, 17, 18, 19, 12, 13, 14, 15, 8, 9,
+            10, 11, 4, 5, 6, 7, 0, 1, 2, 3,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_u32x8(a, indices)
     }
     #[inline(always)]
     fn slide_u32x8<const SHIFT: usize>(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
@@ -9177,6 +9300,15 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        let indices: u8x32<Self> = [
+            24, 25, 26, 27, 28, 29, 30, 31, 16, 17, 18, 19, 20, 21, 22, 23, 8, 9, 10, 11, 12, 13,
+            14, 15, 0, 1, 2, 3, 4, 5, 6, 7,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_f64x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_f64x4<const SHIFT: usize>(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -9706,6 +9838,15 @@ impl Simd for Avx2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i64x4(self, a: i64x4<Self>) -> i64x4<Self> {
+        let indices: u8x32<Self> = [
+            24, 25, 26, 27, 28, 29, 30, 31, 16, 17, 18, 19, 20, 21, 22, 23, 8, 9, 10, 11, 12, 13,
+            14, 15, 0, 1, 2, 3, 4, 5, 6, 7,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_i64x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_i64x4<const SHIFT: usize>(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -10124,6 +10265,15 @@ impl Simd for Avx2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u64x4(self, a: u64x4<Self>) -> u64x4<Self> {
+        let indices: u8x32<Self> = [
+            24, 25, 26, 27, 28, 29, 30, 31, 16, 17, 18, 19, 20, 21, 22, 23, 8, 9, 10, 11, 12, 13,
+            14, 15, 0, 1, 2, 3, 4, 5, 6, 7,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_u64x4(a, indices)
     }
     #[inline(always)]
     fn slide_u64x4<const SHIFT: usize>(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {

--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -1676,6 +1676,18 @@ impl Simd for Avx2 {
         self.xor_mask8x16(a, self.splat_mask8x16(true))
     }
     #[inline(always)]
+    fn reverse_mask8x16(self, a: mask8x16<Self>) -> mask8x16<Self> {
+        let lanes = i8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i8x16(lanes);
+        mask8x16 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask8x16(
         self,
         a: mask8x16<Self>,
@@ -2757,6 +2769,18 @@ impl Simd for Avx2 {
         self.xor_mask16x8(a, self.splat_mask16x8(true))
     }
     #[inline(always)]
+    fn reverse_mask16x8(self, a: mask16x8<Self>) -> mask16x8<Self> {
+        let lanes = i16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i16x8(lanes);
+        mask16x8 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask16x8(
         self,
         a: mask16x8<Self>,
@@ -3803,6 +3827,18 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn not_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
         self.xor_mask32x4(a, self.splat_mask32x4(true))
+    }
+    #[inline(always)]
+    fn reverse_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
+        let lanes = i32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i32x4(lanes);
+        mask32x4 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask32x4(
@@ -5310,6 +5346,18 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn not_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
         self.xor_mask64x2(a, self.splat_mask64x2(true))
+    }
+    #[inline(always)]
+    fn reverse_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
+        let lanes = i64x2 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i64x2(lanes);
+        mask64x2 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask64x2(
@@ -7003,6 +7051,18 @@ impl Simd for Avx2 {
         self.xor_mask8x32(a, self.splat_mask8x32(true))
     }
     #[inline(always)]
+    fn reverse_mask8x32(self, a: mask8x32<Self>) -> mask8x32<Self> {
+        let lanes = i8x32 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i8x32(lanes);
+        mask8x32 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask8x32(
         self,
         a: mask8x32<Self>,
@@ -8130,6 +8190,18 @@ impl Simd for Avx2 {
         self.xor_mask16x16(a, self.splat_mask16x16(true))
     }
     #[inline(always)]
+    fn reverse_mask16x16(self, a: mask16x16<Self>) -> mask16x16<Self> {
+        let lanes = i16x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i16x16(lanes);
+        mask16x16 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask16x16(
         self,
         a: mask16x16<Self>,
@@ -9198,6 +9270,18 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn not_mask32x8(self, a: mask32x8<Self>) -> mask32x8<Self> {
         self.xor_mask32x8(a, self.splat_mask32x8(true))
+    }
+    #[inline(always)]
+    fn reverse_mask32x8(self, a: mask32x8<Self>) -> mask32x8<Self> {
+        let lanes = i32x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i32x8(lanes);
+        mask32x8 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask32x8(
@@ -10749,6 +10833,18 @@ impl Simd for Avx2 {
     #[inline(always)]
     fn not_mask64x4(self, a: mask64x4<Self>) -> mask64x4<Self> {
         self.xor_mask64x4(a, self.splat_mask64x4(true))
+    }
+    #[inline(always)]
+    fn reverse_mask64x4(self, a: mask64x4<Self>) -> mask64x4<Self> {
+        let lanes = i64x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i64x4(lanes);
+        mask64x4 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask64x4(

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -400,6 +400,12 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_f32x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -869,6 +875,12 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        let indices: u8x16<Self> =
+            [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].simd_into(self);
+        self.swizzle_dyn_i8x16(a, indices)
+    }
+    #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         if SHIFT >= 16usize {
             return b;
@@ -1305,6 +1317,12 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        let indices: u8x16<Self> =
+            [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].simd_into(self);
+        self.swizzle_dyn_u8x16(a, indices)
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1889,6 +1907,12 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        let indices: u8x16<Self> =
+            [14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1].simd_into(self);
+        self.swizzle_dyn_i16x8(a, indices)
+    }
+    #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -2307,6 +2331,12 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        let indices: u8x16<Self> =
+            [14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1].simd_into(self);
+        self.swizzle_dyn_u16x8(a, indices)
     }
     #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2829,6 +2859,12 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_i32x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -3241,6 +3277,12 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_u32x4(a, indices)
     }
     #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -3758,6 +3800,12 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_f64x2(a, indices)
+    }
+    #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -4227,6 +4275,12 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_i64x2(a, indices)
+    }
+    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -4619,6 +4673,12 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_u64x2(a, indices)
     }
     #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {
@@ -5113,6 +5173,15 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let indices: u8x32<Self> = [
+            28, 29, 30, 31, 24, 25, 26, 27, 20, 21, 22, 23, 16, 17, 18, 19, 12, 13, 14, 15, 8, 9,
+            10, 11, 4, 5, 6, 7, 0, 1, 2, 3,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_f32x8(a, indices)
     }
     #[inline(always)]
     fn slide_f32x8<const SHIFT: usize>(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
@@ -5640,6 +5709,15 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i8x32(self, a: i8x32<Self>) -> i8x32<Self> {
+        let indices: u8x32<Self> = [
+            31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
+            9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_i8x32(a, indices)
+    }
+    #[inline(always)]
     fn slide_i8x32<const SHIFT: usize>(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -6125,6 +6203,15 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
+        let indices: u8x32<Self> = [
+            31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
+            9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_u8x32(a, indices)
     }
     #[inline(always)]
     fn slide_u8x32<const SHIFT: usize>(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
@@ -6772,6 +6859,15 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i16x16(self, a: i16x16<Self>) -> i16x16<Self> {
+        let indices: u8x32<Self> = [
+            30, 31, 28, 29, 26, 27, 24, 25, 22, 23, 20, 21, 18, 19, 16, 17, 14, 15, 12, 13, 10, 11,
+            8, 9, 6, 7, 4, 5, 2, 3, 0, 1,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_i16x16(a, indices)
+    }
+    #[inline(always)]
     fn slide_i16x16<const SHIFT: usize>(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -7231,6 +7327,15 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u16x16(self, a: u16x16<Self>) -> u16x16<Self> {
+        let indices: u8x32<Self> = [
+            30, 31, 28, 29, 26, 27, 24, 25, 22, 23, 20, 21, 18, 19, 16, 17, 14, 15, 12, 13, 10, 11,
+            8, 9, 6, 7, 4, 5, 2, 3, 0, 1,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_u16x16(a, indices)
     }
     #[inline(always)]
     fn slide_u16x16<const SHIFT: usize>(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
@@ -7808,6 +7913,15 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i32x8(self, a: i32x8<Self>) -> i32x8<Self> {
+        let indices: u8x32<Self> = [
+            28, 29, 30, 31, 24, 25, 26, 27, 20, 21, 22, 23, 16, 17, 18, 19, 12, 13, 14, 15, 8, 9,
+            10, 11, 4, 5, 6, 7, 0, 1, 2, 3,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_i32x8(a, indices)
+    }
+    #[inline(always)]
     fn slide_i32x8<const SHIFT: usize>(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -8255,6 +8369,15 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u32x8(self, a: u32x8<Self>) -> u32x8<Self> {
+        let indices: u8x32<Self> = [
+            28, 29, 30, 31, 24, 25, 26, 27, 20, 21, 22, 23, 16, 17, 18, 19, 12, 13, 14, 15, 8, 9,
+            10, 11, 4, 5, 6, 7, 0, 1, 2, 3,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_u32x8(a, indices)
     }
     #[inline(always)]
     fn slide_u32x8<const SHIFT: usize>(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
@@ -8821,6 +8944,15 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        let indices: u8x32<Self> = [
+            24, 25, 26, 27, 28, 29, 30, 31, 16, 17, 18, 19, 20, 21, 22, 23, 8, 9, 10, 11, 12, 13,
+            14, 15, 0, 1, 2, 3, 4, 5, 6, 7,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_f64x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_f64x4<const SHIFT: usize>(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -9333,6 +9465,15 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i64x4(self, a: i64x4<Self>) -> i64x4<Self> {
+        let indices: u8x32<Self> = [
+            24, 25, 26, 27, 28, 29, 30, 31, 16, 17, 18, 19, 20, 21, 22, 23, 8, 9, 10, 11, 12, 13,
+            14, 15, 0, 1, 2, 3, 4, 5, 6, 7,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_i64x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_i64x4<const SHIFT: usize>(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -9750,6 +9891,15 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u64x4(self, a: u64x4<Self>) -> u64x4<Self> {
+        let indices: u8x32<Self> = [
+            24, 25, 26, 27, 28, 29, 30, 31, 16, 17, 18, 19, 20, 21, 22, 23, 8, 9, 10, 11, 12, 13,
+            14, 15, 0, 1, 2, 3, 4, 5, 6, 7,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_u64x4(a, indices)
     }
     #[inline(always)]
     fn slide_u64x4<const SHIFT: usize>(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self> {
@@ -10283,6 +10433,16 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
+        let indices: u8x64<Self> = [
+            60, 61, 62, 63, 56, 57, 58, 59, 52, 53, 54, 55, 48, 49, 50, 51, 44, 45, 46, 47, 40, 41,
+            42, 43, 36, 37, 38, 39, 32, 33, 34, 35, 28, 29, 30, 31, 24, 25, 26, 27, 20, 21, 22, 23,
+            16, 17, 18, 19, 12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_f32x16(a, indices)
     }
     #[inline(always)]
     fn slide_f32x16<const SHIFT: usize>(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self> {
@@ -10834,6 +10994,16 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i8x64(self, a: i8x64<Self>) -> i8x64<Self> {
+        let indices: u8x64<Self> = [
+            63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42,
+            41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20,
+            19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_i8x64(a, indices)
+    }
+    #[inline(always)]
     fn slide_i8x64<const SHIFT: usize>(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -11329,6 +11499,16 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
+        let indices: u8x64<Self> = [
+            63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42,
+            41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20,
+            19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_u8x64(a, indices)
     }
     #[inline(always)]
     fn slide_u8x64<const SHIFT: usize>(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self> {
@@ -11976,6 +12156,16 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i16x32(self, a: i16x32<Self>) -> i16x32<Self> {
+        let indices: u8x64<Self> = [
+            62, 63, 60, 61, 58, 59, 56, 57, 54, 55, 52, 53, 50, 51, 48, 49, 46, 47, 44, 45, 42, 43,
+            40, 41, 38, 39, 36, 37, 34, 35, 32, 33, 30, 31, 28, 29, 26, 27, 24, 25, 22, 23, 20, 21,
+            18, 19, 16, 17, 14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_i16x32(a, indices)
+    }
+    #[inline(always)]
     fn slide_i16x32<const SHIFT: usize>(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -12445,6 +12635,16 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u16x32(self, a: u16x32<Self>) -> u16x32<Self> {
+        let indices: u8x64<Self> = [
+            62, 63, 60, 61, 58, 59, 56, 57, 54, 55, 52, 53, 50, 51, 48, 49, 46, 47, 44, 45, 42, 43,
+            40, 41, 38, 39, 36, 37, 34, 35, 32, 33, 30, 31, 28, 29, 26, 27, 24, 25, 22, 23, 20, 21,
+            18, 19, 16, 17, 14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_u16x32(a, indices)
     }
     #[inline(always)]
     fn slide_u16x32<const SHIFT: usize>(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self> {
@@ -13024,6 +13224,16 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i32x16(self, a: i32x16<Self>) -> i32x16<Self> {
+        let indices: u8x64<Self> = [
+            60, 61, 62, 63, 56, 57, 58, 59, 52, 53, 54, 55, 48, 49, 50, 51, 44, 45, 46, 47, 40, 41,
+            42, 43, 36, 37, 38, 39, 32, 33, 34, 35, 28, 29, 30, 31, 24, 25, 26, 27, 20, 21, 22, 23,
+            16, 17, 18, 19, 12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_i32x16(a, indices)
+    }
+    #[inline(always)]
     fn slide_i32x16<const SHIFT: usize>(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -13485,6 +13695,16 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u32x16(self, a: u32x16<Self>) -> u32x16<Self> {
+        let indices: u8x64<Self> = [
+            60, 61, 62, 63, 56, 57, 58, 59, 52, 53, 54, 55, 48, 49, 50, 51, 44, 45, 46, 47, 40, 41,
+            42, 43, 36, 37, 38, 39, 32, 33, 34, 35, 28, 29, 30, 31, 24, 25, 26, 27, 20, 21, 22, 23,
+            16, 17, 18, 19, 12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_u32x16(a, indices)
     }
     #[inline(always)]
     fn slide_u32x16<const SHIFT: usize>(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self> {
@@ -14056,6 +14276,16 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
+        let indices: u8x64<Self> = [
+            56, 57, 58, 59, 60, 61, 62, 63, 48, 49, 50, 51, 52, 53, 54, 55, 40, 41, 42, 43, 44, 45,
+            46, 47, 32, 33, 34, 35, 36, 37, 38, 39, 24, 25, 26, 27, 28, 29, 30, 31, 16, 17, 18, 19,
+            20, 21, 22, 23, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_f64x8(a, indices)
+    }
+    #[inline(always)]
     fn slide_f64x8<const SHIFT: usize>(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -14580,6 +14810,16 @@ impl Simd for Avx512 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i64x8(self, a: i64x8<Self>) -> i64x8<Self> {
+        let indices: u8x64<Self> = [
+            56, 57, 58, 59, 60, 61, 62, 63, 48, 49, 50, 51, 52, 53, 54, 55, 40, 41, 42, 43, 44, 45,
+            46, 47, 32, 33, 34, 35, 36, 37, 38, 39, 24, 25, 26, 27, 28, 29, 30, 31, 16, 17, 18, 19,
+            20, 21, 22, 23, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_i64x8(a, indices)
+    }
+    #[inline(always)]
     fn slide_i64x8<const SHIFT: usize>(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -15005,6 +15245,16 @@ impl Simd for Avx512 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u64x8(self, a: u64x8<Self>) -> u64x8<Self> {
+        let indices: u8x64<Self> = [
+            56, 57, 58, 59, 60, 61, 62, 63, 48, 49, 50, 51, 52, 53, 54, 55, 40, 41, 42, 43, 44, 45,
+            46, 47, 32, 33, 34, 35, 36, 37, 38, 39, 24, 25, 26, 27, 28, 29, 30, 31, 16, 17, 18, 19,
+            20, 21, 22, 23, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7,
+        ]
+        .simd_into(self);
+        self.swizzle_dyn_u64x8(a, indices)
     }
     #[inline(always)]
     fn slide_u64x8<const SHIFT: usize>(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self> {

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -1848,6 +1848,13 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
+    fn reverse_mask8x16(self, a: mask8x16<Self>) -> mask8x16<Self> {
+        mask8x16 {
+            val: (a.val.reverse_bits() >> 0usize) as _,
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask8x16(
         self,
         a: mask8x16<Self>,
@@ -2800,6 +2807,13 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
+    fn reverse_mask16x8(self, a: mask16x8<Self>) -> mask16x8<Self> {
+        mask16x8 {
+            val: (a.val.reverse_bits() >> 0usize) as _,
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask16x8(
         self,
         a: mask16x8<Self>,
@@ -3737,6 +3751,13 @@ impl Simd for Avx512 {
     fn not_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
         mask32x4 {
             val: ((!u64::from((a).val)) & 15u64) as _,
+            simd: self,
+        }
+    }
+    #[inline(always)]
+    fn reverse_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
+        mask32x4 {
+            val: (a.val.reverse_bits() >> 4usize) as _,
             simd: self,
         }
     }
@@ -5112,6 +5133,13 @@ impl Simd for Avx512 {
     fn not_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
         mask64x2 {
             val: ((!u64::from((a).val)) & 3u64) as _,
+            simd: self,
+        }
+    }
+    #[inline(always)]
+    fn reverse_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
+        mask64x2 {
+            val: (a.val.reverse_bits() >> 6usize) as _,
             simd: self,
         }
     }
@@ -6786,6 +6814,13 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
+    fn reverse_mask8x32(self, a: mask8x32<Self>) -> mask8x32<Self> {
+        mask8x32 {
+            val: (a.val.reverse_bits() >> 0usize) as _,
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask8x32(
         self,
         a: mask8x32<Self>,
@@ -7840,6 +7875,13 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
+    fn reverse_mask16x16(self, a: mask16x16<Self>) -> mask16x16<Self> {
+        mask16x16 {
+            val: (a.val.reverse_bits() >> 0usize) as _,
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask16x16(
         self,
         a: mask16x16<Self>,
@@ -8867,6 +8909,13 @@ impl Simd for Avx512 {
     fn not_mask32x8(self, a: mask32x8<Self>) -> mask32x8<Self> {
         mask32x8 {
             val: ((!u64::from((a).val)) & 255u64) as _,
+            simd: self,
+        }
+    }
+    #[inline(always)]
+    fn reverse_mask32x8(self, a: mask32x8<Self>) -> mask32x8<Self> {
+        mask32x8 {
+            val: (a.val.reverse_bits() >> 0usize) as _,
             simd: self,
         }
     }
@@ -10358,6 +10407,13 @@ impl Simd for Avx512 {
     fn not_mask64x4(self, a: mask64x4<Self>) -> mask64x4<Self> {
         mask64x4 {
             val: ((!u64::from((a).val)) & 15u64) as _,
+            simd: self,
+        }
+    }
+    #[inline(always)]
+    fn reverse_mask64x4(self, a: mask64x4<Self>) -> mask64x4<Self> {
+        mask64x4 {
+            val: (a.val.reverse_bits() >> 4usize) as _,
             simd: self,
         }
     }
@@ -12091,6 +12147,13 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
+    fn reverse_mask8x64(self, a: mask8x64<Self>) -> mask8x64<Self> {
+        mask8x64 {
+            val: a.val.reverse_bits() >> 0usize,
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask8x64(
         self,
         a: mask8x64<Self>,
@@ -13159,6 +13222,13 @@ impl Simd for Avx512 {
         }
     }
     #[inline(always)]
+    fn reverse_mask16x32(self, a: mask16x32<Self>) -> mask16x32<Self> {
+        mask16x32 {
+            val: (a.val.reverse_bits() >> 0usize) as _,
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask16x32(
         self,
         a: mask16x32<Self>,
@@ -14207,6 +14277,13 @@ impl Simd for Avx512 {
     fn not_mask32x16(self, a: mask32x16<Self>) -> mask32x16<Self> {
         mask32x16 {
             val: ((!u64::from((a).val)) & 65535u64) as _,
+            simd: self,
+        }
+    }
+    #[inline(always)]
+    fn reverse_mask32x16(self, a: mask32x16<Self>) -> mask32x16<Self> {
+        mask32x16 {
+            val: (a.val.reverse_bits() >> 0usize) as _,
             simd: self,
         }
     }
@@ -15721,6 +15798,13 @@ impl Simd for Avx512 {
     fn not_mask64x8(self, a: mask64x8<Self>) -> mask64x8<Self> {
         mask64x8 {
             val: ((!u64::from((a).val)) & 255u64) as _,
+            simd: self,
+        }
+    }
+    #[inline(always)]
+    fn reverse_mask64x8(self, a: mask64x8<Self>) -> mask64x8<Self> {
+        mask64x8 {
+            val: (a.val.reverse_bits() >> 0usize) as _,
             simd: self,
         }
     }

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -202,6 +202,10 @@ impl Simd for Fallback {
         [val; 4usize].simd_into(self)
     }
     #[inline(always)]
+    fn reverse_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        [a[3usize], a[2usize], a[1usize], a[0usize]].simd_into(self)
+    }
+    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         let mut dest = [Default::default(); 4usize];
         dest[..4usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -575,6 +579,15 @@ impl Simd for Fallback {
     #[inline(always)]
     fn splat_i8x16(self, val: i8) -> i8x16<Self> {
         [val; 16usize].simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        [
+            a[15usize], a[14usize], a[13usize], a[12usize], a[11usize], a[10usize], a[9usize],
+            a[8usize], a[7usize], a[6usize], a[5usize], a[4usize], a[3usize], a[2usize], a[1usize],
+            a[0usize],
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
@@ -1321,6 +1334,15 @@ impl Simd for Fallback {
     #[inline(always)]
     fn splat_u8x16(self, val: u8) -> u8x16<Self> {
         [val; 16usize].simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        [
+            a[15usize], a[14usize], a[13usize], a[12usize], a[11usize], a[10usize], a[9usize],
+            a[8usize], a[7usize], a[6usize], a[5usize], a[4usize], a[3usize], a[2usize], a[1usize],
+            a[0usize],
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -2477,6 +2499,13 @@ impl Simd for Fallback {
         [val; 8usize].simd_into(self)
     }
     #[inline(always)]
+    fn reverse_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        [
+            a[7usize], a[6usize], a[5usize], a[4usize], a[3usize], a[2usize], a[1usize], a[0usize],
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         let mut dest = [Default::default(); 8usize];
         dest[..8usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -3005,6 +3034,13 @@ impl Simd for Fallback {
     #[inline(always)]
     fn splat_u16x8(self, val: u16) -> u16x8<Self> {
         [val; 8usize].simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        [
+            a[7usize], a[6usize], a[5usize], a[4usize], a[3usize], a[2usize], a[1usize], a[0usize],
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -3738,6 +3774,10 @@ impl Simd for Fallback {
         [val; 4usize].simd_into(self)
     }
     #[inline(always)]
+    fn reverse_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        [a[3usize], a[2usize], a[1usize], a[0usize]].simd_into(self)
+    }
+    #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         let mut dest = [Default::default(); 4usize];
         dest[..4usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -4084,6 +4124,10 @@ impl Simd for Fallback {
     #[inline(always)]
     fn splat_u32x4(self, val: u32) -> u32x4<Self> {
         [val; 4usize].simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        [a[3usize], a[2usize], a[1usize], a[0usize]].simd_into(self)
     }
     #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4567,6 +4611,10 @@ impl Simd for Fallback {
         [val; 2usize].simd_into(self)
     }
     #[inline(always)]
+    fn reverse_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        [a[1usize], a[0usize]].simd_into(self)
+    }
+    #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         let mut dest = [Default::default(); 2usize];
         dest[..2usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -4847,6 +4895,10 @@ impl Simd for Fallback {
         [val; 2usize].simd_into(self)
     }
     #[inline(always)]
+    fn reverse_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        [a[1usize], a[0usize]].simd_into(self)
+    }
+    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         let mut dest = [Default::default(); 2usize];
         dest[..2usize - SHIFT].copy_from_slice(&a.val.0[SHIFT..]);
@@ -5108,6 +5160,10 @@ impl Simd for Fallback {
     #[inline(always)]
     fn splat_u64x2(self, val: u64) -> u64x2<Self> {
         [val; 2usize].simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        [a[1usize], a[0usize]].simd_into(self)
     }
     #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -2299,6 +2299,28 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn reverse_mask8x16(self, a: mask8x16<Self>) -> mask8x16<Self> {
+        [
+            a.val.0[15usize],
+            a.val.0[14usize],
+            a.val.0[13usize],
+            a.val.0[12usize],
+            a.val.0[11usize],
+            a.val.0[10usize],
+            a.val.0[9usize],
+            a.val.0[8usize],
+            a.val.0[7usize],
+            a.val.0[6usize],
+            a.val.0[5usize],
+            a.val.0[4usize],
+            a.val.0[3usize],
+            a.val.0[2usize],
+            a.val.0[1usize],
+            a.val.0[0usize],
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn select_mask8x16(
         self,
         a: mask8x16<Self>,
@@ -3654,6 +3676,20 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn reverse_mask16x8(self, a: mask16x8<Self>) -> mask16x8<Self> {
+        [
+            a.val.0[7usize],
+            a.val.0[6usize],
+            a.val.0[5usize],
+            a.val.0[4usize],
+            a.val.0[3usize],
+            a.val.0[2usize],
+            a.val.0[1usize],
+            a.val.0[0usize],
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn select_mask16x8(
         self,
         a: mask16x8<Self>,
@@ -4539,6 +4575,16 @@ impl Simd for Fallback {
             i32::not(a.val.0[1usize]),
             i32::not(a.val.0[2usize]),
             i32::not(a.val.0[3usize]),
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
+        [
+            a.val.0[3usize],
+            a.val.0[2usize],
+            a.val.0[1usize],
+            a.val.0[0usize],
         ]
         .simd_into(self)
     }
@@ -5484,6 +5530,10 @@ impl Simd for Fallback {
     #[inline(always)]
     fn not_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
         [i64::not(a.val.0[0usize]), i64::not(a.val.0[1usize])].simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
+        [a.val.0[1usize], a.val.0[0usize]].simd_into(self)
     }
     #[inline(always)]
     fn select_mask64x2(

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -119,6 +119,12 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_f32x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -523,6 +529,12 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        let indices: u8x16<Self> =
+            [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].simd_into(self);
+        self.swizzle_dyn_i8x16(a, indices)
+    }
+    #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         if SHIFT >= 16usize {
             return b;
@@ -846,6 +858,12 @@ impl Simd for Neon {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        let indices: u8x16<Self> =
+            [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].simd_into(self);
+        self.swizzle_dyn_u8x16(a, indices)
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1371,6 +1389,12 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        let indices: u8x16<Self> =
+            [14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1].simd_into(self);
+        self.swizzle_dyn_i16x8(a, indices)
+    }
+    #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -1726,6 +1750,12 @@ impl Simd for Neon {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        let indices: u8x16<Self> =
+            [14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1].simd_into(self);
+        self.swizzle_dyn_u16x8(a, indices)
     }
     #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2242,6 +2272,12 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_i32x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -2609,6 +2645,12 @@ impl Simd for Neon {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_u32x4(a, indices)
     }
     #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -3134,6 +3176,12 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_f64x2(a, indices)
+    }
+    #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -3543,6 +3591,12 @@ impl Simd for Neon {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_i64x2(a, indices)
+    }
+    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -3891,6 +3945,12 @@ impl Simd for Neon {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_u64x2(a, indices)
     }
     #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -1302,6 +1302,18 @@ impl Simd for Neon {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reverse_mask8x16(self, a: mask8x16<Self>) -> mask8x16<Self> {
+        let lanes = i8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i8x16(lanes);
+        mask8x16 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask8x16(
         self,
         a: mask8x16<Self>,
@@ -2183,6 +2195,18 @@ impl Simd for Neon {
             }
         );
         kernel(self, a)
+    }
+    #[inline(always)]
+    fn reverse_mask16x8(self, a: mask16x8<Self>) -> mask16x8<Self> {
+        let lanes = i16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i16x8(lanes);
+        mask16x8 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask16x8(
@@ -3087,6 +3111,18 @@ impl Simd for Neon {
             }
         );
         kernel(self, a)
+    }
+    #[inline(always)]
+    fn reverse_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
+        let lanes = i32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i32x4(lanes);
+        mask32x4 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask32x4(
@@ -4370,6 +4406,18 @@ impl Simd for Neon {
             }
         );
         kernel(self, a)
+    }
+    #[inline(always)]
+    fn reverse_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
+        let lanes = i64x2 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i64x2(lanes);
+        mask64x2 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask64x2(

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -215,6 +215,8 @@ pub trait Simd:
     fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_f32x4(self, val: f32) -> f32x4<Self>;
+    #[doc = "Reverse the order of the vector's elements."]
+    fn reverse_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -339,6 +341,8 @@ pub trait Simd:
     fn cvt_i32_precise_f32x4(self, a: f32x4<Self>) -> i32x4<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i8x16(self, val: i8) -> i8x16<Self>;
+    #[doc = "Reverse the order of the vector's elements."]
+    fn reverse_i8x16(self, a: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -443,6 +447,8 @@ pub trait Simd:
     fn widen_i8x16(self, a: i8x16<Self>) -> (i16x8<Self>, i16x8<Self>);
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u8x16(self, val: u8) -> u8x16<Self>;
+    #[doc = "Reverse the order of the vector's elements."]
+    fn reverse_u8x16(self, a: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -571,6 +577,8 @@ pub trait Simd:
     fn combine_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x32<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i16x8(self, val: i16) -> i16x8<Self>;
+    #[doc = "Reverse the order of the vector's elements."]
+    fn reverse_i16x8(self, a: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -681,6 +689,8 @@ pub trait Simd:
     fn relaxed_narrow_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i8x16<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u16x8(self, val: u16) -> u16x8<Self>;
+    #[doc = "Reverse the order of the vector's elements."]
+    fn reverse_u16x8(self, a: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -824,6 +834,8 @@ pub trait Simd:
     fn combine_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x16<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i32x4(self, val: i32) -> i32x4<Self>;
+    #[doc = "Reverse the order of the vector's elements."]
+    fn reverse_i32x4(self, a: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -936,6 +948,8 @@ pub trait Simd:
     fn cvt_f32_i32x4(self, a: i32x4<Self>) -> f32x4<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u32x4(self, val: u32) -> u32x4<Self>;
+    #[doc = "Reverse the order of the vector's elements."]
+    fn reverse_u32x4(self, a: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -1081,6 +1095,8 @@ pub trait Simd:
     fn combine_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x8<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_f64x2(self, val: f64) -> f64x2<Self>;
+    #[doc = "Reverse the order of the vector's elements."]
+    fn reverse_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -1209,6 +1225,8 @@ pub trait Simd:
     fn cvt_i64_precise_f64x2(self, a: f64x2<Self>) -> i64x2<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_i64x2(self, val: i64) -> i64x2<Self>;
+    #[doc = "Reverse the order of the vector's elements."]
+    fn reverse_i64x2(self, a: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -1319,6 +1337,8 @@ pub trait Simd:
     fn cvt_f64_i64x2(self, a: i64x2<Self>) -> f64x2<Self>;
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat_u64x2(self, val: u64) -> u64x2<Self>;
+    #[doc = "Reverse the order of the vector's elements."]
+    fn reverse_u64x2(self, a: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -1465,6 +1485,12 @@ pub trait Simd:
     fn splat_f32x8(self, val: f32) -> f32x8<Self> {
         let half = self.splat_f32x4(val);
         self.combine_f32x4(half, half)
+    }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(self.reverse_f32x4(a1), self.reverse_f32x4(a0))
     }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f32x8<const SHIFT: usize>(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self>;
@@ -1813,6 +1839,12 @@ pub trait Simd:
         let half = self.splat_i8x16(val);
         self.combine_i8x16(half, half)
     }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_i8x32(self, a: i8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        self.combine_i8x16(self.reverse_i8x16(a1), self.reverse_i8x16(a0))
+    }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i8x32<const SHIFT: usize>(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -2062,6 +2094,12 @@ pub trait Simd:
     fn splat_u8x32(self, val: u8) -> u8x32<Self> {
         let half = self.splat_u8x16(val);
         self.combine_u8x16(half, half)
+    }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        self.combine_u8x16(self.reverse_u8x16(a1), self.reverse_u8x16(a0))
     }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u8x32<const SHIFT: usize>(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self>;
@@ -2407,6 +2445,12 @@ pub trait Simd:
         let half = self.splat_i16x8(val);
         self.combine_i16x8(half, half)
     }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_i16x16(self, a: i16x16<Self>) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        self.combine_i16x8(self.reverse_i16x8(a1), self.reverse_i16x8(a0))
+    }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i16x16<const SHIFT: usize>(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -2687,6 +2731,12 @@ pub trait Simd:
     fn splat_u16x16(self, val: u16) -> u16x16<Self> {
         let half = self.splat_u16x8(val);
         self.combine_u16x8(half, half)
+    }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_u16x16(self, a: u16x16<Self>) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        self.combine_u16x8(self.reverse_u16x8(a1), self.reverse_u16x8(a0))
     }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u16x16<const SHIFT: usize>(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self>;
@@ -3064,6 +3114,12 @@ pub trait Simd:
         let half = self.splat_i32x4(val);
         self.combine_i32x4(half, half)
     }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_i32x8(self, a: i32x8<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        self.combine_i32x4(self.reverse_i32x4(a1), self.reverse_i32x4(a0))
+    }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i32x8<const SHIFT: usize>(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -3346,6 +3402,12 @@ pub trait Simd:
     fn splat_u32x8(self, val: u32) -> u32x8<Self> {
         let half = self.splat_u32x4(val);
         self.combine_u32x4(half, half)
+    }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_u32x8(self, a: u32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        self.combine_u32x4(self.reverse_u32x4(a1), self.reverse_u32x4(a0))
     }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u32x8<const SHIFT: usize>(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self>;
@@ -3725,6 +3787,12 @@ pub trait Simd:
         let half = self.splat_f64x2(val);
         self.combine_f64x2(half, half)
     }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_f64x4(self, a: f64x4<Self>) -> f64x4<Self> {
+        let (a0, a1) = self.split_f64x4(a);
+        self.combine_f64x2(self.reverse_f64x2(a1), self.reverse_f64x2(a0))
+    }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f64x4<const SHIFT: usize>(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -4091,6 +4159,12 @@ pub trait Simd:
         let half = self.splat_i64x2(val);
         self.combine_i64x2(half, half)
     }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_i64x4(self, a: i64x4<Self>) -> i64x4<Self> {
+        let (a0, a1) = self.split_i64x4(a);
+        self.combine_i64x2(self.reverse_i64x2(a1), self.reverse_i64x2(a0))
+    }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i64x4<const SHIFT: usize>(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -4365,6 +4439,12 @@ pub trait Simd:
     fn splat_u64x4(self, val: u64) -> u64x4<Self> {
         let half = self.splat_u64x2(val);
         self.combine_u64x2(half, half)
+    }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_u64x4(self, a: u64x4<Self>) -> u64x4<Self> {
+        let (a0, a1) = self.split_u64x4(a);
+        self.combine_u64x2(self.reverse_u64x2(a1), self.reverse_u64x2(a0))
     }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u64x4<const SHIFT: usize>(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self>;
@@ -4736,6 +4816,12 @@ pub trait Simd:
         let half = self.splat_f32x8(val);
         self.combine_f32x8(half, half)
     }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_f32x16(self, a: f32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_f32x16(a);
+        self.combine_f32x8(self.reverse_f32x8(a1), self.reverse_f32x8(a0))
+    }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f32x16<const SHIFT: usize>(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -5095,6 +5181,12 @@ pub trait Simd:
         let half = self.splat_i8x32(val);
         self.combine_i8x32(half, half)
     }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_i8x64(self, a: i8x64<Self>) -> i8x64<Self> {
+        let (a0, a1) = self.split_i8x64(a);
+        self.combine_i8x32(self.reverse_i8x32(a1), self.reverse_i8x32(a0))
+    }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i8x64<const SHIFT: usize>(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -5342,6 +5434,12 @@ pub trait Simd:
     fn splat_u8x64(self, val: u8) -> u8x64<Self> {
         let half = self.splat_u8x32(val);
         self.combine_u8x32(half, half)
+    }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_u8x64(self, a: u8x64<Self>) -> u8x64<Self> {
+        let (a0, a1) = self.split_u8x64(a);
+        self.combine_u8x32(self.reverse_u8x32(a1), self.reverse_u8x32(a0))
     }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u8x64<const SHIFT: usize>(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self>;
@@ -5683,6 +5781,12 @@ pub trait Simd:
         let half = self.splat_i16x16(val);
         self.combine_i16x16(half, half)
     }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_i16x32(self, a: i16x32<Self>) -> i16x32<Self> {
+        let (a0, a1) = self.split_i16x32(a);
+        self.combine_i16x16(self.reverse_i16x16(a1), self.reverse_i16x16(a0))
+    }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i16x32<const SHIFT: usize>(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -5967,6 +6071,12 @@ pub trait Simd:
     fn splat_u16x32(self, val: u16) -> u16x32<Self> {
         let half = self.splat_u16x16(val);
         self.combine_u16x16(half, half)
+    }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_u16x32(self, a: u16x32<Self>) -> u16x32<Self> {
+        let (a0, a1) = self.split_u16x32(a);
+        self.combine_u16x16(self.reverse_u16x16(a1), self.reverse_u16x16(a0))
     }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u16x32<const SHIFT: usize>(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self>;
@@ -6349,6 +6459,12 @@ pub trait Simd:
         let half = self.splat_i32x8(val);
         self.combine_i32x8(half, half)
     }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_i32x16(self, a: i32x16<Self>) -> i32x16<Self> {
+        let (a0, a1) = self.split_i32x16(a);
+        self.combine_i32x8(self.reverse_i32x8(a1), self.reverse_i32x8(a0))
+    }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i32x16<const SHIFT: usize>(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -6633,6 +6749,12 @@ pub trait Simd:
     fn splat_u32x16(self, val: u32) -> u32x16<Self> {
         let half = self.splat_u32x8(val);
         self.combine_u32x8(half, half)
+    }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_u32x16(self, a: u32x16<Self>) -> u32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        self.combine_u32x8(self.reverse_u32x8(a1), self.reverse_u32x8(a0))
     }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u32x16<const SHIFT: usize>(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self>;
@@ -7012,6 +7134,12 @@ pub trait Simd:
         let half = self.splat_f64x4(val);
         self.combine_f64x4(half, half)
     }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_f64x8(self, a: f64x8<Self>) -> f64x8<Self> {
+        let (a0, a1) = self.split_f64x8(a);
+        self.combine_f64x4(self.reverse_f64x4(a1), self.reverse_f64x4(a0))
+    }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f64x8<const SHIFT: usize>(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -7376,6 +7504,12 @@ pub trait Simd:
         let half = self.splat_i64x4(val);
         self.combine_i64x4(half, half)
     }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_i64x8(self, a: i64x8<Self>) -> i64x8<Self> {
+        let (a0, a1) = self.split_i64x8(a);
+        self.combine_i64x4(self.reverse_i64x4(a1), self.reverse_i64x4(a0))
+    }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i64x8<const SHIFT: usize>(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
@@ -7648,6 +7782,12 @@ pub trait Simd:
     fn splat_u64x8(self, val: u64) -> u64x8<Self> {
         let half = self.splat_u64x4(val);
         self.combine_u64x4(half, half)
+    }
+    #[doc = "Reverse the order of the vector's elements."]
+    #[inline(always)]
+    fn reverse_u64x8(self, a: u64x8<Self>) -> u64x8<Self> {
+        let (a0, a1) = self.split_u64x8(a);
+        self.combine_u64x4(self.reverse_u64x4(a1), self.reverse_u64x4(a0))
     }
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u64x8<const SHIFT: usize>(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self>;
@@ -8563,6 +8703,8 @@ pub trait SimdBase<S: Simd>:
     }
     #[doc = "Create a SIMD vector with all elements set to the given value."]
     fn splat(simd: S, val: Self::Element) -> Self;
+    #[doc = "Reverse the order of the vector's elements."]
+    fn reverse(self) -> Self;
     #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -556,6 +556,8 @@ pub trait Simd:
     fn xor_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self>;
     #[doc = "Compute the logical NOT of the mask."]
     fn not_mask8x16(self, a: mask8x16<Self>) -> mask8x16<Self>;
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    fn reverse_mask8x16(self, a: mask8x16<Self>) -> mask8x16<Self>;
     #[doc = "Select elements from `b` and `c` based on the mask operand `a`.\n\nThis operation's behavior is unspecified if a was constructed from signed integer lanes that are neither all-zeroes (integer value 0) nor all-ones (integer value -1). See the [`Select`] trait's documentation for more information."]
     fn select_mask8x16(
         self,
@@ -813,6 +815,8 @@ pub trait Simd:
     fn xor_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self>;
     #[doc = "Compute the logical NOT of the mask."]
     fn not_mask16x8(self, a: mask16x8<Self>) -> mask16x8<Self>;
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    fn reverse_mask16x8(self, a: mask16x8<Self>) -> mask16x8<Self>;
     #[doc = "Select elements from `b` and `c` based on the mask operand `a`.\n\nThis operation's behavior is unspecified if a was constructed from signed integer lanes that are neither all-zeroes (integer value 0) nor all-ones (integer value -1). See the [`Select`] trait's documentation for more information."]
     fn select_mask16x8(
         self,
@@ -1074,6 +1078,8 @@ pub trait Simd:
     fn xor_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self>;
     #[doc = "Compute the logical NOT of the mask."]
     fn not_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self>;
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    fn reverse_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self>;
     #[doc = "Select elements from `b` and `c` based on the mask operand `a`.\n\nThis operation's behavior is unspecified if a was constructed from signed integer lanes that are neither all-zeroes (integer value 0) nor all-ones (integer value -1). See the [`Select`] trait's documentation for more information."]
     fn select_mask32x4(
         self,
@@ -1461,6 +1467,8 @@ pub trait Simd:
     fn xor_mask64x2(self, a: mask64x2<Self>, b: mask64x2<Self>) -> mask64x2<Self>;
     #[doc = "Compute the logical NOT of the mask."]
     fn not_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self>;
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    fn reverse_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self>;
     #[doc = "Select elements from `b` and `c` based on the mask operand `a`.\n\nThis operation's behavior is unspecified if a was constructed from signed integer lanes that are neither all-zeroes (integer value 0) nor all-ones (integer value -1). See the [`Select`] trait's documentation for more information."]
     fn select_mask64x2(
         self,
@@ -2388,6 +2396,12 @@ pub trait Simd:
         let (a0, a1) = self.split_mask8x32(a);
         self.combine_mask8x16(self.not_mask8x16(a0), self.not_mask8x16(a1))
     }
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    #[inline(always)]
+    fn reverse_mask8x32(self, a: mask8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_mask8x32(a);
+        self.combine_mask8x16(self.reverse_mask8x16(a1), self.reverse_mask8x16(a0))
+    }
     #[doc = "Select elements from `b` and `c` based on the mask operand `a`.\n\nThis operation's behavior is unspecified if a was constructed from signed integer lanes that are neither all-zeroes (integer value 0) nor all-ones (integer value -1). See the [`Select`] trait's documentation for more information."]
     #[inline(always)]
     fn select_mask8x32(
@@ -3056,6 +3070,12 @@ pub trait Simd:
     fn not_mask16x16(self, a: mask16x16<Self>) -> mask16x16<Self> {
         let (a0, a1) = self.split_mask16x16(a);
         self.combine_mask16x8(self.not_mask16x8(a0), self.not_mask16x8(a1))
+    }
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    #[inline(always)]
+    fn reverse_mask16x16(self, a: mask16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_mask16x16(a);
+        self.combine_mask16x8(self.reverse_mask16x8(a1), self.reverse_mask16x8(a0))
     }
     #[doc = "Select elements from `b` and `c` based on the mask operand `a`.\n\nThis operation's behavior is unspecified if a was constructed from signed integer lanes that are neither all-zeroes (integer value 0) nor all-ones (integer value -1). See the [`Select`] trait's documentation for more information."]
     #[inline(always)]
@@ -3729,6 +3749,12 @@ pub trait Simd:
     fn not_mask32x8(self, a: mask32x8<Self>) -> mask32x8<Self> {
         let (a0, a1) = self.split_mask32x8(a);
         self.combine_mask32x4(self.not_mask32x4(a0), self.not_mask32x4(a1))
+    }
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    #[inline(always)]
+    fn reverse_mask32x8(self, a: mask32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_mask32x8(a);
+        self.combine_mask32x4(self.reverse_mask32x4(a1), self.reverse_mask32x4(a0))
     }
     #[doc = "Select elements from `b` and `c` based on the mask operand `a`.\n\nThis operation's behavior is unspecified if a was constructed from signed integer lanes that are neither all-zeroes (integer value 0) nor all-ones (integer value -1). See the [`Select`] trait's documentation for more information."]
     #[inline(always)]
@@ -4759,6 +4785,12 @@ pub trait Simd:
         let (a0, a1) = self.split_mask64x4(a);
         self.combine_mask64x2(self.not_mask64x2(a0), self.not_mask64x2(a1))
     }
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    #[inline(always)]
+    fn reverse_mask64x4(self, a: mask64x4<Self>) -> mask64x4<Self> {
+        let (a0, a1) = self.split_mask64x4(a);
+        self.combine_mask64x2(self.reverse_mask64x2(a1), self.reverse_mask64x2(a0))
+    }
     #[doc = "Select elements from `b` and `c` based on the mask operand `a`.\n\nThis operation's behavior is unspecified if a was constructed from signed integer lanes that are neither all-zeroes (integer value 0) nor all-ones (integer value -1). See the [`Select`] trait's documentation for more information."]
     #[inline(always)]
     fn select_mask64x4(
@@ -5726,6 +5758,12 @@ pub trait Simd:
         let (a0, a1) = self.split_mask8x64(a);
         self.combine_mask8x32(self.not_mask8x32(a0), self.not_mask8x32(a1))
     }
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    #[inline(always)]
+    fn reverse_mask8x64(self, a: mask8x64<Self>) -> mask8x64<Self> {
+        let (a0, a1) = self.split_mask8x64(a);
+        self.combine_mask8x32(self.reverse_mask8x32(a1), self.reverse_mask8x32(a0))
+    }
     #[doc = "Select elements from `b` and `c` based on the mask operand `a`.\n\nThis operation's behavior is unspecified if a was constructed from signed integer lanes that are neither all-zeroes (integer value 0) nor all-ones (integer value -1). See the [`Select`] trait's documentation for more information."]
     #[inline(always)]
     fn select_mask8x64(
@@ -6400,6 +6438,12 @@ pub trait Simd:
     fn not_mask16x32(self, a: mask16x32<Self>) -> mask16x32<Self> {
         let (a0, a1) = self.split_mask16x32(a);
         self.combine_mask16x16(self.not_mask16x16(a0), self.not_mask16x16(a1))
+    }
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    #[inline(always)]
+    fn reverse_mask16x32(self, a: mask16x32<Self>) -> mask16x32<Self> {
+        let (a0, a1) = self.split_mask16x32(a);
+        self.combine_mask16x16(self.reverse_mask16x16(a1), self.reverse_mask16x16(a0))
     }
     #[doc = "Select elements from `b` and `c` based on the mask operand `a`.\n\nThis operation's behavior is unspecified if a was constructed from signed integer lanes that are neither all-zeroes (integer value 0) nor all-ones (integer value -1). See the [`Select`] trait's documentation for more information."]
     #[inline(always)]
@@ -7078,6 +7122,12 @@ pub trait Simd:
     fn not_mask32x16(self, a: mask32x16<Self>) -> mask32x16<Self> {
         let (a0, a1) = self.split_mask32x16(a);
         self.combine_mask32x8(self.not_mask32x8(a0), self.not_mask32x8(a1))
+    }
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    #[inline(always)]
+    fn reverse_mask32x16(self, a: mask32x16<Self>) -> mask32x16<Self> {
+        let (a0, a1) = self.split_mask32x16(a);
+        self.combine_mask32x8(self.reverse_mask32x8(a1), self.reverse_mask32x8(a0))
     }
     #[doc = "Select elements from `b` and `c` based on the mask operand `a`.\n\nThis operation's behavior is unspecified if a was constructed from signed integer lanes that are neither all-zeroes (integer value 0) nor all-ones (integer value -1). See the [`Select`] trait's documentation for more information."]
     #[inline(always)]
@@ -8100,6 +8150,12 @@ pub trait Simd:
         let (a0, a1) = self.split_mask64x8(a);
         self.combine_mask64x4(self.not_mask64x4(a0), self.not_mask64x4(a1))
     }
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    #[inline(always)]
+    fn reverse_mask64x8(self, a: mask64x8<Self>) -> mask64x8<Self> {
+        let (a0, a1) = self.split_mask64x8(a);
+        self.combine_mask64x4(self.reverse_mask64x4(a1), self.reverse_mask64x4(a0))
+    }
     #[doc = "Select elements from `b` and `c` based on the mask operand `a`.\n\nThis operation's behavior is unspecified if a was constructed from signed integer lanes that are neither all-zeroes (integer value 0) nor all-ones (integer value -1). See the [`Select`] trait's documentation for more information."]
     #[inline(always)]
     fn select_mask64x8(
@@ -8909,6 +8965,8 @@ pub trait SimdMask<S: Simd>:
     #[doc = r""]
     #[doc = r" The slice must be exactly the size of the SIMD mask."]
     fn store_slice(&self, slice: &mut [Self::Element]);
+    #[doc = "Reverse the order of the mask's logical lanes."]
+    fn reverse(self) -> Self;
     #[doc = "Compare two vectors element-wise for equality.\n\nReturns a mask where each logical lane is true if the corresponding elements are equal, and false if not."]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Returns true if any logical lanes in this mask are true.\n\nMasks may be converted to and from signed integer lane arrays for compatibility with older APIs. For those conversions, false is encoded as all zeroes (integer value 0) and true is encoded as all ones (integer value -1).\n\nBehavior on masks constructed from any other integer bit pattern is unspecified. It may vary depending on architecture, feature level, the mask elements' width, the mask vector's width, or library version.\n\nThe behavior is also not guaranteed to be logically consistent for such non-canonical masks. `any_true` may not return the same result as `!all_false`, and `all_true` may not return the same result as `!any_false`.\n\nThe [`select`](crate::Select::select) operation also has unspecified behavior for non-canonical masks. That behavior may not match the behavior of this operation."]

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -927,6 +927,10 @@ impl<S: Simd> SimdMask<S> for mask8x16<S> {
         *slice = (*self).into();
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_mask8x16(self)
+    }
+    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.simd_eq_mask8x16(self, rhs.simd_into(self.simd))
     }
@@ -1571,6 +1575,10 @@ impl<S: Simd> SimdMask<S> for mask16x8<S> {
         *slice = (*self).into();
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_mask16x8(self)
+    }
+    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.simd_eq_mask16x8(self, rhs.simd_into(self.simd))
     }
@@ -2213,6 +2221,10 @@ impl<S: Simd> SimdMask<S> for mask32x4<S> {
     fn store_slice(&self, slice: &mut [i32]) {
         let slice: &mut [i32; 4] = slice.try_into().unwrap();
         *slice = (*self).into();
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_mask32x4(self)
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -3161,6 +3173,10 @@ impl<S: Simd> SimdMask<S> for mask64x2<S> {
     fn store_slice(&self, slice: &mut [i64]) {
         let slice: &mut [i64; 2] = slice.try_into().unwrap();
         *slice = (*self).into();
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_mask64x2(self)
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -4132,6 +4148,10 @@ impl<S: Simd> SimdMask<S> for mask8x32<S> {
         *slice = (*self).into();
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_mask8x32(self)
+    }
+    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.simd_eq_mask8x32(self, rhs.simd_into(self.simd))
     }
@@ -4782,6 +4802,10 @@ impl<S: Simd> SimdMask<S> for mask16x16<S> {
     fn store_slice(&self, slice: &mut [i16]) {
         let slice: &mut [i16; 16] = slice.try_into().unwrap();
         *slice = (*self).into();
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_mask16x16(self)
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -5440,6 +5464,10 @@ impl<S: Simd> SimdMask<S> for mask32x8<S> {
     fn store_slice(&self, slice: &mut [i32]) {
         let slice: &mut [i32; 8] = slice.try_into().unwrap();
         *slice = (*self).into();
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_mask32x8(self)
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -6373,6 +6401,10 @@ impl<S: Simd> SimdMask<S> for mask64x4<S> {
     fn store_slice(&self, slice: &mut [i64]) {
         let slice: &mut [i64; 4] = slice.try_into().unwrap();
         *slice = (*self).into();
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_mask64x4(self)
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -7399,6 +7431,10 @@ impl<S: Simd> SimdMask<S> for mask8x64<S> {
         *slice = (*self).into();
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_mask8x64(self)
+    }
+    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.simd_eq_mask8x64(self, rhs.simd_into(self.simd))
     }
@@ -8071,6 +8107,10 @@ impl<S: Simd> SimdMask<S> for mask16x32<S> {
         *slice = (*self).into();
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_mask16x32(self)
+    }
+    #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.simd_eq_mask16x32(self, rhs.simd_into(self.simd))
     }
@@ -8733,6 +8773,10 @@ impl<S: Simd> SimdMask<S> for mask32x16<S> {
     fn store_slice(&self, slice: &mut [i32]) {
         let slice: &mut [i32; 16] = slice.try_into().unwrap();
         *slice = (*self).into();
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_mask32x16(self)
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -9684,6 +9728,10 @@ impl<S: Simd> SimdMask<S> for mask64x8<S> {
     fn store_slice(&self, slice: &mut [i64]) {
         let slice: &mut [i64; 8] = slice.try_into().unwrap();
         *slice = (*self).into();
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_mask64x8(self)
     }
     #[inline(always)]
     fn simd_eq(self, rhs: impl SimdInto<Self, S>) -> Self {

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -155,6 +155,10 @@ impl<S: Simd> SimdBase<S> for f32x4<S> {
             .swizzle_dyn_precise_f32x4(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_f32x4(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_f32x4(self, rhs.simd_into(self.simd))
     }
@@ -481,6 +485,10 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
             .swizzle_dyn_precise_i8x16(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_i8x16(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i8x16(self, rhs.simd_into(self.simd))
     }
@@ -743,6 +751,10 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_precise_u8x16(self, indices.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_u8x16(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -1095,6 +1107,10 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
             .swizzle_dyn_precise_i16x8(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_i16x8(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i16x8(self, rhs.simd_into(self.simd))
     }
@@ -1364,6 +1380,10 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_precise_u16x8(self, indices.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_u16x8(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -1719,6 +1739,10 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
             .swizzle_dyn_precise_i32x4(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_i32x4(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i32x4(self, rhs.simd_into(self.simd))
     }
@@ -1988,6 +2012,10 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_precise_u32x4(self, indices.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_u32x4(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -2355,6 +2383,10 @@ impl<S: Simd> SimdBase<S> for f64x2<S> {
             .swizzle_dyn_precise_f64x2(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_f64x2(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_f64x2(self, rhs.simd_into(self.simd))
     }
@@ -2669,6 +2701,10 @@ impl<S: Simd> SimdBase<S> for i64x2<S> {
             .swizzle_dyn_precise_i64x2(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_i64x2(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i64x2(self, rhs.simd_into(self.simd))
     }
@@ -2931,6 +2967,10 @@ impl<S: Simd> SimdBase<S> for u64x2<S> {
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_precise_u64x2(self, indices.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_u64x2(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -3303,6 +3343,10 @@ impl<S: Simd> SimdBase<S> for f32x8<S> {
             .swizzle_dyn_precise_f32x8(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_f32x8(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_f32x8(self, rhs.simd_into(self.simd))
     }
@@ -3640,6 +3684,10 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
             .swizzle_dyn_precise_i8x32(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_i8x32(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i8x32(self, rhs.simd_into(self.simd))
     }
@@ -3913,6 +3961,10 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_precise_u8x32(self, indices.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_u8x32(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -4268,6 +4320,10 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
             .swizzle_dyn_precise_i16x16(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_i16x16(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i16x16(self, rhs.simd_into(self.simd))
     }
@@ -4541,6 +4597,10 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_precise_u16x16(self, indices.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_u16x16(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -4904,6 +4964,10 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
             .swizzle_dyn_precise_i32x8(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_i32x8(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i32x8(self, rhs.simd_into(self.simd))
     }
@@ -5180,6 +5244,10 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_precise_u32x8(self, indices.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_u32x8(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -5542,6 +5610,10 @@ impl<S: Simd> SimdBase<S> for f64x4<S> {
             .swizzle_dyn_precise_f64x4(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_f64x4(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_f64x4(self, rhs.simd_into(self.simd))
     }
@@ -5851,6 +5923,10 @@ impl<S: Simd> SimdBase<S> for i64x4<S> {
             .swizzle_dyn_precise_i64x4(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_i64x4(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i64x4(self, rhs.simd_into(self.simd))
     }
@@ -6108,6 +6184,10 @@ impl<S: Simd> SimdBase<S> for u64x4<S> {
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_precise_u64x4(self, indices.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_u64x4(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -6484,6 +6564,10 @@ impl<S: Simd> SimdBase<S> for f32x16<S> {
             .swizzle_dyn_precise_f32x16(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_f32x16(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_f32x16(self, rhs.simd_into(self.simd))
     }
@@ -6848,6 +6932,10 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
             .swizzle_dyn_precise_i8x64(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_i8x64(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i8x64(self, rhs.simd_into(self.simd))
     }
@@ -7147,6 +7235,10 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_precise_u8x64(self, indices.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_u8x64(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -7512,6 +7604,10 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
             .swizzle_dyn_precise_i16x32(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_i16x32(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i16x32(self, rhs.simd_into(self.simd))
     }
@@ -7795,6 +7891,10 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_precise_u16x32(self, indices.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_u16x32(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -8160,6 +8260,10 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
             .swizzle_dyn_precise_i32x16(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_i32x16(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i32x16(self, rhs.simd_into(self.simd))
     }
@@ -8439,6 +8543,10 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_precise_u32x16(self, indices.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_u32x16(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -8808,6 +8916,10 @@ impl<S: Simd> SimdBase<S> for f64x8<S> {
             .swizzle_dyn_precise_f64x8(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_f64x8(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_f64x8(self, rhs.simd_into(self.simd))
     }
@@ -9123,6 +9235,10 @@ impl<S: Simd> SimdBase<S> for i64x8<S> {
             .swizzle_dyn_precise_i64x8(self, indices.simd_into(self.simd))
     }
     #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_i64x8(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i64x8(self, rhs.simd_into(self.simd))
     }
@@ -9386,6 +9502,10 @@ impl<S: Simd> SimdBase<S> for u64x8<S> {
     fn swizzle_dyn_precise(self, indices: impl SimdInto<Self::Bytes, S>) -> Self {
         self.simd
             .swizzle_dyn_precise_u64x8(self, indices.simd_into(self.simd))
+    }
+    #[inline(always)]
+    fn reverse(self) -> Self {
+        self.simd.reverse_u64x8(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -1960,6 +1960,18 @@ impl Simd for Sse2 {
         self.xor_mask8x16(a, self.splat_mask8x16(true))
     }
     #[inline(always)]
+    fn reverse_mask8x16(self, a: mask8x16<Self>) -> mask8x16<Self> {
+        let lanes = i8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i8x16(lanes);
+        mask8x16 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask8x16(
         self,
         a: mask8x16<Self>,
@@ -3042,6 +3054,18 @@ impl Simd for Sse2 {
         self.xor_mask16x8(a, self.splat_mask16x8(true))
     }
     #[inline(always)]
+    fn reverse_mask16x8(self, a: mask16x8<Self>) -> mask16x8<Self> {
+        let lanes = i16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i16x8(lanes);
+        mask16x8 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask16x8(
         self,
         a: mask16x8<Self>,
@@ -4122,6 +4146,18 @@ impl Simd for Sse2 {
     #[inline(always)]
     fn not_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
         self.xor_mask32x4(a, self.splat_mask32x4(true))
+    }
+    #[inline(always)]
+    fn reverse_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
+        let lanes = i32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i32x4(lanes);
+        mask32x4 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask32x4(
@@ -5476,6 +5512,18 @@ impl Simd for Sse2 {
     #[inline(always)]
     fn not_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
         self.xor_mask64x2(a, self.splat_mask64x2(true))
+    }
+    #[inline(always)]
+    fn reverse_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
+        let lanes = i64x2 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i64x2(lanes);
+        mask64x2 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask64x2(

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -222,6 +222,10 @@ impl Simd for Sse2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        [a[3usize], a[2usize], a[1usize], a[0usize]].simd_into(self)
+    }
+    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -701,6 +705,15 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        [
+            a[15usize], a[14usize], a[13usize], a[12usize], a[11usize], a[10usize], a[9usize],
+            a[8usize], a[7usize], a[6usize], a[5usize], a[4usize], a[3usize], a[2usize], a[1usize],
+            a[0usize],
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
@@ -1239,6 +1252,15 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        [
+            a[15usize], a[14usize], a[13usize], a[12usize], a[11usize], a[10usize], a[9usize],
+            a[8usize], a[7usize], a[6usize], a[5usize], a[4usize], a[3usize], a[2usize], a[1usize],
+            a[0usize],
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -2029,6 +2051,13 @@ impl Simd for Sse2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        [
+            a[7usize], a[6usize], a[5usize], a[4usize], a[3usize], a[2usize], a[1usize], a[0usize],
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -2463,6 +2492,13 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        [
+            a[7usize], a[6usize], a[5usize], a[4usize], a[3usize], a[2usize], a[1usize], a[0usize],
+        ]
+        .simd_into(self)
     }
     #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -3097,6 +3133,10 @@ impl Simd for Sse2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        [a[3usize], a[2usize], a[1usize], a[0usize]].simd_into(self)
+    }
+    #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -3542,6 +3582,10 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        [a[3usize], a[2usize], a[1usize], a[0usize]].simd_into(self)
     }
     #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4171,6 +4215,10 @@ impl Simd for Sse2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        [a[1usize], a[0usize]].simd_into(self)
+    }
+    #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -4608,6 +4656,10 @@ impl Simd for Sse2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        [a[1usize], a[0usize]].simd_into(self)
+    }
+    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -4985,6 +5037,10 @@ impl Simd for Sse2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        [a[1usize], a[0usize]].simd_into(self)
     }
     #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -200,6 +200,12 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_f32x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -784,6 +790,12 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        let indices: u8x16<Self> =
+            [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].simd_into(self);
+        self.swizzle_dyn_i8x16(a, indices)
+    }
+    #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         if SHIFT >= 16usize {
             return b;
@@ -1243,6 +1255,12 @@ impl Simd for Sse4_2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        let indices: u8x16<Self> =
+            [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].simd_into(self);
+        self.swizzle_dyn_u8x16(a, indices)
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1905,6 +1923,12 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        let indices: u8x16<Self> =
+            [14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1].simd_into(self);
+        self.swizzle_dyn_i16x8(a, indices)
+    }
+    #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -2356,6 +2380,12 @@ impl Simd for Sse4_2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        let indices: u8x16<Self> =
+            [14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1].simd_into(self);
+        self.swizzle_dyn_u16x8(a, indices)
     }
     #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2973,6 +3003,12 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_i32x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -3402,6 +3438,12 @@ impl Simd for Sse4_2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_u32x4(a, indices)
     }
     #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4000,6 +4042,12 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_f64x2(a, indices)
+    }
+    #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -4545,6 +4593,12 @@ impl Simd for Sse4_2 {
         kernel(self, val)
     }
     #[inline(always)]
+    fn reverse_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_i64x2(a, indices)
+    }
+    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -4952,6 +5006,12 @@ impl Simd for Sse4_2 {
             }
         );
         kernel(self, val)
+    }
+    #[inline(always)]
+    fn reverse_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_u64x2(a, indices)
     }
     #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -1836,6 +1836,18 @@ impl Simd for Sse4_2 {
         self.xor_mask8x16(a, self.splat_mask8x16(true))
     }
     #[inline(always)]
+    fn reverse_mask8x16(self, a: mask8x16<Self>) -> mask8x16<Self> {
+        let lanes = i8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i8x16(lanes);
+        mask8x16 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask8x16(
         self,
         a: mask8x16<Self>,
@@ -2916,6 +2928,18 @@ impl Simd for Sse4_2 {
         self.xor_mask16x8(a, self.splat_mask16x8(true))
     }
     #[inline(always)]
+    fn reverse_mask16x8(self, a: mask16x8<Self>) -> mask16x8<Self> {
+        let lanes = i16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i16x8(lanes);
+        mask16x8 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask16x8(
         self,
         a: mask16x8<Self>,
@@ -3953,6 +3977,18 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn not_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
         self.xor_mask32x4(a, self.splat_mask32x4(true))
+    }
+    #[inline(always)]
+    fn reverse_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
+        let lanes = i32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i32x4(lanes);
+        mask32x4 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask32x4(
@@ -5483,6 +5519,18 @@ impl Simd for Sse4_2 {
     #[inline(always)]
     fn not_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
         self.xor_mask64x2(a, self.splat_mask64x2(true))
+    }
+    #[inline(always)]
+    fn reverse_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
+        let lanes = i64x2 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i64x2(lanes);
+        mask64x2 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask64x2(

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -1112,6 +1112,18 @@ impl Simd for WasmSimd128 {
         v128_not(a.into()).simd_into(self)
     }
     #[inline(always)]
+    fn reverse_mask8x16(self, a: mask8x16<Self>) -> mask8x16<Self> {
+        let lanes = i8x16 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i8x16(lanes);
+        mask8x16 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask8x16(
         self,
         a: mask8x16<Self>,
@@ -1675,6 +1687,18 @@ impl Simd for WasmSimd128 {
         v128_not(a.into()).simd_into(self)
     }
     #[inline(always)]
+    fn reverse_mask16x8(self, a: mask16x8<Self>) -> mask16x8<Self> {
+        let lanes = i16x8 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i16x8(lanes);
+        mask16x8 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
+    }
+    #[inline(always)]
     fn select_mask16x8(
         self,
         a: mask16x8<Self>,
@@ -2230,6 +2254,18 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn not_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
         v128_not(a.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
+        let lanes = i32x4 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i32x4(lanes);
+        mask32x4 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask32x4(
@@ -3084,6 +3120,18 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn not_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
         v128_not(a.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_mask64x2(self, a: mask64x2<Self>) -> mask64x2<Self> {
+        let lanes = i64x2 {
+            val: crate::transmute::checked_transmute_copy(&a.val),
+            simd: self,
+        };
+        let reversed = self.reverse_i64x2(lanes);
+        mask64x2 {
+            val: crate::transmute::checked_transmute_copy(&reversed.val),
+            simd: self,
+        }
     }
     #[inline(always)]
     fn select_mask64x2(

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -204,6 +204,12 @@ impl Simd for WasmSimd128 {
         f32x4_splat(val).simd_into(self)
     }
     #[inline(always)]
+    fn reverse_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_f32x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -494,6 +500,12 @@ impl Simd for WasmSimd128 {
         i8x16_splat(val).simd_into(self)
     }
     #[inline(always)]
+    fn reverse_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        let indices: u8x16<Self> =
+            [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].simd_into(self);
+        self.swizzle_dyn_i8x16(a, indices)
+    }
+    #[inline(always)]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         if SHIFT >= 16usize {
             return b;
@@ -758,6 +770,12 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn splat_u8x16(self, val: u8) -> u8x16<Self> {
         u8x16_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        let indices: u8x16<Self> =
+            [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].simd_into(self);
+        self.swizzle_dyn_u8x16(a, indices)
     }
     #[inline(always)]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1141,6 +1159,12 @@ impl Simd for WasmSimd128 {
         i16x8_splat(val).simd_into(self)
     }
     #[inline(always)]
+    fn reverse_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        let indices: u8x16<Self> =
+            [14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1].simd_into(self);
+        self.swizzle_dyn_i16x8(a, indices)
+    }
+    #[inline(always)]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         if SHIFT >= 8usize {
             return b;
@@ -1373,6 +1397,12 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn splat_u16x8(self, val: u16) -> u16x8<Self> {
         u16x8_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        let indices: u8x16<Self> =
+            [14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1].simd_into(self);
+        self.swizzle_dyn_u16x8(a, indices)
     }
     #[inline(always)]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -1692,6 +1722,12 @@ impl Simd for WasmSimd128 {
         i32x4_splat(val).simd_into(self)
     }
     #[inline(always)]
+    fn reverse_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_i32x4(a, indices)
+    }
+    #[inline(always)]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         if SHIFT >= 4usize {
             return b;
@@ -1921,6 +1957,12 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn splat_u32x4(self, val: u32) -> u32x4<Self> {
         u32x4_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        let indices: u8x16<Self> =
+            [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3].simd_into(self);
+        self.swizzle_dyn_u32x4(a, indices)
     }
     #[inline(always)]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -2237,6 +2279,12 @@ impl Simd for WasmSimd128 {
         f64x2_splat(val).simd_into(self)
     }
     #[inline(always)]
+    fn reverse_f64x2(self, a: f64x2<Self>) -> f64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_f64x2(a, indices)
+    }
+    #[inline(always)]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -2509,6 +2557,12 @@ impl Simd for WasmSimd128 {
         i64x2_splat(val).simd_into(self)
     }
     #[inline(always)]
+    fn reverse_i64x2(self, a: i64x2<Self>) -> i64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_i64x2(a, indices)
+    }
+    #[inline(always)]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         if SHIFT >= 2usize {
             return b;
@@ -2742,6 +2796,12 @@ impl Simd for WasmSimd128 {
     #[inline(always)]
     fn splat_u64x2(self, val: u64) -> u64x2<Self> {
         u64x2_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn reverse_u64x2(self, a: u64x2<Self>) -> u64x2<Self> {
+        let indices: u8x16<Self> =
+            [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7].simd_into(self);
+        self.swizzle_dyn_u64x2(a, indices)
     }
     #[inline(always)]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -69,6 +69,11 @@ pub(crate) fn reversed_compare_op(op: &Op, vec_ty: &VecType) -> Option<TokenStre
 pub(crate) fn reverse_method(op: Op, vec_ty: &VecType) -> TokenStream {
     assert_eq!(op.method, "reverse");
     assert!(matches!(op.sig, OpSig::Unary));
+    assert_ne!(
+        vec_ty.scalar,
+        ScalarType::Mask,
+        "reverse_method requires byte-swizzlable non-mask vectors"
+    );
 
     let method_sig = op.simd_trait_method_sig(vec_ty);
     let bytes_ty = vec_ty.bytes_ty();
@@ -86,6 +91,40 @@ pub(crate) fn reverse_method(op: Op, vec_ty: &VecType) -> TokenStream {
         #method_sig {
             let indices: #bytes<Self> = [#(#indices),*].simd_into(self);
             self.#swizzle(a, indices)
+        }
+    }
+}
+
+/// Reverse a native vector-backed mask by reusing the corresponding signed-vector operation.
+///
+/// Compact predicate masks such as AVX-512 masks must use a representation-specific lowering
+/// instead.
+pub(crate) fn reverse_vector_mask_method(op: Op, vec_ty: &VecType) -> TokenStream {
+    assert_eq!(op.method, "reverse");
+    assert!(matches!(op.sig, OpSig::Unary));
+    assert_eq!(
+        vec_ty.scalar,
+        ScalarType::Mask,
+        "reverse_vector_mask_method only implements masks"
+    );
+
+    let method_sig = op.simd_trait_method_sig(vec_ty);
+    let int_ty = vec_ty.cast(ScalarType::Int);
+    let int = int_ty.rust();
+    let mask = vec_ty.rust();
+    let reverse_int = generic_op_name("reverse", &int_ty);
+
+    quote! {
+        #method_sig {
+            let lanes = #int {
+                val: crate::transmute::checked_transmute_copy(&a.val),
+                simd: self,
+            };
+            let reversed = self.#reverse_int(lanes);
+            #mask {
+                val: crate::transmute::checked_transmute_copy(&reversed.val),
+                simd: self,
+            }
         }
     }
 }

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -62,6 +62,34 @@ pub(crate) fn reversed_compare_op(op: &Op, vec_ty: &VecType) -> Option<TokenStre
     })
 }
 
+/// Implement a fixed lane reversal as a byte swizzle with compile-time-known indices.
+///
+/// Backends use this only at widths they handle natively. Emulated wider vectors recurse through
+/// [`generic_op`], which also reverses the order of their halves.
+pub(crate) fn reverse_method(op: Op, vec_ty: &VecType) -> TokenStream {
+    assert_eq!(op.method, "reverse");
+    assert!(matches!(op.sig, OpSig::Unary));
+
+    let method_sig = op.simd_trait_method_sig(vec_ty);
+    let bytes_ty = vec_ty.bytes_ty();
+    let bytes = bytes_ty.rust();
+    let swizzle = generic_op_name("swizzle_dyn", vec_ty);
+    let element_bytes = vec_ty.scalar_bits / 8;
+    let indices = (0..bytes_ty.len).map(|output_byte| {
+        let output_element = output_byte / element_bytes;
+        let byte_in_element = output_byte % element_bytes;
+        let input_byte = (vec_ty.len - 1 - output_element) * element_bytes + byte_in_element;
+        Literal::u8_unsuffixed(u8::try_from(input_byte).unwrap())
+    });
+
+    quote! {
+        #method_sig {
+            let indices: #bytes<Self> = [#(#indices),*].simd_into(self);
+            self.#swizzle(a, indices)
+        }
+    }
+}
+
 pub(crate) fn recursive_swizzle_dyn_precise_body<T: ToTokens + ?Sized>(
     vec_ty: &VecType,
     token: &T,
@@ -143,10 +171,15 @@ pub(crate) fn generic_op(op: &Op, ty: &VecType) -> TokenStream {
             }
         }
         OpSig::Unary => {
+            let halves = if op.method == "reverse" {
+                quote! { self.#do_half(a1), self.#do_half(a0) }
+            } else {
+                quote! { self.#do_half(a0), self.#do_half(a1) }
+            };
             quote! {
                 #method_sig {
                     let (a0, a1) = self.#split(a);
-                    self.#combine(self.#do_half(a0), self.#do_half(a1))
+                    self.#combine(#halves)
                 }
             }
         }

--- a/fearless_simd_gen/src/main.rs
+++ b/fearless_simd_gen/src/main.rs
@@ -5,6 +5,10 @@
     missing_docs,
     reason = "TODO: https://github.com/linebender/fearless_simd/issues/40"
 )]
+#![expect(
+    clippy::missing_assert_message,
+    reason = "Asserts inside the generator are usually self-explanatory"
+)]
 
 use std::{fs::File, io::Write, path::Path};
 

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -248,6 +248,20 @@ impl Level for Fallback {
                 }
             }
             OpSig::Unary => {
+                if method == "reverse" {
+                    let items = make_list(
+                        (0..vec_ty.len)
+                            .rev()
+                            .map(|idx| lane(quote! { a }, vec_ty, idx))
+                            .collect::<Vec<_>>(),
+                    );
+                    return quote! {
+                        #method_sig {
+                            #items.simd_into(self)
+                        }
+                    };
+                }
+
                 if matches!(method, "count_ones" | "count_zeros") {
                     return count_bits_method(op, vec_ty);
                 }

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -6,7 +6,7 @@ use quote::{ToTokens as _, format_ident, quote};
 
 use crate::generic::{
     count_zeros_method, fallback_method, generic_mask_set, generic_op_name,
-    integer_lane_mask_splat_arg, reverse_method,
+    integer_lane_mask_splat_arg, reverse_method, reverse_vector_mask_method,
 };
 use crate::level::Level;
 use crate::ops::{NarrowingMode, Op, SlideGranularity, relaxed_narrow_method};
@@ -185,6 +185,9 @@ impl Level for Neon {
             }
             OpSig::Unary => {
                 if method == "reverse" {
+                    if vec_ty.scalar == ScalarType::Mask {
+                        return reverse_vector_mask_method(op, vec_ty);
+                    }
                     return reverse_method(op, vec_ty);
                 }
 

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -6,7 +6,7 @@ use quote::{ToTokens as _, format_ident, quote};
 
 use crate::generic::{
     count_zeros_method, fallback_method, generic_mask_set, generic_op_name,
-    integer_lane_mask_splat_arg,
+    integer_lane_mask_splat_arg, reverse_method,
 };
 use crate::level::Level;
 use crate::ops::{NarrowingMode, Op, SlideGranularity, relaxed_narrow_method};
@@ -184,6 +184,10 @@ impl Level for Neon {
                 })
             }
             OpSig::Unary => {
+                if method == "reverse" {
+                    return reverse_method(op, vec_ty);
+                }
+
                 if method == "count_zeros" {
                     return count_zeros_method(op, vec_ty);
                 }

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -8,7 +8,7 @@ use crate::arch::wasm::{arch_prefix, v128_intrinsic};
 use crate::generic::{
     count_zeros_method, fallback_method, generic_block_combine, generic_block_split,
     generic_mask_set, generic_op_name, integer_lane_mask_splat_arg,
-    recursive_swizzle_dyn_precise_body, reverse_method,
+    recursive_swizzle_dyn_precise_body, reverse_method, reverse_vector_mask_method,
 };
 use crate::level::Level;
 use crate::ops::{NarrowingMode, Op, Quantifier, SlideGranularity, relaxed_narrow_method};
@@ -201,6 +201,9 @@ impl Level for WasmSimd128 {
             }
             OpSig::Unary => {
                 if method == "reverse" {
+                    if vec_ty.scalar == ScalarType::Mask {
+                        return reverse_vector_mask_method(op, vec_ty);
+                    }
                     return reverse_method(op, vec_ty);
                 }
 

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -8,7 +8,7 @@ use crate::arch::wasm::{arch_prefix, v128_intrinsic};
 use crate::generic::{
     count_zeros_method, fallback_method, generic_block_combine, generic_block_split,
     generic_mask_set, generic_op_name, integer_lane_mask_splat_arg,
-    recursive_swizzle_dyn_precise_body,
+    recursive_swizzle_dyn_precise_body, reverse_method,
 };
 use crate::level::Level;
 use crate::ops::{NarrowingMode, Op, Quantifier, SlideGranularity, relaxed_narrow_method};
@@ -200,6 +200,10 @@ impl Level for WasmSimd128 {
                 }
             }
             OpSig::Unary => {
+                if method == "reverse" {
+                    return reverse_method(op, vec_ty);
+                }
+
                 if method == "count_zeros" {
                     return count_zeros_method(op, vec_ty);
                 }

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -9,7 +9,7 @@ use crate::arch::x86::{
 use crate::generic::{
     count_zeros_method, fallback_method, generic_block_combine, generic_block_split,
     generic_mask_from_bitmask, generic_mask_set, generic_op_name, integer_lane_mask_splat_arg,
-    recursive_swizzle_dyn_precise_body,
+    recursive_swizzle_dyn_precise_body, reverse_method,
 };
 use crate::level::Level;
 use crate::ops::{NarrowingMode, Op, OpSig, Quantifier, SlideGranularity, relaxed_narrow_method};
@@ -1476,6 +1476,14 @@ impl X86 {
         method: &str,
         vec_ty: &VecType,
     ) -> TokenStream {
+        if method == "reverse" {
+            return if *self == Self::Sse2 {
+                fallback_method(op, vec_ty)
+            } else {
+                reverse_method(op, vec_ty)
+            };
+        }
+
         if method == "count_zeros" {
             return self.handle_count_zeros(op, vec_ty);
         }

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -9,7 +9,7 @@ use crate::arch::x86::{
 use crate::generic::{
     count_zeros_method, fallback_method, generic_block_combine, generic_block_split,
     generic_mask_from_bitmask, generic_mask_set, generic_op_name, integer_lane_mask_splat_arg,
-    recursive_swizzle_dyn_precise_body, reverse_method,
+    recursive_swizzle_dyn_precise_body, reverse_method, reverse_vector_mask_method,
 };
 use crate::level::Level;
 use crate::ops::{NarrowingMode, Op, OpSig, Quantifier, SlideGranularity, relaxed_narrow_method};
@@ -1477,6 +1477,19 @@ impl X86 {
         vec_ty: &VecType,
     ) -> TokenStream {
         if method == "reverse" {
+            if vec_ty.scalar == ScalarType::Mask {
+                if *self == Self::Avx512 {
+                    let shift = avx512_mask_register_bits(vec_ty) - vec_ty.len;
+                    let result =
+                        avx512_mask_value(vec_ty, quote! { a.val.reverse_bits() >> #shift });
+                    return quote! {
+                        #method_sig {
+                            #result
+                        }
+                    };
+                }
+                return reverse_vector_mask_method(op, vec_ty);
+            }
             return if *self == Self::Sse2 {
                 fallback_method(op, vec_ty)
             } else {

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -1023,6 +1023,12 @@ const MASK_OPS: &[Op] = &[
         "Compute the logical NOT of the mask.",
     ),
     Op::new(
+        "reverse",
+        OpKind::VecTraitMethod,
+        OpSig::Unary,
+        "Reverse the order of the mask's logical lanes.",
+    ),
+    Op::new(
         "select",
         OpKind::OwnTrait,
         OpSig::Select,

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -532,6 +532,12 @@ const BASE_OPS: &[Op] = &[
         "Create a SIMD vector with all elements set to the given value.",
     ),
     Op::new(
+        "reverse",
+        OpKind::BaseTraitMethod,
+        OpSig::Unary,
+        "Reverse the order of the vector's elements.",
+    ),
+    Op::new(
         "slide",
         OpKind::BaseTraitMethod,
         OpSig::Slide {

--- a/fearless_simd_tests/tests/harness/ops/mod.rs
+++ b/fearless_simd_tests/tests/harness/ops/mod.rs
@@ -57,6 +57,7 @@ mod native_width;
 mod neg;
 mod not;
 mod or;
+mod reverse;
 mod rotate_elements_left;
 mod rotate_elements_right;
 mod round_ties_even;

--- a/fearless_simd_tests/tests/harness/ops/reverse.rs
+++ b/fearless_simd_tests/tests/harness/ops/reverse.rs
@@ -1,0 +1,323 @@
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use fearless_simd::*;
+use fearless_simd_dev_macros::simd_test;
+
+#[simd_test]
+fn reverse_i8x16<S: Simd>(simd: S) {
+    let a = i8x16::from_slice(
+        simd,
+        &[
+            1, -2, 3, -4, 5, -6, 7, -8, 9, -10, 11, -12, 13, -14, 15, -16,
+        ],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [
+            -16, 15, -14, 13, -12, 11, -10, 9, -8, 7, -6, 5, -4, 3, -2, 1
+        ]
+    );
+}
+
+#[simd_test]
+fn reverse_u8x16<S: Simd>(simd: S) {
+    let a = u8x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    );
+}
+
+#[simd_test]
+fn reverse_i16x8<S: Simd>(simd: S) {
+    let a = i16x8::from_slice(simd, &[1, -2, 3, -4, 5, -6, 7, -8]);
+    assert_eq!(*a.reverse(), [-8, 7, -6, 5, -4, 3, -2, 1]);
+}
+
+#[simd_test]
+fn reverse_u16x8<S: Simd>(simd: S) {
+    let a = u16x8::from_slice(simd, &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(*a.reverse(), [7, 6, 5, 4, 3, 2, 1, 0]);
+}
+
+#[simd_test]
+fn reverse_i32x4<S: Simd>(simd: S) {
+    let a = i32x4::from_slice(simd, &[1, -2, 3, -4]);
+    assert_eq!(*a.reverse(), [-4, 3, -2, 1]);
+}
+
+#[simd_test]
+fn reverse_u32x4<S: Simd>(simd: S) {
+    let a = u32x4::from_slice(simd, &[0, 1, 2, 3]);
+    assert_eq!(*a.reverse(), [3, 2, 1, 0]);
+}
+
+#[simd_test]
+fn reverse_i64x2<S: Simd>(simd: S) {
+    let a = i64x2::from_slice(simd, &[1, -2]);
+    assert_eq!(*a.reverse(), [-2, 1]);
+}
+
+#[simd_test]
+fn reverse_u64x2<S: Simd>(simd: S) {
+    let a = u64x2::from_slice(simd, &[0, 1]);
+    assert_eq!(*a.reverse(), [1, 0]);
+}
+
+#[simd_test]
+fn reverse_f32x4<S: Simd>(simd: S) {
+    let a = f32x4::from_slice(simd, &[1.0, -2.0, 3.0, -4.0]);
+    assert_eq!(*a.reverse(), [-4.0, 3.0, -2.0, 1.0]);
+}
+
+#[simd_test]
+fn reverse_f64x2<S: Simd>(simd: S) {
+    let a = f64x2::from_slice(simd, &[1.0, -2.0]);
+    assert_eq!(*a.reverse(), [-2.0, 1.0]);
+}
+
+#[simd_test]
+fn reverse_i8x32<S: Simd>(simd: S) {
+    let a = i8x32::from_slice(
+        simd,
+        &[
+            1, -2, 3, -4, 5, -6, 7, -8, 9, -10, 11, -12, 13, -14, 15, -16, 17, -18, 19, -20, 21,
+            -22, 23, -24, 25, -26, 27, -28, 29, -30, 31, -32,
+        ],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [
+            -32, 31, -30, 29, -28, 27, -26, 25, -24, 23, -22, 21, -20, 19, -18, 17, -16, 15, -14,
+            13, -12, 11, -10, 9, -8, 7, -6, 5, -4, 3, -2, 1
+        ]
+    );
+}
+
+#[simd_test]
+fn reverse_u8x32<S: Simd>(simd: S) {
+    let a = u8x32::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [
+            31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
+            9, 8, 7, 6, 5, 4, 3, 2, 1, 0
+        ]
+    );
+}
+
+#[simd_test]
+fn reverse_i16x16<S: Simd>(simd: S) {
+    let a = i16x16::from_slice(
+        simd,
+        &[
+            1, -2, 3, -4, 5, -6, 7, -8, 9, -10, 11, -12, 13, -14, 15, -16,
+        ],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [
+            -16, 15, -14, 13, -12, 11, -10, 9, -8, 7, -6, 5, -4, 3, -2, 1
+        ]
+    );
+}
+
+#[simd_test]
+fn reverse_u16x16<S: Simd>(simd: S) {
+    let a = u16x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    );
+}
+
+#[simd_test]
+fn reverse_i32x8<S: Simd>(simd: S) {
+    let a = i32x8::from_slice(simd, &[1, -2, 3, -4, 5, -6, 7, -8]);
+    assert_eq!(*a.reverse(), [-8, 7, -6, 5, -4, 3, -2, 1]);
+}
+
+#[simd_test]
+fn reverse_u32x8<S: Simd>(simd: S) {
+    let a = u32x8::from_slice(simd, &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(*a.reverse(), [7, 6, 5, 4, 3, 2, 1, 0]);
+}
+
+#[simd_test]
+fn reverse_i64x4<S: Simd>(simd: S) {
+    let a = i64x4::from_slice(simd, &[1, -2, 3, -4]);
+    assert_eq!(*a.reverse(), [-4, 3, -2, 1]);
+}
+
+#[simd_test]
+fn reverse_u64x4<S: Simd>(simd: S) {
+    let a = u64x4::from_slice(simd, &[0, 1, 2, 3]);
+    assert_eq!(*a.reverse(), [3, 2, 1, 0]);
+}
+
+#[simd_test]
+fn reverse_f32x8<S: Simd>(simd: S) {
+    let a = f32x8::from_slice(simd, &[1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0]);
+    assert_eq!(*a.reverse(), [-8.0, 7.0, -6.0, 5.0, -4.0, 3.0, -2.0, 1.0]);
+}
+
+#[simd_test]
+fn reverse_f64x4<S: Simd>(simd: S) {
+    let a = f64x4::from_slice(simd, &[1.0, -2.0, 3.0, -4.0]);
+    assert_eq!(*a.reverse(), [-4.0, 3.0, -2.0, 1.0]);
+}
+
+#[simd_test]
+fn reverse_i8x64<S: Simd>(simd: S) {
+    let a = i8x64::from_slice(
+        simd,
+        &[
+            1, -2, 3, -4, 5, -6, 7, -8, 9, -10, 11, -12, 13, -14, 15, -16, 17, -18, 19, -20, 21,
+            -22, 23, -24, 25, -26, 27, -28, 29, -30, 31, -32, 33, -34, 35, -36, 37, -38, 39, -40,
+            41, -42, 43, -44, 45, -46, 47, -48, 49, -50, 51, -52, 53, -54, 55, -56, 57, -58, 59,
+            -60, 61, -62, 63, -64,
+        ],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [
+            -64, 63, -62, 61, -60, 59, -58, 57, -56, 55, -54, 53, -52, 51, -50, 49, -48, 47, -46,
+            45, -44, 43, -42, 41, -40, 39, -38, 37, -36, 35, -34, 33, -32, 31, -30, 29, -28, 27,
+            -26, 25, -24, 23, -22, 21, -20, 19, -18, 17, -16, 15, -14, 13, -12, 11, -10, 9, -8, 7,
+            -6, 5, -4, 3, -2, 1
+        ]
+    );
+}
+
+#[simd_test]
+fn reverse_u8x64<S: Simd>(simd: S) {
+    let a = u8x64::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+            46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+        ],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [
+            63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42,
+            41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20,
+            19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
+        ]
+    );
+}
+
+#[simd_test]
+fn reverse_i16x32<S: Simd>(simd: S) {
+    let a = i16x32::from_slice(
+        simd,
+        &[
+            1, -2, 3, -4, 5, -6, 7, -8, 9, -10, 11, -12, 13, -14, 15, -16, 17, -18, 19, -20, 21,
+            -22, 23, -24, 25, -26, 27, -28, 29, -30, 31, -32,
+        ],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [
+            -32, 31, -30, 29, -28, 27, -26, 25, -24, 23, -22, 21, -20, 19, -18, 17, -16, 15, -14,
+            13, -12, 11, -10, 9, -8, 7, -6, 5, -4, 3, -2, 1
+        ]
+    );
+}
+
+#[simd_test]
+fn reverse_u16x32<S: Simd>(simd: S) {
+    let a = u16x32::from_slice(
+        simd,
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [
+            31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
+            9, 8, 7, 6, 5, 4, 3, 2, 1, 0
+        ]
+    );
+}
+
+#[simd_test]
+fn reverse_i32x16<S: Simd>(simd: S) {
+    let a = i32x16::from_slice(
+        simd,
+        &[
+            1, -2, 3, -4, 5, -6, 7, -8, 9, -10, 11, -12, 13, -14, 15, -16,
+        ],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [
+            -16, 15, -14, 13, -12, 11, -10, 9, -8, 7, -6, 5, -4, 3, -2, 1
+        ]
+    );
+}
+
+#[simd_test]
+fn reverse_u32x16<S: Simd>(simd: S) {
+    let a = u32x16::from_slice(
+        simd,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    );
+}
+
+#[simd_test]
+fn reverse_i64x8<S: Simd>(simd: S) {
+    let a = i64x8::from_slice(simd, &[1, -2, 3, -4, 5, -6, 7, -8]);
+    assert_eq!(*a.reverse(), [-8, 7, -6, 5, -4, 3, -2, 1]);
+}
+
+#[simd_test]
+fn reverse_u64x8<S: Simd>(simd: S) {
+    let a = u64x8::from_slice(simd, &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(*a.reverse(), [7, 6, 5, 4, 3, 2, 1, 0]);
+}
+
+#[simd_test]
+fn reverse_f32x16<S: Simd>(simd: S) {
+    let a = f32x16::from_slice(
+        simd,
+        &[
+            1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0, 11.0, -12.0, 13.0, -14.0, 15.0,
+            -16.0,
+        ],
+    );
+    assert_eq!(
+        *a.reverse(),
+        [
+            -16.0, 15.0, -14.0, 13.0, -12.0, 11.0, -10.0, 9.0, -8.0, 7.0, -6.0, 5.0, -4.0, 3.0,
+            -2.0, 1.0
+        ]
+    );
+}
+
+#[simd_test]
+fn reverse_f64x8<S: Simd>(simd: S) {
+    let a = f64x8::from_slice(simd, &[1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0]);
+    assert_eq!(*a.reverse(), [-8.0, 7.0, -6.0, 5.0, -4.0, 3.0, -2.0, 1.0]);
+}

--- a/fearless_simd_tests/tests/harness/ops/reverse.rs
+++ b/fearless_simd_tests/tests/harness/ops/reverse.rs
@@ -321,3 +321,121 @@ fn reverse_f64x8<S: Simd>(simd: S) {
     let a = f64x8::from_slice(simd, &[1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0]);
     assert_eq!(*a.reverse(), [-8.0, 7.0, -6.0, 5.0, -4.0, 3.0, -2.0, 1.0]);
 }
+
+#[simd_test]
+fn reverse_mask8x16<S: Simd>(simd: S) {
+    let lanes: [i8; 16] = [-1, 0, -1, 0, -1, -1, 0, 0, 0, -1, 0, 0, -1, 0, 0, 0];
+    let a = mask8x16::from_slice(simd, &lanes);
+    let mut expected = lanes;
+    expected.reverse();
+    assert_eq!(<[i8; 16]>::from(a.reverse()), expected);
+}
+
+#[simd_test]
+fn reverse_mask16x8<S: Simd>(simd: S) {
+    let lanes: [i16; 8] = [-1, 0, -1, 0, -1, -1, 0, 0];
+    let a = mask16x8::from_slice(simd, &lanes);
+    let mut expected = lanes;
+    expected.reverse();
+    assert_eq!(<[i16; 8]>::from(a.reverse()), expected);
+}
+
+#[simd_test]
+fn reverse_mask32x4<S: Simd>(simd: S) {
+    let lanes: [i32; 4] = [-1, 0, -1, 0];
+    let a = mask32x4::from_slice(simd, &lanes);
+    let mut expected = lanes;
+    expected.reverse();
+    assert_eq!(<[i32; 4]>::from(a.reverse()), expected);
+}
+
+#[simd_test]
+fn reverse_mask64x2<S: Simd>(simd: S) {
+    let lanes: [i64; 2] = [-1, 0];
+    let a = mask64x2::from_slice(simd, &lanes);
+    let mut expected = lanes;
+    expected.reverse();
+    assert_eq!(<[i64; 2]>::from(a.reverse()), expected);
+}
+
+#[simd_test]
+fn reverse_mask8x32<S: Simd>(simd: S) {
+    let lanes: [i8; 32] = [
+        -1, -1, -1, 0, 0, -1, -1, 0, -1, 0, -1, 0, 0, 0, -1, 0, -1, -1, 0, 0, 0, -1, 0, 0, -1, 0,
+        0, 0, 0, 0, 0, 0,
+    ];
+    let a = mask8x32::from_slice(simd, &lanes);
+    let mut expected = lanes;
+    expected.reverse();
+    assert_eq!(<[i8; 32]>::from(a.reverse()), expected);
+}
+
+#[simd_test]
+fn reverse_mask16x16<S: Simd>(simd: S) {
+    let lanes: [i16; 16] = [-1, 0, -1, 0, -1, -1, 0, 0, 0, -1, 0, 0, -1, 0, 0, 0];
+    let a = mask16x16::from_slice(simd, &lanes);
+    let mut expected = lanes;
+    expected.reverse();
+    assert_eq!(<[i16; 16]>::from(a.reverse()), expected);
+}
+
+#[simd_test]
+fn reverse_mask32x8<S: Simd>(simd: S) {
+    let lanes: [i32; 8] = [-1, 0, -1, 0, -1, -1, 0, 0];
+    let a = mask32x8::from_slice(simd, &lanes);
+    let mut expected = lanes;
+    expected.reverse();
+    assert_eq!(<[i32; 8]>::from(a.reverse()), expected);
+}
+
+#[simd_test]
+fn reverse_mask64x4<S: Simd>(simd: S) {
+    let lanes: [i64; 4] = [-1, 0, -1, 0];
+    let a = mask64x4::from_slice(simd, &lanes);
+    let mut expected = lanes;
+    expected.reverse();
+    assert_eq!(<[i64; 4]>::from(a.reverse()), expected);
+}
+
+#[simd_test]
+fn reverse_mask8x64<S: Simd>(simd: S) {
+    let lanes: [i8; 64] = [
+        -1, -1, -1, -1, 0, -1, -1, -1, -1, 0, -1, -1, 0, 0, -1, -1, -1, -1, 0, -1, 0, -1, 0, -1,
+        -1, 0, 0, -1, 0, 0, 0, -1, -1, -1, -1, 0, 0, -1, -1, 0, -1, 0, -1, 0, 0, 0, -1, 0, -1, -1,
+        0, 0, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+    ];
+    let a = mask8x64::from_slice(simd, &lanes);
+    let mut expected = lanes;
+    expected.reverse();
+    assert_eq!(<[i8; 64]>::from(a.reverse()), expected);
+}
+
+#[simd_test]
+fn reverse_mask16x32<S: Simd>(simd: S) {
+    let lanes: [i16; 32] = [
+        -1, -1, -1, 0, 0, -1, -1, 0, -1, 0, -1, 0, 0, 0, -1, 0, -1, -1, 0, 0, 0, -1, 0, 0, -1, 0,
+        0, 0, 0, 0, 0, 0,
+    ];
+    let a = mask16x32::from_slice(simd, &lanes);
+    let mut expected = lanes;
+    expected.reverse();
+    assert_eq!(<[i16; 32]>::from(a.reverse()), expected);
+}
+
+#[simd_test]
+fn reverse_mask32x16<S: Simd>(simd: S) {
+    let lanes: [i32; 16] = [-1, 0, -1, 0, -1, -1, 0, 0, 0, -1, 0, 0, -1, 0, 0, 0];
+    let a = mask32x16::from_slice(simd, &lanes);
+    let mut expected = lanes;
+    expected.reverse();
+    assert_eq!(<[i32; 16]>::from(a.reverse()), expected);
+}
+
+#[simd_test]
+fn reverse_mask64x8<S: Simd>(simd: S) {
+    let lanes: [i64; 8] = [-1, 0, -1, 0, -1, -1, 0, 0];
+    let a = mask64x8::from_slice(simd, &lanes);
+    let mut expected = lanes;
+    expected.reverse();
+    assert_eq!(<[i64; 8]>::from(a.reverse()), expected);
+}


### PR DESCRIPTION
This deserves its own op because it has better lowerings than `swizzle_dyn`: we can splt/combine to move data across blocks for free in larger-than-native vectors, e.g. for 512-bit vectors on SSE4.2. 

Other than the block split, it just reuses `swizzle_dyn` under the hood, so the implementation is generic and pretty clean.

Masks also get this op, lowering into either a bitcast into a vector on most backends or into scalar ops on a packed mask on AVX-512.

Matches std::simd API