### PR TITLE
Fix fract() on NEON

### DIFF
--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -464,9 +464,7 @@ impl Simd for Neon {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Neon, a: f32x4<Neon>) -> f32x4<Neon> {
-                let c1 = vcvtq_s32_f32(a.into());
-                let c2 = vcvtq_f32_s32(c1);
-                vsubq_f32(a.into(), c2).simd_into(token)
+                vsubq_f32(a.into(), vrndq_f32(a.into())).simd_into(token)
             }
         );
         kernel(self, a)
@@ -3787,9 +3785,7 @@ impl Simd for Neon {
         crate::kernel!(
             #[inline(always)]
             fn kernel(token: Neon, a: f64x2<Neon>) -> f64x2<Neon> {
-                let c1 = vcvtq_s64_f64(a.into());
-                let c2 = vcvtq_f64_s64(c1);
-                vsubq_f64(a.into(), c2).simd_into(token)
+                vsubq_f64(a.into(), vrndq_f64(a.into())).simd_into(token)
             }
         );
         kernel(self, a)

--- a/fearless_simd_gen/src/arch/neon.rs
+++ b/fearless_simd_gen/src/arch/neon.rs
@@ -68,16 +68,10 @@ pub(crate) fn expr(op: &str, ty: &VecType, args: &[TokenStream]) -> TokenStream 
             quote! { #intrinsic ( #( #args ),* ) }
         }
         "fract" => {
-            let to = VecType::new(ScalarType::Int, ty.scalar_bits, ty.len);
-            let c1 = cvt_intrinsic("vcvt", &to, ty);
-            let c2 = cvt_intrinsic("vcvt", ty, &to);
+            let trunc = simple_intrinsic("vrnd", ty);
             let sub = simple_intrinsic("vsub", ty);
-            quote! {
-                let c1 = #c1(a.into());
-                let c2 = #c2(c1);
-
-                #sub(a.into(), c2)
-            }
+            let a = &args[0];
+            quote! { #sub(#a, #trunc(#a)) }
         }
         "approximate_recip" => {
             let vrecpe = simple_intrinsic("vrecpe", ty);

--- a/fearless_simd_tests/tests/harness/ops/fract.rs
+++ b/fearless_simd_tests/tests/harness/ops/fract.rs
@@ -102,3 +102,71 @@ fn fract_f64x4<S: Simd>(simd: S) {
     let result = simd.fract_f64x4(a);
     assert_eq!(result.as_slice(), expected.as_slice());
 }
+
+#[simd_test]
+fn fract_f32x4_edge_cases<S: Simd>(simd: S) {
+    let values = [
+        -0.0,
+        2_147_483_904.0_f32, // 2^31 + one f32 ULP
+        f32::MAX,
+        f32::INFINITY,
+    ];
+    let a = f32x4::from_slice(simd, &values);
+    let result = simd.fract_f32x4(a);
+
+    assert_eq!(result[0].to_bits(), 0.0_f32.to_bits());
+    assert_eq!(result[1].to_bits(), 0.0_f32.to_bits());
+    assert_eq!(result[2].to_bits(), 0.0_f32.to_bits());
+    assert!(result[3].is_nan());
+
+    let values = [
+        -2_147_483_904.0_f32, // -2^31 - one f32 ULP
+        f32::MIN,
+        f32::NEG_INFINITY,
+        f32::NAN,
+    ];
+    let a = f32x4::from_slice(simd, &values);
+    let result = simd.fract_f32x4(a);
+
+    assert_eq!(result[0].to_bits(), 0.0_f32.to_bits());
+    assert_eq!(result[1].to_bits(), 0.0_f32.to_bits());
+    assert!(result[2].is_nan());
+    assert!(result[3].is_nan());
+}
+
+#[simd_test]
+fn fract_f64x2_edge_cases<S: Simd>(simd: S) {
+    let values = [
+        -0.0,
+        9_223_372_036_854_777_856.0_f64, // 2^63 + one f64 ULP
+    ];
+    let a = f64x2::from_slice(simd, &values);
+    let result = simd.fract_f64x2(a);
+
+    assert_eq!(result[0].to_bits(), 0.0_f64.to_bits());
+    assert_eq!(result[1].to_bits(), 0.0_f64.to_bits());
+
+    let values = [f64::MAX, f64::INFINITY];
+    let a = f64x2::from_slice(simd, &values);
+    let result = simd.fract_f64x2(a);
+
+    assert_eq!(result[0].to_bits(), 0.0_f64.to_bits());
+    assert!(result[1].is_nan());
+
+    let values = [
+        -9_223_372_036_854_777_856.0_f64, // -2^63 - one f64 ULP
+        f64::MIN,
+    ];
+    let a = f64x2::from_slice(simd, &values);
+    let result = simd.fract_f64x2(a);
+
+    assert_eq!(result[0].to_bits(), 0.0_f64.to_bits());
+    assert_eq!(result[1].to_bits(), 0.0_f64.to_bits());
+
+    let values = [f64::NEG_INFINITY, f64::NAN];
+    let a = f64x2::from_slice(simd, &values);
+    let result = simd.fract_f64x2(a);
+
+    assert!(result[0].is_nan());
+    assert!(result[1].is_nan());
+}


### PR DESCRIPTION
Fixes #364, adds regression tests

This is also faster on llvm-mca than the previous formulation, as a bonus