### PR TITLE
Implement reduce_sum()

### DIFF
--- a/fearless_simd/src/generated/avx2.rs
+++ b/fearless_simd/src/generated/avx2.rs
@@ -316,6 +316,18 @@ impl Simd for Avx2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_f32x4(self, a: f32x4<Self>) -> f32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: f32x4<Avx2>) -> f32 {
+                let a: __m128 = a.into();
+                let adjacent = _mm_add_ps(a, _mm_shuffle_ps::<0b10_11_00_01>(a, a));
+                _mm_cvtss_f32(_mm_add_ss(adjacent, _mm_movehl_ps(adjacent, adjacent)))
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -958,6 +970,22 @@ impl Simd for Avx2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i8x16(self, a: i8x16<Self>) -> i8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i8x16<Avx2>) -> i8 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<2>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<1>(sum));
+                let lanes: [i8; 16usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1499,6 +1527,22 @@ impl Simd for Avx2 {
                     let lanes: [u8; 16usize] = crate::transmute::checked_transmute_copy(&reduced);
                     lanes[0]
                 }
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u8x16(self, a: u8x16<Self>) -> u8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u8x16<Avx2>) -> u8 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<2>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<1>(sum));
+                let lanes: [u8; 16usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)
@@ -2139,6 +2183,21 @@ impl Simd for Avx2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i16x8(self, a: i16x8<Self>) -> i16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i16x8<Avx2>) -> i16 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<2>(sum));
+                let lanes: [i16; 8usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2632,6 +2691,21 @@ impl Simd for Avx2 {
                     let lanes: [u16; 8usize] = crate::transmute::checked_transmute_copy(&reduced);
                     lanes[0]
                 }
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u16x8(self, a: u16x8<Self>) -> u16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u16x8<Avx2>) -> u16 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<2>(sum));
+                let lanes: [u16; 8usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)
@@ -3304,6 +3378,20 @@ impl Simd for Avx2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i32x4(self, a: i32x4<Self>) -> i32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i32x4<Avx2>) -> i32 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<4>(sum));
+                let lanes: [i32; 4usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3775,6 +3863,20 @@ impl Simd for Avx2 {
                     let lanes: [u32; 4usize] = crate::transmute::checked_transmute_copy(&reduced);
                     lanes[0]
                 }
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u32x4(self, a: u32x4<Self>) -> u32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u32x4<Avx2>) -> u32 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<4>(sum));
+                let lanes: [u32; 4usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)
@@ -4415,6 +4517,17 @@ impl Simd for Avx2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_f64x2(self, a: f64x2<Self>) -> f64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: f64x2<Avx2>) -> f64 {
+                let a: __m128d = a.into();
+                _mm_cvtsd_f64(_mm_add_sd(a, _mm_unpackhi_pd(a, a)))
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5005,6 +5118,19 @@ impl Simd for Avx2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i64x2(self, a: i64x2<Self>) -> i64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: i64x2<Avx2>) -> i64 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi64(sum, _mm_srli_si128::<8>(sum));
+                let lanes: [i64; 2usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         [
             i64::max(a[0usize], b[0usize]),
@@ -5436,6 +5562,19 @@ impl Simd for Avx2 {
             fn kernel(token: Avx2, a: u64x2<Avx2>) -> u64 {
                 let lanes: [u64; 2] = a.into();
                 lanes[0].min(lanes[1])
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u64x2(self, a: u64x2<Self>) -> u64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx2, a: u64x2<Avx2>) -> u64 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi64(sum, _mm_srli_si128::<8>(sum));
+                let lanes: [u64; 2usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)

--- a/fearless_simd/src/generated/avx512.rs
+++ b/fearless_simd/src/generated/avx512.rs
@@ -574,6 +574,18 @@ impl Simd for Avx512 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_f32x4(self, a: f32x4<Self>) -> f32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: f32x4<Avx512>) -> f32 {
+                let a: __m128 = a.into();
+                let adjacent = _mm_add_ps(a, _mm_shuffle_ps::<0b10_11_00_01>(a, a));
+                _mm_cvtss_f32(_mm_add_ss(adjacent, _mm_movehl_ps(adjacent, adjacent)))
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1160,6 +1172,22 @@ impl Simd for Avx512 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i8x16(self, a: i8x16<Self>) -> i8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i8x16<Avx512>) -> i8 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<2>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<1>(sum));
+                let lanes: [i8; 16usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1687,6 +1715,22 @@ impl Simd for Avx512 {
                     let lanes: [u8; 16usize] = crate::transmute::checked_transmute_copy(&reduced);
                     lanes[0]
                 }
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u8x16(self, a: u8x16<Self>) -> u8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u8x16<Avx512>) -> u8 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<2>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<1>(sum));
+                let lanes: [u8; 16usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)
@@ -2242,6 +2286,21 @@ impl Simd for Avx512 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i16x8(self, a: i16x8<Self>) -> i16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i16x8<Avx512>) -> i16 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<2>(sum));
+                let lanes: [i16; 8usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2703,6 +2762,21 @@ impl Simd for Avx512 {
                     let lanes: [u16; 8usize] = crate::transmute::checked_transmute_copy(&reduced);
                     lanes[0]
                 }
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u16x8(self, a: u16x8<Self>) -> u16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u16x8<Avx512>) -> u16 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<2>(sum));
+                let lanes: [u16; 8usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)
@@ -3277,6 +3351,20 @@ impl Simd for Avx512 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i32x4(self, a: i32x4<Self>) -> i32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i32x4<Avx512>) -> i32 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<4>(sum));
+                let lanes: [i32; 4usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3728,6 +3816,20 @@ impl Simd for Avx512 {
                     let lanes: [u32; 4usize] = crate::transmute::checked_transmute_copy(&reduced);
                     lanes[0]
                 }
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u32x4(self, a: u32x4<Self>) -> u32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u32x4<Avx512>) -> u32 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<4>(sum));
+                let lanes: [u32; 4usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)
@@ -4287,6 +4389,17 @@ impl Simd for Avx512 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_f64x2(self, a: f64x2<Self>) -> f64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: f64x2<Avx512>) -> f64 {
+                let a: __m128d = a.into();
+                _mm_cvtsd_f64(_mm_add_sd(a, _mm_unpackhi_pd(a, a)))
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -4810,6 +4923,19 @@ impl Simd for Avx512 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i64x2(self, a: i64x2<Self>) -> i64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: i64x2<Avx512>) -> i64 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi64(sum, _mm_srli_si128::<8>(sum));
+                let lanes: [i64; 2usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5227,6 +5353,19 @@ impl Simd for Avx512 {
             fn kernel(token: Avx512, a: u64x2<Avx512>) -> u64 {
                 let lanes: [u64; 2] = a.into();
                 lanes[0].min(lanes[1])
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u64x2(self, a: u64x2<Self>) -> u64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Avx512, a: u64x2<Avx512>) -> u64 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi64(sum, _mm_srli_si128::<8>(sum));
+                let lanes: [u64; 2usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -333,6 +333,12 @@ impl Simd for Fallback {
         reduced[0]
     }
     #[inline(always)]
+    fn reduce_sum_f32x4(self, a: f32x4<Self>) -> f32 {
+        let sum_level_0: [f32; 2usize] = [a[0usize] + a[1usize], a[2usize] + a[3usize]];
+        let sum_level_1: [f32; 1usize] = [sum_level_0[0usize] + sum_level_0[1usize]];
+        sum_level_1[0]
+    }
+    #[inline(always)]
     fn max_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         [
             f32::max(a[0usize], b[0usize]),
@@ -967,6 +973,31 @@ impl Simd for Fallback {
         ];
         let reduced: [i8; 1usize] = [i8::min(reduced[0usize], reduced[1usize])];
         reduced[0]
+    }
+    #[inline(always)]
+    fn reduce_sum_i8x16(self, a: i8x16<Self>) -> i8 {
+        let sum_level_0: [i8; 8usize] = [
+            a[0usize].wrapping_add(a[1usize]),
+            a[2usize].wrapping_add(a[3usize]),
+            a[4usize].wrapping_add(a[5usize]),
+            a[6usize].wrapping_add(a[7usize]),
+            a[8usize].wrapping_add(a[9usize]),
+            a[10usize].wrapping_add(a[11usize]),
+            a[12usize].wrapping_add(a[13usize]),
+            a[14usize].wrapping_add(a[15usize]),
+        ];
+        let sum_level_1: [i8; 4usize] = [
+            sum_level_0[0usize].wrapping_add(sum_level_0[1usize]),
+            sum_level_0[2usize].wrapping_add(sum_level_0[3usize]),
+            sum_level_0[4usize].wrapping_add(sum_level_0[5usize]),
+            sum_level_0[6usize].wrapping_add(sum_level_0[7usize]),
+        ];
+        let sum_level_2: [i8; 2usize] = [
+            sum_level_1[0usize].wrapping_add(sum_level_1[1usize]),
+            sum_level_1[2usize].wrapping_add(sum_level_1[3usize]),
+        ];
+        let sum_level_3: [i8; 1usize] = [sum_level_2[0usize].wrapping_add(sum_level_2[1usize])];
+        sum_level_3[0]
     }
     #[inline(always)]
     fn max_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
@@ -1867,6 +1898,31 @@ impl Simd for Fallback {
         ];
         let reduced: [u8; 1usize] = [u8::min(reduced[0usize], reduced[1usize])];
         reduced[0]
+    }
+    #[inline(always)]
+    fn reduce_sum_u8x16(self, a: u8x16<Self>) -> u8 {
+        let sum_level_0: [u8; 8usize] = [
+            a[0usize].wrapping_add(a[1usize]),
+            a[2usize].wrapping_add(a[3usize]),
+            a[4usize].wrapping_add(a[5usize]),
+            a[6usize].wrapping_add(a[7usize]),
+            a[8usize].wrapping_add(a[9usize]),
+            a[10usize].wrapping_add(a[11usize]),
+            a[12usize].wrapping_add(a[13usize]),
+            a[14usize].wrapping_add(a[15usize]),
+        ];
+        let sum_level_1: [u8; 4usize] = [
+            sum_level_0[0usize].wrapping_add(sum_level_0[1usize]),
+            sum_level_0[2usize].wrapping_add(sum_level_0[3usize]),
+            sum_level_0[4usize].wrapping_add(sum_level_0[5usize]),
+            sum_level_0[6usize].wrapping_add(sum_level_0[7usize]),
+        ];
+        let sum_level_2: [u8; 2usize] = [
+            sum_level_1[0usize].wrapping_add(sum_level_1[1usize]),
+            sum_level_1[2usize].wrapping_add(sum_level_1[3usize]),
+        ];
+        let sum_level_3: [u8; 1usize] = [sum_level_2[0usize].wrapping_add(sum_level_2[1usize])];
+        sum_level_3[0]
     }
     #[inline(always)]
     fn max_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -2883,6 +2939,21 @@ impl Simd for Fallback {
         reduced[0]
     }
     #[inline(always)]
+    fn reduce_sum_i16x8(self, a: i16x8<Self>) -> i16 {
+        let sum_level_0: [i16; 4usize] = [
+            a[0usize].wrapping_add(a[1usize]),
+            a[2usize].wrapping_add(a[3usize]),
+            a[4usize].wrapping_add(a[5usize]),
+            a[6usize].wrapping_add(a[7usize]),
+        ];
+        let sum_level_1: [i16; 2usize] = [
+            sum_level_0[0usize].wrapping_add(sum_level_0[1usize]),
+            sum_level_0[2usize].wrapping_add(sum_level_0[3usize]),
+        ];
+        let sum_level_2: [i16; 1usize] = [sum_level_1[0usize].wrapping_add(sum_level_1[1usize])];
+        sum_level_2[0]
+    }
+    #[inline(always)]
     fn max_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         [
             i16::max(a[0usize], b[0usize]),
@@ -3448,6 +3519,21 @@ impl Simd for Fallback {
         ];
         let reduced: [u16; 1usize] = [u16::min(reduced[0usize], reduced[1usize])];
         reduced[0]
+    }
+    #[inline(always)]
+    fn reduce_sum_u16x8(self, a: u16x8<Self>) -> u16 {
+        let sum_level_0: [u16; 4usize] = [
+            a[0usize].wrapping_add(a[1usize]),
+            a[2usize].wrapping_add(a[3usize]),
+            a[4usize].wrapping_add(a[5usize]),
+            a[6usize].wrapping_add(a[7usize]),
+        ];
+        let sum_level_1: [u16; 2usize] = [
+            sum_level_0[0usize].wrapping_add(sum_level_0[1usize]),
+            sum_level_0[2usize].wrapping_add(sum_level_0[3usize]),
+        ];
+        let sum_level_2: [u16; 1usize] = [sum_level_1[0usize].wrapping_add(sum_level_1[1usize])];
+        sum_level_2[0]
     }
     #[inline(always)]
     fn max_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -4165,6 +4251,15 @@ impl Simd for Fallback {
         reduced[0]
     }
     #[inline(always)]
+    fn reduce_sum_i32x4(self, a: i32x4<Self>) -> i32 {
+        let sum_level_0: [i32; 2usize] = [
+            a[0usize].wrapping_add(a[1usize]),
+            a[2usize].wrapping_add(a[3usize]),
+        ];
+        let sum_level_1: [i32; 1usize] = [sum_level_0[0usize].wrapping_add(sum_level_0[1usize])];
+        sum_level_1[0]
+    }
+    #[inline(always)]
     fn max_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         [
             i32::max(a[0usize], b[0usize]),
@@ -4533,6 +4628,15 @@ impl Simd for Fallback {
         ];
         let reduced: [u32; 1usize] = [u32::min(reduced[0usize], reduced[1usize])];
         reduced[0]
+    }
+    #[inline(always)]
+    fn reduce_sum_u32x4(self, a: u32x4<Self>) -> u32 {
+        let sum_level_0: [u32; 2usize] = [
+            a[0usize].wrapping_add(a[1usize]),
+            a[2usize].wrapping_add(a[3usize]),
+        ];
+        let sum_level_1: [u32; 1usize] = [sum_level_0[0usize].wrapping_add(sum_level_0[1usize])];
+        sum_level_1[0]
     }
     #[inline(always)]
     fn max_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -4976,6 +5080,11 @@ impl Simd for Fallback {
         reduced[0]
     }
     #[inline(always)]
+    fn reduce_sum_f64x2(self, a: f64x2<Self>) -> f64 {
+        let sum_level_0: [f64; 1usize] = [a[0usize] + a[1usize]];
+        sum_level_0[0]
+    }
+    #[inline(always)]
     fn max_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         [
             f64::max(a[0usize], b[0usize]),
@@ -5314,6 +5423,11 @@ impl Simd for Fallback {
         reduced[0]
     }
     #[inline(always)]
+    fn reduce_sum_i64x2(self, a: i64x2<Self>) -> i64 {
+        let sum_level_0: [i64; 1usize] = [a[0usize].wrapping_add(a[1usize])];
+        sum_level_0[0]
+    }
+    #[inline(always)]
     fn max_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         [
             i64::max(a[0usize], b[0usize]),
@@ -5589,6 +5703,11 @@ impl Simd for Fallback {
     fn reduce_min_u64x2(self, a: u64x2<Self>) -> u64 {
         let reduced: [u64; 1usize] = [u64::min(a[0usize], a[1usize])];
         reduced[0]
+    }
+    #[inline(always)]
+    fn reduce_sum_u64x2(self, a: u64x2<Self>) -> u64 {
+        let sum_level_0: [u64; 1usize] = [a[0usize].wrapping_add(a[1usize])];
+        sum_level_0[0]
     }
     #[inline(always)]
     fn max_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -272,6 +272,16 @@ impl Simd for Neon {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_f32x4(self, a: f32x4<Self>) -> f32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: f32x4<Neon>) -> f32 {
+                vaddvq_f32(a.into())
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -735,6 +745,16 @@ impl Simd for Neon {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i8x16(self, a: i8x16<Self>) -> i8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i8x16<Neon>) -> i8 {
+                vaddvq_s8(a.into())
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1113,6 +1133,16 @@ impl Simd for Neon {
             #[inline(always)]
             fn kernel(token: Neon, a: u8x16<Neon>) -> u8 {
                 vminvq_u8(a.into())
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u8x16(self, a: u8x16<Self>) -> u8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u8x16<Neon>) -> u8 {
+                vaddvq_u8(a.into())
             }
         );
         kernel(self, a)
@@ -1648,6 +1678,16 @@ impl Simd for Neon {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i16x8(self, a: i16x8<Self>) -> i16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i16x8<Neon>) -> i16 {
+                vaddvq_s16(a.into())
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2025,6 +2065,16 @@ impl Simd for Neon {
             #[inline(always)]
             fn kernel(token: Neon, a: u16x8<Neon>) -> u16 {
                 vminvq_u16(a.into())
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u16x8(self, a: u16x8<Self>) -> u16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u16x8<Neon>) -> u16 {
+                vaddvq_u16(a.into())
             }
         );
         kernel(self, a)
@@ -2585,6 +2635,16 @@ impl Simd for Neon {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i32x4(self, a: i32x4<Self>) -> i32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i32x4<Neon>) -> i32 {
+                vaddvq_s32(a.into())
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2972,6 +3032,16 @@ impl Simd for Neon {
             #[inline(always)]
             fn kernel(token: Neon, a: u32x4<Neon>) -> u32 {
                 vminvq_u32(a.into())
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u32x4(self, a: u32x4<Self>) -> u32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u32x4<Neon>) -> u32 {
+                vaddvq_u32(a.into())
             }
         );
         kernel(self, a)
@@ -3525,6 +3595,16 @@ impl Simd for Neon {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_f64x2(self, a: f64x2<Self>) -> f64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: f64x2<Neon>) -> f64 {
+                vaddvq_f64(a.into())
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3984,6 +4064,16 @@ impl Simd for Neon {
         reduced[0]
     }
     #[inline(always)]
+    fn reduce_sum_i64x2(self, a: i64x2<Self>) -> i64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: i64x2<Neon>) -> i64 {
+                vaddvq_s64(a.into())
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         [
             i64::max(a[0usize], b[0usize]),
@@ -4348,6 +4438,16 @@ impl Simd for Neon {
     fn reduce_min_u64x2(self, a: u64x2<Self>) -> u64 {
         let reduced: [u64; 1usize] = [u64::min(a[0usize], a[1usize])];
         reduced[0]
+    }
+    #[inline(always)]
+    fn reduce_sum_u64x2(self, a: u64x2<Self>) -> u64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Neon, a: u64x2<Neon>) -> u64 {
+                vaddvq_u64(a.into())
+            }
+        );
+        kernel(self, a)
     }
     #[inline(always)]
     fn max_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -269,6 +269,8 @@ pub trait Simd:
     fn reduce_max_precise_f32x4(self, a: f32x4<Self>) -> f32;
     #[doc = "Return the minimum element in the vector, ignoring quiet NaNs.\n\nFor integer vectors, this operation is the same as `reduce_min`.\n\nFor floating-point vectors, quiet NaNs are ignored. If there is at least one numeric lane, this returns the true minimum of the numeric lanes. If all lanes are quiet NaNs, this returns NaN, with an unspecified payload and sign.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned.\n\nIf any lane is a *signaling* NaN, the result is fully non-deterministic: it may be NaN or a numeric lane and is not guaranteed to be the true minimum.\nSignaling NaN values are not produced by floating-point math operations, only from manual initialization with specific bit patterns. You probably don't need to worry about them."]
     fn reduce_min_precise_f32x4(self, a: f32x4<Self>) -> f32;
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    fn reduce_sum_f32x4(self, a: f32x4<Self>) -> f32;
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     fn max_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Return the element-wise minimum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `min_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
@@ -407,6 +409,8 @@ pub trait Simd:
     fn reduce_max_i8x16(self, a: i8x16<Self>) -> i8;
     #[doc = "Return the minimum element in the vector. Integer vectors always return the exact minimum.\n\nFor floating-point vectors with no NaNs, this returns the true minimum. If any lane is NaN, the entire result is implementation-defined: it may be NaN or a numeric lane that is not the true minimum. See `reduce_min_precise` for a version that ignores quiet NaNs.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned."]
     fn reduce_min_i8x16(self, a: i8x16<Self>) -> i8;
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    fn reduce_sum_i8x16(self, a: i8x16<Self>) -> i8;
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     fn max_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Return the element-wise minimum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `min_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
@@ -508,6 +512,8 @@ pub trait Simd:
     fn reduce_max_u8x16(self, a: u8x16<Self>) -> u8;
     #[doc = "Return the minimum element in the vector. Integer vectors always return the exact minimum.\n\nFor floating-point vectors with no NaNs, this returns the true minimum. If any lane is NaN, the entire result is implementation-defined: it may be NaN or a numeric lane that is not the true minimum. See `reduce_min_precise` for a version that ignores quiet NaNs.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned."]
     fn reduce_min_u8x16(self, a: u8x16<Self>) -> u8;
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    fn reduce_sum_u8x16(self, a: u8x16<Self>) -> u8;
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     fn max_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Return the element-wise minimum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `min_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
@@ -653,6 +659,8 @@ pub trait Simd:
     fn reduce_max_i16x8(self, a: i16x8<Self>) -> i16;
     #[doc = "Return the minimum element in the vector. Integer vectors always return the exact minimum.\n\nFor floating-point vectors with no NaNs, this returns the true minimum. If any lane is NaN, the entire result is implementation-defined: it may be NaN or a numeric lane that is not the true minimum. See `reduce_min_precise` for a version that ignores quiet NaNs.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned."]
     fn reduce_min_i16x8(self, a: i16x8<Self>) -> i16;
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    fn reduce_sum_i16x8(self, a: i16x8<Self>) -> i16;
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     fn max_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Return the element-wise minimum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `min_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
@@ -769,6 +777,8 @@ pub trait Simd:
     fn reduce_max_u16x8(self, a: u16x8<Self>) -> u16;
     #[doc = "Return the minimum element in the vector. Integer vectors always return the exact minimum.\n\nFor floating-point vectors with no NaNs, this returns the true minimum. If any lane is NaN, the entire result is implementation-defined: it may be NaN or a numeric lane that is not the true minimum. See `reduce_min_precise` for a version that ignores quiet NaNs.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned."]
     fn reduce_min_u16x8(self, a: u16x8<Self>) -> u16;
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    fn reduce_sum_u16x8(self, a: u16x8<Self>) -> u16;
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     fn max_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Return the element-wise minimum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `min_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
@@ -920,6 +930,8 @@ pub trait Simd:
     fn reduce_max_i32x4(self, a: i32x4<Self>) -> i32;
     #[doc = "Return the minimum element in the vector. Integer vectors always return the exact minimum.\n\nFor floating-point vectors with no NaNs, this returns the true minimum. If any lane is NaN, the entire result is implementation-defined: it may be NaN or a numeric lane that is not the true minimum. See `reduce_min_precise` for a version that ignores quiet NaNs.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned."]
     fn reduce_min_i32x4(self, a: i32x4<Self>) -> i32;
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    fn reduce_sum_i32x4(self, a: i32x4<Self>) -> i32;
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     fn max_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Return the element-wise minimum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `min_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
@@ -1038,6 +1050,8 @@ pub trait Simd:
     fn reduce_max_u32x4(self, a: u32x4<Self>) -> u32;
     #[doc = "Return the minimum element in the vector. Integer vectors always return the exact minimum.\n\nFor floating-point vectors with no NaNs, this returns the true minimum. If any lane is NaN, the entire result is implementation-defined: it may be NaN or a numeric lane that is not the true minimum. See `reduce_min_precise` for a version that ignores quiet NaNs.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned."]
     fn reduce_min_u32x4(self, a: u32x4<Self>) -> u32;
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    fn reduce_sum_u32x4(self, a: u32x4<Self>) -> u32;
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     fn max_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Return the element-wise minimum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `min_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
@@ -1187,6 +1201,8 @@ pub trait Simd:
     fn reduce_max_precise_f64x2(self, a: f64x2<Self>) -> f64;
     #[doc = "Return the minimum element in the vector, ignoring quiet NaNs.\n\nFor integer vectors, this operation is the same as `reduce_min`.\n\nFor floating-point vectors, quiet NaNs are ignored. If there is at least one numeric lane, this returns the true minimum of the numeric lanes. If all lanes are quiet NaNs, this returns NaN, with an unspecified payload and sign.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned.\n\nIf any lane is a *signaling* NaN, the result is fully non-deterministic: it may be NaN or a numeric lane and is not guaranteed to be the true minimum.\nSignaling NaN values are not produced by floating-point math operations, only from manual initialization with specific bit patterns. You probably don't need to worry about them."]
     fn reduce_min_precise_f64x2(self, a: f64x2<Self>) -> f64;
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    fn reduce_sum_f64x2(self, a: f64x2<Self>) -> f64;
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     fn max_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Return the element-wise minimum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `min_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
@@ -1329,6 +1345,8 @@ pub trait Simd:
     fn reduce_max_i64x2(self, a: i64x2<Self>) -> i64;
     #[doc = "Return the minimum element in the vector. Integer vectors always return the exact minimum.\n\nFor floating-point vectors with no NaNs, this returns the true minimum. If any lane is NaN, the entire result is implementation-defined: it may be NaN or a numeric lane that is not the true minimum. See `reduce_min_precise` for a version that ignores quiet NaNs.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned."]
     fn reduce_min_i64x2(self, a: i64x2<Self>) -> i64;
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    fn reduce_sum_i64x2(self, a: i64x2<Self>) -> i64;
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     fn max_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Return the element-wise minimum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `min_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
@@ -1445,6 +1463,8 @@ pub trait Simd:
     fn reduce_max_u64x2(self, a: u64x2<Self>) -> u64;
     #[doc = "Return the minimum element in the vector. Integer vectors always return the exact minimum.\n\nFor floating-point vectors with no NaNs, this returns the true minimum. If any lane is NaN, the entire result is implementation-defined: it may be NaN or a numeric lane that is not the true minimum. See `reduce_min_precise` for a version that ignores quiet NaNs.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned."]
     fn reduce_min_u64x2(self, a: u64x2<Self>) -> u64;
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    fn reduce_sum_u64x2(self, a: u64x2<Self>) -> u64;
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     fn max_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Return the element-wise minimum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `min_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
@@ -1664,6 +1684,12 @@ pub trait Simd:
     fn reduce_min_precise_f32x8(self, a: f32x8<Self>) -> f32 {
         let (a0, a1) = self.split_f32x8(a);
         self.reduce_min_precise_f32x4(self.min_precise_f32x4(a0, a1))
+    }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_f32x8(self, a: f32x8<Self>) -> f32 {
+        let (a0, a1) = self.split_f32x8(a);
+        self.reduce_sum_f32x4(self.add_f32x4(a0, a1))
     }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
@@ -2054,6 +2080,12 @@ pub trait Simd:
         let (a0, a1) = self.split_i8x32(a);
         self.reduce_min_i8x16(self.min_i8x16(a0, a1))
     }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_i8x32(self, a: i8x32<Self>) -> i8 {
+        let (a0, a1) = self.split_i8x32(a);
+        self.reduce_sum_i8x16(self.add_i8x16(a0, a1))
+    }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
     fn max_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
@@ -2320,6 +2352,12 @@ pub trait Simd:
     fn reduce_min_u8x32(self, a: u8x32<Self>) -> u8 {
         let (a0, a1) = self.split_u8x32(a);
         self.reduce_min_u8x16(self.min_u8x16(a0, a1))
+    }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_u8x32(self, a: u8x32<Self>) -> u8 {
+        let (a0, a1) = self.split_u8x32(a);
+        self.reduce_sum_u8x16(self.add_u8x16(a0, a1))
     }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
@@ -2694,6 +2732,12 @@ pub trait Simd:
         let (a0, a1) = self.split_i16x16(a);
         self.reduce_min_i16x8(self.min_i16x8(a0, a1))
     }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_i16x16(self, a: i16x16<Self>) -> i16 {
+        let (a0, a1) = self.split_i16x16(a);
+        self.reduce_sum_i16x8(self.add_i16x8(a0, a1))
+    }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
     fn max_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
@@ -2992,6 +3036,12 @@ pub trait Simd:
     fn reduce_min_u16x16(self, a: u16x16<Self>) -> u16 {
         let (a0, a1) = self.split_u16x16(a);
         self.reduce_min_u16x8(self.min_u16x8(a0, a1))
+    }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_u16x16(self, a: u16x16<Self>) -> u16 {
+        let (a0, a1) = self.split_u16x16(a);
+        self.reduce_sum_u16x8(self.add_u16x8(a0, a1))
     }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
@@ -3389,6 +3439,12 @@ pub trait Simd:
         let (a0, a1) = self.split_i32x8(a);
         self.reduce_min_i32x4(self.min_i32x4(a0, a1))
     }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_i32x8(self, a: i32x8<Self>) -> i32 {
+        let (a0, a1) = self.split_i32x8(a);
+        self.reduce_sum_i32x4(self.add_i32x4(a0, a1))
+    }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
     fn max_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
@@ -3689,6 +3745,12 @@ pub trait Simd:
     fn reduce_min_u32x8(self, a: u32x8<Self>) -> u32 {
         let (a0, a1) = self.split_u32x8(a);
         self.reduce_min_u32x4(self.min_u32x4(a0, a1))
+    }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_u32x8(self, a: u32x8<Self>) -> u32 {
+        let (a0, a1) = self.split_u32x8(a);
+        self.reduce_sum_u32x4(self.add_u32x4(a0, a1))
     }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
@@ -4079,6 +4141,12 @@ pub trait Simd:
     fn reduce_min_precise_f64x4(self, a: f64x4<Self>) -> f64 {
         let (a0, a1) = self.split_f64x4(a);
         self.reduce_min_precise_f64x2(self.min_precise_f64x2(a0, a1))
+    }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_f64x4(self, a: f64x4<Self>) -> f64 {
+        let (a0, a1) = self.split_f64x4(a);
+        self.reduce_sum_f64x2(self.add_f64x2(a0, a1))
     }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
@@ -4488,6 +4556,12 @@ pub trait Simd:
         let (a0, a1) = self.split_i64x4(a);
         self.reduce_min_i64x2(self.min_i64x2(a0, a1))
     }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_i64x4(self, a: i64x4<Self>) -> i64 {
+        let (a0, a1) = self.split_i64x4(a);
+        self.reduce_sum_i64x2(self.add_i64x2(a0, a1))
+    }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
     fn max_i64x4(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self> {
@@ -4780,6 +4854,12 @@ pub trait Simd:
     fn reduce_min_u64x4(self, a: u64x4<Self>) -> u64 {
         let (a0, a1) = self.split_u64x4(a);
         self.reduce_min_u64x2(self.min_u64x2(a0, a1))
+    }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_u64x4(self, a: u64x4<Self>) -> u64 {
+        let (a0, a1) = self.split_u64x4(a);
+        self.reduce_sum_u64x2(self.add_u64x2(a0, a1))
     }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
@@ -5166,6 +5246,12 @@ pub trait Simd:
     fn reduce_min_precise_f32x16(self, a: f32x16<Self>) -> f32 {
         let (a0, a1) = self.split_f32x16(a);
         self.reduce_min_precise_f32x8(self.min_precise_f32x8(a0, a1))
+    }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_f32x16(self, a: f32x16<Self>) -> f32 {
+        let (a0, a1) = self.split_f32x16(a);
+        self.reduce_sum_f32x8(self.add_f32x8(a0, a1))
     }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
@@ -5564,6 +5650,12 @@ pub trait Simd:
         let (a0, a1) = self.split_i8x64(a);
         self.reduce_min_i8x32(self.min_i8x32(a0, a1))
     }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_i8x64(self, a: i8x64<Self>) -> i8 {
+        let (a0, a1) = self.split_i8x64(a);
+        self.reduce_sum_i8x32(self.add_i8x32(a0, a1))
+    }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
     fn max_i8x64(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self> {
@@ -5828,6 +5920,12 @@ pub trait Simd:
     fn reduce_min_u8x64(self, a: u8x64<Self>) -> u8 {
         let (a0, a1) = self.split_u8x64(a);
         self.reduce_min_u8x32(self.min_u8x32(a0, a1))
+    }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_u8x64(self, a: u8x64<Self>) -> u8 {
+        let (a0, a1) = self.split_u8x64(a);
+        self.reduce_sum_u8x32(self.add_u8x32(a0, a1))
     }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
@@ -6198,6 +6296,12 @@ pub trait Simd:
         let (a0, a1) = self.split_i16x32(a);
         self.reduce_min_i16x16(self.min_i16x16(a0, a1))
     }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_i16x32(self, a: i16x32<Self>) -> i16 {
+        let (a0, a1) = self.split_i16x32(a);
+        self.reduce_sum_i16x16(self.add_i16x16(a0, a1))
+    }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
     fn max_i16x32(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self> {
@@ -6500,6 +6604,12 @@ pub trait Simd:
     fn reduce_min_u16x32(self, a: u16x32<Self>) -> u16 {
         let (a0, a1) = self.split_u16x32(a);
         self.reduce_min_u16x16(self.min_u16x16(a0, a1))
+    }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_u16x32(self, a: u16x32<Self>) -> u16 {
+        let (a0, a1) = self.split_u16x32(a);
+        self.reduce_sum_u16x16(self.add_u16x16(a0, a1))
     }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
@@ -6906,6 +7016,12 @@ pub trait Simd:
         let (a0, a1) = self.split_i32x16(a);
         self.reduce_min_i32x8(self.min_i32x8(a0, a1))
     }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_i32x16(self, a: i32x16<Self>) -> i32 {
+        let (a0, a1) = self.split_i32x16(a);
+        self.reduce_sum_i32x8(self.add_i32x8(a0, a1))
+    }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
     fn max_i32x16(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self> {
@@ -7208,6 +7324,12 @@ pub trait Simd:
     fn reduce_min_u32x16(self, a: u32x16<Self>) -> u32 {
         let (a0, a1) = self.split_u32x16(a);
         self.reduce_min_u32x8(self.min_u32x8(a0, a1))
+    }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_u32x16(self, a: u32x16<Self>) -> u32 {
+        let (a0, a1) = self.split_u32x16(a);
+        self.reduce_sum_u32x8(self.add_u32x8(a0, a1))
     }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
@@ -7594,6 +7716,12 @@ pub trait Simd:
     fn reduce_min_precise_f64x8(self, a: f64x8<Self>) -> f64 {
         let (a0, a1) = self.split_f64x8(a);
         self.reduce_min_precise_f64x4(self.min_precise_f64x4(a0, a1))
+    }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_f64x8(self, a: f64x8<Self>) -> f64 {
+        let (a0, a1) = self.split_f64x8(a);
+        self.reduce_sum_f64x4(self.add_f64x4(a0, a1))
     }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
@@ -8001,6 +8129,12 @@ pub trait Simd:
         let (a0, a1) = self.split_i64x8(a);
         self.reduce_min_i64x4(self.min_i64x4(a0, a1))
     }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_i64x8(self, a: i64x8<Self>) -> i64 {
+        let (a0, a1) = self.split_i64x8(a);
+        self.reduce_sum_i64x4(self.add_i64x4(a0, a1))
+    }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
     fn max_i64x8(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self> {
@@ -8291,6 +8425,12 @@ pub trait Simd:
     fn reduce_min_u64x8(self, a: u64x8<Self>) -> u64 {
         let (a0, a1) = self.split_u64x8(a);
         self.reduce_min_u64x4(self.min_u64x4(a0, a1))
+    }
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    #[inline(always)]
+    fn reduce_sum_u64x8(self, a: u64x8<Self>) -> u64 {
+        let (a0, a1) = self.split_u64x8(a);
+        self.reduce_sum_u64x4(self.add_u64x4(a0, a1))
     }
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     #[inline(always)]
@@ -9115,6 +9255,8 @@ pub trait SimdBase<S: Simd>:
     fn reduce_max_precise(self) -> Self::Element;
     #[doc = "Return the minimum element in the vector, ignoring quiet NaNs.\n\nFor integer vectors, this operation is the same as `reduce_min`.\n\nFor floating-point vectors, quiet NaNs are ignored. If there is at least one numeric lane, this returns the true minimum of the numeric lanes. If all lanes are quiet NaNs, this returns NaN, with an unspecified payload and sign.\n\nIf the floating-point vector contains both positive zero and negative zero, either sign of zero may be returned.\n\nIf any lane is a *signaling* NaN, the result is fully non-deterministic: it may be NaN or a numeric lane and is not guaranteed to be the true minimum.\nSignaling NaN values are not produced by floating-point math operations, only from manual initialization with specific bit patterns. You probably don't need to worry about them."]
     fn reduce_min_precise(self) -> Self::Element;
+    #[doc = "Return the sum of all elements in the vector. Integer addition wraps.\n\n# Floating-point accuracy\n\nFor an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\nFor a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\nThis fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\nBecause floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different."]
+    fn reduce_sum(self) -> Self::Element;
     #[doc = "Return the element-wise maximum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `max_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Return the element-wise minimum of two vectors.\n\nFor floating-point vectors, if either operand is NaN, the result for that lane is implementation-defined-- it could be either the first or second operand. See `min_precise` for a version that returns the non-NaN operand if only one is NaN.\n\nIf one floating-point operand is positive zero and the other is negative zero, the result is also implementation-defined, and it could be either one."]

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -175,6 +175,10 @@ impl<S: Simd> SimdBase<S> for f32x4<S> {
         self.simd.reduce_min_precise_f32x4(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_f32x4(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_f32x4(self, rhs.simd_into(self.simd))
     }
@@ -521,6 +525,10 @@ impl<S: Simd> SimdBase<S> for i8x16<S> {
         self.simd.reduce_min_i8x16(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_i8x16(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i8x16(self, rhs.simd_into(self.simd))
     }
@@ -803,6 +811,10 @@ impl<S: Simd> SimdBase<S> for u8x16<S> {
     #[inline(always)]
     fn reduce_min_precise(self) -> Self::Element {
         self.simd.reduce_min_u8x16(self)
+    }
+    #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_u8x16(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -1179,6 +1191,10 @@ impl<S: Simd> SimdBase<S> for i16x8<S> {
         self.simd.reduce_min_i16x8(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_i16x8(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i16x8(self, rhs.simd_into(self.simd))
     }
@@ -1468,6 +1484,10 @@ impl<S: Simd> SimdBase<S> for u16x8<S> {
     #[inline(always)]
     fn reduce_min_precise(self) -> Self::Element {
         self.simd.reduce_min_u16x8(self)
+    }
+    #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_u16x8(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -1847,6 +1867,10 @@ impl<S: Simd> SimdBase<S> for i32x4<S> {
         self.simd.reduce_min_i32x4(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_i32x4(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i32x4(self, rhs.simd_into(self.simd))
     }
@@ -2136,6 +2160,10 @@ impl<S: Simd> SimdBase<S> for u32x4<S> {
     #[inline(always)]
     fn reduce_min_precise(self) -> Self::Element {
         self.simd.reduce_min_u32x4(self)
+    }
+    #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_u32x4(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -2527,6 +2555,10 @@ impl<S: Simd> SimdBase<S> for f64x2<S> {
         self.simd.reduce_min_precise_f64x2(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_f64x2(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_f64x2(self, rhs.simd_into(self.simd))
     }
@@ -2861,6 +2893,10 @@ impl<S: Simd> SimdBase<S> for i64x2<S> {
         self.simd.reduce_min_i64x2(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_i64x2(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i64x2(self, rhs.simd_into(self.simd))
     }
@@ -3143,6 +3179,10 @@ impl<S: Simd> SimdBase<S> for u64x2<S> {
     #[inline(always)]
     fn reduce_min_precise(self) -> Self::Element {
         self.simd.reduce_min_u64x2(self)
+    }
+    #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_u64x2(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -3539,6 +3579,10 @@ impl<S: Simd> SimdBase<S> for f32x8<S> {
         self.simd.reduce_min_precise_f32x8(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_f32x8(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_f32x8(self, rhs.simd_into(self.simd))
     }
@@ -3896,6 +3940,10 @@ impl<S: Simd> SimdBase<S> for i8x32<S> {
         self.simd.reduce_min_i8x32(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_i8x32(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i8x32(self, rhs.simd_into(self.simd))
     }
@@ -4189,6 +4237,10 @@ impl<S: Simd> SimdBase<S> for u8x32<S> {
     #[inline(always)]
     fn reduce_min_precise(self) -> Self::Element {
         self.simd.reduce_min_u8x32(self)
+    }
+    #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_u8x32(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -4568,6 +4620,10 @@ impl<S: Simd> SimdBase<S> for i16x16<S> {
         self.simd.reduce_min_i16x16(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_i16x16(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i16x16(self, rhs.simd_into(self.simd))
     }
@@ -4861,6 +4917,10 @@ impl<S: Simd> SimdBase<S> for u16x16<S> {
     #[inline(always)]
     fn reduce_min_precise(self) -> Self::Element {
         self.simd.reduce_min_u16x16(self)
+    }
+    #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_u16x16(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -5248,6 +5308,10 @@ impl<S: Simd> SimdBase<S> for i32x8<S> {
         self.simd.reduce_min_i32x8(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_i32x8(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i32x8(self, rhs.simd_into(self.simd))
     }
@@ -5544,6 +5608,10 @@ impl<S: Simd> SimdBase<S> for u32x8<S> {
     #[inline(always)]
     fn reduce_min_precise(self) -> Self::Element {
         self.simd.reduce_min_u32x8(self)
+    }
+    #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_u32x8(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -5930,6 +5998,10 @@ impl<S: Simd> SimdBase<S> for f64x4<S> {
         self.simd.reduce_min_precise_f64x4(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_f64x4(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_f64x4(self, rhs.simd_into(self.simd))
     }
@@ -6259,6 +6331,10 @@ impl<S: Simd> SimdBase<S> for i64x4<S> {
         self.simd.reduce_min_i64x4(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_i64x4(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i64x4(self, rhs.simd_into(self.simd))
     }
@@ -6536,6 +6612,10 @@ impl<S: Simd> SimdBase<S> for u64x4<S> {
     #[inline(always)]
     fn reduce_min_precise(self) -> Self::Element {
         self.simd.reduce_min_u64x4(self)
+    }
+    #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_u64x4(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -6936,6 +7016,10 @@ impl<S: Simd> SimdBase<S> for f32x16<S> {
         self.simd.reduce_min_precise_f32x16(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_f32x16(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_f32x16(self, rhs.simd_into(self.simd))
     }
@@ -7320,6 +7404,10 @@ impl<S: Simd> SimdBase<S> for i8x64<S> {
         self.simd.reduce_min_i8x64(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_i8x64(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i8x64(self, rhs.simd_into(self.simd))
     }
@@ -7639,6 +7727,10 @@ impl<S: Simd> SimdBase<S> for u8x64<S> {
     #[inline(always)]
     fn reduce_min_precise(self) -> Self::Element {
         self.simd.reduce_min_u8x64(self)
+    }
+    #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_u8x64(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -8028,6 +8120,10 @@ impl<S: Simd> SimdBase<S> for i16x32<S> {
         self.simd.reduce_min_i16x32(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_i16x32(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i16x32(self, rhs.simd_into(self.simd))
     }
@@ -8331,6 +8427,10 @@ impl<S: Simd> SimdBase<S> for u16x32<S> {
     #[inline(always)]
     fn reduce_min_precise(self) -> Self::Element {
         self.simd.reduce_min_u16x32(self)
+    }
+    #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_u16x32(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -8720,6 +8820,10 @@ impl<S: Simd> SimdBase<S> for i32x16<S> {
         self.simd.reduce_min_i32x16(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_i32x16(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i32x16(self, rhs.simd_into(self.simd))
     }
@@ -9019,6 +9123,10 @@ impl<S: Simd> SimdBase<S> for u32x16<S> {
     #[inline(always)]
     fn reduce_min_precise(self) -> Self::Element {
         self.simd.reduce_min_u32x16(self)
+    }
+    #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_u32x16(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
@@ -9412,6 +9520,10 @@ impl<S: Simd> SimdBase<S> for f64x8<S> {
         self.simd.reduce_min_precise_f64x8(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_f64x8(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_f64x8(self, rhs.simd_into(self.simd))
     }
@@ -9747,6 +9859,10 @@ impl<S: Simd> SimdBase<S> for i64x8<S> {
         self.simd.reduce_min_i64x8(self)
     }
     #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_i64x8(self)
+    }
+    #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {
         self.simd.max_i64x8(self, rhs.simd_into(self.simd))
     }
@@ -10030,6 +10146,10 @@ impl<S: Simd> SimdBase<S> for u64x8<S> {
     #[inline(always)]
     fn reduce_min_precise(self) -> Self::Element {
         self.simd.reduce_min_u64x8(self)
+    }
+    #[inline(always)]
+    fn reduce_sum(self) -> Self::Element {
+        self.simd.reduce_sum_u64x8(self)
     }
     #[inline(always)]
     fn max(self, rhs: impl SimdInto<Self, S>) -> Self {

--- a/fearless_simd/src/generated/sse2.rs
+++ b/fearless_simd/src/generated/sse2.rs
@@ -422,6 +422,18 @@ impl Simd for Sse2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_f32x4(self, a: f32x4<Self>) -> f32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: f32x4<Sse2>) -> f32 {
+                let a: __m128 = a.into();
+                let adjacent = _mm_add_ps(a, _mm_shuffle_ps::<0b10_11_00_01>(a, a));
+                _mm_cvtss_f32(_mm_add_ss(adjacent, _mm_movehl_ps(adjacent, adjacent)))
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1115,6 +1127,22 @@ impl Simd for Sse2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i8x16(self, a: i8x16<Self>) -> i8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: i8x16<Sse2>) -> i8 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<2>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<1>(sum));
+                let lanes: [i8; 16usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1790,6 +1818,22 @@ impl Simd for Sse2 {
                     let lanes: [u8; 16usize] = crate::transmute::checked_transmute_copy(&reduced);
                     lanes[0]
                 }
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u8x16(self, a: u8x16<Self>) -> u8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: u8x16<Sse2>) -> u8 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<2>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<1>(sum));
+                let lanes: [u8; 16usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)
@@ -2498,6 +2542,21 @@ impl Simd for Sse2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i16x8(self, a: i16x8<Self>) -> i16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: i16x8<Sse2>) -> i16 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<2>(sum));
+                let lanes: [i16; 8usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3048,6 +3107,21 @@ impl Simd for Sse2 {
                     let lanes: [u16; 8usize] = crate::transmute::checked_transmute_copy(&reduced);
                     lanes[0]
                 }
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u16x8(self, a: u16x8<Self>) -> u16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: u16x8<Sse2>) -> u16 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<2>(sum));
+                let lanes: [u16; 8usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)
@@ -3749,6 +3823,20 @@ impl Simd for Sse2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i32x4(self, a: i32x4<Self>) -> i32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: i32x4<Sse2>) -> i32 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<4>(sum));
+                let lanes: [i32; 4usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -4279,6 +4367,20 @@ impl Simd for Sse2 {
                     let lanes: [u32; 4usize] = crate::transmute::checked_transmute_copy(&reduced);
                     lanes[0]
                 }
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u32x4(self, a: u32x4<Self>) -> u32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: u32x4<Sse2>) -> u32 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<4>(sum));
+                let lanes: [u32; 4usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)
@@ -4955,6 +5057,17 @@ impl Simd for Sse2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_f64x2(self, a: f64x2<Self>) -> f64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: f64x2<Sse2>) -> f64 {
+                let a: __m128d = a.into();
+                _mm_cvtsd_f64(_mm_add_sd(a, _mm_unpackhi_pd(a, a)))
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5444,6 +5557,19 @@ impl Simd for Sse2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i64x2(self, a: i64x2<Self>) -> i64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: i64x2<Sse2>) -> i64 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi64(sum, _mm_srli_si128::<8>(sum));
+                let lanes: [i64; 2usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         [
             i64::max(a[0usize], b[0usize]),
@@ -5846,6 +5972,19 @@ impl Simd for Sse2 {
             fn kernel(token: Sse2, a: u64x2<Sse2>) -> u64 {
                 let lanes: [u64; 2] = a.into();
                 lanes[0].min(lanes[1])
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u64x2(self, a: u64x2<Self>) -> u64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse2, a: u64x2<Sse2>) -> u64 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi64(sum, _mm_srli_si128::<8>(sum));
+                let lanes: [u64; 2usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)

--- a/fearless_simd/src/generated/sse4_2.rs
+++ b/fearless_simd/src/generated/sse4_2.rs
@@ -390,6 +390,18 @@ impl Simd for Sse4_2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_f32x4(self, a: f32x4<Self>) -> f32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: f32x4<Sse4_2>) -> f32 {
+                let a: __m128 = a.into();
+                let adjacent = _mm_add_ps(a, _mm_shuffle_ps::<0b10_11_00_01>(a, a));
+                _mm_cvtss_f32(_mm_add_ss(adjacent, _mm_movehl_ps(adjacent, adjacent)))
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1108,6 +1120,22 @@ impl Simd for Sse4_2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i8x16(self, a: i8x16<Self>) -> i8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i8x16<Sse4_2>) -> i8 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<2>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<1>(sum));
+                let lanes: [i8; 16usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -1654,6 +1682,22 @@ impl Simd for Sse4_2 {
                     let lanes: [u8; 16usize] = crate::transmute::checked_transmute_copy(&reduced);
                     lanes[0]
                 }
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u8x16(self, a: u8x16<Self>) -> u8 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u8x16<Sse4_2>) -> u8 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<2>(sum));
+                let sum = _mm_add_epi8(sum, _mm_srli_si128::<1>(sum));
+                let lanes: [u8; 16usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)
@@ -2296,6 +2340,21 @@ impl Simd for Sse4_2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i16x8(self, a: i16x8<Self>) -> i16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i16x8<Sse4_2>) -> i16 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<2>(sum));
+                let lanes: [i16; 8usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -2790,6 +2849,21 @@ impl Simd for Sse4_2 {
                     let lanes: [u16; 8usize] = crate::transmute::checked_transmute_copy(&reduced);
                     lanes[0]
                 }
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u16x8(self, a: u16x8<Self>) -> u16 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u16x8<Sse4_2>) -> u16 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<4>(sum));
+                let sum = _mm_add_epi16(sum, _mm_srli_si128::<2>(sum));
+                let lanes: [u16; 8usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)
@@ -3460,6 +3534,20 @@ impl Simd for Sse4_2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i32x4(self, a: i32x4<Self>) -> i32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i32x4<Sse4_2>) -> i32 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<4>(sum));
+                let lanes: [i32; 4usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -3928,6 +4016,20 @@ impl Simd for Sse4_2 {
                     let lanes: [u32; 4usize] = crate::transmute::checked_transmute_copy(&reduced);
                     lanes[0]
                 }
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u32x4(self, a: u32x4<Self>) -> u32 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u32x4<Sse4_2>) -> u32 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<8>(sum));
+                let sum = _mm_add_epi32(sum, _mm_srli_si128::<4>(sum));
+                let lanes: [u32; 4usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)
@@ -4562,6 +4664,17 @@ impl Simd for Sse4_2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_f64x2(self, a: f64x2<Self>) -> f64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: f64x2<Sse4_2>) -> f64 {
+                let a: __m128d = a.into();
+                _mm_cvtsd_f64(_mm_add_sd(a, _mm_unpackhi_pd(a, a)))
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         crate::kernel!(
             #[inline(always)]
@@ -5168,6 +5281,19 @@ impl Simd for Sse4_2 {
         kernel(self, a)
     }
     #[inline(always)]
+    fn reduce_sum_i64x2(self, a: i64x2<Self>) -> i64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: i64x2<Sse4_2>) -> i64 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi64(sum, _mm_srli_si128::<8>(sum));
+                let lanes: [i64; 2usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
     fn max_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         [
             i64::max(a[0usize], b[0usize]),
@@ -5602,6 +5728,19 @@ impl Simd for Sse4_2 {
             fn kernel(token: Sse4_2, a: u64x2<Sse4_2>) -> u64 {
                 let lanes: [u64; 2] = a.into();
                 lanes[0].min(lanes[1])
+            }
+        );
+        kernel(self, a)
+    }
+    #[inline(always)]
+    fn reduce_sum_u64x2(self, a: u64x2<Self>) -> u64 {
+        crate::kernel!(
+            #[inline(always)]
+            fn kernel(token: Sse4_2, a: u64x2<Sse4_2>) -> u64 {
+                let sum: __m128i = a.into();
+                let sum = _mm_add_epi64(sum, _mm_srli_si128::<8>(sum));
+                let lanes: [u64; 2usize] = crate::transmute::checked_transmute_copy(&sum);
+                lanes[0]
             }
         );
         kernel(self, a)

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -300,6 +300,13 @@ impl Simd for WasmSimd128 {
         f32x4_extract_lane::<0>(reduced.into())
     }
     #[inline(always)]
+    fn reduce_sum_f32x4(self, a: f32x4<Self>) -> f32 {
+        let a: v128 = a.into();
+        let adjacent = f32x4_add(a, i32x4_shuffle::<1, 0, 3, 2>(a, a));
+        let result = f32x4_add(adjacent, i32x4_shuffle::<2, 3, 2, 3>(adjacent, adjacent));
+        f32x4_extract_lane::<0>(result)
+    }
+    #[inline(always)]
     fn max_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
         #[cfg(target_feature = "relaxed-simd")]
         {
@@ -702,6 +709,27 @@ impl Simd for WasmSimd128 {
         i8x16_extract_lane::<0>(reduced.into())
     }
     #[inline(always)]
+    fn reduce_sum_i8x16(self, a: i8x16<Self>) -> i8 {
+        let sum: v128 = a.into();
+        let sum = i8x16_add(
+            sum,
+            i8x16_shuffle::<8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7>(sum, sum),
+        );
+        let sum = i8x16_add(
+            sum,
+            i8x16_shuffle::<4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3>(sum, sum),
+        );
+        let sum = i8x16_add(
+            sum,
+            i8x16_shuffle::<2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1>(sum, sum),
+        );
+        let sum = i8x16_add(
+            sum,
+            i8x16_shuffle::<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0>(sum, sum),
+        );
+        i8x16_extract_lane::<0>(sum)
+    }
+    #[inline(always)]
     fn max_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
         i8x16_max(a.into(), b.into()).simd_into(self)
     }
@@ -1061,6 +1089,27 @@ impl Simd for WasmSimd128 {
         .simd_into(self);
         let reduced = self.min_u8x16(reduced, shuffled);
         u8x16_extract_lane::<0>(reduced.into())
+    }
+    #[inline(always)]
+    fn reduce_sum_u8x16(self, a: u8x16<Self>) -> u8 {
+        let sum: v128 = a.into();
+        let sum = u8x16_add(
+            sum,
+            u8x16_shuffle::<8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7>(sum, sum),
+        );
+        let sum = u8x16_add(
+            sum,
+            u8x16_shuffle::<4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3>(sum, sum),
+        );
+        let sum = u8x16_add(
+            sum,
+            u8x16_shuffle::<2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1>(sum, sum),
+        );
+        let sum = u8x16_add(
+            sum,
+            u8x16_shuffle::<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0>(sum, sum),
+        );
+        u8x16_extract_lane::<0>(sum)
     }
     #[inline(always)]
     fn max_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -1444,6 +1493,14 @@ impl Simd for WasmSimd128 {
         i16x8_extract_lane::<0>(reduced.into())
     }
     #[inline(always)]
+    fn reduce_sum_i16x8(self, a: i16x8<Self>) -> i16 {
+        let sum: v128 = a.into();
+        let sum = i16x8_add(sum, i16x8_shuffle::<4, 5, 6, 7, 0, 1, 2, 3>(sum, sum));
+        let sum = i16x8_add(sum, i16x8_shuffle::<2, 3, 4, 5, 6, 7, 0, 1>(sum, sum));
+        let sum = i16x8_add(sum, i16x8_shuffle::<1, 2, 3, 4, 5, 6, 7, 0>(sum, sum));
+        i16x8_extract_lane::<0>(sum)
+    }
+    #[inline(always)]
     fn max_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
         i16x8_max(a.into(), b.into()).simd_into(self)
     }
@@ -1710,6 +1767,14 @@ impl Simd for WasmSimd128 {
             u16x8_shuffle::<1, 2, 3, 4, 5, 6, 7, 0>(reduced.into(), reduced.into()).simd_into(self);
         let reduced = self.min_u16x8(reduced, shuffled);
         u16x8_extract_lane::<0>(reduced.into())
+    }
+    #[inline(always)]
+    fn reduce_sum_u16x8(self, a: u16x8<Self>) -> u16 {
+        let sum: v128 = a.into();
+        let sum = u16x8_add(sum, u16x8_shuffle::<4, 5, 6, 7, 0, 1, 2, 3>(sum, sum));
+        let sum = u16x8_add(sum, u16x8_shuffle::<2, 3, 4, 5, 6, 7, 0, 1>(sum, sum));
+        let sum = u16x8_add(sum, u16x8_shuffle::<1, 2, 3, 4, 5, 6, 7, 0>(sum, sum));
+        u16x8_extract_lane::<0>(sum)
     }
     #[inline(always)]
     fn max_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -2058,6 +2123,13 @@ impl Simd for WasmSimd128 {
         i32x4_extract_lane::<0>(reduced.into())
     }
     #[inline(always)]
+    fn reduce_sum_i32x4(self, a: i32x4<Self>) -> i32 {
+        let sum: v128 = a.into();
+        let sum = i32x4_add(sum, i32x4_shuffle::<2, 3, 0, 1>(sum, sum));
+        let sum = i32x4_add(sum, i32x4_shuffle::<1, 2, 3, 0>(sum, sum));
+        i32x4_extract_lane::<0>(sum)
+    }
+    #[inline(always)]
     fn max_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
         i32x4_max(a.into(), b.into()).simd_into(self)
     }
@@ -2311,6 +2383,13 @@ impl Simd for WasmSimd128 {
         let shuffled = u32x4_shuffle::<1, 2, 3, 0>(reduced.into(), reduced.into()).simd_into(self);
         let reduced = self.min_u32x4(reduced, shuffled);
         u32x4_extract_lane::<0>(reduced.into())
+    }
+    #[inline(always)]
+    fn reduce_sum_u32x4(self, a: u32x4<Self>) -> u32 {
+        let sum: v128 = a.into();
+        let sum = u32x4_add(sum, u32x4_shuffle::<2, 3, 0, 1>(sum, sum));
+        let sum = u32x4_add(sum, u32x4_shuffle::<1, 2, 3, 0>(sum, sum));
+        u32x4_extract_lane::<0>(sum)
     }
     #[inline(always)]
     fn max_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -2647,6 +2726,12 @@ impl Simd for WasmSimd128 {
         f64x2_extract_lane::<0>(reduced.into())
     }
     #[inline(always)]
+    fn reduce_sum_f64x2(self, a: f64x2<Self>) -> f64 {
+        let a: v128 = a.into();
+        let result = f64x2_add(a, i64x2_shuffle::<1, 1>(a, a));
+        f64x2_extract_lane::<0>(result)
+    }
+    #[inline(always)]
     fn max_f64x2(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self> {
         #[cfg(target_feature = "relaxed-simd")]
         {
@@ -2963,6 +3048,12 @@ impl Simd for WasmSimd128 {
         reduced[0]
     }
     #[inline(always)]
+    fn reduce_sum_i64x2(self, a: i64x2<Self>) -> i64 {
+        let sum: v128 = a.into();
+        let sum = i64x2_add(sum, i64x2_shuffle::<1, 0>(sum, sum));
+        i64x2_extract_lane::<0>(sum)
+    }
+    #[inline(always)]
     fn max_i64x2(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self> {
         [
             i64::max(a[0usize], b[0usize]),
@@ -3212,6 +3303,12 @@ impl Simd for WasmSimd128 {
     fn reduce_min_u64x2(self, a: u64x2<Self>) -> u64 {
         let reduced: [u64; 1usize] = [u64::min(a[0usize], a[1usize])];
         reduced[0]
+    }
+    #[inline(always)]
+    fn reduce_sum_u64x2(self, a: u64x2<Self>) -> u64 {
+        let sum: v128 = a.into();
+        let sum = u64x2_add(sum, u64x2_shuffle::<1, 0>(sum, sum));
+        u64x2_extract_lane::<0>(sum)
     }
     #[inline(always)]
     fn max_u64x2(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self> {

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -10,7 +10,7 @@ use crate::level::Level;
 use crate::ops::{NarrowingMode, Op, OpSig, relaxed_narrow_method};
 use crate::types::{ScalarType, VecType};
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 
 #[derive(Clone, Copy)]
 pub(crate) struct Fallback;
@@ -290,7 +290,13 @@ impl Level for Fallback {
                     }
                 }
             }
-            OpSig::Reduce { lane_op } => fallback_reduce_min_max(method_sig, vec_ty, lane_op),
+            OpSig::Reduce { lane_op } => {
+                if lane_op == "add" {
+                    fallback_reduce_sum(method_sig, vec_ty)
+                } else {
+                    fallback_reduce_min_max(method_sig, vec_ty, lane_op)
+                }
+            }
             OpSig::Widen { target_ty } => {
                 let scalar = target_ty.scalar.rust(target_ty.scalar_bits);
                 let half_len = vec_ty.len / 2;
@@ -817,6 +823,54 @@ fn fallback_reduce_min_max(
         });
         previous = quote! { reduced };
         previous_len = next_len;
+    }
+
+    quote! {
+        #method_sig {
+            #(#statements)*
+            #previous[0]
+        }
+    }
+}
+
+/// Build an adjacent balanced reduction one horizontal level at a time.
+fn fallback_reduce_sum(method_sig: TokenStream, vec_ty: &VecType) -> TokenStream {
+    // The structure directly mirrors the SIMD constructions for two reasons:
+    // 1. We promise the same output across all platforms, which means
+    //    we have to perform additions in the same SIMD-friendly order,
+    //    because floating-point addition is not associative.
+    // 2. Expressing individual stages as arrays allows for autovectorization
+    //    on platforms we don't have explicit intrinsics for.
+    assert_eq!(
+        vec_ty.n_bits(),
+        128,
+        "wide reductions must use the generic 128-bit-grained implementation"
+    );
+
+    let scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
+    let mut statements = Vec::new();
+    let mut previous = quote! { a };
+    let mut previous_len = vec_ty.len;
+    let mut level = 0;
+
+    while previous_len > 1 {
+        let name = format_ident!("sum_level_{level}");
+        let next_len = previous_len / 2;
+        let additions = (0..next_len).map(|index| {
+            let left_index = index * 2;
+            let right_index = left_index + 1;
+            if vec_ty.scalar == ScalarType::Float {
+                quote! { #previous[#left_index] + #previous[#right_index] }
+            } else {
+                quote! { #previous[#left_index].wrapping_add(#previous[#right_index]) }
+            }
+        });
+        statements.push(quote! {
+            let #name: [#scalar; #next_len] = [#(#additions),*];
+        });
+        previous = quote! { #name };
+        previous_len = next_len;
+        level += 1;
     }
 
     quote! {

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -214,18 +214,20 @@ impl Level for Neon {
                     "wide reductions must use the generic 128-bit-grained implementation"
                 );
 
-                if vec_ty.scalar_bits == 64
+                if lane_op != "add"
+                    && vec_ty.scalar_bits == 64
                     && matches!(vec_ty.scalar, ScalarType::Int | ScalarType::Unsigned)
                 {
                     return fallback_method(op, vec_ty);
                 }
 
                 let intrinsic = match lane_op {
+                    "add" => "vaddv",
                     "min" => "vminv",
                     "max" => "vmaxv",
                     "min_precise" => "vminnmv",
                     "max_precise" => "vmaxnmv",
-                    _ => unreachable!("unsupported min/max reduction lane operation"),
+                    _ => unreachable!("unsupported reduction lane operation"),
                 };
                 let reduce = simple_intrinsic(intrinsic, vec_ty);
                 self.kernel_method(op, vec_ty, |_| quote! { #reduce(a.into()) })

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -167,6 +167,58 @@ fn reduce_min_max(method_sig: TokenStream, vec_ty: &VecType, lane_op: &str) -> T
     }
 }
 
+fn reduce_sum(method_sig: TokenStream, vec_ty: &VecType) -> TokenStream {
+    assert_eq!(
+        vec_ty.n_bits(),
+        128,
+        "wide reductions must use the generic 128-bit-grained implementation"
+    );
+
+    let body = match (vec_ty.scalar, vec_ty.scalar_bits) {
+        (ScalarType::Float, 32) => quote! {
+            let a: v128 = a.into();
+            let adjacent = f32x4_add(a, i32x4_shuffle::<1, 0, 3, 2>(a, a));
+            let result = f32x4_add(
+                adjacent,
+                i32x4_shuffle::<2, 3, 2, 3>(adjacent, adjacent),
+            );
+            f32x4_extract_lane::<0>(result)
+        },
+        (ScalarType::Float, 64) => quote! {
+            let a: v128 = a.into();
+            let result = f64x2_add(a, i64x2_shuffle::<1, 1>(a, a));
+            f64x2_extract_lane::<0>(result)
+        },
+        (ScalarType::Int | ScalarType::Unsigned, _) => {
+            let add = simple_intrinsic("add", vec_ty);
+            let shuffle = simple_intrinsic("shuffle", vec_ty);
+            let extract = simple_intrinsic("extract_lane", vec_ty);
+            let mut stages = Vec::new();
+            let mut offset = vec_ty.len / 2;
+            while offset > 0 {
+                let indices = (0..vec_ty.len)
+                    .map(|index| Literal::usize_unsuffixed((index + offset) % vec_ty.len));
+                stages.push(quote! {
+                    let sum = #add(sum, #shuffle::<#(#indices),*>(sum, sum));
+                });
+                offset /= 2;
+            }
+            quote! {
+                let sum: v128 = a.into();
+                #(#stages)*
+                #extract::<0>(sum)
+            }
+        }
+        _ => unreachable!("reduce_sum only operates on numeric vectors"),
+    };
+
+    quote! {
+        #method_sig {
+            #body
+        }
+    }
+}
+
 impl Level for WasmSimd128 {
     fn name(&self) -> &'static str {
         "WasmSimd128"
@@ -290,7 +342,9 @@ impl Level for WasmSimd128 {
                 }
             }
             OpSig::Reduce { lane_op } => {
-                if vec_ty.scalar_bits == 64
+                if lane_op == "add" {
+                    reduce_sum(method_sig, vec_ty)
+                } else if vec_ty.scalar_bits == 64
                     && matches!(vec_ty.scalar, ScalarType::Int | ScalarType::Unsigned)
                 {
                     fallback_method(op, vec_ty)

--- a/fearless_simd_gen/src/mk_x86.rs
+++ b/fearless_simd_gen/src/mk_x86.rs
@@ -318,7 +318,13 @@ impl Level for X86 {
             OpSig::Splat => self.handle_splat(op, vec_ty),
             OpSig::Compare => self.handle_compare(op, method, vec_ty),
             OpSig::Unary => self.handle_unary(op, method_sig, method, vec_ty),
-            OpSig::Reduce { lane_op } => self.handle_reduce_min_max(op, vec_ty, lane_op),
+            OpSig::Reduce { lane_op } => {
+                if lane_op == "add" {
+                    self.handle_reduce_sum(op, vec_ty)
+                } else {
+                    self.handle_reduce_min_max(op, vec_ty, lane_op)
+                }
+            }
             OpSig::Widen { target_ty } => self.handle_widen(op, vec_ty, target_ty),
             OpSig::Narrow { target_ty, mode } => self.handle_narrow(op, vec_ty, target_ty, mode),
             OpSig::Binary => self.handle_binary(op, method, vec_ty),
@@ -1280,6 +1286,56 @@ impl X86 {
                 #result
             }
         })
+    }
+
+    pub(crate) fn handle_reduce_sum(&self, op: Op, vec_ty: &VecType) -> TokenStream {
+        assert_eq!(
+            vec_ty.n_bits(),
+            128,
+            "wide reductions must use the generic 128-bit-grained implementation"
+        );
+
+        match (vec_ty.scalar, vec_ty.scalar_bits) {
+            (ScalarType::Float, 32) => self.kernel_method(op, vec_ty, |_| {
+                quote! {
+                    // _mm_hadd_ps is slower than shuffle followed by add
+                    let a: __m128 = a.into();
+                    let adjacent = _mm_add_ps(a, _mm_shuffle_ps::<0b10_11_00_01>(a, a));
+                    _mm_cvtss_f32(_mm_add_ss(adjacent, _mm_movehl_ps(adjacent, adjacent)))
+                }
+            }),
+            (ScalarType::Float, 64) => self.kernel_method(op, vec_ty, |_| {
+                quote! {
+                    let a: __m128d = a.into();
+                    _mm_cvtsd_f64(_mm_add_sd(a, _mm_unpackhi_pd(a, a)))
+                }
+            }),
+            (ScalarType::Int | ScalarType::Unsigned, _) => {
+                let add = simple_sign_unaware_intrinsic("add", vec_ty);
+                let scalar = vec_ty.scalar.rust(vec_ty.scalar_bits);
+                let len = vec_ty.len;
+                let mut stages = Vec::new();
+                let mut shift_bytes = 8;
+                let scalar_bytes = vec_ty.scalar_bits / 8;
+                while shift_bytes >= scalar_bytes {
+                    let shift = Literal::i32_unsuffixed(i32::try_from(shift_bytes).unwrap());
+                    stages.push(quote! {
+                        let sum = #add(sum, _mm_srli_si128::<#shift>(sum));
+                    });
+                    shift_bytes /= 2;
+                }
+                self.kernel_method(op, vec_ty, |_| {
+                    quote! {
+                        let sum: __m128i = a.into();
+                        #(#stages)*
+                        let lanes: [#scalar; #len] =
+                            crate::transmute::checked_transmute_copy(&sum);
+                        lanes[0]
+                    }
+                })
+            }
+            _ => unreachable!("reduce_sum only operates on numeric vectors"),
+        }
     }
 
     pub(crate) fn handle_splat(&self, op: Op, vec_ty: &VecType) -> TokenStream {

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -639,6 +639,17 @@ const COMMON_BASE_OPS: &[Op] = &[
         Signaling NaN values are not produced by floating-point math operations, only from manual initialization with specific bit patterns. You probably don't need to worry about them.",
     ),
     Op::new(
+        "reduce_sum",
+        OpKind::BaseTraitMethod,
+        OpSig::Reduce { lane_op: "add" },
+        "Return the sum of all elements in the vector. Integer addition wraps.\n\n\
+        # Floating-point accuracy\n\n\
+        For an input vector with N lanes, any lane's contribution may be rounded at most `log2(N)` times.\n\n\
+        For a fixed vector type and lane count, this operation produces the same result on all platforms and backends down to the bit pattern, except for NaNs, the exact bit patterns are unspecified.\n\n\
+        This fixed-width guarantee does not make code using native-width associated types such as `S::f32s` independent of the selected SIMD level, because their lane counts can differ.\n\n\
+        Because floating-point addition is not associative, separately reducing two 128-bit vectors and then adding the results can differ from reducing their combined 256-bit vector. See [Taming Floating-Point Sums](https://orlp.net/blog/taming-float-sums/) for more information and for other summation algorithms, including exact summation without accumulated rounding error. In that article's terms, our method has the precision properties of pairwise summation, although the exact pairing of values is different.",
+    ),
+    Op::new(
         "max",
         OpKind::BaseTraitMethod,
         OpSig::Binary,

--- a/fearless_simd_tests/tests/generics.rs
+++ b/fearless_simd_tests/tests/generics.rs
@@ -80,6 +80,11 @@ fn generic_reduce_max_precise<S: Simd, V: SimdBase<S>>(vector: V) -> V::Element 
     vector.reduce_max_precise()
 }
 
+// Ensure that a generic numeric vector can be reduced to its element type.
+fn generic_reduce_sum<S: Simd, V: SimdBase<S>>(vector: V) -> V::Element {
+    vector.reduce_sum()
+}
+
 // Ensure that a generic vector's 128-bit block is its own block
 fn generic_block_splat<S: Simd, V: SimdBase<S>>(block: V::Block) -> V::Block {
     V::Block::block_splat(block)

--- a/fearless_simd_tests/tests/harness/ops/mod.rs
+++ b/fearless_simd_tests/tests/harness/ops/mod.rs
@@ -61,6 +61,7 @@ mod reduce_max;
 mod reduce_max_precise;
 mod reduce_min;
 mod reduce_min_precise;
+mod reduce_sum;
 mod reverse;
 mod rotate_elements_left;
 mod rotate_elements_right;

--- a/fearless_simd_tests/tests/harness/ops/reduce_sum.rs
+++ b/fearless_simd_tests/tests/harness/ops/reduce_sum.rs
@@ -1,0 +1,496 @@
+// Copyright 2026 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use fearless_simd::*;
+use fearless_simd_dev_macros::simd_test;
+
+// This operation uses a very specific, portable operation order,
+// which guarantees the same output regardless of the platform.
+// The large values intersperced with 1.0 are there to catch
+// deviations from that order, which result in large deviations
+// in output result due to rounding a large float
+// that can't increment by 1 due to the very large exponent.
+
+#[simd_test]
+fn reduce_sum_f32x4<S: Simd>(simd: S) {
+    assert_eq!(
+        f32x4::from_slice(simd, &[1.0, 2.0, 3.0, 4.0])
+            .reduce_sum()
+            .to_bits(),
+        10.0_f32.to_bits()
+    );
+
+    let large = 1.0e30_f32;
+    assert_eq!(
+        f32x4::from_slice(simd, &[large, 1.0, -large, 1.0])
+            .reduce_sum()
+            .to_bits(),
+        0.0_f32.to_bits()
+    );
+    assert_eq!(
+        f32x4::from_slice(simd, &[-0.0; 4]).reduce_sum().to_bits(),
+        (-0.0_f32).to_bits()
+    );
+    assert_eq!(
+        f32x4::from_slice(simd, &[0.0; 4]).reduce_sum().to_bits(),
+        0.0_f32.to_bits()
+    );
+    let nan = f32::from_bits(0x7fc0_1234);
+    assert!(
+        f32x4::from_slice(simd, &[0.0, 0.0, 0.0, nan])
+            .reduce_sum()
+            .is_nan()
+    );
+}
+
+#[simd_test]
+fn reduce_sum_i8x16<S: Simd>(simd: S) {
+    assert_eq!(i8x16::from_slice(simd, &[1; 16]).reduce_sum(), 16);
+
+    let mut overflow = [0; 16];
+    overflow[0] = i8::MAX;
+    overflow[1] = 1;
+    assert_eq!(i8x16::from_slice(simd, &overflow).reduce_sum(), i8::MIN);
+
+    let mut underflow = [0; 16];
+    underflow[0] = i8::MIN;
+    underflow[1] = -1;
+    assert_eq!(i8x16::from_slice(simd, &underflow).reduce_sum(), i8::MAX);
+}
+
+#[simd_test]
+fn reduce_sum_u8x16<S: Simd>(simd: S) {
+    assert_eq!(u8x16::from_slice(simd, &[1; 16]).reduce_sum(), 16);
+
+    let mut overflow = [0; 16];
+    overflow[0] = u8::MAX;
+    overflow[1] = 1;
+    assert_eq!(u8x16::from_slice(simd, &overflow).reduce_sum(), 0);
+}
+
+#[simd_test]
+fn reduce_sum_i16x8<S: Simd>(simd: S) {
+    assert_eq!(i16x8::from_slice(simd, &[1; 8]).reduce_sum(), 8);
+
+    let mut overflow = [0; 8];
+    overflow[0] = i16::MAX;
+    overflow[1] = 1;
+    assert_eq!(i16x8::from_slice(simd, &overflow).reduce_sum(), i16::MIN);
+
+    let mut underflow = [0; 8];
+    underflow[0] = i16::MIN;
+    underflow[1] = -1;
+    assert_eq!(i16x8::from_slice(simd, &underflow).reduce_sum(), i16::MAX);
+}
+
+#[simd_test]
+fn reduce_sum_u16x8<S: Simd>(simd: S) {
+    assert_eq!(u16x8::from_slice(simd, &[1; 8]).reduce_sum(), 8);
+
+    let mut overflow = [0; 8];
+    overflow[0] = u16::MAX;
+    overflow[1] = 1;
+    assert_eq!(u16x8::from_slice(simd, &overflow).reduce_sum(), 0);
+}
+
+#[simd_test]
+fn reduce_sum_i32x4<S: Simd>(simd: S) {
+    assert_eq!(i32x4::from_slice(simd, &[1; 4]).reduce_sum(), 4);
+
+    let mut overflow = [0; 4];
+    overflow[0] = i32::MAX;
+    overflow[1] = 1;
+    assert_eq!(i32x4::from_slice(simd, &overflow).reduce_sum(), i32::MIN);
+
+    let mut underflow = [0; 4];
+    underflow[0] = i32::MIN;
+    underflow[1] = -1;
+    assert_eq!(i32x4::from_slice(simd, &underflow).reduce_sum(), i32::MAX);
+}
+
+#[simd_test]
+fn reduce_sum_u32x4<S: Simd>(simd: S) {
+    assert_eq!(u32x4::from_slice(simd, &[1; 4]).reduce_sum(), 4);
+
+    let mut overflow = [0; 4];
+    overflow[0] = u32::MAX;
+    overflow[1] = 1;
+    assert_eq!(u32x4::from_slice(simd, &overflow).reduce_sum(), 0);
+}
+
+#[simd_test]
+fn reduce_sum_f64x2<S: Simd>(simd: S) {
+    assert_eq!(
+        f64x2::from_slice(simd, &[1.0, 2.0]).reduce_sum().to_bits(),
+        3.0_f64.to_bits()
+    );
+    assert_eq!(
+        f64x2::from_slice(simd, &[-0.0; 2]).reduce_sum().to_bits(),
+        (-0.0_f64).to_bits()
+    );
+    assert_eq!(
+        f64x2::from_slice(simd, &[0.0; 2]).reduce_sum().to_bits(),
+        0.0_f64.to_bits()
+    );
+    let nan = f64::from_bits(0x7ff8_0000_0000_1234);
+    assert!(f64x2::from_slice(simd, &[0.0, nan]).reduce_sum().is_nan());
+}
+
+#[simd_test]
+fn reduce_sum_i64x2<S: Simd>(simd: S) {
+    assert_eq!(i64x2::from_slice(simd, &[1; 2]).reduce_sum(), 2);
+
+    let overflow = [i64::MAX, 1];
+    assert_eq!(i64x2::from_slice(simd, &overflow).reduce_sum(), i64::MIN);
+
+    let underflow = [i64::MIN, -1];
+    assert_eq!(i64x2::from_slice(simd, &underflow).reduce_sum(), i64::MAX);
+}
+
+#[simd_test]
+fn reduce_sum_u64x2<S: Simd>(simd: S) {
+    assert_eq!(u64x2::from_slice(simd, &[1; 2]).reduce_sum(), 2);
+
+    let overflow = [u64::MAX, 1];
+    assert_eq!(u64x2::from_slice(simd, &overflow).reduce_sum(), 0);
+}
+
+#[simd_test]
+fn reduce_sum_f32x8<S: Simd>(simd: S) {
+    assert_eq!(
+        f32x8::from_slice(simd, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+            .reduce_sum()
+            .to_bits(),
+        36.0_f32.to_bits()
+    );
+
+    let large = 1.0e30_f32;
+    assert_eq!(
+        f32x8::from_slice(
+            simd,
+            &[large, large, large, 1.0, -large, -large, -large, 1.0],
+        )
+        .reduce_sum()
+        .to_bits(),
+        2.0_f32.to_bits()
+    );
+    assert_eq!(
+        f32x8::from_slice(simd, &[-0.0; 8]).reduce_sum().to_bits(),
+        (-0.0_f32).to_bits()
+    );
+    assert_eq!(
+        f32x8::from_slice(simd, &[0.0; 8]).reduce_sum().to_bits(),
+        0.0_f32.to_bits()
+    );
+    let nan = f32::from_bits(0x7fc0_1234);
+    assert!(
+        f32x8::from_slice(simd, &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, nan])
+            .reduce_sum()
+            .is_nan()
+    );
+}
+
+#[simd_test]
+fn reduce_sum_i8x32<S: Simd>(simd: S) {
+    assert_eq!(i8x32::from_slice(simd, &[1; 32]).reduce_sum(), 32);
+
+    let mut overflow = [0; 32];
+    overflow[0] = i8::MAX;
+    overflow[16] = 1;
+    assert_eq!(i8x32::from_slice(simd, &overflow).reduce_sum(), i8::MIN);
+
+    let mut underflow = [0; 32];
+    underflow[0] = i8::MIN;
+    underflow[16] = -1;
+    assert_eq!(i8x32::from_slice(simd, &underflow).reduce_sum(), i8::MAX);
+}
+
+#[simd_test]
+fn reduce_sum_u8x32<S: Simd>(simd: S) {
+    assert_eq!(u8x32::from_slice(simd, &[1; 32]).reduce_sum(), 32);
+
+    let mut overflow = [0; 32];
+    overflow[0] = u8::MAX;
+    overflow[16] = 1;
+    assert_eq!(u8x32::from_slice(simd, &overflow).reduce_sum(), 0);
+}
+
+#[simd_test]
+fn reduce_sum_i16x16<S: Simd>(simd: S) {
+    assert_eq!(i16x16::from_slice(simd, &[1; 16]).reduce_sum(), 16);
+
+    let mut overflow = [0; 16];
+    overflow[0] = i16::MAX;
+    overflow[8] = 1;
+    assert_eq!(i16x16::from_slice(simd, &overflow).reduce_sum(), i16::MIN);
+
+    let mut underflow = [0; 16];
+    underflow[0] = i16::MIN;
+    underflow[8] = -1;
+    assert_eq!(i16x16::from_slice(simd, &underflow).reduce_sum(), i16::MAX);
+}
+
+#[simd_test]
+fn reduce_sum_u16x16<S: Simd>(simd: S) {
+    assert_eq!(u16x16::from_slice(simd, &[1; 16]).reduce_sum(), 16);
+
+    let mut overflow = [0; 16];
+    overflow[0] = u16::MAX;
+    overflow[8] = 1;
+    assert_eq!(u16x16::from_slice(simd, &overflow).reduce_sum(), 0);
+}
+
+#[simd_test]
+fn reduce_sum_i32x8<S: Simd>(simd: S) {
+    assert_eq!(i32x8::from_slice(simd, &[1; 8]).reduce_sum(), 8);
+
+    let mut overflow = [0; 8];
+    overflow[0] = i32::MAX;
+    overflow[4] = 1;
+    assert_eq!(i32x8::from_slice(simd, &overflow).reduce_sum(), i32::MIN);
+
+    let mut underflow = [0; 8];
+    underflow[0] = i32::MIN;
+    underflow[4] = -1;
+    assert_eq!(i32x8::from_slice(simd, &underflow).reduce_sum(), i32::MAX);
+}
+
+#[simd_test]
+fn reduce_sum_u32x8<S: Simd>(simd: S) {
+    assert_eq!(u32x8::from_slice(simd, &[1; 8]).reduce_sum(), 8);
+
+    let mut overflow = [0; 8];
+    overflow[0] = u32::MAX;
+    overflow[4] = 1;
+    assert_eq!(u32x8::from_slice(simd, &overflow).reduce_sum(), 0);
+}
+
+#[simd_test]
+fn reduce_sum_f64x4<S: Simd>(simd: S) {
+    assert_eq!(
+        f64x4::from_slice(simd, &[1.0, 2.0, 3.0, 4.0])
+            .reduce_sum()
+            .to_bits(),
+        10.0_f64.to_bits()
+    );
+
+    let large = 1.0e300_f64;
+    assert_eq!(
+        f64x4::from_slice(simd, &[large, 1.0, -large, 1.0])
+            .reduce_sum()
+            .to_bits(),
+        2.0_f64.to_bits()
+    );
+    assert_eq!(
+        f64x4::from_slice(simd, &[-0.0; 4]).reduce_sum().to_bits(),
+        (-0.0_f64).to_bits()
+    );
+    assert_eq!(
+        f64x4::from_slice(simd, &[0.0; 4]).reduce_sum().to_bits(),
+        0.0_f64.to_bits()
+    );
+    let nan = f64::from_bits(0x7ff8_0000_0000_1234);
+    assert!(
+        f64x4::from_slice(simd, &[0.0, 0.0, 0.0, nan])
+            .reduce_sum()
+            .is_nan()
+    );
+}
+
+#[simd_test]
+fn reduce_sum_i64x4<S: Simd>(simd: S) {
+    assert_eq!(i64x4::from_slice(simd, &[1; 4]).reduce_sum(), 4);
+
+    let mut overflow = [0; 4];
+    overflow[0] = i64::MAX;
+    overflow[2] = 1;
+    assert_eq!(i64x4::from_slice(simd, &overflow).reduce_sum(), i64::MIN);
+
+    let mut underflow = [0; 4];
+    underflow[0] = i64::MIN;
+    underflow[2] = -1;
+    assert_eq!(i64x4::from_slice(simd, &underflow).reduce_sum(), i64::MAX);
+}
+
+#[simd_test]
+fn reduce_sum_u64x4<S: Simd>(simd: S) {
+    assert_eq!(u64x4::from_slice(simd, &[1; 4]).reduce_sum(), 4);
+
+    let mut overflow = [0; 4];
+    overflow[0] = u64::MAX;
+    overflow[2] = 1;
+    assert_eq!(u64x4::from_slice(simd, &overflow).reduce_sum(), 0);
+}
+
+#[simd_test]
+fn reduce_sum_f32x16<S: Simd>(simd: S) {
+    assert_eq!(
+        f32x16::from_slice(simd, &[1.0; 16]).reduce_sum().to_bits(),
+        16.0_f32.to_bits()
+    );
+
+    let large = 1.0e30_f32;
+    assert_eq!(
+        f32x16::from_slice(
+            simd,
+            &[
+                large, large, 1.0, 0.0, -large, -large, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 0.0,
+            ],
+        )
+        .reduce_sum()
+        .to_bits(),
+        1.0_f32.to_bits()
+    );
+    assert_eq!(
+        f32x16::from_slice(simd, &[-0.0; 16]).reduce_sum().to_bits(),
+        (-0.0_f32).to_bits()
+    );
+    assert_eq!(
+        f32x16::from_slice(simd, &[0.0; 16]).reduce_sum().to_bits(),
+        0.0_f32.to_bits()
+    );
+    let nan = f32::from_bits(0x7fc0_1234);
+    assert!(
+        f32x16::from_slice(
+            simd,
+            &[
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, nan,
+            ],
+        )
+        .reduce_sum()
+        .is_nan()
+    );
+}
+
+#[simd_test]
+fn reduce_sum_i8x64<S: Simd>(simd: S) {
+    assert_eq!(i8x64::from_slice(simd, &[1; 64]).reduce_sum(), 64);
+
+    let mut overflow = [0; 64];
+    overflow[0] = i8::MAX;
+    overflow[32] = 1;
+    assert_eq!(i8x64::from_slice(simd, &overflow).reduce_sum(), i8::MIN);
+
+    let mut underflow = [0; 64];
+    underflow[0] = i8::MIN;
+    underflow[32] = -1;
+    assert_eq!(i8x64::from_slice(simd, &underflow).reduce_sum(), i8::MAX);
+}
+
+#[simd_test]
+fn reduce_sum_u8x64<S: Simd>(simd: S) {
+    assert_eq!(u8x64::from_slice(simd, &[1; 64]).reduce_sum(), 64);
+
+    let mut overflow = [0; 64];
+    overflow[0] = u8::MAX;
+    overflow[32] = 1;
+    assert_eq!(u8x64::from_slice(simd, &overflow).reduce_sum(), 0);
+}
+
+#[simd_test]
+fn reduce_sum_i16x32<S: Simd>(simd: S) {
+    assert_eq!(i16x32::from_slice(simd, &[1; 32]).reduce_sum(), 32);
+
+    let mut overflow = [0; 32];
+    overflow[0] = i16::MAX;
+    overflow[16] = 1;
+    assert_eq!(i16x32::from_slice(simd, &overflow).reduce_sum(), i16::MIN);
+
+    let mut underflow = [0; 32];
+    underflow[0] = i16::MIN;
+    underflow[16] = -1;
+    assert_eq!(i16x32::from_slice(simd, &underflow).reduce_sum(), i16::MAX);
+}
+
+#[simd_test]
+fn reduce_sum_u16x32<S: Simd>(simd: S) {
+    assert_eq!(u16x32::from_slice(simd, &[1; 32]).reduce_sum(), 32);
+
+    let mut overflow = [0; 32];
+    overflow[0] = u16::MAX;
+    overflow[16] = 1;
+    assert_eq!(u16x32::from_slice(simd, &overflow).reduce_sum(), 0);
+}
+
+#[simd_test]
+fn reduce_sum_i32x16<S: Simd>(simd: S) {
+    assert_eq!(i32x16::from_slice(simd, &[1; 16]).reduce_sum(), 16);
+
+    let mut overflow = [0; 16];
+    overflow[0] = i32::MAX;
+    overflow[8] = 1;
+    assert_eq!(i32x16::from_slice(simd, &overflow).reduce_sum(), i32::MIN);
+
+    let mut underflow = [0; 16];
+    underflow[0] = i32::MIN;
+    underflow[8] = -1;
+    assert_eq!(i32x16::from_slice(simd, &underflow).reduce_sum(), i32::MAX);
+}
+
+#[simd_test]
+fn reduce_sum_u32x16<S: Simd>(simd: S) {
+    assert_eq!(u32x16::from_slice(simd, &[1; 16]).reduce_sum(), 16);
+
+    let mut overflow = [0; 16];
+    overflow[0] = u32::MAX;
+    overflow[8] = 1;
+    assert_eq!(u32x16::from_slice(simd, &overflow).reduce_sum(), 0);
+}
+
+#[simd_test]
+fn reduce_sum_f64x8<S: Simd>(simd: S) {
+    assert_eq!(
+        f64x8::from_slice(simd, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+            .reduce_sum()
+            .to_bits(),
+        36.0_f64.to_bits()
+    );
+
+    let large = 1.0e300_f64;
+    assert_eq!(
+        f64x8::from_slice(simd, &[large, 1.0, -large, 0.0, -1.0, 0.0, 0.0, 0.0])
+            .reduce_sum()
+            .to_bits(),
+        1.0_f64.to_bits()
+    );
+    assert_eq!(
+        f64x8::from_slice(simd, &[-0.0; 8]).reduce_sum().to_bits(),
+        (-0.0_f64).to_bits()
+    );
+    assert_eq!(
+        f64x8::from_slice(simd, &[0.0; 8]).reduce_sum().to_bits(),
+        0.0_f64.to_bits()
+    );
+    let nan = f64::from_bits(0x7ff8_0000_0000_1234);
+    assert!(
+        f64x8::from_slice(simd, &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, nan])
+            .reduce_sum()
+            .is_nan()
+    );
+}
+
+#[simd_test]
+fn reduce_sum_i64x8<S: Simd>(simd: S) {
+    assert_eq!(i64x8::from_slice(simd, &[1; 8]).reduce_sum(), 8);
+
+    let mut overflow = [0; 8];
+    overflow[0] = i64::MAX;
+    overflow[4] = 1;
+    assert_eq!(i64x8::from_slice(simd, &overflow).reduce_sum(), i64::MIN);
+
+    let mut underflow = [0; 8];
+    underflow[0] = i64::MIN;
+    underflow[4] = -1;
+    assert_eq!(i64x8::from_slice(simd, &underflow).reduce_sum(), i64::MAX);
+}
+
+#[simd_test]
+fn reduce_sum_u64x8<S: Simd>(simd: S) {
+    assert_eq!(u64x8::from_slice(simd, &[1; 8]).reduce_sum(), 8);
+
+    let mut overflow = [0; 8];
+    overflow[0] = u64::MAX;
+    overflow[4] = 1;
+    assert_eq!(u64x8::from_slice(simd, &overflow).reduce_sum(), 0);
+}


### PR DESCRIPTION
This implements the hardest part of https://github.com/linebender/fearless_simd/issues/340

With floats this is very tricky. Their addition is non-trivial due to accumulating precision loss, and there are many algorithms and many precision trade-offs. See https://orlp.net/blog/taming-float-sums/ for more info.

This PR's implementation splits vectors in half and performs lane-wise addition down to 128-bit vectors, then reduces the 128-bit vector down to a single value with pairwise summation. This is a fast and precise-ish algorithm with log2(N) roundings.

I feel this is a good default because it is portable (bit-exact output everywhere, except for NaN payloads) and pretty fast. This leaves us space to add a `_relaxed` variant if higher-performance options with fewer guarantees are ever discovered, and/or a `_precise` variant for Kahann summation with a single rounding instead of log2(N) roundings.

We handily beat `std::simd` which sums floats one by one left to right, which is awful for both precision and performance: it forces a long chain of scalar additions, and [this is the worst case for precision too](https://orlp.net/blog/taming-float-sums/), causing N roundings for st::simd as opposed to log2(N) in this PR.

Integers are not under any of the same constraints, so I tried looking for faster formulations for integers, but couldn't find anything. This reinforces my hunch that this is about as fast as this op can get, even for floats.

cc @Mnwa who requested this feature