### PR TITLE
Rename ::N to ::LEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ You can find its changes [documented below](#070-2026-08-11).
 
 ### Changed
 
+- Breaking change: `SimdBase::N` and `SimdMask::N` have been renamed to `LEN`, matching the `std::simd` naming.
 - Breaking change: `SimdBase::as_array` now borrows the vector and returns an array reference, while owned extraction has moved to `to_array`. The old `as_array_ref` and `as_array_mut` methods have been replaced by `as_array` and `as_mut_array`, matching the `std::simd` API.
 
 ## [0.7.0][] (2026-08-11)

--- a/fearless_simd/README.md
+++ b/fearless_simd/README.md
@@ -75,7 +75,7 @@ use fearless_simd::{dispatch, prelude::*, Level};
 
 #[inline(always)]
 fn double_u32s<S: Simd>(simd: S, values: &mut [u32]) {
-    let mut chunks = values.chunks_exact_mut(S::u32s::N); // the CPU's native SIMD width
+    let mut chunks = values.chunks_exact_mut(S::u32s::LEN); // the CPU's native SIMD width
     for chunk in &mut chunks {
         let v = S::u32s::from_slice(simd, chunk);
         (v * 2).store_slice(chunk);

--- a/fearless_simd/examples/disable_avx2_for_one_function.rs
+++ b/fearless_simd/examples/disable_avx2_for_one_function.rs
@@ -27,7 +27,7 @@ fn sigmoid<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
     // the callee will also never get an AVX2 implementation.
     // The downgrade only needs to happen once anywhere in the call chain.
 
-    let n = S::f32s::N;
+    let n = S::f32s::LEN;
     for (x, y) in x.chunks_exact(n).zip(out.chunks_exact_mut(n)) {
         let a = S::f32s::from_slice(simd, x);
         let b = a / (a * a + 1.0).sqrt();

--- a/fearless_simd/examples/sigmoid.rs
+++ b/fearless_simd/examples/sigmoid.rs
@@ -10,7 +10,7 @@ use fearless_simd::{Level, dispatch, prelude::*};
 
 #[inline(always)]
 fn sigmoid<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
-    let n = S::f32s::N;
+    let n = S::f32s::LEN;
     for (x, y) in x.chunks_exact(n).zip(out.chunks_exact_mut(n)) {
         let a = S::f32s::from_slice(simd, x);
         let b = a / (a * a + 1.0).sqrt();

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -195,7 +195,7 @@ pub trait Simd:
     #[doc = r"     simd.vectorize("]
     #[doc = r"         #[inline(always)]"]
     #[doc = r"         || {"]
-    #[doc = r"             let mut chunks = values.chunks_exact_mut(S::u32s::N);"]
+    #[doc = r"             let mut chunks = values.chunks_exact_mut(S::u32s::LEN);"]
     #[doc = r"             for chunk in &mut chunks {"]
     #[doc = r"                 let value = S::u32s::from_slice(simd, chunk);"]
     #[doc = r"                 (value * 2).store_slice(chunk);"]
@@ -217,7 +217,7 @@ pub trait Simd:
     fn splat_f32x4(self, val: f32) -> f32x4<Self>;
     #[doc = "Reverse the order of the vector's elements."]
     fn reverse_f32x4(self, a: f32x4<Self>) -> f32x4<Self>;
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f32x4<const SHIFT: usize>(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -355,7 +355,7 @@ pub trait Simd:
     fn splat_i8x16(self, val: i8) -> i8x16<Self>;
     #[doc = "Reverse the order of the vector's elements."]
     fn reverse_i8x16(self, a: i8x16<Self>) -> i8x16<Self>;
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i8x16<const SHIFT: usize>(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -473,7 +473,7 @@ pub trait Simd:
     fn splat_u8x16(self, val: u8) -> u8x16<Self>;
     #[doc = "Reverse the order of the vector's elements."]
     fn reverse_u8x16(self, a: u8x16<Self>) -> u8x16<Self>;
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u8x16<const SHIFT: usize>(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -584,12 +584,12 @@ pub trait Simd:
     fn to_bitmask_mask8x16(self, a: mask8x16<Self>) -> u64;
     #[doc = "Set one logical lane of a SIMD mask."]
     fn set_mask8x16(self, a: &mut mask8x16<Self>, index: usize, value: bool) -> ();
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left_mask8x16<const OFFSET: usize>(
         self,
         a: mask8x16<Self>,
     ) -> mask8x16<Self>;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right_mask8x16<const OFFSET: usize>(
         self,
         a: mask8x16<Self>,
@@ -627,7 +627,7 @@ pub trait Simd:
     fn splat_i16x8(self, val: i16) -> i16x8<Self>;
     #[doc = "Reverse the order of the vector's elements."]
     fn reverse_i16x8(self, a: i16x8<Self>) -> i16x8<Self>;
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i16x8<const SHIFT: usize>(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -751,7 +751,7 @@ pub trait Simd:
     fn splat_u16x8(self, val: u16) -> u16x8<Self>;
     #[doc = "Reverse the order of the vector's elements."]
     fn reverse_u16x8(self, a: u16x8<Self>) -> u16x8<Self>;
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u16x8<const SHIFT: usize>(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -877,12 +877,12 @@ pub trait Simd:
     fn to_bitmask_mask16x8(self, a: mask16x8<Self>) -> u64;
     #[doc = "Set one logical lane of a SIMD mask."]
     fn set_mask16x8(self, a: &mut mask16x8<Self>, index: usize, value: bool) -> ();
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left_mask16x8<const OFFSET: usize>(
         self,
         a: mask16x8<Self>,
     ) -> mask16x8<Self>;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right_mask16x8<const OFFSET: usize>(
         self,
         a: mask16x8<Self>,
@@ -920,7 +920,7 @@ pub trait Simd:
     fn splat_i32x4(self, val: i32) -> i32x4<Self>;
     #[doc = "Reverse the order of the vector's elements."]
     fn reverse_i32x4(self, a: i32x4<Self>) -> i32x4<Self>;
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i32x4<const SHIFT: usize>(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -1046,7 +1046,7 @@ pub trait Simd:
     fn splat_u32x4(self, val: u32) -> u32x4<Self>;
     #[doc = "Reverse the order of the vector's elements."]
     fn reverse_u32x4(self, a: u32x4<Self>) -> u32x4<Self>;
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u32x4<const SHIFT: usize>(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -1174,12 +1174,12 @@ pub trait Simd:
     fn to_bitmask_mask32x4(self, a: mask32x4<Self>) -> u64;
     #[doc = "Set one logical lane of a SIMD mask."]
     fn set_mask32x4(self, a: &mut mask32x4<Self>, index: usize, value: bool) -> ();
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left_mask32x4<const OFFSET: usize>(
         self,
         a: mask32x4<Self>,
     ) -> mask32x4<Self>;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right_mask32x4<const OFFSET: usize>(
         self,
         a: mask32x4<Self>,
@@ -1217,7 +1217,7 @@ pub trait Simd:
     fn splat_f64x2(self, val: f64) -> f64x2<Self>;
     #[doc = "Reverse the order of the vector's elements."]
     fn reverse_f64x2(self, a: f64x2<Self>) -> f64x2<Self>;
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f64x2<const SHIFT: usize>(self, a: f64x2<Self>, b: f64x2<Self>) -> f64x2<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -1359,7 +1359,7 @@ pub trait Simd:
     fn splat_i64x2(self, val: i64) -> i64x2<Self>;
     #[doc = "Reverse the order of the vector's elements."]
     fn reverse_i64x2(self, a: i64x2<Self>) -> i64x2<Self>;
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i64x2<const SHIFT: usize>(self, a: i64x2<Self>, b: i64x2<Self>) -> i64x2<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -1483,7 +1483,7 @@ pub trait Simd:
     fn splat_u64x2(self, val: u64) -> u64x2<Self>;
     #[doc = "Reverse the order of the vector's elements."]
     fn reverse_u64x2(self, a: u64x2<Self>) -> u64x2<Self>;
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u64x2<const SHIFT: usize>(self, a: u64x2<Self>, b: u64x2<Self>) -> u64x2<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -1609,12 +1609,12 @@ pub trait Simd:
     fn to_bitmask_mask64x2(self, a: mask64x2<Self>) -> u64;
     #[doc = "Set one logical lane of a SIMD mask."]
     fn set_mask64x2(self, a: &mut mask64x2<Self>, index: usize, value: bool) -> ();
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left_mask64x2<const OFFSET: usize>(
         self,
         a: mask64x2<Self>,
     ) -> mask64x2<Self>;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right_mask64x2<const OFFSET: usize>(
         self,
         a: mask64x2<Self>,
@@ -1660,7 +1660,7 @@ pub trait Simd:
         let (a0, a1) = self.split_f32x8(a);
         self.combine_f32x4(self.reverse_f32x4(a1), self.reverse_f32x4(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f32x8<const SHIFT: usize>(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -2049,7 +2049,7 @@ pub trait Simd:
         let (a0, a1) = self.split_i8x32(a);
         self.combine_i8x16(self.reverse_i8x16(a1), self.reverse_i8x16(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i8x32<const SHIFT: usize>(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -2349,7 +2349,7 @@ pub trait Simd:
         let (a0, a1) = self.split_u8x32(a);
         self.combine_u8x16(self.reverse_u8x16(a1), self.reverse_u8x16(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u8x32<const SHIFT: usize>(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -2653,12 +2653,12 @@ pub trait Simd:
     }
     #[doc = "Set one logical lane of a SIMD mask."]
     fn set_mask8x32(self, a: &mut mask8x32<Self>, index: usize, value: bool) -> ();
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left_mask8x32<const OFFSET: usize>(
         self,
         a: mask8x32<Self>,
     ) -> mask8x32<Self>;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right_mask8x32<const OFFSET: usize>(
         self,
         a: mask8x32<Self>,
@@ -2759,7 +2759,7 @@ pub trait Simd:
         let (a0, a1) = self.split_i16x16(a);
         self.combine_i16x8(self.reverse_i16x8(a1), self.reverse_i16x8(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i16x16<const SHIFT: usize>(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -3090,7 +3090,7 @@ pub trait Simd:
         let (a0, a1) = self.split_u16x16(a);
         self.combine_u16x8(self.reverse_u16x8(a1), self.reverse_u16x8(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u16x16<const SHIFT: usize>(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -3426,12 +3426,12 @@ pub trait Simd:
     }
     #[doc = "Set one logical lane of a SIMD mask."]
     fn set_mask16x16(self, a: &mut mask16x16<Self>, index: usize, value: bool) -> ();
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left_mask16x16<const OFFSET: usize>(
         self,
         a: mask16x16<Self>,
     ) -> mask16x16<Self>;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right_mask16x16<const OFFSET: usize>(
         self,
         a: mask16x16<Self>,
@@ -3532,7 +3532,7 @@ pub trait Simd:
         let (a0, a1) = self.split_i32x8(a);
         self.combine_i32x4(self.reverse_i32x4(a1), self.reverse_i32x4(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i32x8<const SHIFT: usize>(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -3865,7 +3865,7 @@ pub trait Simd:
         let (a0, a1) = self.split_u32x8(a);
         self.combine_u32x4(self.reverse_u32x4(a1), self.reverse_u32x4(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u32x8<const SHIFT: usize>(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -4203,12 +4203,12 @@ pub trait Simd:
     }
     #[doc = "Set one logical lane of a SIMD mask."]
     fn set_mask32x8(self, a: &mut mask32x8<Self>, index: usize, value: bool) -> ();
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left_mask32x8<const OFFSET: usize>(
         self,
         a: mask32x8<Self>,
     ) -> mask32x8<Self>;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right_mask32x8<const OFFSET: usize>(
         self,
         a: mask32x8<Self>,
@@ -4309,7 +4309,7 @@ pub trait Simd:
         let (a0, a1) = self.split_f64x4(a);
         self.combine_f64x2(self.reverse_f64x2(a1), self.reverse_f64x2(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f64x4<const SHIFT: usize>(self, a: f64x4<Self>, b: f64x4<Self>) -> f64x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -4717,7 +4717,7 @@ pub trait Simd:
         let (a0, a1) = self.split_i64x4(a);
         self.combine_i64x2(self.reverse_i64x2(a1), self.reverse_i64x2(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i64x4<const SHIFT: usize>(self, a: i64x4<Self>, b: i64x4<Self>) -> i64x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -5042,7 +5042,7 @@ pub trait Simd:
         let (a0, a1) = self.split_u64x4(a);
         self.combine_u64x2(self.reverse_u64x2(a1), self.reverse_u64x2(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u64x4<const SHIFT: usize>(self, a: u64x4<Self>, b: u64x4<Self>) -> u64x4<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -5372,12 +5372,12 @@ pub trait Simd:
     }
     #[doc = "Set one logical lane of a SIMD mask."]
     fn set_mask64x4(self, a: &mut mask64x4<Self>, index: usize, value: bool) -> ();
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left_mask64x4<const OFFSET: usize>(
         self,
         a: mask64x4<Self>,
     ) -> mask64x4<Self>;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right_mask64x4<const OFFSET: usize>(
         self,
         a: mask64x4<Self>,
@@ -5478,7 +5478,7 @@ pub trait Simd:
         let (a0, a1) = self.split_f32x16(a);
         self.combine_f32x8(self.reverse_f32x8(a1), self.reverse_f32x8(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f32x16<const SHIFT: usize>(self, a: f32x16<Self>, b: f32x16<Self>) -> f32x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -5879,7 +5879,7 @@ pub trait Simd:
         let (a0, a1) = self.split_i8x64(a);
         self.combine_i8x32(self.reverse_i8x32(a1), self.reverse_i8x32(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i8x64<const SHIFT: usize>(self, a: i8x64<Self>, b: i8x64<Self>) -> i8x64<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -6177,7 +6177,7 @@ pub trait Simd:
         let (a0, a1) = self.split_u8x64(a);
         self.combine_u8x32(self.reverse_u8x32(a1), self.reverse_u8x32(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u8x64<const SHIFT: usize>(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -6479,12 +6479,12 @@ pub trait Simd:
     }
     #[doc = "Set one logical lane of a SIMD mask."]
     fn set_mask8x64(self, a: &mut mask8x64<Self>, index: usize, value: bool) -> ();
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left_mask8x64<const OFFSET: usize>(
         self,
         a: mask8x64<Self>,
     ) -> mask8x64<Self>;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right_mask8x64<const OFFSET: usize>(
         self,
         a: mask8x64<Self>,
@@ -6583,7 +6583,7 @@ pub trait Simd:
         let (a0, a1) = self.split_i16x32(a);
         self.combine_i16x16(self.reverse_i16x16(a1), self.reverse_i16x16(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i16x32<const SHIFT: usize>(self, a: i16x32<Self>, b: i16x32<Self>) -> i16x32<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -6918,7 +6918,7 @@ pub trait Simd:
         let (a0, a1) = self.split_u16x32(a);
         self.combine_u16x16(self.reverse_u16x16(a1), self.reverse_u16x16(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u16x32<const SHIFT: usize>(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -7258,12 +7258,12 @@ pub trait Simd:
     }
     #[doc = "Set one logical lane of a SIMD mask."]
     fn set_mask16x32(self, a: &mut mask16x32<Self>, index: usize, value: bool) -> ();
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left_mask16x32<const OFFSET: usize>(
         self,
         a: mask16x32<Self>,
     ) -> mask16x32<Self>;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right_mask16x32<const OFFSET: usize>(
         self,
         a: mask16x32<Self>,
@@ -7365,7 +7365,7 @@ pub trait Simd:
         let (a0, a1) = self.split_i32x16(a);
         self.combine_i32x8(self.reverse_i32x8(a1), self.reverse_i32x8(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i32x16<const SHIFT: usize>(self, a: i32x16<Self>, b: i32x16<Self>) -> i32x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -7700,7 +7700,7 @@ pub trait Simd:
         let (a0, a1) = self.split_u32x16(a);
         self.combine_u32x8(self.reverse_u32x8(a1), self.reverse_u32x8(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u32x16<const SHIFT: usize>(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -8040,12 +8040,12 @@ pub trait Simd:
     }
     #[doc = "Set one logical lane of a SIMD mask."]
     fn set_mask32x16(self, a: &mut mask32x16<Self>, index: usize, value: bool) -> ();
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left_mask32x16<const OFFSET: usize>(
         self,
         a: mask32x16<Self>,
     ) -> mask32x16<Self>;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right_mask32x16<const OFFSET: usize>(
         self,
         a: mask32x16<Self>,
@@ -8144,7 +8144,7 @@ pub trait Simd:
         let (a0, a1) = self.split_f64x8(a);
         self.combine_f64x4(self.reverse_f64x4(a1), self.reverse_f64x4(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_f64x8<const SHIFT: usize>(self, a: f64x8<Self>, b: f64x8<Self>) -> f64x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -8550,7 +8550,7 @@ pub trait Simd:
         let (a0, a1) = self.split_i64x8(a);
         self.combine_i64x4(self.reverse_i64x4(a1), self.reverse_i64x4(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_i64x8<const SHIFT: usize>(self, a: i64x8<Self>, b: i64x8<Self>) -> i64x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -8873,7 +8873,7 @@ pub trait Simd:
         let (a0, a1) = self.split_u64x8(a);
         self.combine_u64x4(self.reverse_u64x4(a1), self.reverse_u64x4(a0))
     }
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide_u64x8<const SHIFT: usize>(self, a: u64x8<Self>, b: u64x8<Self>) -> u64x8<Self>;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     #[inline(always)]
@@ -9201,12 +9201,12 @@ pub trait Simd:
     }
     #[doc = "Set one logical lane of a SIMD mask."]
     fn set_mask64x8(self, a: &mut mask64x8<Self>, index: usize, value: bool) -> ();
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left_mask64x8<const OFFSET: usize>(
         self,
         a: mask64x8<Self>,
     ) -> mask64x8<Self>;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right_mask64x8<const OFFSET: usize>(
         self,
         a: mask64x8<Self>,
@@ -9483,7 +9483,7 @@ pub trait SimdBase<S: Simd>:
     #[doc = r" This vector type's lane count. This is useful when you're"]
     #[doc = r" working with a native-width vector (e.g. [`Simd::f32s`]) and"]
     #[doc = r" want to process data in native-width chunks."]
-    const N: usize;
+    const LEN: usize;
     #[doc = r" A SIMD vector mask with the same number of logical lanes."]
     #[doc = r""]
     #[doc = r" Masks intentionally do not implement [`SimdBase`]. SSE, NEON, WASM, and the"]
@@ -9493,7 +9493,7 @@ pub trait SimdBase<S: Simd>:
     #[doc = r" A 128-bit SIMD vector of the same scalar type."]
     type Block: SimdBase<S, Element = Self::Element, Block = Self::Block>;
     #[doc = r" The array type that this vector type corresponds to, which will"]
-    #[doc = r" always be `[Self::Element; Self::N]`. It has the same layout as"]
+    #[doc = r" always be `[Self::Element; Self::LEN]`. It has the same layout as"]
     #[doc = r" this vector type, but likely has a lower alignment."]
     type Array: Copy
         + Debug
@@ -9548,14 +9548,14 @@ pub trait SimdBase<S: Simd>:
     fn block_splat(block: Self::Block) -> Self;
     #[doc = r" Create a SIMD vector where each element is produced by"]
     #[doc = r" calling `f` with that element's lane index (from 0 to"]
-    #[doc = r" [`SimdBase::N`] - 1)."]
+    #[doc = r" [`SimdBase::LEN`] - 1)."]
     fn from_fn(simd: S, f: impl FnMut(usize) -> Self::Element) -> Self;
     #[doc = r" Rotate the vector elements to the left by `OFFSET`."]
     #[doc = r""]
-    #[doc = r" If `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = r" If `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     #[inline(always)]
     fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
-        match OFFSET % Self::N {
+        match OFFSET % Self::LEN {
             0 => self.slide::<0>(self),
             1 => self.slide::<1>(self),
             2 => self.slide::<2>(self),
@@ -9625,10 +9625,10 @@ pub trait SimdBase<S: Simd>:
     }
     #[doc = r" Rotate the vector elements to the right by `OFFSET`."]
     #[doc = r""]
-    #[doc = r" If `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = r" If `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     #[inline(always)]
     fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
-        match Self::N - OFFSET % Self::N {
+        match Self::LEN - OFFSET % Self::LEN {
             1 => self.slide::<1>(self),
             2 => self.slide::<2>(self),
             3 => self.slide::<3>(self),
@@ -9698,10 +9698,10 @@ pub trait SimdBase<S: Simd>:
     }
     #[doc = r" Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right."]
     #[doc = r""]
-    #[doc = r" If `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
+    #[doc = r" If `OFFSET` is greater than or equal to `Self::LEN`, all lanes are filled with `padding`."]
     #[inline(always)]
     fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
-        match OFFSET.min(Self::N) {
+        match OFFSET.min(Self::LEN) {
             0 => self.slide::<0>(padding),
             1 => self.slide::<1>(padding),
             2 => self.slide::<2>(padding),
@@ -9772,11 +9772,11 @@ pub trait SimdBase<S: Simd>:
     }
     #[doc = r" Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left."]
     #[doc = r""]
-    #[doc = r" If `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`."]
+    #[doc = r" If `OFFSET` is greater than or equal to `Self::LEN`, all lanes are filled with `padding`."]
     #[inline(always)]
     fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
         let padding = Self::splat(self.witness(), padding);
-        match Self::N.saturating_sub(OFFSET) {
+        match Self::LEN.saturating_sub(OFFSET) {
             0 => padding.slide::<0>(self),
             1 => padding.slide::<1>(self),
             2 => padding.slide::<2>(self),
@@ -9849,7 +9849,7 @@ pub trait SimdBase<S: Simd>:
     fn splat(simd: S, val: Self::Element) -> Self;
     #[doc = "Reverse the order of the vector's elements."]
     fn reverse(self) -> Self;
-    #[doc = "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::N`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
+    #[doc = "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n`SHIFT` must be within [0, `Self::LEN`].\n\nThis can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\nThis can also be used to rotate items within a vector by providing the same vector as both operands.\n\n```text\n\nslide::<1>([a b c d], [e f g h]) == [b c d e]\n\n```"]
     fn slide<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self;
     #[doc = "Like `slide`, but operates independently on each 128-bit block."]
     fn slide_within_blocks<const SHIFT: usize>(self, rhs: impl SimdInto<Self, S>) -> Self;
@@ -10030,7 +10030,7 @@ pub trait SimdMask<S: Simd>:
     #[doc = r" (integer value -1)."]
     type Element: SimdElement;
     #[doc = r" This mask type's lane count."]
-    const N: usize;
+    const LEN: usize;
     #[doc = r" Get the [`Simd`] implementation associated with this type."]
     fn witness(&self) -> S;
     #[doc = r" Create a SIMD mask with all lanes set to the given boolean value."]
@@ -10038,12 +10038,12 @@ pub trait SimdMask<S: Simd>:
     #[doc = r" Create a mask from a compact bitmask."]
     #[doc = r""]
     #[doc = r" Bit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above"]
-    #[doc = r" [`Self::N`] are ignored."]
+    #[doc = r" [`Self::LEN`] are ignored."]
     fn from_bitmask(simd: S, bits: u64) -> Self;
     #[doc = r" Convert this mask to a compact bitmask."]
     #[doc = r""]
     #[doc = r" Bit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above"]
-    #[doc = r" [`Self::N`] are cleared."]
+    #[doc = r" [`Self::LEN`] are cleared."]
     fn to_bitmask(self) -> u64;
     #[doc = r" Test whether one logical lane is set."]
     #[doc = r""]
@@ -10051,9 +10051,9 @@ pub trait SimdMask<S: Simd>:
     #[inline(always)]
     fn test(&self, index: usize) -> bool {
         assert!(
-            index < Self::N,
+            index < Self::LEN,
             "mask lane index {index} is out of bounds for {} lanes",
-            Self::N
+            Self::LEN
         );
         (((*self).to_bitmask() >> index) & 1) != 0
     }
@@ -10069,9 +10069,9 @@ pub trait SimdMask<S: Simd>:
     #[doc = r""]
     #[doc = r" The slice must be exactly the size of the SIMD mask."]
     fn store_slice(&self, slice: &mut [Self::Element]);
-    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the left by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_left<const OFFSET: usize>(self) -> Self;
-    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`."]
+    #[doc = "Rotate the mask elements to the right by `OFFSET`.\n\nIf `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`."]
     fn rotate_elements_right<const OFFSET: usize>(self) -> Self;
     #[doc = "Reverse the order of the mask's logical lanes."]
     fn reverse(self) -> Self;

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -93,7 +93,7 @@ impl<S: Simd> Bytes for f32x4<S> {
 impl<S: Simd> SimdBase<S> for f32x4<S> {
     type Element = f32;
     type ByteVector = u8x16<S>;
-    const N: usize = 4;
+    const LEN: usize = 4;
     type Mask = mask32x4<S>;
     type Block = f32x4<S>;
     type Array = [f32; 4];
@@ -427,7 +427,7 @@ impl<S: Simd> Bytes for i8x16<S> {
 impl<S: Simd> SimdBase<S> for i8x16<S> {
     type Element = i8;
     type ByteVector = u8x16<S>;
-    const N: usize = 16;
+    const LEN: usize = 16;
     type Mask = mask8x16<S>;
     type Block = i8x16<S>;
     type Array = [i8; 16];
@@ -729,7 +729,7 @@ impl<S: Simd> Bytes for u8x16<S> {
 impl<S: Simd> SimdBase<S> for u8x16<S> {
     type Element = u8;
     type ByteVector = u8x16<S>;
-    const N: usize = 16;
+    const LEN: usize = 16;
     type Mask = mask8x16<S>;
     type Block = u8x16<S>;
     type Array = [u8; 16];
@@ -987,7 +987,7 @@ impl<S: Simd> Select<mask8x16<S>> for mask8x16<S> {
 }
 impl<S: Simd> SimdMask<S> for mask8x16<S> {
     type Element = i8;
-    const N: usize = 16;
+    const LEN: usize = 16;
     #[inline(always)]
     fn witness(&self) -> S {
         self.simd
@@ -1137,7 +1137,7 @@ impl<S: Simd> Bytes for i16x8<S> {
 impl<S: Simd> SimdBase<S> for i16x8<S> {
     type Element = i16;
     type ByteVector = u8x16<S>;
-    const N: usize = 8;
+    const LEN: usize = 8;
     type Mask = mask16x8<S>;
     type Block = i16x8<S>;
     type Array = [i16; 8];
@@ -1446,7 +1446,7 @@ impl<S: Simd> Bytes for u16x8<S> {
 impl<S: Simd> SimdBase<S> for u16x8<S> {
     type Element = u16;
     type ByteVector = u8x16<S>;
-    const N: usize = 8;
+    const LEN: usize = 8;
     type Mask = mask16x8<S>;
     type Block = u16x8<S>;
     type Array = [u16; 8];
@@ -1711,7 +1711,7 @@ impl<S: Simd> Select<mask16x8<S>> for mask16x8<S> {
 }
 impl<S: Simd> SimdMask<S> for mask16x8<S> {
     type Element = i16;
-    const N: usize = 8;
+    const LEN: usize = 8;
     #[inline(always)]
     fn witness(&self) -> S {
         self.simd
@@ -1861,7 +1861,7 @@ impl<S: Simd> Bytes for i32x4<S> {
 impl<S: Simd> SimdBase<S> for i32x4<S> {
     type Element = i32;
     type ByteVector = u8x16<S>;
-    const N: usize = 4;
+    const LEN: usize = 4;
     type Mask = mask32x4<S>;
     type Block = i32x4<S>;
     type Array = [i32; 4];
@@ -2170,7 +2170,7 @@ impl<S: Simd> Bytes for u32x4<S> {
 impl<S: Simd> SimdBase<S> for u32x4<S> {
     type Element = u32;
     type ByteVector = u8x16<S>;
-    const N: usize = 4;
+    const LEN: usize = 4;
     type Mask = mask32x4<S>;
     type Block = u32x4<S>;
     type Array = [u32; 4];
@@ -2435,7 +2435,7 @@ impl<S: Simd> Select<mask32x4<S>> for mask32x4<S> {
 }
 impl<S: Simd> SimdMask<S> for mask32x4<S> {
     type Element = i32;
-    const N: usize = 4;
+    const LEN: usize = 4;
     #[inline(always)]
     fn witness(&self) -> S {
         self.simd
@@ -2585,7 +2585,7 @@ impl<S: Simd> Bytes for f64x2<S> {
 impl<S: Simd> SimdBase<S> for f64x2<S> {
     type Element = f64;
     type ByteVector = u8x16<S>;
-    const N: usize = 2;
+    const LEN: usize = 2;
     type Mask = mask64x2<S>;
     type Block = f64x2<S>;
     type Array = [f64; 2];
@@ -2927,7 +2927,7 @@ impl<S: Simd> Bytes for i64x2<S> {
 impl<S: Simd> SimdBase<S> for i64x2<S> {
     type Element = i64;
     type ByteVector = u8x16<S>;
-    const N: usize = 2;
+    const LEN: usize = 2;
     type Mask = mask64x2<S>;
     type Block = i64x2<S>;
     type Array = [i64; 2];
@@ -3229,7 +3229,7 @@ impl<S: Simd> Bytes for u64x2<S> {
 impl<S: Simd> SimdBase<S> for u64x2<S> {
     type Element = u64;
     type ByteVector = u8x16<S>;
-    const N: usize = 2;
+    const LEN: usize = 2;
     type Mask = mask64x2<S>;
     type Block = u64x2<S>;
     type Array = [u64; 2];
@@ -3487,7 +3487,7 @@ impl<S: Simd> Select<mask64x2<S>> for mask64x2<S> {
 }
 impl<S: Simd> SimdMask<S> for mask64x2<S> {
     type Element = i64;
-    const N: usize = 2;
+    const LEN: usize = 2;
     #[inline(always)]
     fn witness(&self) -> S {
         self.simd
@@ -3637,7 +3637,7 @@ impl<S: Simd> Bytes for f32x8<S> {
 impl<S: Simd> SimdBase<S> for f32x8<S> {
     type Element = f32;
     type ByteVector = u8x32<S>;
-    const N: usize = 8;
+    const LEN: usize = 8;
     type Mask = mask32x8<S>;
     type Block = f32x4<S>;
     type Array = [f32; 8];
@@ -3978,7 +3978,7 @@ impl<S: Simd> Bytes for i8x32<S> {
 impl<S: Simd> SimdBase<S> for i8x32<S> {
     type Element = i8;
     type ByteVector = u8x32<S>;
-    const N: usize = 32;
+    const LEN: usize = 32;
     type Mask = mask8x32<S>;
     type Block = i8x16<S>;
     type Array = [i8; 32];
@@ -4291,7 +4291,7 @@ impl<S: Simd> Bytes for u8x32<S> {
 impl<S: Simd> SimdBase<S> for u8x32<S> {
     type Element = u8;
     type ByteVector = u8x32<S>;
-    const N: usize = 32;
+    const LEN: usize = 32;
     type Mask = mask8x32<S>;
     type Block = u8x16<S>;
     type Array = [u8; 32];
@@ -4560,7 +4560,7 @@ impl<S: Simd> Select<mask8x32<S>> for mask8x32<S> {
 }
 impl<S: Simd> SimdMask<S> for mask8x32<S> {
     type Element = i8;
-    const N: usize = 32;
+    const LEN: usize = 32;
     #[inline(always)]
     fn witness(&self) -> S {
         self.simd
@@ -4710,7 +4710,7 @@ impl<S: Simd> Bytes for i16x16<S> {
 impl<S: Simd> SimdBase<S> for i16x16<S> {
     type Element = i16;
     type ByteVector = u8x32<S>;
-    const N: usize = 16;
+    const LEN: usize = 16;
     type Mask = mask16x16<S>;
     type Block = i16x8<S>;
     type Array = [i16; 16];
@@ -5023,7 +5023,7 @@ impl<S: Simd> Bytes for u16x16<S> {
 impl<S: Simd> SimdBase<S> for u16x16<S> {
     type Element = u16;
     type ByteVector = u8x32<S>;
-    const N: usize = 16;
+    const LEN: usize = 16;
     type Mask = mask16x16<S>;
     type Block = u16x8<S>;
     type Array = [u16; 16];
@@ -5292,7 +5292,7 @@ impl<S: Simd> Select<mask16x16<S>> for mask16x16<S> {
 }
 impl<S: Simd> SimdMask<S> for mask16x16<S> {
     type Element = i16;
-    const N: usize = 16;
+    const LEN: usize = 16;
     #[inline(always)]
     fn witness(&self) -> S {
         self.simd
@@ -5442,7 +5442,7 @@ impl<S: Simd> Bytes for i32x8<S> {
 impl<S: Simd> SimdBase<S> for i32x8<S> {
     type Element = i32;
     type ByteVector = u8x32<S>;
-    const N: usize = 8;
+    const LEN: usize = 8;
     type Mask = mask32x8<S>;
     type Block = i32x4<S>;
     type Array = [i32; 8];
@@ -5758,7 +5758,7 @@ impl<S: Simd> Bytes for u32x8<S> {
 impl<S: Simd> SimdBase<S> for u32x8<S> {
     type Element = u32;
     type ByteVector = u8x32<S>;
-    const N: usize = 8;
+    const LEN: usize = 8;
     type Mask = mask32x8<S>;
     type Block = u32x4<S>;
     type Array = [u32; 8];
@@ -6030,7 +6030,7 @@ impl<S: Simd> Select<mask32x8<S>> for mask32x8<S> {
 }
 impl<S: Simd> SimdMask<S> for mask32x8<S> {
     type Element = i32;
-    const N: usize = 8;
+    const LEN: usize = 8;
     #[inline(always)]
     fn witness(&self) -> S {
         self.simd
@@ -6180,7 +6180,7 @@ impl<S: Simd> Bytes for f64x4<S> {
 impl<S: Simd> SimdBase<S> for f64x4<S> {
     type Element = f64;
     type ByteVector = u8x32<S>;
-    const N: usize = 4;
+    const LEN: usize = 4;
     type Mask = mask64x4<S>;
     type Block = f64x2<S>;
     type Array = [f64; 4];
@@ -6517,7 +6517,7 @@ impl<S: Simd> Bytes for i64x4<S> {
 impl<S: Simd> SimdBase<S> for i64x4<S> {
     type Element = i64;
     type ByteVector = u8x32<S>;
-    const N: usize = 4;
+    const LEN: usize = 4;
     type Mask = mask64x4<S>;
     type Block = i64x2<S>;
     type Array = [i64; 4];
@@ -6814,7 +6814,7 @@ impl<S: Simd> Bytes for u64x4<S> {
 impl<S: Simd> SimdBase<S> for u64x4<S> {
     type Element = u64;
     type ByteVector = u8x32<S>;
-    const N: usize = 4;
+    const LEN: usize = 4;
     type Mask = mask64x4<S>;
     type Block = u64x2<S>;
     type Array = [u64; 4];
@@ -7067,7 +7067,7 @@ impl<S: Simd> Select<mask64x4<S>> for mask64x4<S> {
 }
 impl<S: Simd> SimdMask<S> for mask64x4<S> {
     type Element = i64;
-    const N: usize = 4;
+    const LEN: usize = 4;
     #[inline(always)]
     fn witness(&self) -> S {
         self.simd
@@ -7217,7 +7217,7 @@ impl<S: Simd> Bytes for f32x16<S> {
 impl<S: Simd> SimdBase<S> for f32x16<S> {
     type Element = f32;
     type ByteVector = u8x64<S>;
-    const N: usize = 16;
+    const LEN: usize = 16;
     type Mask = mask32x16<S>;
     type Block = f32x4<S>;
     type Array = [f32; 16];
@@ -7561,7 +7561,7 @@ impl<S: Simd> Bytes for i8x64<S> {
 impl<S: Simd> SimdBase<S> for i8x64<S> {
     type Element = i8;
     type ByteVector = u8x64<S>;
-    const N: usize = 64;
+    const LEN: usize = 64;
     type Mask = mask8x64<S>;
     type Block = i8x16<S>;
     type Array = [i8; 64];
@@ -7900,7 +7900,7 @@ impl<S: Simd> Bytes for u8x64<S> {
 impl<S: Simd> SimdBase<S> for u8x64<S> {
     type Element = u8;
     type ByteVector = u8x64<S>;
-    const N: usize = 64;
+    const LEN: usize = 64;
     type Mask = mask8x64<S>;
     type Block = u8x16<S>;
     type Array = [u8; 64];
@@ -8195,7 +8195,7 @@ impl<S: Simd> Select<mask8x64<S>> for mask8x64<S> {
 }
 impl<S: Simd> SimdMask<S> for mask8x64<S> {
     type Element = i8;
-    const N: usize = 64;
+    const LEN: usize = 64;
     #[inline(always)]
     fn witness(&self) -> S {
         self.simd
@@ -8345,7 +8345,7 @@ impl<S: Simd> Bytes for i16x32<S> {
 impl<S: Simd> SimdBase<S> for i16x32<S> {
     type Element = i16;
     type ByteVector = u8x64<S>;
-    const N: usize = 32;
+    const LEN: usize = 32;
     type Mask = mask16x32<S>;
     type Block = i16x8<S>;
     type Array = [i16; 32];
@@ -8668,7 +8668,7 @@ impl<S: Simd> Bytes for u16x32<S> {
 impl<S: Simd> SimdBase<S> for u16x32<S> {
     type Element = u16;
     type ByteVector = u8x64<S>;
-    const N: usize = 32;
+    const LEN: usize = 32;
     type Mask = mask16x32<S>;
     type Block = u16x8<S>;
     type Array = [u16; 32];
@@ -8947,7 +8947,7 @@ impl<S: Simd> Select<mask16x32<S>> for mask16x32<S> {
 }
 impl<S: Simd> SimdMask<S> for mask16x32<S> {
     type Element = i16;
-    const N: usize = 32;
+    const LEN: usize = 32;
     #[inline(always)]
     fn witness(&self) -> S {
         self.simd
@@ -9097,7 +9097,7 @@ impl<S: Simd> Bytes for i32x16<S> {
 impl<S: Simd> SimdBase<S> for i32x16<S> {
     type Element = i32;
     type ByteVector = u8x64<S>;
-    const N: usize = 16;
+    const LEN: usize = 16;
     type Mask = mask32x16<S>;
     type Block = i32x4<S>;
     type Array = [i32; 16];
@@ -9416,7 +9416,7 @@ impl<S: Simd> Bytes for u32x16<S> {
 impl<S: Simd> SimdBase<S> for u32x16<S> {
     type Element = u32;
     type ByteVector = u8x64<S>;
-    const N: usize = 16;
+    const LEN: usize = 16;
     type Mask = mask32x16<S>;
     type Block = u32x4<S>;
     type Array = [u32; 16];
@@ -9691,7 +9691,7 @@ impl<S: Simd> Select<mask32x16<S>> for mask32x16<S> {
 }
 impl<S: Simd> SimdMask<S> for mask32x16<S> {
     type Element = i32;
-    const N: usize = 16;
+    const LEN: usize = 16;
     #[inline(always)]
     fn witness(&self) -> S {
         self.simd
@@ -9841,7 +9841,7 @@ impl<S: Simd> Bytes for f64x8<S> {
 impl<S: Simd> SimdBase<S> for f64x8<S> {
     type Element = f64;
     type ByteVector = u8x64<S>;
-    const N: usize = 8;
+    const LEN: usize = 8;
     type Mask = mask64x8<S>;
     type Block = f64x2<S>;
     type Array = [f64; 8];
@@ -10184,7 +10184,7 @@ impl<S: Simd> Bytes for i64x8<S> {
 impl<S: Simd> SimdBase<S> for i64x8<S> {
     type Element = i64;
     type ByteVector = u8x64<S>;
-    const N: usize = 8;
+    const LEN: usize = 8;
     type Mask = mask64x8<S>;
     type Block = i64x2<S>;
     type Array = [i64; 8];
@@ -10487,7 +10487,7 @@ impl<S: Simd> Bytes for u64x8<S> {
 impl<S: Simd> SimdBase<S> for u64x8<S> {
     type Element = u64;
     type ByteVector = u8x64<S>;
-    const N: usize = 8;
+    const LEN: usize = 8;
     type Mask = mask64x8<S>;
     type Block = u64x2<S>;
     type Array = [u64; 8];
@@ -10746,7 +10746,7 @@ impl<S: Simd> Select<mask64x8<S>> for mask64x8<S> {
 }
 impl<S: Simd> SimdMask<S> for mask64x8<S> {
     type Element = i64;
-    const N: usize = 8;
+    const LEN: usize = 8;
     #[inline(always)]
     fn witness(&self) -> S {
         self.simd

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! #[inline(always)]
 //! fn double_u32s<S: Simd>(simd: S, values: &mut [u32]) {
-//!     let mut chunks = values.chunks_exact_mut(S::u32s::N); // the CPU's native SIMD width
+//!     let mut chunks = values.chunks_exact_mut(S::u32s::LEN); // the CPU's native SIMD width
 //!     for chunk in &mut chunks {
 //!         let v = S::u32s::from_slice(simd, chunk);
 //!         (v * 2).store_slice(chunk);

--- a/fearless_simd/src/traits.rs
+++ b/fearless_simd/src/traits.rs
@@ -294,7 +294,7 @@ pub trait SimdCvtFloat<T: Seal>: Seal {
 ///     simd: S,
 ///     pixels: &mut [V::Element],
 /// ) {
-///     let mut chunks = pixels.chunks_exact_mut(V::N * 4);
+///     let mut chunks = pixels.chunks_exact_mut(V::LEN * 4);
 ///     for chunk in &mut chunks {
 ///         let [red, green, blue, alpha] = V::load_four_interleaved(simd, chunk);
 ///         V::store_four_interleaved([blue, green, red, alpha], chunk);
@@ -316,7 +316,7 @@ pub trait SimdInterleaved<S: Simd>: SimdBase<S> {
     ///
     /// # Panics
     ///
-    /// Panics unless `src.len()` is exactly `Self::N * 4`.
+    /// Panics unless `src.len()` is exactly `Self::LEN * 4`.
     fn load_four_interleaved(simd: S, src: &[Self::Element]) -> [Self; 4];
 
     /// Store four vectors into a scalar slice with four-way interleaving.
@@ -330,7 +330,7 @@ pub trait SimdInterleaved<S: Simd>: SimdBase<S> {
     ///
     /// # Panics
     ///
-    /// Panics unless `dest.len()` is exactly `Self::N * 4`.
+    /// Panics unless `dest.len()` is exactly `Self::LEN * 4`.
     fn store_four_interleaved(vectors: [Self; 4], dest: &mut [Self::Element]);
 }
 

--- a/fearless_simd_gen/src/mk_simd_trait.rs
+++ b/fearless_simd_gen/src/mk_simd_trait.rs
@@ -168,7 +168,7 @@ pub(crate) fn mk_simd_trait() -> TokenStream {
             ///     simd.vectorize(
             ///         #[inline(always)]
             ///         || {
-            ///             let mut chunks = values.chunks_exact_mut(S::u32s::N);
+            ///             let mut chunks = values.chunks_exact_mut(S::u32s::LEN);
             ///             for chunk in &mut chunks {
             ///                 let value = S::u32s::from_slice(simd, chunk);
             ///                 (value * 2).store_slice(chunk);
@@ -297,7 +297,7 @@ fn mk_simd_base() -> TokenStream {
             /// This vector type's lane count. This is useful when you're
             /// working with a native-width vector (e.g. [`Simd::f32s`]) and
             /// want to process data in native-width chunks.
-            const N: usize;
+            const LEN: usize;
             /// A SIMD vector mask with the same number of logical lanes.
             ///
             /// Masks intentionally do not implement [`SimdBase`]. SSE, NEON, WASM, and the
@@ -307,7 +307,7 @@ fn mk_simd_base() -> TokenStream {
             /// A 128-bit SIMD vector of the same scalar type.
             type Block: SimdBase<S, Element = Self::Element, Block = Self::Block>;
             /// The array type that this vector type corresponds to, which will
-            /// always be `[Self::Element; Self::N]`. It has the same layout as
+            /// always be `[Self::Element; Self::LEN]`. It has the same layout as
             /// this vector type, but likely has a lower alignment.
             type Array: Copy
                 + Debug
@@ -362,15 +362,15 @@ fn mk_simd_base() -> TokenStream {
             fn block_splat(block: Self::Block) -> Self;
             /// Create a SIMD vector where each element is produced by
             /// calling `f` with that element's lane index (from 0 to
-            /// [`SimdBase::N`] - 1).
+            /// [`SimdBase::LEN`] - 1).
             fn from_fn(simd: S, f: impl FnMut(usize) -> Self::Element) -> Self;
 
             /// Rotate the vector elements to the left by `OFFSET`.
             ///
-            /// If `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`.
+            /// If `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`.
             #[inline(always)]
             fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
-                match OFFSET % Self::N {
+                match OFFSET % Self::LEN {
                     #(#rotate_left_arms,)*
                     _ => unreachable!(),
                 }
@@ -378,10 +378,10 @@ fn mk_simd_base() -> TokenStream {
 
             /// Rotate the vector elements to the right by `OFFSET`.
             ///
-            /// If `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`.
+            /// If `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`.
             #[inline(always)]
             fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
-                match Self::N - OFFSET % Self::N {
+                match Self::LEN - OFFSET % Self::LEN {
                     #(#rotate_right_arms,)*
                     _ => unreachable!(),
                 }
@@ -389,10 +389,10 @@ fn mk_simd_base() -> TokenStream {
 
             /// Shift the vector elements to the left by `OFFSET`, filling in with `padding` from the right.
             ///
-            /// If `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`.
+            /// If `OFFSET` is greater than or equal to `Self::LEN`, all lanes are filled with `padding`.
             #[inline(always)]
             fn shift_elements_left<const OFFSET: usize>(self, padding: Self::Element) -> Self {
-                match OFFSET.min(Self::N) {
+                match OFFSET.min(Self::LEN) {
                     #(#shift_left_arms,)*
                     _ => unreachable!(),
                 }
@@ -400,11 +400,11 @@ fn mk_simd_base() -> TokenStream {
 
             /// Shift the vector elements to the right by `OFFSET`, filling in with `padding` from the left.
             ///
-            /// If `OFFSET` is greater than or equal to `Self::N`, all lanes are filled with `padding`.
+            /// If `OFFSET` is greater than or equal to `Self::LEN`, all lanes are filled with `padding`.
             #[inline(always)]
             fn shift_elements_right<const OFFSET: usize>(self, padding: Self::Element) -> Self {
                 let padding = Self::splat(self.witness(), padding);
-                match Self::N.saturating_sub(OFFSET) {
+                match Self::LEN.saturating_sub(OFFSET) {
                     #(#shift_right_arms,)*
                     _ => unreachable!(),
                 }
@@ -530,7 +530,7 @@ fn mk_simd_mask() -> TokenStream {
             type Element: SimdElement;
 
             /// This mask type's lane count.
-            const N: usize;
+            const LEN: usize;
 
             /// Get the [`Simd`] implementation associated with this type.
             fn witness(&self) -> S;
@@ -541,13 +541,13 @@ fn mk_simd_mask() -> TokenStream {
             /// Create a mask from a compact bitmask.
             ///
             /// Bit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above
-            /// [`Self::N`] are ignored.
+            /// [`Self::LEN`] are ignored.
             fn from_bitmask(simd: S, bits: u64) -> Self;
 
             /// Convert this mask to a compact bitmask.
             ///
             /// Bit `i` maps to lane `i`, with lane 0 in the least significant bit. Bits above
-            /// [`Self::N`] are cleared.
+            /// [`Self::LEN`] are cleared.
             fn to_bitmask(self) -> u64;
 
             /// Test whether one logical lane is set.
@@ -556,9 +556,9 @@ fn mk_simd_mask() -> TokenStream {
             #[inline(always)]
             fn test(&self, index: usize) -> bool {
                 assert!(
-                    index < Self::N,
+                    index < Self::LEN,
                     "mask lane index {index} is out of bounds for {} lanes",
-                    Self::N
+                    Self::LEN
                 );
                 (((*self).to_bitmask() >> index) & 1) != 0
             }

--- a/fearless_simd_gen/src/mk_simd_types.rs
+++ b/fearless_simd_gen/src/mk_simd_types.rs
@@ -416,7 +416,7 @@ fn simd_mask_impl(ty: &VecType) -> TokenStream {
     quote! {
         impl<S: Simd> SimdMask<S> for #name<S> {
             type Element = #scalar;
-            const N: usize = #len;
+            const LEN: usize = #len;
 
             #[inline(always)]
             fn witness(&self) -> S {
@@ -556,7 +556,7 @@ fn simd_vec_impl(ty: &VecType) -> TokenStream {
         impl<S: Simd> SimdBase<S> for #name<S> {
             type Element = #scalar;
             type ByteVector = #byte_vector<S>;
-            const N: usize = #len;
+            const LEN: usize = #len;
             type Mask = #mask_ty<S>;
             type Block = #block_ty<S>;
             type Array = [#scalar; #len];

--- a/fearless_simd_gen/src/ops.rs
+++ b/fearless_simd_gen/src/ops.rs
@@ -575,9 +575,9 @@ const BASE_OPS: &[Op] = &[
         OpSig::Slide {
             granularity: SlideGranularity::AcrossBlocks,
         },
-        "Concatenate `[self, rhs]` and extract `Self::N` elements starting at index `SHIFT`.\n\n\
-         `SHIFT` must be within [0, `Self::N`].\n\n\
-         This can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::N - M`.\n\n\
+        "Concatenate `[self, rhs]` and extract `Self::LEN` elements starting at index `SHIFT`.\n\n\
+         `SHIFT` must be within [0, `Self::LEN`].\n\n\
+         This can be used to implement a \"shift items\" operation by providing all zeroes as one operand. For a left shift, the right-hand side should be all zeroes. For a right shift by `M` items, the left-hand side should be all zeroes, and the shift amount will be `Self::LEN - M`.\n\n\
          This can also be used to rotate items within a vector by providing the same vector as both operands.\n\n\
          ```text\n\n\
          slide::<1>([a b c d], [e f g h]) == [b c d e]\n\n\
@@ -1129,7 +1129,7 @@ const MASK_OPS: &[Op] = &[
             direction: ElementDirection::Left,
         },
         "Rotate the mask elements to the left by `OFFSET`.\n\n\
-        If `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`.",
+        If `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`.",
     ),
     Op::new(
         "rotate_elements_right",
@@ -1138,7 +1138,7 @@ const MASK_OPS: &[Op] = &[
             direction: ElementDirection::Right,
         },
         "Rotate the mask elements to the right by `OFFSET`.\n\n\
-        If `OFFSET` is greater than or equal to `Self::N`, it wraps modulo `Self::N`.",
+        If `OFFSET` is greater than or equal to `Self::LEN`, it wraps modulo `Self::LEN`.",
     ),
     Op::new(
         "and",

--- a/fearless_simd_tests/tests/generics.rs
+++ b/fearless_simd_tests/tests/generics.rs
@@ -109,7 +109,7 @@ fn generic_four_interleaved_color_transform<S: Simd, V: SimdInterleaved<S>>(
     simd: S,
     pixels: &mut [V::Element],
 ) {
-    let mut chunks = pixels.chunks_exact_mut(V::N * 4);
+    let mut chunks = pixels.chunks_exact_mut(V::LEN * 4);
     for chunk in &mut chunks {
         let [red, green, blue, alpha] = V::load_four_interleaved(simd, chunk);
         V::store_four_interleaved([blue, green, red, alpha], chunk);

--- a/fearless_simd_tests/tests/harness/lm_generated/mask_roundtrip.rs
+++ b/fearless_simd_tests/tests/harness/lm_generated/mask_roundtrip.rs
@@ -9,14 +9,14 @@ use fearless_simd_dev_macros::simd_test;
 fn assert_mask_set_roundtrip<S: Simd, M: SimdMask<S>>(simd: S) {
     let mut mask = M::from_bitmask(simd, 0);
     let mut expected = 0_u64;
-    for i in 0..M::N {
+    for i in 0..M::LEN {
         mask.set(i, true);
         expected |= 1_u64 << i;
         assert_eq!(mask.to_bitmask(), expected);
         assert!(mask.test(i));
     }
 
-    for i in 0..M::N {
+    for i in 0..M::LEN {
         mask.set(i, false);
         expected &= !(1_u64 << i);
         assert_eq!(mask.to_bitmask(), expected);

--- a/fearless_simd_tests/tests/harness/ops/add.rs
+++ b/fearless_simd_tests/tests/harness/ops/add.rs
@@ -81,7 +81,7 @@ fn add_u32x4<S: Simd>(simd: S) {
 fn wrapping_add_u32<S: Simd>(simd: S) {
     assert_eq!(
         (S::u32s::splat(simd, u32::MAX) + 1).as_slice(),
-        &vec![0; S::u32s::N]
+        &vec![0; S::u32s::LEN]
     );
 }
 

--- a/fearless_simd_tests/tests/harness/ops/bitcast.rs
+++ b/fearless_simd_tests/tests/harness/ops/bitcast.rs
@@ -8,7 +8,7 @@ use fearless_simd_dev_macros::simd_test;
 
 #[simd_test]
 fn bitcast_native<S: Simd>(simd: S) {
-    let expected: Vec<u8> = (0..S::u8s::N).map(|i| i as u8).collect();
+    let expected: Vec<u8> = (0..S::u8s::LEN).map(|i| i as u8).collect();
     let u8s = S::u8s::from_slice(simd, &expected);
     let i8s: S::i8s = u8s.bitcast();
     let u16s: S::u16s = i8s.bitcast();

--- a/fearless_simd_tests/tests/harness/ops/narrow.rs
+++ b/fearless_simd_tests/tests/harness/ops/narrow.rs
@@ -1813,7 +1813,7 @@ fn widen_narrow_random<S: Simd>(simd: S) {
         let input_f32: [f32; 8] = core::array::from_fn(|_| f32::from_bits(rng.u32(..)));
         let input_f32 = f32x8::from_slice(simd, &input_f32);
         let (low, high) = input_f32.widen();
-        for i in 0..f64x4::<S>::N {
+        for i in 0..f64x4::<S>::LEN {
             let expected_low = input_f32[i] as f64;
             let expected_high = input_f32[i + 4] as f64;
             if expected_low.is_nan() {
@@ -1838,7 +1838,7 @@ fn widen_narrow_random<S: Simd>(simd: S) {
         let roundtrip = low.narrow(high);
         let saturated_roundtrip = low.saturating_narrow(high);
         let relaxed_roundtrip = low.relaxed_narrow(high);
-        for i in 0..f32x8::<S>::N {
+        for i in 0..f32x8::<S>::LEN {
             if input_f32[i].is_nan() {
                 assert!(roundtrip[i].is_nan(), "f32 roundtrip iteration {iteration}");
                 assert!(
@@ -1875,7 +1875,7 @@ fn widen_narrow_random<S: Simd>(simd: S) {
         let narrowed = a_f64.narrow(b_f64);
         let saturated = a_f64.saturating_narrow(b_f64);
         let relaxed = a_f64.relaxed_narrow(b_f64);
-        for i in 0..f32x8::<S>::N {
+        for i in 0..f32x8::<S>::LEN {
             let source = if i < 4 { a_f64[i] } else { b_f64[i - 4] };
             let expected = source as f32;
             if expected.is_nan() {

--- a/fearless_simd_tests/tests/harness/ops/native_width.rs
+++ b/fearless_simd_tests/tests/harness/ops/native_width.rs
@@ -12,44 +12,48 @@ fn mask_lane(value: bool) -> i64 {
 
 #[simd_test]
 fn native_width_i64_u64<S: Simd>(simd: S) {
-    let mask_vals: Vec<i64> = (0..S::mask64s::N).map(|i| mask_lane(i % 2 == 0)).collect();
+    let mask_vals: Vec<i64> = (0..S::mask64s::LEN)
+        .map(|i| mask_lane(i % 2 == 0))
+        .collect();
     let mask = S::mask64s::from_slice(simd, &mask_vals);
 
-    let u_true: Vec<u64> = (0..S::u64s::N).map(|i| (1_u64 << 63) + i as u64).collect();
-    let u_false: Vec<u64> = (0..S::u64s::N).map(|i| i as u64).collect();
+    let u_true: Vec<u64> = (0..S::u64s::LEN)
+        .map(|i| (1_u64 << 63) + i as u64)
+        .collect();
+    let u_false: Vec<u64> = (0..S::u64s::LEN).map(|i| i as u64).collect();
     let u_selected = mask.select(
         S::u64s::from_slice(simd, &u_true),
         S::u64s::from_slice(simd, &u_false),
     );
-    let u_expected: Vec<u64> = (0..S::u64s::N)
+    let u_expected: Vec<u64> = (0..S::u64s::LEN)
         .map(|i| if i % 2 == 0 { u_true[i] } else { u_false[i] })
         .collect();
     assert_eq!(u_selected.as_slice(), u_expected);
     assert_eq!(
         (S::u64s::splat(simd, 3) * 7).as_slice(),
-        vec![21; S::u64s::N]
+        vec![21; S::u64s::LEN]
     );
 
-    let i_true: Vec<i64> = (0..S::i64s::N)
+    let i_true: Vec<i64> = (0..S::i64s::LEN)
         .map(|i| -i64::try_from(i).expect("native vector length fits in i64") - 1)
         .collect();
-    let i_false: Vec<i64> = (0..S::i64s::N)
+    let i_false: Vec<i64> = (0..S::i64s::LEN)
         .map(|i| i64::try_from(i).expect("native vector length fits in i64") + 1)
         .collect();
     let i_selected = mask.select(
         S::i64s::from_slice(simd, &i_true),
         S::i64s::from_slice(simd, &i_false),
     );
-    let i_expected: Vec<i64> = (0..S::i64s::N)
+    let i_expected: Vec<i64> = (0..S::i64s::LEN)
         .map(|i| if i % 2 == 0 { i_true[i] } else { i_false[i] })
         .collect();
     assert_eq!(i_selected.as_slice(), i_expected);
     assert_eq!(
         (S::i64s::block_splat(i64x2::from_slice(simd, &[11, -12]))).as_slice(),
-        [11, -12].repeat(S::i64s::N / 2)
+        [11, -12].repeat(S::i64s::LEN / 2)
     );
     assert_eq!(
         (S::u64s::block_splat(u64x2::from_slice(simd, &[13, 14]))).as_slice(),
-        [13, 14].repeat(S::u64s::N / 2)
+        [13, 14].repeat(S::u64s::LEN / 2)
     );
 }

--- a/fearless_simd_tests/tests/harness/ops/select.rs
+++ b/fearless_simd_tests/tests/harness/ops/select.rs
@@ -139,49 +139,49 @@ fn select_mask32x4<S: Simd>(simd: S) {
 #[simd_test]
 fn select_native_width_vectors<S: Simd>(simd: S) {
     // Test with native f32 vectors
-    let a_f32 = S::f32s::from_slice(simd, &vec![1.0_f32; S::f32s::N]);
-    let b_f32 = S::f32s::from_slice(simd, &vec![2.0_f32; S::f32s::N]);
-    let mask_f32 = S::mask32s::from_slice(simd, &vec![-1_i32; S::mask32s::N]);
+    let a_f32 = S::f32s::from_slice(simd, &vec![1.0_f32; S::f32s::LEN]);
+    let b_f32 = S::f32s::from_slice(simd, &vec![2.0_f32; S::f32s::LEN]);
+    let mask_f32 = S::mask32s::from_slice(simd, &vec![-1_i32; S::mask32s::LEN]);
     let result_f32 = mask_f32.select(a_f32, b_f32);
-    assert_eq!(result_f32.as_slice(), vec![1.0_f32; S::f32s::N]);
+    assert_eq!(result_f32.as_slice(), vec![1.0_f32; S::f32s::LEN]);
 
     // Test with native u32 vectors
-    let a_u32 = S::u32s::from_slice(simd, &vec![10_u32; S::u32s::N]);
-    let b_u32 = S::u32s::from_slice(simd, &vec![20_u32; S::u32s::N]);
+    let a_u32 = S::u32s::from_slice(simd, &vec![10_u32; S::u32s::LEN]);
+    let b_u32 = S::u32s::from_slice(simd, &vec![20_u32; S::u32s::LEN]);
     let result_u32 = mask_f32.select(a_u32, b_u32);
-    assert_eq!(result_u32.as_slice(), vec![10_u32; S::u32s::N]);
+    assert_eq!(result_u32.as_slice(), vec![10_u32; S::u32s::LEN]);
 
     // Test with native i32 vectors
-    let a_i32 = S::i32s::from_slice(simd, &vec![100_i32; S::i32s::N]);
-    let b_i32 = S::i32s::from_slice(simd, &vec![-100_i32; S::i32s::N]);
+    let a_i32 = S::i32s::from_slice(simd, &vec![100_i32; S::i32s::LEN]);
+    let b_i32 = S::i32s::from_slice(simd, &vec![-100_i32; S::i32s::LEN]);
     let result_i32 = mask_f32.select(a_i32, b_i32);
-    assert_eq!(result_i32.as_slice(), vec![100_i32; S::i32s::N]);
+    assert_eq!(result_i32.as_slice(), vec![100_i32; S::i32s::LEN]);
 
     // Test with native u8 vectors
-    let a_u8 = S::u8s::from_slice(simd, &vec![1_u8; S::u8s::N]);
-    let b_u8 = S::u8s::from_slice(simd, &vec![2_u8; S::u8s::N]);
-    let mask_u8 = S::mask8s::from_slice(simd, &vec![0_i8; S::u8s::N]);
+    let a_u8 = S::u8s::from_slice(simd, &vec![1_u8; S::u8s::LEN]);
+    let b_u8 = S::u8s::from_slice(simd, &vec![2_u8; S::u8s::LEN]);
+    let mask_u8 = S::mask8s::from_slice(simd, &vec![0_i8; S::u8s::LEN]);
     let result_u8 = mask_u8.select(a_u8, b_u8);
-    assert_eq!(result_u8.as_slice(), vec![2_u8; S::u8s::N]);
+    assert_eq!(result_u8.as_slice(), vec![2_u8; S::u8s::LEN]);
 
     // Test with native i8 vectors
-    let a_i8 = S::i8s::from_slice(simd, &vec![10_i8; S::i8s::N]);
-    let b_i8 = S::i8s::from_slice(simd, &vec![-10_i8; S::i8s::N]);
+    let a_i8 = S::i8s::from_slice(simd, &vec![10_i8; S::i8s::LEN]);
+    let b_i8 = S::i8s::from_slice(simd, &vec![-10_i8; S::i8s::LEN]);
     let result_i8 = mask_u8.select(a_i8, b_i8);
-    assert_eq!(result_i8.as_slice(), vec![-10_i8; S::i8s::N]);
+    assert_eq!(result_i8.as_slice(), vec![-10_i8; S::i8s::LEN]);
 
     // Test with native u16 vectors
-    let a_u16 = S::u16s::from_slice(simd, &vec![100_u16; S::u16s::N]);
-    let b_u16 = S::u16s::from_slice(simd, &vec![200_u16; S::u16s::N]);
-    let mask_u16 = S::mask16s::from_slice(simd, &vec![-1_i16; S::mask16s::N]);
+    let a_u16 = S::u16s::from_slice(simd, &vec![100_u16; S::u16s::LEN]);
+    let b_u16 = S::u16s::from_slice(simd, &vec![200_u16; S::u16s::LEN]);
+    let mask_u16 = S::mask16s::from_slice(simd, &vec![-1_i16; S::mask16s::LEN]);
     let result_u16 = mask_u16.select(a_u16, b_u16);
-    assert_eq!(result_u16.as_slice(), vec![100_u16; S::u16s::N]);
+    assert_eq!(result_u16.as_slice(), vec![100_u16; S::u16s::LEN]);
 
     // Test with native i16 vectors
-    let a_i16 = S::i16s::from_slice(simd, &vec![50_i16; S::i16s::N]);
-    let b_i16 = S::i16s::from_slice(simd, &vec![-50_i16; S::i16s::N]);
+    let a_i16 = S::i16s::from_slice(simd, &vec![50_i16; S::i16s::LEN]);
+    let b_i16 = S::i16s::from_slice(simd, &vec![-50_i16; S::i16s::LEN]);
     let result_i16 = mask_u16.select(a_i16, b_i16);
-    assert_eq!(result_i16.as_slice(), vec![50_i16; S::i16s::N]);
+    assert_eq!(result_i16.as_slice(), vec![50_i16; S::i16s::LEN]);
 }
 
 #[simd_test]


### PR DESCRIPTION
Matches `std::simd` and is more clear overall.

I went back and forth on this, but I think this is a good idea after all, and we should do this before 1.0.