### PR TITLE
Ligthen CI load, test on latest stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,4 @@
 env:
-  # We aim to always test with the latest stable Rust toolchain, however we pin to a specific
-  # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
-  # come automatically. If the version specified here is no longer the latest stable version,
-  # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.89" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
   # The purpose of checking with the minimum supported Rust toolchain is to detect its staleness.
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,
@@ -16,7 +11,6 @@ env:
   FEATURES_DEPENDING_ON_STD: "std,default"
   # List of packages that can not target Wasm.
   NO_WASM_PKGS: "--exclude fearless_simd_gen"
-
 
 # Rationale
 #
@@ -36,8 +30,8 @@ env:
 # Using cargo-hack also allows us to more easily test the feature matrix of our packages.
 # We use --each-feature & --optional-deps which will run a separate check for every feature.
 #
-# The MSRV jobs run only cargo check because different clippy versions can disagree on goals and
-# running tests introduces dev dependencies which may require a higher MSRV than the bare package.
+# Clippy jobs run on MSRV to avoid newly added lints firing and breaking CI.
+# They also double as MSRV enforcement checks to save CI time and CI job slots.
 #
 # For no_std checks we target x86_64-unknown-none, because this target doesn't support std
 # and as such will error out if our dependency tree accidentally tries to use std.
@@ -69,7 +63,7 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
+          toolchain: stable
           components: rustfmt
 
       - name: cargo fmt
@@ -99,7 +93,7 @@ jobs:
       - name: Run cargo rdme (fearless_simd)
         run: cargo rdme --check --workspace-project=fearless_simd
 
-  clippy-stable:
+  clippy-msrv:
     name: cargo clippy
     runs-on: ${{ matrix.os }}
     strategy:
@@ -111,7 +105,7 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
+          toolchain: ${{ env.RUST_MIN_VER }}
           targets: x86_64-unknown-none
           components: clippy
 
@@ -135,7 +129,7 @@ jobs:
         run: cargo hack clippy --workspace --locked --optional-deps --each-feature --ignore-unknown-features --features std --tests --benches --examples -- -D warnings
 
 
-  clippy-stable-wasm:
+  clippy-msrv-wasm:
     name: cargo clippy (wasm32)
     runs-on: ubuntu-latest
     steps:
@@ -144,7 +138,7 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
+          toolchain: ${{ env.RUST_MIN_VER }}
           targets: wasm32-unknown-unknown
           components: clippy
 
@@ -177,7 +171,7 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
+          toolchain: stable
           components: rustfmt
 
       - name: restore cache
@@ -208,7 +202,7 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
+          toolchain: stable
           targets: ${{ matrix.platform.target }}
 
       - name: restore cache
@@ -241,7 +235,7 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
+          toolchain: stable
           targets: ${{ matrix.platform.target }}
 
       - name: restore cache
@@ -300,7 +294,7 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
+          toolchain: stable
           targets: ${{ matrix.platform.target }}
 
       - name: restore cache
@@ -357,7 +351,7 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
+          toolchain: stable
           targets: wasm32-unknown-unknown,wasm32-wasip1
 
       - name: restore cache
@@ -394,67 +388,6 @@ jobs:
             --config 'target.wasm32-wasip1.rustflags = "-Ctarget-feature=+simd128,+relaxed-simd"' \
             --config 'target.wasm32-wasip1.rustdocflags = "-Ctarget-feature=+simd128,+relaxed-simd"' \
             --config 'target.wasm32-wasip1.runner = "wasmtime"'
-
-
-  check-msrv:
-    name: cargo check (msrv)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: install msrv toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_MIN_VER }}
-          targets: x86_64-unknown-none,aarch64-unknown-none
-
-      - name: install cargo-hack
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-hack
-
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
-      - name: cargo check (no_std)
-        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} --target x86_64-unknown-none
-
-      - name: cargo check (no_std aarch64)
-        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} --target aarch64-unknown-none
-
-      - name: cargo check
-        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features std
-
-
-  check-msrv-wasm:
-    name: cargo check (msrv) (wasm32)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: install msrv toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_MIN_VER }}
-          targets: wasm32-unknown-unknown
-
-      - name: install cargo-hack
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-hack
-
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
-      - name: cargo check
-        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features std
 
   doc:
     name: cargo doc


### PR DESCRIPTION
We've gone over the limit of 20 concurrent jobs, so CI takes much longer than it has to. This gets us back under that limit.

Prior to this PR all jobs ran on v1.89, this uses latest stable for some jobs instead.

Clippy already doubles as 'cargo check', so remove separate 'cargo check' jobs and only run Clippy on MSRV, where we want to keep it anyway to avoid spurious new lints breaking CI.

With Clippy pinned to MSRV, we can safely use the latest toolchain to discover any newly introduced issues. While previously we had all the jobs running on 1.89, now we can cargo check on MSRV and actually test on the latest stable.