### PR TITLE
Minor fixes

### DIFF
--- a/fearless_simd/examples/disable_avx2_for_one_function.rs
+++ b/fearless_simd/examples/disable_avx2_for_one_function.rs
@@ -31,7 +31,7 @@ fn sigmoid<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
     for (x, y) in x.chunks_exact(n).zip(out.chunks_exact_mut(n)) {
         let a = S::f32s::from_slice(simd, x);
         let b = a / (a * a + 1.0).sqrt();
-        y.copy_from_slice(b.as_slice());
+        b.store_slice(y);
     }
 }
 

--- a/fearless_simd/examples/sigmoid.rs
+++ b/fearless_simd/examples/sigmoid.rs
@@ -22,7 +22,7 @@ fn sigmoid<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
     for (x, y) in x.chunks_exact(n).zip(out.chunks_exact_mut(n)) {
         let a = S::f32s::from_slice(simd, x);
         let b = a / (a * a + 1.0).sqrt();
-        y.copy_from_slice(b.as_slice());
+        b.store_slice(y);
     }
 
     // scalar processing of the remainder smaller than a single vector

--- a/fearless_simd/examples/sigmoid.rs
+++ b/fearless_simd/examples/sigmoid.rs
@@ -17,19 +17,28 @@ use fearless_simd::{Level, dispatch, prelude::*};
 #[inline(always)]
 fn sigmoid<S: Simd>(simd: S, x: &[f32], out: &mut [f32]) {
     let n = S::f32s::LEN; // CPU's native vector size
+
+    // fast vectorized loop
     for (x, y) in x.chunks_exact(n).zip(out.chunks_exact_mut(n)) {
         let a = S::f32s::from_slice(simd, x);
         let b = a / (a * a + 1.0).sqrt();
         y.copy_from_slice(b.as_slice());
+    }
+
+    // scalar processing of the remainder smaller than a single vector
+    let x_remainder = x.chunks_exact(n).remainder();
+    let y_remainder = out.chunks_exact_mut(n).into_remainder();
+    for (a, b) in x_remainder.iter().zip(y_remainder) {
+        *b = a / (a * a + 1.0).sqrt();
     }
 }
 
 fn main() {
     let level = Level::new();
     let inp = [
-        0.1, -0.2, 0.001, 0.4, 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.,
+        0.1, -0.2, 0.001, 0.4, 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14.,
     ];
-    let mut out = [0.; 16];
+    let mut out = [0.; 18];
     // dispatch! selects the best implementation for the CPU we're running on
     dispatch!(level, simd => sigmoid(simd, &inp, &mut out));
 

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -194,6 +194,7 @@ macro_rules! __fearless_simd_dispatch_dispatch_avx512 {
     any(
         disable_dispatch_avx512,
         not(all(
+            target_feature = "adx",
             target_feature = "aes",
             target_feature = "avx512bitalg",
             target_feature = "avx512bw",
@@ -241,6 +242,7 @@ macro_rules! __fearless_simd_dispatch_dispatch_avx2 {
     disable_dispatch_avx2,
     all(
         not(disable_dispatch_avx512),
+        target_feature = "adx",
         target_feature = "aes",
         target_feature = "avx512bitalg",
         target_feature = "avx512bw",


### PR DESCRIPTION
I had Astra review the codebase for bugs and this is what it flagged.

1. A syntheric feature flag configuration can produce a panic in dispatcher due to a desync between feature strings
2. Sigmoid example didn't demonstrate the scalar remainder handling, which I feel we should include in the example code